### PR TITLE
Fix trailing hyphen in regex character class treated as range operator

### DIFF
--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -4197,16 +4197,23 @@ pub(crate) fn validate_js_pattern(source: &str, _flags: &str) -> Result<(), Stri
                                 source
                             ));
                         }
-                        if let (Some(start_val), Some(end_val)) = (prev_value, val)
-                            && start_val > end_val
-                        {
-                            return Err(format!(
-                                "Invalid regular expression: /{}/ : Range out of order in character class",
-                                source
-                            ));
+                        if let (Some(start_val), Some(end_val)) = (prev_value, val) {
+                            if start_val > end_val {
+                                return Err(format!(
+                                    "Invalid regular expression: /{}/ : Range out of order in character class",
+                                    source
+                                ));
+                            }
+                            // Valid range: both endpoints are consumed, neither
+                            // is available as the start of a new range.
+                            prev_value = None;
+                            prev_is_class_escape = false;
+                        } else {
+                            // Degenerate range (class escape endpoint in non-unicode Annex B):
+                            // the end atom remains a standalone literal.
+                            prev_value = val;
+                            prev_is_class_escape = is_class_esc;
                         }
-                        prev_value = val;
-                        prev_is_class_escape = is_class_esc;
                         continue;
                     }
 


### PR DESCRIPTION
## Summary
- Fixes the regex validator incorrectly treating a `-` after a completed character range (e.g. `a-z`) as a range operator instead of a literal hyphen
- After validating a range, both endpoints are now marked as consumed (`prev_value = None`), preventing the range end from being reused as the start of a new range
- Patterns like `/[^+/0-9A-Za-z-_]/` now correctly parse instead of erroring with "Range out of order in character class"

Fixes #48

## Test plan
- [x] Reproducer from issue (`/[^+/0-9A-Za-z-_]/`) now prints `ok`
- [x] Out-of-order ranges (`[z-a]`) still correctly error
- [x] Valid ranges (`[a-z]`, `[0-9A-Za-z]`) still work
- [x] Literal hyphen at end of class (`[a-z-]`) works
- [x] Annex B class escape ranges (`[\d-z]`) work in non-unicode mode
- [x] test262 `language/literals/regexp/`: 476/476, 0 regressions
- [x] test262 `built-ins/RegExp/` (excl. property-escapes): 0 regressions