### PR TITLE
Optimize interpreter: Rc-wrap bodies, FxHashMap, with-scope guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "icu_normalizer",
  "num-bigint",
  "regex",
+ "rustc-hash",
  "ryu-js",
  "tinystr",
  "unicode-ident",
@@ -876,6 +877,12 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustversion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+rustc-hash = "2"
 num-bigint = "0.4"
 unicode-ident = "1.0"
 regex = "1"

--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use crate::interpreter::types::{BufferData, SharedBufferInner};
 use crate::types::{JsBigInt, JsObject, JsString, JsValue};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 use std::sync::atomic::{
     AtomicI8, AtomicI16, AtomicI32, AtomicI64, AtomicU8, AtomicU16, AtomicU32, Ordering,
 };
@@ -12,7 +12,7 @@ struct WaiterEntry {
 }
 
 static WAITER_MAP: LazyLock<Mutex<HashMap<(u64, usize), Vec<WaiterEntry>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+    LazyLock::new(|| Mutex::new(HashMap::default()));
 
 fn check_ta_detached(interp: &mut Interpreter, ta_val: &JsValue) -> Result<(), JsValue> {
     if let JsValue::Object(o) = ta_val

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -71,7 +71,7 @@ fn is_valid_variants_value(s: &str) -> bool {
         return false;
     }
     let parts: Vec<&str> = s.split('-').collect();
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::default();
     for part in &parts {
         let lower = part.to_ascii_lowercase();
         if !seen.insert(lower) {

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2523,8 +2523,8 @@ impl Interpreter {
                         dynamic_fn_env.borrow_mut().strict = false;
                         let js_func = JsFunction::User {
                             name: Some("anonymous".to_string()),
-                            params: fe.params.clone(),
-                            body: fe.body.clone(),
+                            params: Rc::new(fe.params.clone()),
+                            body: Rc::new(fe.body.clone()),
                             closure: dynamic_fn_env,
                             is_arrow: false,
                             is_strict,
@@ -3085,8 +3085,8 @@ impl Interpreter {
                         dynamic_fn_env.borrow_mut().strict = false;
                         let js_func = JsFunction::User {
                             name: Some("anonymous".to_string()),
-                            params: fe.params.clone(),
-                            body: fe.body.clone(),
+                            params: Rc::new(fe.params.clone()),
+                            body: Rc::new(fe.body.clone()),
                             closure: dynamic_fn_env,
                             is_arrow: false,
                             is_strict,
@@ -3242,8 +3242,8 @@ impl Interpreter {
                         dynamic_fn_env.borrow_mut().strict = false;
                         let js_func = JsFunction::User {
                             name: Some("anonymous".to_string()),
-                            params: fe.params.clone(),
-                            body: fe.body.clone(),
+                            params: Rc::new(fe.params.clone()),
+                            body: Rc::new(fe.body.clone()),
                             closure: dynamic_fn_env,
                             is_arrow: false,
                             is_strict,
@@ -3401,8 +3401,8 @@ impl Interpreter {
                         dynamic_fn_env.borrow_mut().strict = false;
                         let js_func = JsFunction::User {
                             name: Some("anonymous".to_string()),
-                            params: fe.params.clone(),
-                            body: fe.body.clone(),
+                            params: Rc::new(fe.params.clone()),
+                            body: Rc::new(fe.body.clone()),
                             closure: dynamic_fn_env,
                             is_arrow: false,
                             is_strict,
@@ -7885,8 +7885,7 @@ impl Interpreter {
                     }
                     let property_order = obj.borrow().property_order.clone();
                     // Collect keys already in property_order into virtual_indices set for dedup
-                    let existing_keys: std::collections::HashSet<String> =
-                        property_order.iter().cloned().collect();
+                    let existing_keys: HashSet<String> = property_order.iter().cloned().collect();
                     // OrdinaryOwnPropertyKeys: indices ascending, then strings, then symbols
                     let mut indices: Vec<(u32, usize)> = Vec::new();
                     let mut strings: Vec<(String, usize)> = Vec::new();

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -796,8 +796,7 @@ impl VClassSet {
             }
         }
         // Intersect strings: keep strings that appear in both
-        let b_strings: std::collections::HashSet<&str> =
-            b.strings.iter().map(|s| s.as_str()).collect();
+        let b_strings: HashSet<&str> = b.strings.iter().map(|s| s.as_str()).collect();
         for s in &a.strings {
             if b_strings.contains(s.as_str()) {
                 result.strings.push(s.clone());
@@ -829,8 +828,7 @@ impl VClassSet {
             }
         }
         // Subtract b's strings from a's strings
-        let b_strings: std::collections::HashSet<&str> =
-            b.strings.iter().map(|s| s.as_str()).collect();
+        let b_strings: HashSet<&str> = b.strings.iter().map(|s| s.as_str()).collect();
         let result_strings: Vec<String> = a
             .strings
             .iter()
@@ -844,7 +842,7 @@ impl VClassSet {
     }
 
     fn dedup_strings(&mut self) {
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         self.strings.retain(|s| seen.insert(s.clone()));
     }
 
@@ -1364,7 +1362,7 @@ fn sanitize_group_name(name: &str) -> String {
 
 pub(super) struct TranslationResult {
     pub(super) pattern: String,
-    dup_group_map: std::collections::HashMap<String, Vec<(String, u32)>>,
+    dup_group_map: HashMap<String, Vec<(String, u32)>>,
     group_name_order: Vec<String>,
     needs_bytes_mode: bool,
 }
@@ -1476,7 +1474,7 @@ fn find_matching_close_paren(chars: &[char], open: usize) -> Option<usize> {
 
 /// Check if `body` (JS pattern fragment) contains a `\k<name>` reference to any
 /// name in `names`. Used to decide if it's safe to strip named groups from a copy.
-fn body_has_named_backref_to(chars: &[char], names: &std::collections::HashSet<String>) -> bool {
+fn body_has_named_backref_to(chars: &[char], names: &HashSet<String>) -> bool {
     let len = chars.len();
     let mut i = 0;
     let mut in_cc = false;
@@ -1509,7 +1507,7 @@ fn body_has_named_backref_to(chars: &[char], names: &std::collections::HashSet<S
 }
 
 /// Check if `body` contains any named capturing group whose name is in `names`.
-fn body_has_dup_named_group(chars: &[char], names: &std::collections::HashSet<String>) -> bool {
+fn body_has_dup_named_group(chars: &[char], names: &HashSet<String>) -> bool {
     let len = chars.len();
     let mut i = 0;
     let mut in_cc = false;
@@ -1603,11 +1601,7 @@ fn anonymize_named_groups(chars: &[char]) -> String {
 /// for names in the duplicate set.
 /// Also renames ALL other capturing groups (named and unnamed) with `__jsse_qi` prefix
 /// so they are properly stripped from the result.
-fn rename_groups_and_backrefs(
-    chars: &[char],
-    dup_names: &std::collections::HashSet<String>,
-    idx: u32,
-) -> String {
+fn rename_groups_and_backrefs(chars: &[char], dup_names: &HashSet<String>, idx: u32) -> String {
     let len = chars.len();
     let mut result = String::new();
     let mut i = 0;
@@ -1684,10 +1678,7 @@ fn rename_groups_and_backrefs(
 /// duplicate-named groups. If BODY has no backreferences to duplicate names, expands to
 /// `(?:ANON_BODY){N-1}(?:BODY)`. If BODY has backreferences, uses renaming to keep
 /// groups and backrefs paired per iteration.
-fn expand_quantified_dup_groups(
-    source: &str,
-    dup_names: &std::collections::HashSet<String>,
-) -> String {
+fn expand_quantified_dup_groups(source: &str, dup_names: &HashSet<String>) -> String {
     if dup_names.is_empty() {
         return source.to_string();
     }
@@ -1854,8 +1845,7 @@ pub(super) fn translate_js_pattern_ex(
     let mut groups_seen: u32 = 0;
     let mut open_groups: Vec<u32> = Vec::new();
     let mut open_group_names: Vec<Option<String>> = Vec::new();
-    let mut group_num_to_name: std::collections::HashMap<u32, String> =
-        std::collections::HashMap::new();
+    let mut group_num_to_name: HashMap<u32, String> = HashMap::default();
     let mut group_is_capturing: Vec<bool> = Vec::new();
     let mut lookbehind_depth: u32 = 0;
     let mut is_lookbehind_group: Vec<bool> = Vec::new();
@@ -1944,11 +1934,11 @@ pub(super) fn translate_js_pattern_ex(
             j += 1;
         }
     }
-    let mut name_count: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut name_count: HashMap<String, usize> = HashMap::default();
     for name in &all_group_names {
         *name_count.entry(name.clone()).or_insert(0) += 1;
     }
-    let mut duplicated_names: std::collections::HashSet<String> = name_count
+    let mut duplicated_names: HashSet<String> = name_count
         .into_iter()
         .filter(|(_, count)| *count > 1)
         .map(|(name, _)| name)
@@ -2000,8 +1990,7 @@ pub(super) fn translate_js_pattern_ex(
             }
             // Re-compute duplicated_names from expanded source (renamed groups
             // like __jsse_qi0__x are also duplicates)
-            let mut new_name_count: std::collections::HashMap<String, usize> =
-                std::collections::HashMap::new();
+            let mut new_name_count: HashMap<String, usize> = HashMap::default();
             for name in &new_names {
                 *new_name_count.entry(name.clone()).or_insert(0) += 1;
             }
@@ -2023,12 +2012,10 @@ pub(super) fn translate_js_pattern_ex(
     // prefix so we can use named backreferences throughout.
     let has_named_groups = !all_group_names.is_empty();
     // Track how many times we've seen each duplicated name during translation
-    let mut dup_seen_count: std::collections::HashMap<String, u32> =
-        std::collections::HashMap::new();
-    let mut dup_group_map: std::collections::HashMap<String, Vec<(String, u32)>> =
-        std::collections::HashMap::new();
+    let mut dup_seen_count: HashMap<String, u32> = HashMap::default();
+    let mut dup_group_map: HashMap<String, Vec<(String, u32)>> = HashMap::default();
     let mut group_name_order: Vec<String> = Vec::new();
-    let mut group_name_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut group_name_seen: HashSet<String> = HashSet::default();
 
     while i < len {
         let c = chars[i];
@@ -4554,7 +4541,7 @@ pub(crate) fn validate_js_pattern(source: &str, _flags: &str) -> Result<(), Stri
 
     // Check for dangling \k<name> backreferences
     if !backref_names.is_empty() {
-        let defined_names: std::collections::HashSet<&str> =
+        let defined_names: HashSet<&str> =
             named_groups.iter().map(|(n, _, _)| n.as_str()).collect();
         for bref in &backref_names {
             if !defined_names.contains(bref.as_str()) && (_unicode || has_any_named_group) {
@@ -4619,7 +4606,7 @@ impl RegexCaptures {
     }
 }
 
-type DupGroupMap = std::collections::HashMap<String, Vec<(String, u32)>>;
+type DupGroupMap = HashMap<String, Vec<(String, u32)>>;
 
 fn clear_stale_dup_captures(caps: &mut RegexCaptures, dup_map: &DupGroupMap) {
     if dup_map.is_empty() {
@@ -5534,7 +5521,7 @@ fn fix_assertion_only_quantified_groups(pattern: &str) -> String {
     }
 
     // For each non-capturing group followed by a quantifier, check if it's assertion-only
-    let mut insert_positions: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut insert_positions: HashSet<usize> = HashSet::default();
     for g in &groups {
         if !g.is_non_capturing {
             continue;
@@ -7095,7 +7082,7 @@ impl Interpreter {
 
                 // Validate flags: no invalid chars and no duplicates
                 {
-                    let mut seen = std::collections::HashSet::new();
+                    let mut seen = HashSet::default();
                     for c in flags_str.chars() {
                         if !matches!(c, 'g' | 'i' | 'm' | 's' | 'u' | 'v' | 'y' | 'd') {
                             return Completion::Throw(interp.create_error(
@@ -8739,7 +8726,7 @@ impl Interpreter {
                         ));
                     }
                 }
-                let mut seen = std::collections::HashSet::new();
+                let mut seen = HashSet::default();
                 for c in flags_str.chars() {
                     if !seen.insert(c) {
                         return Completion::Throw(interp.create_error(

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -397,7 +397,7 @@ impl Interpreter {
             Expression::Function(f) => {
                 let closure_env = if let Some(ref name) = f.name {
                     let func_env = Rc::new(RefCell::new(Environment {
-                        bindings: HashMap::new(),
+                        bindings: HashMap::default(),
                         parent: Some(env.clone()),
                         strict: env.borrow().strict || f.body_is_strict,
                         is_function_scope: false,
@@ -427,8 +427,8 @@ impl Interpreter {
                 let force_method = self.next_function_is_method;
                 let func = JsFunction::User {
                     name: f.name.clone(),
-                    params: f.params.clone(),
-                    body: f.body.clone(),
+                    params: Rc::new(f.params.clone()),
+                    body: Rc::new(f.body.clone()),
                     closure: closure_env.clone(),
                     is_arrow: false,
                     is_strict: f.body_is_strict || enclosing_strict,
@@ -454,8 +454,8 @@ impl Interpreter {
                 };
                 let func = JsFunction::User {
                     name: None,
-                    params: af.params.clone(),
-                    body: body_stmts.clone(),
+                    params: Rc::new(af.params.clone()),
+                    body: Rc::new(body_stmts),
                     closure: env.clone(),
                     is_arrow: true,
                     is_strict: af.body_is_strict || enclosing_strict,
@@ -481,17 +481,19 @@ impl Interpreter {
             Expression::Typeof(operand) => {
                 if let Expression::Identifier(name) = operand.as_ref() {
                     let strict = env.borrow().strict;
-                    match self.resolve_with_has_binding(name, env) {
-                        Ok(Some(obj_id)) => {
-                            return match self.with_get_binding_value(obj_id, name, strict) {
-                                Completion::Normal(val) => Completion::Normal(JsValue::String(
-                                    JsString::from_str(typeof_val(&val, &self.objects)),
-                                )),
-                                other => other,
-                            };
+                    if self.with_scope_depth > 0 || self.has_ever_entered_with {
+                        match self.resolve_with_has_binding(name, env) {
+                            Ok(Some(obj_id)) => {
+                                return match self.with_get_binding_value(obj_id, name, strict) {
+                                    Completion::Normal(val) => Completion::Normal(JsValue::String(
+                                        JsString::from_str(typeof_val(&val, &self.objects)),
+                                    )),
+                                    other => other,
+                                };
+                            }
+                            Ok(None) => {}
+                            Err(e) => return Completion::Throw(e),
                         }
-                        Ok(None) => {}
-                        Err(e) => return Completion::Throw(e),
                     }
                     if let Some(result) = self.resolve_global_getter(name, env) {
                         return match result {
@@ -711,15 +713,17 @@ impl Interpreter {
                 }
                 Expression::Identifier(name) => {
                     // Check with-scopes first (Bug C fix)
-                    match self.resolve_with_has_binding(name, env) {
-                        Ok(Some(obj_id)) => {
-                            return match self.proxy_delete_property(obj_id, name) {
-                                Ok(b) => Completion::Normal(JsValue::Boolean(b)),
-                                Err(e) => Completion::Throw(e),
-                            };
+                    if self.with_scope_depth > 0 || self.has_ever_entered_with {
+                        match self.resolve_with_has_binding(name, env) {
+                            Ok(Some(obj_id)) => {
+                                return match self.proxy_delete_property(obj_id, name) {
+                                    Ok(b) => Completion::Normal(JsValue::Boolean(b)),
+                                    Err(e) => Completion::Throw(e),
+                                };
+                            }
+                            Ok(None) => {}
+                            Err(e) => return Completion::Throw(e),
                         }
-                        Ok(None) => {}
-                        Err(e) => return Completion::Throw(e),
                     }
 
                     let mut current = Some(env.clone());
@@ -11719,10 +11723,10 @@ impl Interpreter {
                                     Environment::new_function_scope(Some(func_env.clone()));
                                 body_env.borrow_mut().strict = func_env.borrow().strict;
                                 body_env.borrow_mut().has_simple_params = false;
-                                let mut var_names = std::collections::HashSet::new();
+                                let mut var_names = HashSet::default();
                                 Self::collect_var_names_from_stmts(&body, &mut var_names);
-                                let mut param_names_set = std::collections::HashSet::new();
-                                for p in &params {
+                                let mut param_names_set = HashSet::default();
+                                for p in params.iter() {
                                     Self::collect_var_names_from_pattern(p, &mut param_names_set);
                                 }
                                 for name in &var_names {
@@ -11888,10 +11892,10 @@ impl Interpreter {
                                     Environment::new_function_scope(Some(func_env.clone()));
                                 body_env.borrow_mut().strict = func_env.borrow().strict;
                                 body_env.borrow_mut().has_simple_params = false;
-                                let mut var_names = std::collections::HashSet::new();
+                                let mut var_names = HashSet::default();
                                 Self::collect_var_names_from_stmts(&body, &mut var_names);
-                                let mut param_names_set = std::collections::HashSet::new();
-                                for p in &params {
+                                let mut param_names_set = HashSet::default();
+                                for p in params.iter() {
                                     Self::collect_var_names_from_pattern(p, &mut param_names_set);
                                 }
                                 for name in &var_names {
@@ -12056,10 +12060,10 @@ impl Interpreter {
                             let body_env = Environment::new_function_scope(Some(func_env.clone()));
                             body_env.borrow_mut().strict = func_env.borrow().strict;
                             body_env.borrow_mut().has_simple_params = false;
-                            let mut var_names = std::collections::HashSet::new();
+                            let mut var_names = HashSet::default();
                             Self::collect_var_names_from_stmts(&body, &mut var_names);
-                            let mut param_names = std::collections::HashSet::new();
-                            for p in &params {
+                            let mut param_names = HashSet::default();
+                            for p in params.iter() {
                                 Self::collect_var_names_from_pattern(p, &mut param_names);
                             }
                             for name in &var_names {
@@ -12468,8 +12472,7 @@ impl Interpreter {
                     function_boundary_count += 1;
                 }
                 if let Some(ref names) = borrowed.class_private_names {
-                    let name_set: std::collections::HashSet<String> =
-                        names.keys().cloned().collect();
+                    let name_set: HashSet<String> = names.keys().cloned().collect();
                     p.set_eval_in_class_with_names(name_set);
                     break;
                 }
@@ -12672,7 +12675,7 @@ impl Interpreter {
         }
         // Per spec: reverse order, keep last occurrence of each name
         funcs.reverse();
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         funcs.retain(|f| seen.insert(f.name.clone()));
         funcs
     }
@@ -12698,7 +12701,7 @@ impl Interpreter {
         let mut all_var_names = Vec::new();
         Self::collect_eval_var_names(body, &mut all_var_names);
         let declared_var_names: Vec<String> = {
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = HashSet::default();
             all_var_names
                 .into_iter()
                 .filter(|n| !declared_func_names.contains(n) && seen.insert(n.clone()))
@@ -12864,8 +12867,8 @@ impl Interpreter {
             let enclosing_strict = lex_env.borrow().strict;
             let func = JsFunction::User {
                 name: Some(f.name.clone()),
-                params: f.params.clone(),
-                body: f.body.clone(),
+                params: Rc::new(f.params.clone()),
+                body: Rc::new(f.body.clone()),
                 closure: lex_env.clone(),
                 is_arrow: false,
                 is_strict: f.body_is_strict || enclosing_strict,
@@ -13911,8 +13914,7 @@ impl Interpreter {
                     .collect();
                 (nc, c)
             };
-            let trap_set: std::collections::HashSet<&str> =
-                trap_keys.iter().map(|s| s.as_str()).collect();
+            let trap_set: HashSet<&str> = trap_keys.iter().map(|s| s.as_str()).collect();
 
             for key in &target_nonconfig {
                 if !trap_set.contains(key.as_str()) {
@@ -13923,7 +13925,7 @@ impl Interpreter {
             }
 
             if !target_extensible {
-                let target_keys: std::collections::HashSet<&str> = target_nonconfig
+                let target_keys: HashSet<&str> = target_nonconfig
                     .iter()
                     .chain(target_config.iter())
                     .map(|s| s.as_str())
@@ -14048,40 +14050,39 @@ impl Interpreter {
         name: &str,
         env: &EnvRef,
     ) -> Result<IdentifierRef, JsValue> {
-        match self.resolve_with_has_binding(name, env)? {
-            Some(obj_id) => Ok(IdentifierRef::WithObject(obj_id)),
-            None => {
-                if let Some(specific_env) = Environment::find_binding_env(env, name) {
-                    let (has_binding, global_obj_id) = {
-                        let e = specific_env.borrow();
-                        let in_bindings =
-                            e.bindings.contains_key(name) || e.is_indirect_binding(name);
-                        if in_bindings {
-                            (true, None)
-                        } else if let Some(ref global_obj) = e.global_object {
-                            let own = global_obj.borrow().properties.contains_key(name);
-                            let gid = global_obj.borrow().id;
-                            (own, if !own { gid } else { None })
-                        } else {
-                            (false, None)
-                        }
-                    };
-                    if has_binding {
-                        Ok(IdentifierRef::SpecificEnv(specific_env))
-                    } else if let Some(gid) = global_obj_id {
-                        // Check prototype chain (handles Proxy has traps)
-                        if self.proxy_has_property(gid, name)? {
-                            Ok(IdentifierRef::SpecificEnv(specific_env))
-                        } else {
-                            Ok(IdentifierRef::Unresolvable)
-                        }
-                    } else {
-                        Ok(IdentifierRef::Unresolvable)
-                    }
+        if (self.with_scope_depth > 0 || self.has_ever_entered_with)
+            && let Some(obj_id) = self.resolve_with_has_binding(name, env)?
+        {
+            return Ok(IdentifierRef::WithObject(obj_id));
+        }
+        if let Some(specific_env) = Environment::find_binding_env(env, name) {
+            let (has_binding, global_obj_id) = {
+                let e = specific_env.borrow();
+                let in_bindings = e.bindings.contains_key(name) || e.is_indirect_binding(name);
+                if in_bindings {
+                    (true, None)
+                } else if let Some(ref global_obj) = e.global_object {
+                    let own = global_obj.borrow().properties.contains_key(name);
+                    let gid = global_obj.borrow().id;
+                    (own, if !own { gid } else { None })
+                } else {
+                    (false, None)
+                }
+            };
+            if has_binding {
+                Ok(IdentifierRef::SpecificEnv(specific_env))
+            } else if let Some(gid) = global_obj_id {
+                // Check prototype chain (handles Proxy has traps)
+                if self.proxy_has_property(gid, name)? {
+                    Ok(IdentifierRef::SpecificEnv(specific_env))
                 } else {
                     Ok(IdentifierRef::Unresolvable)
                 }
+            } else {
+                Ok(IdentifierRef::Unresolvable)
             }
+        } else {
+            Ok(IdentifierRef::Unresolvable)
         }
     }
 
@@ -15206,7 +15207,7 @@ impl Interpreter {
                                 ));
                             }
                         }
-                        let mut seen = std::collections::HashSet::new();
+                        let mut seen = HashSet::default();
                         for key in &keys {
                             let key_str = to_property_key_string(key);
                             if !seen.insert(key_str) {
@@ -15325,7 +15326,7 @@ impl Interpreter {
         &mut self,
         obj_id: u64,
     ) -> Result<Vec<String>, JsValue> {
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         let mut keys = Vec::new();
         let mut current_id = Some(obj_id);
 

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -208,7 +208,7 @@ impl Interpreter {
     ) -> Completion {
         let brand_id = self.next_class_brand_id;
         self.next_class_brand_id += 1;
-        let mut pn_set = std::collections::HashMap::new();
+        let mut pn_set = HashMap::default();
         for elem in body {
             match elem {
                 ClassElement::Method(m) => {
@@ -312,8 +312,8 @@ impl Interpreter {
         let ctor_func = if let Some(cm) = ctor_method {
             JsFunction::User {
                 name: Some(name.to_string()),
-                params: cm.value.params.clone(),
-                body: cm.value.body.clone(),
+                params: Rc::new(cm.value.params.clone()),
+                body: Rc::new(cm.value.body.clone()),
                 closure: class_env.clone(),
                 is_arrow: false,
                 is_strict: true,
@@ -326,13 +326,15 @@ impl Interpreter {
         } else if super_val.is_some() {
             JsFunction::User {
                 name: Some(name.to_string()),
-                params: vec![Pattern::Rest(Box::new(Pattern::Identifier("args".into())))],
-                body: vec![Statement::Expression(Expression::Call(
+                params: Rc::new(vec![Pattern::Rest(Box::new(Pattern::Identifier(
+                    "args".into(),
+                )))]),
+                body: Rc::new(vec![Statement::Expression(Expression::Call(
                     Box::new(Expression::Super),
                     vec![Expression::Spread(Box::new(Expression::Identifier(
                         "args".into(),
                     )))],
-                ))],
+                ))]),
                 closure: class_env.clone(),
                 is_arrow: false,
                 is_strict: true,
@@ -345,8 +347,8 @@ impl Interpreter {
         } else {
             JsFunction::User {
                 name: Some(name.to_string()),
-                params: vec![],
-                body: vec![],
+                params: Rc::new(vec![]),
+                body: Rc::new(vec![]),
                 closure: class_env.clone(),
                 is_arrow: false,
                 is_strict: true,
@@ -560,8 +562,8 @@ impl Interpreter {
                                 .initialize_binding("__home_object__", priv_home_target);
                             let method_func = JsFunction::User {
                                 name: Some(format!("#{name}")),
-                                params: m.value.params.clone(),
-                                body: m.value.body.clone(),
+                                params: Rc::new(m.value.params.clone()),
+                                body: Rc::new(m.value.body.clone()),
                                 closure: method_closure,
                                 is_arrow: false,
                                 is_strict: true,
@@ -733,8 +735,8 @@ impl Interpreter {
                         .initialize_binding("__home_object__", home_target);
                     let method_func = JsFunction::User {
                         name: Some(method_display_name),
-                        params: m.value.params.clone(),
-                        body: m.value.body.clone(),
+                        params: Rc::new(m.value.params.clone()),
+                        body: Rc::new(m.value.body.clone()),
                         closure: method_closure,
                         is_arrow: false,
                         is_strict: true,

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -15,7 +15,7 @@ impl Interpreter {
             env,
             module_path,
             original_key,
-            &mut std::collections::HashSet::new(),
+            &mut HashSet::default(),
         )
     }
 
@@ -25,7 +25,7 @@ impl Interpreter {
         env: &crate::interpreter::types::EnvRef,
         module_path: Option<&std::path::Path>,
         original_key: &str,
-        visited: &mut std::collections::HashSet<(std::path::PathBuf, String)>,
+        visited: &mut HashSet<(std::path::PathBuf, String)>,
     ) -> Result<JsValue, JsValue> {
         if let Some(mp) = module_path {
             let key = (mp.to_path_buf(), binding_name.to_string());
@@ -212,7 +212,7 @@ impl Interpreter {
         }
 
         // Check ReadyForSyncExecution
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         if !self.ready_for_sync_execution(&module_path, &mut seen) {
             return Err(self.create_type_error(
                 "Cannot synchronously evaluate a module with top-level await or that is currently being evaluated",

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -239,7 +239,7 @@ impl Interpreter {
         }
 
         // §16.1.7 step 6: For each var name, check HasLexicalDeclaration
-        let mut var_names = std::collections::HashSet::new();
+        let mut var_names = HashSet::default();
         Self::collect_var_names_from_stmts(stmts, &mut var_names);
         for name in &var_names {
             if let Some(binding) = env.borrow().bindings.get(name)
@@ -296,8 +296,8 @@ impl Interpreter {
         let enclosing_strict = env.borrow().strict;
         let func = JsFunction::User {
             name: Some(f.name.clone()),
-            params: f.params.clone(),
-            body: f.body.clone(),
+            params: Rc::new(f.params.clone()),
+            body: Rc::new(f.body.clone()),
             closure: env.clone(),
             is_arrow: false,
             is_strict: f.body_is_strict || enclosing_strict,
@@ -512,10 +512,7 @@ impl Interpreter {
         }
     }
 
-    pub(crate) fn collect_var_names_from_pattern(
-        pat: &Pattern,
-        out: &mut std::collections::HashSet<String>,
-    ) {
+    pub(crate) fn collect_var_names_from_pattern(pat: &Pattern, out: &mut HashSet<String>) {
         match pat {
             Pattern::Identifier(name) => {
                 out.insert(name.clone());
@@ -548,16 +545,13 @@ impl Interpreter {
         }
     }
 
-    pub(crate) fn collect_var_names_from_stmts(
-        stmts: &[Statement],
-        out: &mut std::collections::HashSet<String>,
-    ) {
+    pub(crate) fn collect_var_names_from_stmts(stmts: &[Statement], out: &mut HashSet<String>) {
         for stmt in stmts {
             Self::collect_var_names_from_stmt(stmt, out);
         }
     }
 
-    fn collect_var_names_from_stmt(stmt: &Statement, out: &mut std::collections::HashSet<String>) {
+    fn collect_var_names_from_stmt(stmt: &Statement, out: &mut HashSet<String>) {
         match stmt {
             Statement::Variable(decl) if decl.kind == VarKind::Var => {
                 for d in &decl.declarations {
@@ -949,7 +943,7 @@ impl Interpreter {
                 if let JsValue::Object(obj_ref) = &obj_val {
                     if let Some(obj_data) = self.get_object(obj_ref.id) {
                         let with_env = Rc::new(RefCell::new(Environment {
-                            bindings: HashMap::new(),
+                            bindings: HashMap::default(),
                             parent: Some(env.clone()),
                             strict: env.borrow().strict,
                             is_function_scope: false,
@@ -971,7 +965,10 @@ impl Interpreter {
                             indirect_bindings: None,
                             module_path: None,
                         }));
+                        self.with_scope_depth += 1;
+                        self.has_ever_entered_with = true;
                         let c = self.exec_statement(body, &with_env);
+                        self.with_scope_depth -= 1;
                         // UpdateEmpty(C, undefined) per §14.11.2 step 9
                         match c {
                             Completion::Empty => Completion::Normal(JsValue::Undefined),
@@ -1075,7 +1072,8 @@ impl Interpreter {
             // §13.3.2.4 step 2: ResolveBinding BEFORE evaluating Initializer
             // Pre-resolve with-scope binding so the reference is captured before
             // side effects in the initializer can change it.
-            let pre_resolved_with = if decl.kind == VarKind::Var
+            let pre_resolved_with = if (self.with_scope_depth > 0 || self.has_ever_entered_with)
+                && decl.kind == VarKind::Var
                 && d.init.is_some()
                 && let Pattern::Identifier(ref name) = d.pattern
             {
@@ -1177,13 +1175,17 @@ impl Interpreter {
                         var_scope.borrow_mut().declare(name, kind);
                     }
                     // For var initializers inside with-scopes, write through with-object
-                    match self.resolve_with_has_binding(name, env) {
-                        Ok(Some(obj_id)) => {
-                            let strict = env.borrow().strict;
-                            self.with_set_mutable_binding(obj_id, name, val, strict)
+                    if self.with_scope_depth > 0 || self.has_ever_entered_with {
+                        match self.resolve_with_has_binding(name, env) {
+                            Ok(Some(obj_id)) => {
+                                let strict = env.borrow().strict;
+                                self.with_set_mutable_binding(obj_id, name, val, strict)
+                            }
+                            Ok(None) => env.borrow_mut().set(name, val),
+                            Err(e) => Err(e),
                         }
-                        Ok(None) => env.borrow_mut().set(name, val),
-                        Err(e) => Err(e),
+                    } else {
+                        env.borrow_mut().set(name, val)
                     }
                 } else {
                     env.borrow_mut().declare(name, kind);
@@ -1425,7 +1427,12 @@ impl Interpreter {
                                 if !already {
                                     var_scope.borrow_mut().declare(binding_name, kind);
                                 }
-                                let resolved = self.resolve_with_has_binding(binding_name, env)?;
+                                let resolved =
+                                    if self.with_scope_depth > 0 || self.has_ever_entered_with {
+                                        self.resolve_with_has_binding(binding_name, env)?
+                                    } else {
+                                        None
+                                    };
 
                                 // Step 3: v = GetV(value, propertyName)
                                 let mut v = if let JsValue::Object(o) = &obj_val {
@@ -2256,8 +2263,8 @@ impl Interpreter {
                     let enclosing_strict = switch_env.borrow().strict;
                     let func = JsFunction::User {
                         name: Some(f.name.clone()),
-                        params: f.params.clone(),
-                        body: f.body.clone(),
+                        params: Rc::new(f.params.clone()),
+                        body: Rc::new(f.body.clone()),
                         closure: switch_env.clone(),
                         is_arrow: false,
                         is_strict: f.body_is_strict || enclosing_strict,

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -467,7 +467,7 @@ impl Interpreter {
 
     pub(crate) fn collect_env_roots(env: &EnvRef, worklist: &mut Vec<u64>) {
         let mut current = Some(env.clone());
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         while let Some(e) = current {
             let ptr = Rc::as_ptr(&e) as usize;
             if !seen.insert(ptr) {

--- a/src/interpreter/generator_analysis.rs
+++ b/src/interpreter/generator_analysis.rs
@@ -1,5 +1,5 @@
 use crate::ast::*;
-use std::collections::HashSet;
+use rustc_hash::FxHashSet as HashSet;
 
 #[derive(Debug, Clone)]
 pub struct GeneratorAnalysis {
@@ -78,7 +78,7 @@ impl AnalysisContext {
             current_try: None,
             current_loop: None,
             current_label: None,
-            seen_vars: HashSet::new(),
+            seen_vars: HashSet::default(),
         }
     }
 }

--- a/src/interpreter/generator_transform.rs
+++ b/src/interpreter/generator_transform.rs
@@ -1,7 +1,7 @@
 use crate::ast::*;
 use crate::interpreter::generator_analysis::*;
 use crate::types::JsValue;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -151,8 +151,8 @@ impl TransformContext {
             analysis,
             yield_counter: 0,
             temp_counter: 0,
-            break_targets: HashMap::new(),
-            continue_targets: HashMap::new(),
+            break_targets: HashMap::default(),
+            continue_targets: HashMap::default(),
             try_stack: Vec::new(),
             temp_vars: Vec::new(),
             is_async,

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -190,7 +190,7 @@ pub(crate) fn typeof_val<'a>(
     }
 }
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 fn json_quote(s: &str) -> String {
     json_quote_units(&s.encode_utf16().collect::<Vec<u16>>())
@@ -771,7 +771,7 @@ pub(crate) fn json_parse_value_with_source(
     interp: &mut Interpreter,
     s: &str,
 ) -> (Completion, SourceTextMap) {
-    let mut source_map = SourceTextMap::new();
+    let mut source_map = SourceTextMap::default();
     let result = json_parse_value_inner(interp, s, Some(&mut source_map));
     (result, source_map)
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,8 +1,8 @@
 use crate::ast::*;
 use crate::parser;
 use crate::types::{JsBigInt, JsString, JsValue, bigint_ops, number_ops};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -81,7 +81,7 @@ pub struct Interpreter {
     pub(crate) call_stack_frames: Vec<CallFrame>,
     pub(crate) gc_temp_roots: Vec<u64>,
     // microtask roots are now stored inline in the microtask_queue tuples
-    pub(crate) class_private_names: Vec<std::collections::HashMap<String, String>>,
+    pub(crate) class_private_names: Vec<HashMap<String, String>>,
     next_class_brand_id: u64,
     next_auto_accessor_id: u64,
     pub(crate) regexp_legacy_input: String,
@@ -115,6 +115,8 @@ pub struct Interpreter {
     pub(crate) static_module_load_depth: u32,
     module_async_evaluation_count: u64,
     module_async_info: HashMap<u64, PathBuf>,
+    pub(crate) with_scope_depth: u32,
+    pub(crate) has_ever_entered_with: bool,
 }
 
 pub(crate) struct CallFrame {
@@ -193,8 +195,8 @@ impl Interpreter {
             realms: vec![realm],
             current_realm_id: 0,
             objects: Vec::new(),
-            global_symbol_registry: HashMap::new(),
-            well_known_symbols: HashMap::new(),
+            global_symbol_registry: HashMap::default(),
+            well_known_symbols: HashMap::default(),
             next_symbol_id: 1,
             new_target: None,
             free_list: Vec::new(),
@@ -206,11 +208,11 @@ impl Interpreter {
             generator_context: None,
             destructuring_yield: false,
             pending_iter_close: Vec::new(),
-            generator_inline_iters: HashMap::new(),
+            generator_inline_iters: HashMap::default(),
             microtask_queue: Vec::new(),
             cached_has_instance_key: None,
-            module_registry: HashMap::new(),
-            synthetic_module_registry: HashMap::new(),
+            module_registry: HashMap::default(),
+            synthetic_module_registry: HashMap::default(),
             current_module_path: None,
             loading_deferred: false,
             last_call_had_explicit_return: false,
@@ -230,7 +232,7 @@ impl Interpreter {
             regexp_legacy_right_context: String::new(),
             regexp_legacy_parens: Default::default(),
             regexp_constructor_id: None,
-            function_realm_map: HashMap::new(),
+            function_realm_map: HashMap::default(),
             in_tail_position: false,
             in_state_machine: false,
             next_function_is_method: false,
@@ -244,16 +246,18 @@ impl Interpreter {
                 std::sync::Mutex::new(Vec::new()),
                 std::sync::Condvar::new(),
             )),
-            iterator_next_cache: HashMap::new(),
+            iterator_next_cache: HashMap::default(),
             last_identifier_with_base: None,
-            async_gen_queues: HashMap::new(),
+            async_gen_queues: HashMap::default(),
             async_gen_yield_pending: false,
-            async_function_states: HashMap::new(),
+            async_function_states: HashMap::default(),
             next_async_function_id: 0,
             pending_async_dispose_await: false,
             static_module_load_depth: 0,
             module_async_evaluation_count: 0,
-            module_async_info: HashMap::new(),
+            module_async_info: HashMap::default(),
+            with_scope_depth: 0,
+            has_ever_entered_with: false,
         };
         interp.setup_globals();
         interp
@@ -1141,8 +1145,8 @@ impl Interpreter {
                     },
                 );
 
-                let mut map = HashMap::new();
-                let mut mapped_names: HashSet<&str> = HashSet::new();
+                let mut map = HashMap::default();
+                let mut mapped_names: HashSet<&str> = HashSet::default();
                 for i in (0..param_names.len()).rev() {
                     let name = &param_names[i];
                     if mapped_names.contains(name.as_str()) {
@@ -1320,13 +1324,13 @@ impl Interpreter {
         let loaded_module = Rc::new(RefCell::new(LoadedModule {
             path: canon_path_entry.clone(),
             env: module_env.clone(),
-            exports: HashMap::new(),
-            export_bindings: HashMap::new(),
+            exports: HashMap::default(),
+            export_bindings: HashMap::default(),
             cached_namespace: None,
             cached_deferred_namespace: None,
             cached_import_meta: None,
             error: None,
-            namespace_imports: HashMap::new(),
+            namespace_imports: HashMap::default(),
             star_export_sources: Vec::new(),
             evaluated: false,
             is_evaluating: false,
@@ -1628,7 +1632,7 @@ impl Interpreter {
         }
         let has_export = binding_info.is_some();
         if has_export {
-            let mut visited = std::collections::HashSet::new();
+            let mut visited = HashSet::default();
             match self.resolve_export_binding(resolved, imported, &mut visited) {
                 Ok((source_env, binding_name)) => {
                     if binding_name == "*namespace*" {
@@ -1696,13 +1700,13 @@ impl Interpreter {
                         // — check if they resolve to the same (module, binding)
                         if existing != &new_reexport {
                             let is_ambiguous = if let Some(ref mp) = module_path {
-                                let mut v1 = std::collections::HashSet::new();
+                                let mut v1 = HashSet::default();
                                 let r1 = self.resolve_export_binding(mp, &export_name, &mut v1);
                                 module
                                     .borrow_mut()
                                     .export_bindings
                                     .insert(export_name.clone(), new_reexport.clone());
-                                let mut v2 = std::collections::HashSet::new();
+                                let mut v2 = HashSet::default();
                                 let r2 = self.resolve_export_binding(mp, &export_name, &mut v2);
                                 module
                                     .borrow_mut()
@@ -1825,12 +1829,12 @@ impl Interpreter {
                 path: canon_path.clone(),
                 env: module_env.clone(),
                 exports: {
-                    let mut m = HashMap::new();
+                    let mut m = HashMap::default();
                     m.insert("default".to_string(), parsed.clone());
                     m
                 },
                 export_bindings: {
-                    let mut m = HashMap::new();
+                    let mut m = HashMap::default();
                     m.insert("default".to_string(), "*default*".to_string());
                     m
                 },
@@ -1838,7 +1842,7 @@ impl Interpreter {
                 cached_deferred_namespace: None,
                 cached_import_meta: None,
                 error: None,
-                namespace_imports: HashMap::new(),
+                namespace_imports: HashMap::default(),
                 star_export_sources: Vec::new(),
                 evaluated: true,
                 is_evaluating: false,
@@ -1903,13 +1907,13 @@ impl Interpreter {
         let loaded_module = Rc::new(RefCell::new(LoadedModule {
             path: canon_path.clone(),
             env: module_env.clone(),
-            exports: HashMap::new(),
-            export_bindings: HashMap::new(),
+            exports: HashMap::default(),
+            export_bindings: HashMap::default(),
             cached_namespace: None,
             cached_deferred_namespace: None,
             cached_import_meta: None,
             error: None,
-            namespace_imports: HashMap::new(),
+            namespace_imports: HashMap::default(),
             star_export_sources: Vec::new(),
             evaluated: false,
             is_evaluating: false,
@@ -2116,13 +2120,13 @@ impl Interpreter {
         let loaded_module = Rc::new(RefCell::new(LoadedModule {
             path: canon_path.clone(),
             env: module_env.clone(),
-            exports: HashMap::new(),
-            export_bindings: HashMap::new(),
+            exports: HashMap::default(),
+            export_bindings: HashMap::default(),
             cached_namespace: None,
             cached_deferred_namespace: None,
             cached_import_meta: None,
             error: None,
-            namespace_imports: HashMap::new(),
+            namespace_imports: HashMap::default(),
             star_export_sources: Vec::new(),
             evaluated: false,
             is_evaluating: false,
@@ -2283,12 +2287,12 @@ impl Interpreter {
             path: canon_path,
             env: module_env,
             exports: {
-                let mut m = HashMap::new();
+                let mut m = HashMap::default();
                 m.insert("default".to_string(), value);
                 m
             },
             export_bindings: {
-                let mut m = HashMap::new();
+                let mut m = HashMap::default();
                 m.insert("default".to_string(), "*default*".to_string());
                 m
             },
@@ -2296,7 +2300,7 @@ impl Interpreter {
             cached_deferred_namespace: None,
             cached_import_meta: None,
             error: None,
-            namespace_imports: HashMap::new(),
+            namespace_imports: HashMap::default(),
             star_export_sources: Vec::new(),
             evaluated: true,
             is_evaluating: false,
@@ -2610,7 +2614,7 @@ impl Interpreter {
         for (dep_canon, is_deferred) in &dep_paths {
             if *is_deferred {
                 let mut to_eval = Vec::new();
-                let mut seen = std::collections::HashSet::new();
+                let mut seen = HashSet::default();
                 self.gather_async_transitive_deps(dep_canon, &mut to_eval, &mut seen);
                 for async_dep in to_eval {
                     if !evaluation_list.contains(&async_dep) {
@@ -3027,7 +3031,7 @@ impl Interpreter {
     /// Eagerly evaluate async transitive dependencies of a deferred module
     fn evaluate_async_transitive_deps(&mut self, deferred_path: &Path) {
         let mut to_eval = Vec::new();
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         self.gather_async_transitive_deps(deferred_path, &mut to_eval, &mut seen);
 
         for path in to_eval {
@@ -3044,7 +3048,7 @@ impl Interpreter {
         &self,
         module_path: &Path,
         result: &mut Vec<PathBuf>,
-        seen: &mut std::collections::HashSet<PathBuf>,
+        seen: &mut HashSet<PathBuf>,
     ) {
         let canon = module_path
             .canonicalize()
@@ -3128,11 +3132,7 @@ impl Interpreter {
     }
 
     /// Check if a module and all its transitive deps are ready for synchronous execution
-    fn ready_for_sync_execution(
-        &self,
-        path: &Path,
-        seen: &mut std::collections::HashSet<PathBuf>,
-    ) -> bool {
+    fn ready_for_sync_execution(&self, path: &Path, seen: &mut HashSet<PathBuf>) -> bool {
         let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         if !seen.insert(canon.clone()) {
             return true; // cycle — spec says return true
@@ -3195,7 +3195,7 @@ impl Interpreter {
         let resolved = self.resolve_module_specifier(source, Some(current_module))?;
 
         for spec in specifiers {
-            let mut visited = std::collections::HashSet::new();
+            let mut visited = HashSet::default();
             self.resolve_export(&resolved, &spec.local, &mut visited)?;
         }
         Ok(())
@@ -3207,7 +3207,7 @@ impl Interpreter {
         &mut self,
         module_path: &Path,
         export_name: &str,
-        visited: &mut std::collections::HashSet<(PathBuf, String)>,
+        visited: &mut HashSet<(PathBuf, String)>,
     ) -> Result<(EnvRef, String), JsValue> {
         let canon_path = module_path
             .canonicalize()
@@ -3303,7 +3303,7 @@ impl Interpreter {
         &mut self,
         module_path: &Path,
         export_name: &str,
-        visited: &mut std::collections::HashSet<(PathBuf, String)>,
+        visited: &mut HashSet<(PathBuf, String)>,
     ) -> Result<(), JsValue> {
         let canon_path = module_path
             .canonicalize()
@@ -3377,13 +3377,13 @@ impl Interpreter {
                 if found_in_star {
                     // §16.2.1.6.3 step 10.d.ii: ambiguous — same name from multiple stars
                     // Check if they resolve to the same (module, binding)
-                    let mut va = std::collections::HashSet::new();
+                    let mut va = HashSet::default();
                     let ra = self.resolve_export_binding(
                         first_star_source.as_ref().unwrap(),
                         export_name,
                         &mut va,
                     );
-                    let mut vb = std::collections::HashSet::new();
+                    let mut vb = HashSet::default();
                     let rb = self.resolve_export_binding(&resolved, export_name, &mut vb);
                     match (ra, rb) {
                         (Ok((env1, name1)), Ok((env2, name2))) => {
@@ -3779,8 +3779,8 @@ impl Interpreter {
                 env.borrow_mut().declare(&f.name, BindingKind::Var);
                 let func = JsFunction::User {
                     name: Some(f.name.clone()),
-                    params: f.params.clone(),
-                    body: f.body.clone(),
+                    params: Rc::new(f.params.clone()),
+                    body: Rc::new(f.body.clone()),
                     closure: env.clone(),
                     is_arrow: false,
                     is_strict: true, // Module code is always strict
@@ -3826,8 +3826,8 @@ impl Interpreter {
                     } else {
                         f.name.clone()
                     }),
-                    params: f.params.clone(),
-                    body: f.body.clone(),
+                    params: Rc::new(f.params.clone()),
+                    body: Rc::new(f.body.clone()),
                     closure: env.clone(),
                     is_arrow: false,
                     is_strict: true,
@@ -4004,8 +4004,8 @@ impl Interpreter {
                 let enclosing_strict = env.borrow().strict;
                 let js_func = JsFunction::User {
                     name: Some(name),
-                    params: func.params.clone(),
-                    body: func.body.clone(),
+                    params: Rc::new(func.params.clone()),
+                    body: Rc::new(func.body.clone()),
                     closure: env.clone(),
                     is_arrow: false,
                     is_strict: func.body_is_strict || enclosing_strict,

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -2,8 +2,8 @@ use crate::ast::*;
 use crate::interpreter::generator_transform::{GeneratorStateMachine, SentValueBinding};
 use crate::interpreter::helpers::same_value;
 use crate::types::{JsString, JsValue};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -395,7 +395,7 @@ impl Realm {
             global_env,
             global_object: None,
             throw_type_error: None,
-            template_cache: HashMap::new(),
+            template_cache: HashMap::default(),
             builtin_eval_id: None,
             object_prototype: None,
             array_prototype: None,
@@ -614,7 +614,7 @@ pub struct Environment {
     pub(crate) global_object: Option<Rc<RefCell<JsObjectData>>>,
     // Annex B.3.3: names registered for block-level function var hoisting
     pub(crate) annexb_function_names: Option<Vec<String>>,
-    pub(crate) class_private_names: Option<std::collections::HashMap<String, String>>,
+    pub(crate) class_private_names: Option<HashMap<String, String>>,
     pub(crate) is_field_initializer: bool,
     pub(crate) arguments_immutable: bool,
     pub(crate) has_parameter_expressions: bool,
@@ -698,7 +698,7 @@ impl Environment {
     pub fn new(parent: Option<EnvRef>) -> EnvRef {
         let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
         Rc::new(RefCell::new(Environment {
-            bindings: HashMap::new(),
+            bindings: HashMap::default(),
             parent,
             strict,
             is_function_scope: false,
@@ -722,7 +722,7 @@ impl Environment {
     pub fn new_function_scope(parent: Option<EnvRef>) -> EnvRef {
         let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
         Rc::new(RefCell::new(Environment {
-            bindings: HashMap::new(),
+            bindings: HashMap::default(),
             parent,
             strict,
             is_function_scope: true,
@@ -793,7 +793,7 @@ impl Environment {
         source_env: EnvRef,
         source_name: String,
     ) {
-        let map = self.indirect_bindings.get_or_insert_with(HashMap::new);
+        let map = self.indirect_bindings.get_or_insert_with(HashMap::default);
         map.insert(local_name.to_string(), (source_env, source_name));
     }
 
@@ -1096,8 +1096,8 @@ impl Environment {
 pub enum JsFunction {
     User {
         name: Option<String>,
-        params: Vec<Pattern>,
-        body: Vec<Statement>,
+        params: Rc<Vec<Pattern>>,
+        body: Rc<Vec<Statement>>,
         closure: EnvRef,
         is_arrow: bool,
         is_strict: bool,
@@ -1299,7 +1299,7 @@ pub enum IteratorState {
         done: bool,
     },
     Generator {
-        body: Vec<Statement>,
+        body: Rc<Vec<Statement>>,
         func_env: EnvRef,
         is_strict: bool,
         execution_state: GeneratorExecutionState,
@@ -1317,7 +1317,7 @@ pub enum IteratorState {
         pending_return: Option<JsValue>,
     },
     AsyncGenerator {
-        body: Vec<Statement>,
+        body: Rc<Vec<Statement>>,
         func_env: EnvRef,
         is_strict: bool,
         execution_state: GeneratorExecutionState,
@@ -1695,7 +1695,7 @@ impl JsObjectData {
     pub(crate) fn new() -> Self {
         Self {
             id: None,
-            properties: HashMap::new(),
+            properties: HashMap::default(),
             property_order: Vec::new(),
             prototype: None,
             callable: None,
@@ -1703,7 +1703,7 @@ impl JsObjectData {
             class_name: "Object".to_string(),
             extensible: true,
             primitive_value: None,
-            private_fields: HashMap::new(),
+            private_fields: HashMap::default(),
             class_instance_field_defs: Vec::new(),
             iterator_state: None,
             parameter_map: None,
@@ -2100,7 +2100,7 @@ impl JsObjectData {
     }
 
     pub fn enumerable_keys_with_proto(&self) -> Vec<String> {
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         let mut keys = Vec::new();
 
         // Collect own keys, separating integer indices from string keys

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -434,10 +434,8 @@ impl<'a> Parser<'a> {
         let mut has_constructor = false;
         // Track private names: value is (getter_static, setter_static, has_other)
         // Option<bool> = None means no getter/setter, Some(is_static) means present with staticness
-        let mut private_names: std::collections::HashMap<
-            String,
-            (Option<bool>, Option<bool>, bool),
-        > = std::collections::HashMap::new();
+        let mut private_names: HashMap<String, (Option<bool>, Option<bool>, bool)> =
+            HashMap::default();
         while self.current != Token::RightBrace {
             if self.current == Token::Semicolon {
                 self.advance()?;
@@ -1258,7 +1256,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn set_function_param_names(&mut self, params: &[Pattern]) {
-        let mut names = std::collections::HashSet::new();
+        let mut names = HashSet::default();
         for p in params {
             let mut bound = Vec::new();
             Self::collect_bound_names(p, &mut bound);

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -9,7 +9,7 @@ fn validate_regexp_literal(pattern: &str, flags: &str) -> Result<(), ParseError>
             });
         }
     }
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::default();
     for c in flags.chars() {
         if !seen.insert(c) {
             return Err(ParseError {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,6 @@
 use crate::ast::*;
 use crate::lexer::{Keyword, LexError, Lexer, Token};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::fmt;
 
 mod declarations;
@@ -57,10 +58,10 @@ pub struct Parser<'a> {
     no_in: bool,
     pub last_string_literal_has_escape: bool,
     pub last_string_literal_has_legacy_octal: bool,
-    private_name_scopes: Vec<(std::collections::HashSet<String>, Vec<(String, usize)>)>,
+    private_name_scopes: Vec<(HashSet<String>, Vec<(String, usize)>)>,
     in_field_initializer_eval: bool,
     in_static_block: bool,
-    function_param_names: Option<std::collections::HashSet<String>>,
+    function_param_names: Option<HashSet<String>>,
     eval_new_target_allowed: bool,
     last_expr_parenthesized: bool,
     last_obj_had_proto_dup: bool,
@@ -188,7 +189,7 @@ impl<'a> Parser<'a> {
         self.lexer.strict = strict;
     }
 
-    pub fn set_eval_in_class_with_names(&mut self, names: std::collections::HashSet<String>) {
+    pub fn set_eval_in_class_with_names(&mut self, names: HashSet<String>) {
         self.private_name_scopes.push((names, Vec::new()));
     }
 
@@ -213,7 +214,7 @@ impl<'a> Parser<'a> {
 
     fn push_private_scope(&mut self) {
         self.private_name_scopes
-            .push((std::collections::HashSet::new(), Vec::new()));
+            .push((HashSet::default(), Vec::new()));
     }
 
     fn declare_private_name(&mut self, name: &str) {
@@ -409,7 +410,7 @@ impl<'a> Parser<'a> {
     }
 
     fn check_duplicate_params_strict(&self, params: &[Pattern]) -> Result<(), ParseError> {
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         let mut names = Vec::new();
         for p in params {
             Self::collect_bound_names(p, &mut names);
@@ -1100,7 +1101,7 @@ impl<'a> Parser<'a> {
         self.set_strict(true);
 
         let mut module_items = Vec::new();
-        let mut exported_names = std::collections::HashSet::new();
+        let mut exported_names = HashSet::default();
 
         while self.current != Token::Eof {
             let item = self.parse_module_item()?;
@@ -1214,11 +1215,11 @@ impl<'a> Parser<'a> {
 
     /// §16.2.1.1 Static Semantics: Early Errors for Module
     fn validate_module_early_errors(&self, items: &[ModuleItem]) -> Result<(), ParseError> {
-        use std::collections::HashSet;
+        use HashSet;
 
-        let mut lex_names: HashSet<String> = HashSet::new();
-        let mut var_names: HashSet<String> = HashSet::new();
-        let mut exported_bindings: HashSet<String> = HashSet::new();
+        let mut lex_names: HashSet<String> = HashSet::default();
+        let mut var_names: HashSet<String> = HashSet::default();
+        let mut exported_bindings: HashSet<String> = HashSet::default();
 
         // Collect all lexically-declared and var-declared names
         for item in items {
@@ -1274,11 +1275,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn collect_module_var_names(
-        &self,
-        stmt: &Statement,
-        names: &mut std::collections::HashSet<String>,
-    ) {
+    fn collect_module_var_names(&self, stmt: &Statement, names: &mut HashSet<String>) {
         match stmt {
             Statement::Variable(decl) if decl.kind == VarKind::Var => {
                 for d in &decl.declarations {
@@ -1294,7 +1291,7 @@ impl<'a> Parser<'a> {
     fn collect_module_lex_names(
         &self,
         stmt: &Statement,
-        names: &mut std::collections::HashSet<String>,
+        names: &mut HashSet<String>,
     ) -> Result<(), ParseError> {
         match stmt {
             Statement::Variable(decl) if decl.kind != VarKind::Var => {
@@ -1329,11 +1326,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn collect_export_var_names(
-        &self,
-        export: &ExportDeclaration,
-        names: &mut std::collections::HashSet<String>,
-    ) {
+    fn collect_export_var_names(&self, export: &ExportDeclaration, names: &mut HashSet<String>) {
         if let ExportDeclaration::Named {
             declaration: Some(decl),
             ..
@@ -1346,7 +1339,7 @@ impl<'a> Parser<'a> {
     fn collect_export_lex_names(
         &self,
         export: &ExportDeclaration,
-        names: &mut std::collections::HashSet<String>,
+        names: &mut HashSet<String>,
     ) -> Result<(), ParseError> {
         match export {
             ExportDeclaration::Named {
@@ -1374,11 +1367,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn collect_exported_bindings(
-        &self,
-        export: &ExportDeclaration,
-        names: &mut std::collections::HashSet<String>,
-    ) {
+    fn collect_exported_bindings(&self, export: &ExportDeclaration, names: &mut HashSet<String>) {
         if let ExportDeclaration::Named {
             specifiers,
             source: None,

--- a/src/parser/modules.rs
+++ b/src/parser/modules.rs
@@ -168,7 +168,7 @@ impl<'a> Parser<'a> {
         if is_with && !self.prev_line_terminator {
             self.advance()?; // with
             self.eat(&Token::LeftBrace)?;
-            let mut seen_keys = std::collections::HashSet::new();
+            let mut seen_keys = HashSet::default();
             let mut attributes = Vec::new();
             while self.current != Token::RightBrace {
                 // AttributeKey: IdentifierName | StringLiteral

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -456,7 +456,7 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::default();
         for name in &bound {
             if !seen.insert(name.as_str()) {
                 return Err(ParseError {
@@ -1058,7 +1058,7 @@ impl<'a> Parser<'a> {
                         for d in &decls {
                             Self::collect_bound_names(&d.pattern, &mut names);
                         }
-                        let mut seen = std::collections::HashSet::new();
+                        let mut seen = HashSet::default();
                         for name in &names {
                             if !seen.insert(name.clone()) {
                                 return Err(self.error(format!(
@@ -1141,7 +1141,7 @@ impl<'a> Parser<'a> {
                     for d in &decls {
                         Self::collect_bound_names(&d.pattern, &mut names);
                     }
-                    let mut seen = std::collections::HashSet::new();
+                    let mut seen = HashSet::default();
                     for name in &names {
                         if !seen.insert(name.clone()) {
                             return Err(self
@@ -1350,7 +1350,7 @@ impl<'a> Parser<'a> {
             if let Some(ref p) = param {
                 let mut bound = Vec::new();
                 Self::collect_bound_names(p, &mut bound);
-                let mut seen = std::collections::HashSet::new();
+                let mut seen = HashSet::default();
                 for name in &bound {
                     if !seen.insert(name.as_str()) {
                         return Err(


### PR DESCRIPTION
## Summary

Three performance optimizations targeting the splay benchmark (#55), informed by callgrind profiling:

- **Rc-wrap function bodies/params**: Change `JsFunction::User` `body`/`params` and `IteratorState` body fields from `Vec<Statement>` to `Rc<Vec<Statement>>`, eliminating deep AST cloning on every function call and generator resume. Addresses 6% of runtime spent in `Expression::clone` / `Statement::clone`.
- **Switch to FxHashMap/FxHashSet**: Replace all `std::collections::HashMap`/`HashSet` with `rustc_hash::FxHashMap`/`FxHashSet`. Addresses 23% of runtime spent in SipHash on property lookups and environment bindings.
- **Skip with-scope resolution**: Add `with_scope_depth` counter and `has_ever_entered_with` flag to `Interpreter`, guarding all 7 `resolve_with_has_binding` call sites. Addresses 2% of runtime walking scope chains for `with` blocks that don't exist.

### Results

| Metric | Before | After |
|--------|--------|-------|
| Mini splay benchmark | 0.63s | 0.38s (**40% faster**) |
| test262 pass rate | 99,020/99,020 (100%) | 99,084/99,084 (100%) |
| Regressions | — | **0** |
| Unit tests | 53/53 | 53/53 |
| Clippy + lint | pass | pass |

The full splay benchmark (120 default iterations) still exceeds 120s due to remaining malloc/free overhead (~36% of runtime) from per-object heap allocations. Follow-up issues filed: #66 (arena allocator), #68 (inline properties), #70 (lazy arguments), #72 (hoisting cache), #74 (string interning).

## Test plan

- [x] `cargo test --release` — 53/53 pass
- [x] `./scripts/lint.sh` — all checks pass
- [x] `uv run python scripts/run-test262.py -j 32` — 99,084/99,084 (100%), 0 regressions
- [x] `uv run python scripts/run-test262.py test262/test/language/statements/with/ -j 8` — 182/182 (100%)
- [x] Mini splay benchmark timing: 0.63s → 0.38s