### PR TITLE
Make PR test262 coverage deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  TEST262_SAMPLE_SEED: 262023
 
 jobs:
   build:
@@ -37,8 +38,18 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
-      - name: Run test262 (10% sample)
-        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1
+      - name: Run test262 smoke set
+        run: |
+          uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 \
+            test262/test/built-ins/Atomics/ \
+            test262/test/built-ins/SharedArrayBuffer/ \
+            test262/test/language/module-code/ \
+            test262/test/language/expressions/dynamic-import/usage/ \
+            test262/test/language/expressions/dynamic-import/namespace/ \
+            test262/test/language/expressions/dynamic-import/import-attributes/
+
+      - name: Run test262 (10% sample, fixed seed ${{ env.TEST262_SAMPLE_SEED }})
+        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1 --seed $TEST262_SAMPLE_SEED
 
   coverage:
     runs-on: ubuntu-latest
@@ -64,7 +75,7 @@ jobs:
           cargo llvm-cov clean --workspace
           cargo build --release
           cargo test --release
-          uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1
+          uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1 --seed $TEST262_SAMPLE_SEED
           cargo llvm-cov report --release --lcov --output-path lcov.info
 
       - name: Upload coverage reports to Codecov

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -609,7 +609,8 @@ def main():
         print(f"Error: test262 directory not found at {test262}", file=sys.stderr)
         sys.exit(2)
 
-    tests = find_tests(test262, args.paths if args.paths else None)
+    selected_paths = args.paths if args.paths else None
+    tests = find_tests(test262, selected_paths)
 
     is_sample_run = args.sample is not None
     if is_sample_run:
@@ -620,6 +621,11 @@ def main():
         tests = sample_tests(tests, rate, args.seed)
         print(
             f"Sampling {rate*100:.1f}% of tests (seed={args.seed}): {len(tests)} files selected.",
+            file=sys.stderr,
+        )
+    elif selected_paths:
+        print(
+            "Selected paths: " + ", ".join(selected_paths),
             file=sys.stderr,
         )
 
@@ -721,6 +727,8 @@ def main():
     print(f"Engine:  {engine_name} ({binary})")
     if is_sample_run:
         print(f"Sample:  {args.sample*100:.1f}% (seed={args.seed})")
+    elif selected_paths:
+        print(f"Paths:   {', '.join(selected_paths)}")
     print(f"Files:   {num_files}")
     print(f"Scenarios: {total}")
     print(f"Run:     {run_total}")


### PR DESCRIPTION
## Summary
- make PR test262 sampling deterministic with a fixed seed in CI
- add a deterministic smoke set for high-risk runtime areas
- print explicit path selections in the test262 runner summary

## Testing
- cargo fmt --check
- cargo check
- uv run python scripts/run-test262.py -j 4 --sample 0.001 --seed 262023 test262/test/built-ins/Atomics/
- uv run python scripts/run-test262.py -j 4 test262/test/built-ins/SharedArrayBuffer/ test262/test/language/expressions/dynamic-import/import-attributes/
- uv run python scripts/run-test262.py -j 4 test262/test/built-ins/Atomics/ test262/test/built-ins/SharedArrayBuffer/ test262/test/language/module-code/ test262/test/language/expressions/dynamic-import/usage/ test262/test/language/expressions/dynamic-import/namespace/ test262/test/language/expressions/dynamic-import/import-attributes/

Closes #23