### PR TITLE
fix: prevent pending_iter_close growth in generator for-of loops

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -7221,6 +7221,16 @@ impl Interpreter {
                     match self.iterator_complete(&step_result) {
                         Ok(true) => {
                             self.gc_unroot_value(&iterator);
+                            if let JsValue::Object(o) = &iterator {
+                                let id = o.id;
+                                self.pending_iter_close.retain(|v| {
+                                    if let JsValue::Object(ov) = v {
+                                        ov.id != id
+                                    } else {
+                                        true
+                                    }
+                                });
+                            }
                             current_id = *after_state;
                         }
                         Ok(false) => {
@@ -7340,7 +7350,21 @@ impl Interpreter {
                                 }
                             }
                             // Add iterator to pending_iter_close so generator.return() can close it
-                            self.pending_iter_close.push(iterator);
+                            let already_pending = if let JsValue::Object(o) = &iterator {
+                                let id = o.id;
+                                self.pending_iter_close.iter().any(|v| {
+                                    if let JsValue::Object(ov) = v {
+                                        ov.id == id
+                                    } else {
+                                        false
+                                    }
+                                })
+                            } else {
+                                false
+                            };
+                            if !already_pending {
+                                self.pending_iter_close.push(iterator);
+                            }
                             current_id = *body_state;
                         }
                         Err(e) => {
@@ -10904,6 +10928,16 @@ impl Interpreter {
                     match self.iterator_complete(&step_result) {
                         Ok(true) => {
                             self.gc_unroot_value(&iterator);
+                            if let JsValue::Object(o) = &iterator {
+                                let id = o.id;
+                                self.pending_iter_close.retain(|v| {
+                                    if let JsValue::Object(ov) = v {
+                                        ov.id != id
+                                    } else {
+                                        true
+                                    }
+                                });
+                            }
                             current_id = *after_state;
                         }
                         Ok(false) => {
@@ -11035,7 +11069,21 @@ impl Interpreter {
                                 }
                                 ForInOfLeft::Expression(_) => {}
                             }
-                            self.pending_iter_close.push(iterator);
+                            let already_pending = if let JsValue::Object(o) = &iterator {
+                                let id = o.id;
+                                self.pending_iter_close.iter().any(|v| {
+                                    if let JsValue::Object(ov) = v {
+                                        ov.id == id
+                                    } else {
+                                        false
+                                    }
+                                })
+                            } else {
+                                false
+                            };
+                            if !already_pending {
+                                self.pending_iter_close.push(iterator);
+                            }
                             current_id = *body_state;
                         }
                         Err(e) => {


### PR DESCRIPTION
### Motivation
- The `ForOfHead` state handler unconditionally pushed loop iterators into `pending_iter_close` on every iteration, while `pending_iter_close` is only drained on `Yield`, allowing unbounded growth if a generator completes before yielding.
- This could exhaust memory for large iterables and cause stale iterators to be closed later when an unrelated yield drains the list, affecting both sync and async generators.

### Description
- Remove completed for-of iterators from `pending_iter_close` when `iterator_complete` returns `true` by retaining only entries that do not match the completed iterator in `src/interpreter/eval.rs`.
- Prevent duplicate entries by checking whether the iterator is already present in `pending_iter_close` before pushing it in both the sync and async `StateTerminator::ForOfHead` paths in `src/interpreter/eval.rs`.
- The changes are minimal and localized to the generator `ForOfHead` execution paths and preserve the existing iterator-close behavior for suspended generators.

### Testing
- Ran `cargo test -q`, which completed successfully with all tests passing (`48` passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b32e8053488332a76476324bc86f96)