### PR TITLE
[codex] Add missing module import SyntaxError regression

### DIFF
--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -299,6 +299,33 @@ fn default_cannot_be_reexported_through_star_resolution() {
 }
 
 #[test]
+fn missing_named_module_import_throws_syntax_error() {
+    let dir = temp_case_dir("module-missing-named-import");
+    let main_path = write_case_file(
+        &dir,
+        "main.js",
+        r#"
+        import { missing } from "./dep.js";
+        globalThis.value = missing;
+        "#,
+    );
+    write_case_file(&dir, "dep.js", r#"export const present = 1;"#);
+
+    let program = parse_module_program(&fs::read_to_string(&main_path).unwrap());
+    let mut interp = Interpreter::new();
+    let result = interp.run_with_path(&program, &main_path);
+    let err = match result {
+        Completion::Throw(err) => err,
+        other => panic!("expected thrown completion, got {other:?}"),
+    };
+    let message = interp.format_value(&err);
+    assert!(message.starts_with("SyntaxError: "));
+    assert!(message.contains("has no export named 'missing'"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn gc_keeps_microtask_roots_alive_until_queue_is_cleared() {
     let mut interp = Interpreter::new();
     let obj = interp.create_object();


### PR DESCRIPTION
## Summary
- add a focused interpreter regression test for missing named module imports
- assert the thrown value formats with the required `SyntaxError:` prefix
- keep the test adjacent to the new module-linking error coverage now present on `main`

## Rebase Note
After rebasing onto current `main`, the runtime-side fix for missing-export module resolution is already present in the base branch. This PR now carries only the regression test that preserves the issue-81 behavior.

## Validation
- `cargo fmt --check`
- `cargo test module -- --nocapture`
- `cargo test link_error -- --nocapture`
- `cargo test default_cannot_be_reexported_through_star_resolution -- --nocapture`
- `cargo build --release`
- `uv run python scripts/run-test262.py test262/test/language/module-code/instn-named-err-not-found.js test262/test/language/module-code/instn-named-err-not-found-as.js test262/test/language/module-code/instn-named-err-not-found-dflt.js test262/test/language/module-code/instn-named-err-dflt-thru-star-as.js test262/test/language/module-code/instn-named-err-dflt-thru-star-dflt.js test262/test/language/import/import-attributes/json-named-bindings.js`
