### PR TITLE
Add test sampling support to test262 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
-      - name: Run test262
-        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262
+      - name: Run test262 (10% sample)
+        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1
 
   coverage:
     runs-on: ubuntu-latest
@@ -64,7 +64,7 @@ jobs:
           cargo llvm-cov clean --workspace
           cargo build --release
           cargo test
-          uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262
+          uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1
           cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Summary
Add support for running a random sample of test262 tests instead of the full suite. This enables faster CI feedback while maintaining representative coverage across test directories.

## Key Changes
- Added `--sample` and `--seed` command-line arguments to `run-test262.py` for controlling test sampling
- Implemented `sample_tests()` function that performs stratified random sampling by directory, ensuring each directory contributes proportionally with a minimum of one test per directory
- Added validation to ensure sample rate is between 0 (exclusive) and 1 (inclusive)
- Modified result reporting to indicate when a sample run was performed and display the sampling rate and seed
- Prevented sampled runs from updating the test262-pass.txt baseline file
- Updated CI workflows to run 10% test samples instead of full test suite for faster feedback

## Implementation Details
- Stratified sampling groups tests by parent directory to ensure representative coverage across all test categories
- Uses `math.ceil()` to calculate sample size per directory, with bounds checking to ensure at least 1 test and at most all tests per directory
- Random seed is optional; when not provided, sampling is non-deterministic
- Sample run information is printed to stderr for visibility in CI logs
- Full test runs (non-sampled) continue to update the baseline pass file as before

https://claude.ai/code/session_01UM3kM7SzUMwfUX2oWEUuR4