### PR TITLE
[codex] Fix top-level-await dynamic import ordering

### DIFF
--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -709,7 +709,7 @@ impl Interpreter {
         let reject_root = reject.clone();
 
         self.microtask_queue.push((
-            vec![promise_root],
+            vec![promise_root, resolve_root.clone(), reject_root.clone()],
             Box::new(move |interp: &mut Interpreter| {
                 match interp.load_module(&resolved_path) {
                     Ok(m) => {

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -733,7 +733,7 @@ impl Interpreter {
                             let _ = interp.call_function(
                                 &reject_root,
                                 &JsValue::Undefined,
-                                &[e.clone()],
+                                std::slice::from_ref(e),
                             );
                             return Completion::Normal(JsValue::Undefined);
                         }

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -695,26 +695,18 @@ impl Interpreter {
                 }
                 return self.create_rejected_promise(e.clone());
             }
-            // Drain microtasks to complete TLA module evaluation
-            self.drain_microtasks();
-            // Check if module evaluation failed (e.g. await rejected)
-            if let Some(err) = module.borrow().error.clone() {
-                return self.create_rejected_promise(err);
-            }
-            let ns = self.create_module_namespace(&module);
-            return self.create_resolved_promise(ns);
+            let (resolve, reject, promise) = self.create_promise_parts();
+            return self.settle_dynamic_import_promise(&module, promise, resolve, reject);
         }
 
         // Inside static module evaluation — defer to microtask so we don't
         // preempt the current module's DFS evaluation order
-        let promise = self.create_promise_object();
-        let pid = if let JsValue::Object(ref o) = promise {
-            o.id
-        } else {
-            0
-        };
+        let (resolve, reject, promise) = self.create_promise_parts();
         let resolved_path = resolved.clone();
         let promise_root = promise.clone();
+        let promise_for_settle = promise.clone();
+        let resolve_root = resolve.clone();
+        let reject_root = reject.clone();
 
         self.microtask_queue.push((
             vec![promise_root],
@@ -738,19 +730,22 @@ impl Interpreter {
                                     }
                                 }
                             }
-                            interp.reject_promise(pid, e.clone());
+                            let _ = interp.call_function(
+                                &reject_root,
+                                &JsValue::Undefined,
+                                &[e.clone()],
+                            );
                             return Completion::Normal(JsValue::Undefined);
                         }
-                        interp.drain_microtasks();
-                        if let Some(err) = m.borrow().error.clone() {
-                            interp.reject_promise(pid, err);
-                            return Completion::Normal(JsValue::Undefined);
-                        }
-                        let ns = interp.create_module_namespace(&m);
-                        interp.fulfill_promise(pid, ns);
+                        let _ = interp.settle_dynamic_import_promise(
+                            &m,
+                            promise_for_settle.clone(),
+                            resolve_root.clone(),
+                            reject_root.clone(),
+                        );
                     }
                     Err(e) => {
-                        interp.reject_promise(pid, e);
+                        let _ = interp.call_function(&reject_root, &JsValue::Undefined, &[e]);
                     }
                 }
                 Completion::Normal(JsValue::Undefined)
@@ -758,6 +753,84 @@ impl Interpreter {
         ));
 
         Completion::Normal(promise)
+    }
+
+    fn settle_dynamic_import_promise(
+        &mut self,
+        module: &Rc<RefCell<LoadedModule>>,
+        promise: JsValue,
+        resolve: JsValue,
+        reject: JsValue,
+    ) -> Completion {
+        if let Some(err) = module.borrow().error.clone() {
+            let _ = self.call_function(&reject, &JsValue::Undefined, &[err]);
+            return Completion::Normal(promise);
+        }
+
+        let evaluation_promise = match self.ensure_module_evaluation_promise(module) {
+            Ok(promise) => promise,
+            Err(err) => {
+                let _ = self.call_function(&reject, &JsValue::Undefined, &[err]);
+                return Completion::Normal(promise);
+            }
+        };
+
+        if let Some(eval_promise) = evaluation_promise {
+            let module_for_ns = module.clone();
+            let on_fulfilled = self.create_function(JsFunction::native(
+                "dynamicImportFulfilled".to_string(),
+                1,
+                move |interp, _this, _args| {
+                    Completion::Normal(interp.create_module_namespace(&module_for_ns))
+                },
+            ));
+            return self.perform_promise_then(
+                &eval_promise,
+                &on_fulfilled,
+                &JsValue::Undefined,
+                promise,
+                resolve,
+                reject,
+            );
+        }
+
+        let ns = self.create_module_namespace(module);
+        let _ = self.call_function(&resolve, &JsValue::Undefined, &[ns]);
+        Completion::Normal(promise)
+    }
+
+    fn ensure_module_evaluation_promise(
+        &mut self,
+        module: &Rc<RefCell<LoadedModule>>,
+    ) -> Result<Option<JsValue>, JsValue> {
+        let root_path = {
+            let m = module.borrow();
+            m.cycle_root
+                .clone()
+                .unwrap_or_else(|| m.path.canonicalize().unwrap_or_else(|_| m.path.clone()))
+        };
+        let root_module = self
+            .module_registry
+            .get(&root_path)
+            .cloned()
+            .unwrap_or_else(|| module.clone());
+
+        {
+            let root = root_module.borrow();
+            if let Some(err) = root.error.clone() {
+                return Err(err);
+            }
+            if root.evaluated || root.async_evaluation_order.is_none() {
+                return Ok(None);
+            }
+            if let Some((promise, _, _)) = root.top_level_capability.clone() {
+                return Ok(Some(promise));
+            }
+        }
+
+        let (resolve, reject, promise) = self.create_promise_parts();
+        root_module.borrow_mut().top_level_capability = Some((promise.clone(), resolve, reject));
+        Ok(Some(promise))
     }
 
     pub(crate) fn create_error_in_realm(

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -62,6 +62,11 @@ impl Interpreter {
             for val in m.exports.values() {
                 Self::collect_value_roots(val, &mut worklist);
             }
+            if let Some((promise, resolve, reject)) = &m.top_level_capability {
+                Self::collect_value_roots(promise, &mut worklist);
+                Self::collect_value_roots(resolve, &mut worklist);
+                Self::collect_value_roots(reject, &mut worklist);
+            }
         }
         for module in self.synthetic_module_registry.values() {
             let m = module.borrow();

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -124,6 +124,26 @@ fn dynamic_import_uses_run_path_during_microtask_drain() {
 }
 
 #[test]
+fn dynamic_import_keeps_resolvers_alive_across_gc_during_module_evaluation() {
+    let dir = temp_case_dir("dynamic-import-gc");
+    let main_path = write_case_file(
+        &dir,
+        "main.js",
+        r#"
+        globalThis.imported = "pending";
+        import("./dep.js").then(ns => { globalThis.imported = ns.value; });
+        $262.gc();
+        "#,
+    );
+    write_case_file(&dir, "dep.js", r#"export const value = "loaded";"#);
+
+    let interp = run_module_with_path(&fs::read_to_string(&main_path).unwrap(), &main_path);
+    assert_eq!(global_string(&interp, "imported"), "loaded");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn module_cycle_preserves_live_bindings_and_reuses_registry_entries() {
     let dir = temp_case_dir("module-cycle");
     let main_path = write_case_file(

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -166,6 +166,148 @@ fn module_cycle_preserves_live_bindings_and_reuses_registry_entries() {
 }
 
 #[test]
+fn dynamic_import_waits_for_async_module_fulfillment_in_leaf_to_root_order() {
+    let dir = temp_case_dir("issue-79-fulfillment");
+    let main_path = write_case_file(
+        &dir,
+        "main.js",
+        r#"
+        import { p1, pA_start, pB_start } from "./setup.js";
+
+        globalThis.result = "pending";
+        let logs = [];
+        const importsP = Promise.all([
+          pB_start.promise
+            .then(() => import("./a.js").finally(() => logs.push("A")))
+            .catch(() => {}),
+          import("./b.js").finally(() => logs.push("B")).catch(() => {}),
+        ]);
+
+        Promise.all([pA_start.promise, pB_start.promise]).then(p1.resolve);
+        importsP.then(() => { globalThis.result = logs.join(","); });
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "setup.js",
+        r#"
+        export const p1 = Promise.withResolvers();
+        export const pA_start = Promise.withResolvers();
+        export const pB_start = Promise.withResolvers();
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "a.js",
+        r#"
+        import "./a-sentinel.js";
+        import "./b.js";
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "a-sentinel.js",
+        r#"
+        import { pA_start } from "./setup.js";
+        pA_start.resolve();
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "b.js",
+        r#"
+        import "./b-sentinel.js";
+        import { p1 } from "./setup.js";
+        await p1.promise;
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "b-sentinel.js",
+        r#"
+        import { pB_start } from "./setup.js";
+        pB_start.resolve();
+        "#,
+    );
+
+    let interp = run_module_with_path(&fs::read_to_string(&main_path).unwrap(), &main_path);
+    assert_eq!(global_string(&interp, "result"), "B,A");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn dynamic_import_waits_for_async_module_rejection_in_leaf_to_root_order() {
+    let dir = temp_case_dir("issue-79-rejection");
+    let main_path = write_case_file(
+        &dir,
+        "main.js",
+        r#"
+        import { p1, pA_start, pB_start } from "./setup.js";
+
+        globalThis.result = "pending";
+        let logs = [];
+        const importsP = Promise.all([
+          pB_start.promise
+            .then(() => import("./a.js").finally(() => logs.push("A")))
+            .catch(() => {}),
+          import("./b.js").finally(() => logs.push("B")).catch(() => {}),
+        ]);
+
+        Promise.all([pA_start.promise, pB_start.promise]).then(p1.reject);
+        importsP.then(() => { globalThis.result = logs.join(","); });
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "setup.js",
+        r#"
+        export const p1 = Promise.withResolvers();
+        export const pA_start = Promise.withResolvers();
+        export const pB_start = Promise.withResolvers();
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "a.js",
+        r#"
+        import "./a-sentinel.js";
+        import "./b.js";
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "a-sentinel.js",
+        r#"
+        import { pA_start } from "./setup.js";
+        pA_start.resolve();
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "b.js",
+        r#"
+        import "./b-sentinel.js";
+        import { p1 } from "./setup.js";
+        await p1.promise;
+        "#,
+    );
+    write_case_file(
+        &dir,
+        "b-sentinel.js",
+        r#"
+        import { pB_start } from "./setup.js";
+        pB_start.resolve();
+        "#,
+    );
+
+    let interp = run_module_with_path(&fs::read_to_string(&main_path).unwrap(), &main_path);
+    assert_eq!(global_string(&interp, "result"), "B,A");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn transitive_module_import_link_error_aborts_parent_before_evaluation() {
     let dir = temp_case_dir("module-link-import-error");
     let main_path = write_case_file(


### PR DESCRIPTION
## Summary

- make dynamic `import()` wait on async module evaluation promises instead of eagerly settling after a local microtask drain
- create and reuse module evaluation promises for async module roots so import settlement follows the spec's async module lifecycle
- root module `top_level_capability` promise parts in GC and add targeted regressions for fulfillment and rejection ordering

## Root cause

Dynamic import was checking module completion too early. That allowed ancestor imports to resolve before the leaf async module finished, which violated the leaf-to-root ordering required by async module fulfillment and rejection. The module evaluation promise also needed to remain GC-reachable while async evaluation was still in flight.

## Impact

This fixes the top-level-await ordering regression from `#79` for both fulfillment and rejection graphs driven by dynamic `import()`.

## Validation

- `cargo test --release dynamic_import_ -- --nocapture`
- `uv run python scripts/run-test262.py test262/test/language/module-code/top-level-await/fulfillment-order.js`
- `uv run python scripts/run-test262.py test262/test/language/module-code/top-level-await/rejection-order.js`
- `uv run python scripts/run-test262.py test262/test/language/module-code/top-level-await/`

Closes #79