### PR TITLE
Add nightly test262 coverage workflow

### DIFF
--- a/.github/workflows/nightly-test262-coverage.yml
+++ b/.github/workflows/nightly-test262-coverage.yml
@@ -1,0 +1,47 @@
+name: Nightly test262 Coverage
+
+on:
+  schedule:
+    # Run every night at 02:00 UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch: # Allow manual triggers
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Generate coverage from full test262 suite
+        run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo llvm-cov clean --workspace
+          cargo build --release
+          cargo test
+          uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262
+          cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: pmatos/jsse
+          flags: nightly-test262
+          name: nightly-test262-full


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that runs nightly code coverage analysis against the full test262 test suite and uploads the results to Codecov.

## Key Changes
- Added `.github/workflows/nightly-test262-coverage.yml` workflow file that:
  - Runs on a nightly schedule (02:00 UTC) with manual trigger support
  - Sets up Rust toolchain with LLVM tools for coverage instrumentation
  - Installs `cargo-llvm-cov` for code coverage generation
  - Builds the project in release mode
  - Runs the full test262 test suite via `scripts/run-test262.py`
  - Generates LCOV coverage reports
  - Uploads coverage data to Codecov with appropriate metadata (nightly-test262 flags)

## Implementation Details
- Uses `cargo-llvm-cov` for accurate Rust code coverage measurement
- Includes 6-hour timeout to accommodate the full test262 suite execution
- Leverages workspace caching to optimize build times
- Configured with explicit Codecov token and repository slug for reliable uploads

https://claude.ai/code/session_01JcNk1YCt2ALwZJsfKLvqs7