### PR TITLE
fix: prevent cross-realm leaks from Function.caller

### DIFF
--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2668,6 +2668,11 @@ impl Interpreter {
                                     JsValue::Object(o) => o.id,
                                     _ => return Completion::Normal(JsValue::Null),
                                 };
+                                let this_realm_id = interp
+                                    .function_realm_map
+                                    .get(&this_id)
+                                    .copied()
+                                    .unwrap_or(interp.current_realm_id);
                                 // Walk call_stack_frames from top to find this function's activation
                                 let mut found_idx = None;
                                 for i in (0..interp.call_stack_frames.len()).rev() {
@@ -2691,6 +2696,15 @@ impl Interpreter {
                                     }
                                     if frame.func_obj_id == 0 {
                                         continue;
+                                    }
+                                    let caller_realm_id = interp
+                                        .function_realm_map
+                                        .get(&frame.func_obj_id)
+                                        .copied()
+                                        .unwrap_or(interp.current_realm_id);
+                                    // Do not leak cross-realm caller function objects.
+                                    if caller_realm_id != this_realm_id {
+                                        return Completion::Normal(JsValue::Null);
                                     }
                                     // Check if the caller is strict — return null for strict callers
                                     if let Some(obj) = interp.get_object(frame.func_obj_id) {


### PR DESCRIPTION
### Motivation
- The sloppy `Function.caller` getter walked `call_stack_frames` and returned a raw `JsValue::Object` for the caller without verifying the caller's realm, allowing ShadowRealm code to obtain and invoke host-realm function objects and break isolation.

### Description
- Resolve the callee's realm by consulting `function_realm_map` for `this` and compute the caller's realm from each `CallFrame` before returning a function object. 
- If the caller's realm differs from the callee's realm the getter now returns `null` instead of exposing the raw function object. 
- The change is a minimal guard added to `src/interpreter/builtins/mod.rs` inside the sloppy `Function.caller` getter implementation.

### Testing
- Ran `cargo fmt --check`, which succeeded. 
- Attempted `cargo test -q` and related `cargo` commands in this environment, but the test run timed out / did not complete, producing no failing test output in the session. 
- `cargo check` / formatting checks were exercised and no formatting regressions were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b3c0e2567c8332a2f2a1ca062962ff)