### PR TITLE
Fix doc and README updater drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run test262 (10% sample)
         run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1
 
+      - name: Validate README progress table contract
+        run: uv run python scripts/update-readme.py --check --from-readme
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ A from-scratch JavaScript engine implemented in Rust. No JS parser/engine librar
   - `expressions.rs` — Expression parsing
   - `statements.rs` — Statement parsing
   - `declarations.rs` — Function, class, variable, destructuring parsing
+  - `modules.rs` — Module-specific parsing
 - `src/interpreter/` — Tree-walking interpreter
   - `mod.rs` — Interpreter struct, new(), run(), object/property helpers
   - `types.rs` — Completion, Environment, JsFunction, PropertyDescriptor, JsObjectData, etc.
@@ -57,6 +58,7 @@ A from-scratch JavaScript engine implemented in Rust. No JS parser/engine librar
 - Primary validation: test262 suite
 - Custom tests: `tests/` directory
 - After any implementation work, run the full test262 suite and update README.md progress.
+- Update README progress with `python3 scripts/update-readme.py` after a full test262 run.
 - Run test262: `uv run python scripts/run-test262.py`
 - Run linter: `./scripts/lint.sh`
 - Python scripts are run via `uv run python` (no virtualenv setup needed).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,132 +1,106 @@
 # JSSE Architecture Overview
 
-A from-scratch JavaScript engine in Rust. No JS parser or engine libraries — every component is implemented from first principles.
+JSSE is a from-scratch JavaScript engine in Rust. The execution model is a direct AST-walking interpreter: source text is tokenized, parsed into an AST, and evaluated without a bytecode or JIT layer.
 
 ## Pipeline
 
-```
-Source Code (.js / -e string / REPL)
+```text
+Source (.js file / -e string / REPL)
         |
         v
-    +-------+
-    | Lexer |   src/lexer.rs  (~1,200 lines)
-    +-------+
-        |  Token stream
+    src/lexer.rs
+        |
         v
-    +--------+
-    | Parser |  src/parser.rs  (~1,800 lines)
-    +--------+
-        |  AST (src/ast.rs, ~380 lines)
+    src/parser/
+        |
         v
