### PR TITLE
Fix promise GC bug: root downstream promise in microtask queue

### DIFF
--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -974,6 +974,7 @@ impl Interpreter {
             then_fn.clone(),
             resolve_fn.clone(),
             reject_fn.clone(),
+            JsValue::Object(crate::types::JsObject { id: promise_id }),
         ];
         self.microtask_queue.push((
             roots,

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -901,6 +901,12 @@ impl Interpreter {
             if let Some(ref h) = reaction.handler {
                 roots.push(h.clone());
             }
+            // Root the downstream promise so GC can trace it from the microtask queue.
+            // The resolve/reject closures only capture promise_id as a u64, which is
+            // invisible to the GC tracer.
+            if let Some(pid) = reaction.promise_id {
+                roots.push(JsValue::Object(crate::types::JsObject { id: pid }));
+            }
             self.microtask_queue.push((
                 roots,
                 Box::new(move |interp| {


### PR DESCRIPTION
## Summary

- Fix GC bug where intermediate promises in long `.then()` chains could be collected, silently breaking the chain
- In `trigger_promise_reactions`, the downstream promise (`reaction.promise_id`) was not included in microtask roots — the resolve/reject closures capture it as a `u64`, invisible to the GC tracer
- Added the downstream promise object to the microtask roots vec so GC can trace it

Fixes #49

## Test plan

- [x] Stress reproducer (2000-element `.then()` chain with GC pressure): prints `2000` consistently across 5 runs
- [x] Promise test262 tests: 1,298/1,298 (100%), 0 regressions
- [x] Async/generator test262 tests: 1,979/1,979 (100%), 0 regressions
- [x] Full test262 suite: 99,020/99,020 (100.00%), 0 regressions
- [x] Clippy: clean
- [x] Lint: clean