### PR TITLE
Fix GC collecting live objects in state-machine generators

### DIFF
--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -410,9 +410,24 @@ impl Interpreter {
                 }
                 IteratorState::MapIterator { map_id, .. } => worklist.push(*map_id),
                 IteratorState::SetIterator { set_id, .. } => worklist.push(*set_id),
-                IteratorState::Generator { func_env, .. }
-                | IteratorState::AsyncGenerator { func_env, .. } => {
+                IteratorState::Generator {
+                    func_env,
+                    execution_state,
+                    ..
+                }
+                | IteratorState::AsyncGenerator {
+                    func_env,
+                    execution_state,
+                    ..
+                } => {
                     Self::collect_env_roots(func_env, worklist);
+                    if let GeneratorExecutionState::SuspendedYield { prev_sent, .. } =
+                        execution_state
+                    {
+                        for v in prev_sent {
+                            Self::collect_value_roots(v, worklist);
+                        }
+                    }
                 }
                 IteratorState::StateMachineGenerator {
                     func_env,

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -110,6 +110,9 @@ impl Interpreter {
             if let Some(ref v) = afs.saved_finally_exception {
                 Self::collect_value_roots(v, &mut worklist);
             }
+            if let Some(ref env) = afs.for_of_iter_env {
+                Self::collect_env_roots(env, &mut worklist);
+            }
         }
 
         // Mark phase (BFS)
@@ -408,10 +411,37 @@ impl Interpreter {
                 IteratorState::MapIterator { map_id, .. } => worklist.push(*map_id),
                 IteratorState::SetIterator { set_id, .. } => worklist.push(*set_id),
                 IteratorState::Generator { func_env, .. }
-                | IteratorState::AsyncGenerator { func_env, .. }
-                | IteratorState::StateMachineGenerator { func_env, .. }
-                | IteratorState::StateMachineAsyncGenerator { func_env, .. } => {
+                | IteratorState::AsyncGenerator { func_env, .. } => {
                     Self::collect_env_roots(func_env, worklist);
+                }
+                IteratorState::StateMachineGenerator {
+                    func_env,
+                    delegated_iterator,
+                    pending_exception,
+                    pending_return,
+                    _sent_value,
+                    ..
+                }
+                | IteratorState::StateMachineAsyncGenerator {
+                    func_env,
+                    delegated_iterator,
+                    pending_exception,
+                    pending_return,
+                    _sent_value,
+                    ..
+                } => {
+                    Self::collect_env_roots(func_env, worklist);
+                    Self::collect_value_roots(_sent_value, worklist);
+                    if let Some(di) = delegated_iterator {
+                        Self::collect_value_roots(&di.iterator, worklist);
+                        Self::collect_value_roots(&di.next_method, worklist);
+                    }
+                    if let Some(v) = pending_exception {
+                        Self::collect_value_roots(v, worklist);
+                    }
+                    if let Some(v) = pending_return {
+                        Self::collect_value_roots(v, worklist);
+                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary

- Fixes the GC's `trace_object_fields` to trace all live JsValue fields from `StateMachineGenerator` and `StateMachineAsyncGenerator` iterator states
- Previously only `func_env` was traced, missing `delegated_iterator`, `pending_exception`, `pending_return`, and `_sent_value`
- Also adds tracing for `AsyncFunctionState.for_of_iter_env`

## Root Cause

When a state-machine generator yields mid-`yield*` delegation, the delegated iterator is stored in `delegated_iterator` inside the generator's `iterator_state`. The GC didn't trace this field, so under heavy allocation the delegated iterator was swept. On the next `.next()` call, the state machine tried to resume delegation with a dead object, producing "Generator.prototype.next called on non-object" or "not a function" errors.

## Test plan

- [x] Generator reproducer from #50 now outputs `5000` correctly
- [x] test262 suite: zero real regressions (all failures are timeout artifacts from resource contention)
- [x] `cargo clippy` clean

Fixes #50