-    +-------------+
-    | Interpreter |  src/interpreter.rs  (~6,200 lines)
-    +-------------+
-        |  JsValue results (src/types.rs, ~550 lines)
+    src/ast.rs
+        |
+        v
+    src/interpreter/
+        |
         v
     stdout / exit code
 ```
 
-## Components
+## Main Components
 
-### Lexer (`src/lexer.rs`)
+### Lexer
 
-Converts source text into tokens. Handles all ES2024 token types:
+`src/lexer.rs` converts source text into tokens, including:
 
-- Identifiers and keywords (with Unicode support via `unicode-ident`)
-- Numeric literals (decimal, hex, octal, binary, BigInt)
-- String literals (single/double quotes, escape sequences)
-- Template literals with substitution tracking
-- RegExp literals
-- All punctuators and operators
-- Line terminator tracking (for ASI in parser)
+- identifiers and keywords with Unicode support
+- numeric, string, template, and RegExp literals
+- punctuators and operators
+- line terminator tracking for ASI-sensitive parsing
 
-### Parser (`src/parser.rs`)
+### Parser
 
-Recursive descent parser producing an AST. Features:
+The parser lives under `src/parser/` and is split by responsibility:
 
-- All statement types (variable declarations, control flow, try/catch, classes, functions)
-- All expression types (binary, unary, assignment, member access, calls, templates)
-- Destructuring patterns (array and object, with rest/defaults)
-- Arrow functions, async, generators (syntax level)
-- Automatic Semicolon Insertion (ASI)
-- Single-token pushback for lookahead
+- `src/parser/mod.rs`: parser entrypoints and shared helpers
+- `src/parser/expressions.rs`: expression parsing
+- `src/parser/statements.rs`: statement parsing
+- `src/parser/declarations.rs`: declarations, destructuring, and class/function parsing
+- `src/parser/modules.rs`: module-specific syntax
 
-### AST (`src/ast.rs`)
+The parser is recursive descent and produces the AST defined in `src/ast.rs`.
 
-Pure data structures — no logic. Key types:
+### AST and Runtime Values
 
-- `Program` → `Vec<Statement>`
-- `Statement`: Block, Variable, If, While, DoWhile, For, ForIn, ForOf, Switch, Try, Return, Throw, Class, Function, Labeled, With
-- `Expression`: Literal, Identifier, Binary, Unary, Assign, Call, New, Member, Arrow, Template, Spread, etc.
-- `Pattern`: Identifier, Array, Object, Assign, Rest (for destructuring)
-- Operator enums: BinaryOp, UnaryOp, LogicalOp, AssignOp, UpdateOp
+`src/ast.rs` holds syntax tree data structures only.
 
-### Types (`src/types.rs`)
+Core JavaScript value types live in `src/types.rs`, including:
 
-JavaScript value system:
+- `JsValue`
+- `JsString`
+- `JsSymbol`
+- `JsBigInt`
+- numeric and bigint operation helpers
 
-- `JsValue` enum: Undefined, Null, Boolean, Number, String, Symbol, BigInt, Object
-- `JsString`: stores UTF-16 code units for spec-correct string indexing
-- `JsSymbol`: unique ID + optional description, well-known symbols
-- `JsBigInt`: wraps `num-bigint::BigInt`
-- `JsObject`: ID reference into interpreter's object store
-- Number/BigInt operation modules for arithmetic, bitwise, comparison
+### Interpreter
 
-### Interpreter (`src/interpreter.rs`)
+The interpreter lives under `src/interpreter/` and is split across runtime subsystems:
 
-Tree-walking interpreter. The largest component. Key subsystems:
+- `src/interpreter/mod.rs`: interpreter state, object store, module loading, runtime entrypoints
+- `src/interpreter/exec.rs`: statement execution
+- `src/interpreter/eval.rs`: expression evaluation
+- `src/interpreter/types.rs`: runtime object, environment, and completion types
+- `src/interpreter/helpers.rs`: coercion, equality, JSON, date, and other shared helpers
+- `src/interpreter/gc.rs`: mark-and-sweep garbage collection
+- `src/interpreter/builtins/`: built-in constructors, prototypes, and related runtime support
 
-**Object Model**
-- `JsObjectData`: properties (HashMap + insertion-order Vec), prototype chain, callable slot, array elements, class name, primitive value wrapper
-- `PropertyDescriptor`: value/writable/enumerable/configurable + get/set for accessors
-- Prototype chain lookup for property access
-- `Object.defineProperty` with full descriptor validation
+Key runtime responsibilities:
 
-**Environment & Scoping**
-- `Environment`: linked list of scopes (global → function → block)
-- `Binding`: value + kind (Var/Let/Const) + initialized flag
-- TDZ enforcement for let/const
-- Var hoisting to function/global scope
+- object model and property descriptors
+- environment chains and lexical scoping
+- completion handling (`return`, `throw`, `break`, `continue`)
+- built-ins and host/test262 support
+- module loading and dynamic import
+- typed arrays, buffers, and Atomics
 
-**Execution**
-- `Completion` enum: Normal, Return, Throw, Break, Continue
-- Statement execution dispatches by statement type
-- Expression evaluation with proper operator semantics
-- ToPrimitive coercion (valueOf/toString) for operators
-- Abstract equality and relational comparison per spec
+## Built-ins Layout
 
-**Built-in Objects**
-- Object: create, defineProperty, keys, values, entries, freeze, seal, assign, is, hasOwn, fromEntries, getPrototypeOf, setPrototypeOf
-- Function: call, apply, bind
-- Array: push, pop, shift, unshift, map, filter, reduce, find, sort, flat, flatMap, splice, slice, concat, indexOf, includes, every, some, at, copyWithin, entries, keys, values
-- String: charAt, indexOf, slice, substring, split, replace, trim, padStart, padEnd, repeat, startsWith, endsWith, match, search, codePointAt
-- Number: isFinite, isNaN, isInteger, isSafeInteger, toFixed, toExponential, toPrecision
-- Math: abs, floor, ceil, round, sqrt, pow, min, max, random, log, sin, cos, tan, atan2, hypot, etc.
-- JSON: stringify, parse
-- RegExp: test, exec (via Rust `regex` crate)
-- Error types: Error, TypeError, ReferenceError, SyntaxError, RangeError
-- Symbol: constructor + well-known symbols (iterator, hasInstance, toPrimitive, toStringTag)
+`src/interpreter/builtins/mod.rs` wires globals and shared helpers together. Larger built-in families live in dedicated modules such as:
 
-### CLI (`src/main.rs`)
+- arrays, strings, numbers, collections, iterators, promises, dates, regexp, typed arrays, atomics
+- feature-specific support such as generators, disposable resources, and Temporal/Intl support where present in the tree
 
-Entry point with three modes:
-1. File execution: `jsse <file.js>`
-2. Inline eval: `jsse -e "expression"`
-3. REPL: `jsse` (no args)
+When adding or debugging a built-in, start in `builtins/mod.rs` to find the setup path, then move into the specialized module for the implementation details.
 
-Uses `clap` for argument parsing. Exit codes: 0 success, 1 runtime error, 2 syntax error.
+## Entry Points and Tooling
 
-## Testing
+- `src/main.rs`: CLI entrypoint for file execution, `-e`, and REPL
+- `scripts/run-test262.py`: primary conformance runner
+- `scripts/run-custom-tests.py`: custom repo tests
+- `scripts/update-readme.py`: updates or validates the managed README test262 progress table
 
-- **test262**: Primary validation. Run via `uv run python scripts/run-test262.py`. Parallel execution, YAML frontmatter parsing, negative test handling.
-- **Custom tests**: `tests/` directory for cases not covered by test262.
-- **Lint**: `scripts/lint.sh` for clippy + rustfmt.
+## Validation Flow
 
-## Dependencies
+The main validation target is test262. A typical workflow is:
 
-| Crate | Purpose |
-|-------|---------|
-| `clap` | CLI argument parsing |
-| `num-bigint` | BigInt arithmetic |
-| `unicode-ident` | Unicode identifier validation |
-| `regex` | RegExp implementation |
+1. build with `cargo build --release`
+2. run targeted or full `test262` via `uv run python scripts/run-test262.py`
+3. update the managed README progress table with `python3 scripts/update-readme.py` after a full run
+
+Custom tests in `tests/` and the CI workflow complement test262, but test262 remains the primary correctness signal for language and built-in behavior.

--- a/scripts/update-readme.py
+++ b/scripts/update-readme.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-"""Update README.md with latest test262 results."""
+"""Update or validate the managed test262 progress table in README.md."""
 
+import argparse
 import json
 import re
 import subprocess
@@ -8,49 +9,158 @@ import sys
 from pathlib import Path
 
 
-def main():
-    readme = Path("README.md")
-    if not readme.exists():
-        print("README.md not found", file=sys.stderr)
-        sys.exit(1)
+README_PATH = Path("README.md")
+RUNNER_COMMAND = ["uv", "run", "python", "scripts/run-test262.py"]
+TABLE_HEADER = "| Test Files | Scenarios | Passing | Failing | Pass Rate |"
+SECTION_RE = re.compile(
+    r"(?P<prefix>## Test262 Progress\s*\n\s*\n)"
+    r"(?P<table>\|[^\n]+\|\n\|[^\n]+\|\n\|[^\n]+\|)",
+    re.MULTILINE,
+)
+DATA_ROW_RE = re.compile(
+    r"^\|\s*(?P<files>[\d,]+)\s*\|"
+    r"\s*(?P<scenarios>[\d,]+)\s*\|"
+    r"\s*(?P<pass>[\d,]+)\s*\|"
+    r"\s*(?P<fail>[\d,]+)\s*\|"
+    r"\s*(?P<percentage>[\d.]+%)\s*\|$"
+)
 
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate README.md instead of rewriting it.",
+    )
+    parser.add_argument(
+        "--from-readme",
+        action="store_true",
+        help="Use the current README table values as the data source. Useful for CI format checks.",
+    )
+    parser.add_argument(
+        "runner_args",
+        nargs=argparse.REMAINDER,
+        help="Optional args passed through to scripts/run-test262.py after '--'.",
+    )
+    return parser.parse_args()
+
+
+def fail(message: str) -> "NoReturn":
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_readme() -> str:
+    if not README_PATH.exists():
+        fail("README.md not found")
+    return README_PATH.read_text()
+
+
+def find_managed_table(content: str) -> tuple[re.Match[str], str]:
+    match = SECTION_RE.search(content)
+    if not match:
+        fail("Could not find the managed '## Test262 Progress' table in README.md")
+    table = match.group("table")
+    lines = table.splitlines()
+    if len(lines) != 3 or lines[0].strip() != TABLE_HEADER:
+        fail("README.md Test262 Progress table does not match the expected format")
+    return match, table
+
+
+def parse_readme_table(content: str) -> dict[str, int | float]:
+    _, table = find_managed_table(content)
+    data_line = table.splitlines()[2]
+    match = DATA_ROW_RE.match(data_line)
+    if not match:
+        fail("README.md Test262 Progress data row does not match the expected format")
+    percentage = match.group("percentage").rstrip("%")
+    return {
+        "files": int(match.group("files").replace(",", "")),
+        "scenarios": int(match.group("scenarios").replace(",", "")),
+        "pass": int(match.group("pass").replace(",", "")),
+        "fail": int(match.group("fail").replace(",", "")),
+        "percentage": float(percentage),
+    }
+
+
+def run_test262(args: list[str]) -> dict[str, int | float]:
+    command = RUNNER_COMMAND + args
     result = subprocess.run(
-        ["uv", "run", "python", "scripts/run-test262.py"],
+        command,
         capture_output=True,
         text=True,
         timeout=7200,
     )
+    if result.returncode != 0:
+        if result.stdout:
+            print(result.stdout, file=sys.stderr, end="")
+        if result.stderr:
+            print(result.stderr, file=sys.stderr, end="")
+        fail("test262 runner failed")
 
     for line in result.stdout.splitlines():
         if line.startswith("JSON: "):
             data = json.loads(line[6:])
             break
     else:
-        print("Could not find JSON output from test runner", file=sys.stderr)
-        print(result.stdout[-500:], file=sys.stderr)
-        sys.exit(1)
+        fail("Could not find JSON output from the test262 runner")
 
-    total = f"{data['total']:,}"
-    run = f"{data['run']:,}"
-    skip = f"{data['skip']:,}"
+    return {
+        "files": data["files"],
+        "scenarios": data["scenarios"],
+        "pass": data["pass"],
+        "fail": data["fail"],
+        "percentage": data["percentage"],
+    }
+
+
+def render_table(data: dict[str, int | float]) -> str:
+    files = f"{data['files']:,}"
+    scenarios = f"{data['scenarios']:,}"
     passed = f"{data['pass']:,}"
-    fail = f"{data['fail']:,}"
-    rate = f"{data['percentage']:.2f}%"
-
-    table = (
-        f"| Total Tests | Run     | Skipped | Passing | Failing | Pass Rate |\n"
-        f"|-------------|---------|---------|---------|---------|-----------|"
-        f"\n| {total:<11} | {run:<7} | {skip:<7} | {passed:<7} | {fail:<7} | {rate:<9} |"
+    failed = f"{data['fail']:,}"
+    percentage = f"{float(data['percentage']):.2f}%"
+    return "\n".join(
+        [
+            TABLE_HEADER,
+            "|------------|-----------|---------|---------|-----------|",
+            f"| {files:<10} | {scenarios:<9} | {passed:<7} | {failed:<7} | {percentage:<9} |",
+        ]
     )
 
-    content = readme.read_text()
-    content = re.sub(
-        r"\| Total Tests.*?\n\|[-| ]+\n\|[^\n]+",
-        table,
-        content,
+
+def update_content(content: str, table: str) -> str:
+    match, current = find_managed_table(content)
+    if current == table:
+        return content
+    return content[: match.start("table")] + table + content[match.end("table") :]
+
+
+def main() -> None:
+    args = parse_args()
+    readme = load_readme()
+    if args.from_readme:
+        data = parse_readme_table(readme)
+    else:
+        runner_args = args.runner_args
+        if runner_args and runner_args[0] == "--":
+            runner_args = runner_args[1:]
+        data = run_test262(runner_args)
+
+    expected_content = update_content(readme, render_table(data))
+
+    if args.check:
+        if expected_content != readme:
+            fail("README.md Test262 Progress table is out of date")
+        print("README.md Test262 Progress table is up to date")
+        return
+
+    README_PATH.write_text(expected_content)
+    print(
+        "Updated README.md: "
+        f"{data['pass']:,} passing ({float(data['percentage']):.2f}%)"
     )
-    readme.write_text(content)
-    print(f"Updated README.md: {passed} passing ({rate})")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the architecture doc to match the split parser/interpreter layout
- repair `scripts/update-readme.py` for the current README progress table and add `--check`
- add a CI contract check for the managed README progress table and refresh top-level contributor guidance

## Testing
- python3 -m py_compile scripts/update-readme.py
- python3 scripts/update-readme.py --help
- python3 scripts/update-readme.py --check --from-readme
- cargo fmt --check
- cargo check

## Notes
- `python3 scripts/update-readme.py --check -- test262/test/built-ins/SharedArrayBuffer/` correctly fails once the requested run result differs from the README table; in the clean PR worktree it was not rerun because `target/release/jsse` was not built there.

Closes #24