### PR TITLE
Isolate module registry per realm to prevent cross-realm module state leakage

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -946,7 +946,7 @@ impl Interpreter {
                     Environment::find_module_path(env).or_else(|| self.current_module_path.clone());
                 if let Some(ref path) = module_path {
                     let canon = path.canonicalize().unwrap_or_else(|_| path.clone());
-                    if let Some(module) = self.module_registry.get(&canon)
+                    if let Some(module) = self.module_registry_get(&canon)
                         && let Some(ref cached) = module.borrow().cached_import_meta
                     {
                         return Completion::Normal(cached.clone());
@@ -970,7 +970,7 @@ impl Interpreter {
                 let meta_val = JsValue::Object(crate::types::JsObject { id });
                 if let Some(ref path) = module_path {
                     let canon = path.canonicalize().unwrap_or_else(|_| path.clone());
-                    if let Some(module) = self.module_registry.get(&canon) {
+                    if let Some(module) = self.module_registry_get(&canon) {
                         module.borrow_mut().cached_import_meta = Some(meta_val.clone());
                     }
                 }

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -44,7 +44,7 @@ impl Interpreter {
                 return Ok(val);
             }
             if let Some(mp) = module_path
-                && let Some(module) = self.module_registry.get(mp)
+                && let Some(module) = self.module_registry_get(mp)
                 && let Some(val) = module.borrow().exports.get(original_key)
             {
                 return Ok(val.clone());
@@ -193,7 +193,7 @@ impl Interpreter {
             None => return Ok(()),
         };
 
-        let module = match self.module_registry.get(&module_path).cloned() {
+        let module = match self.module_registry_get(&module_path) {
             Some(m) => m,
             None => return Ok(()),
         };
@@ -238,7 +238,7 @@ impl Interpreter {
             Err(ref e) => {
                 // Per spec §16.2.1.5.3 step 9: mark all modules on stack as evaluated with error
                 for m_path in &stack {
-                    if let Some(m) = self.module_registry.get(m_path) {
+                    if let Some(m) = self.module_registry_get(m_path) {
                         let mut mb = m.borrow_mut();
                         mb.evaluated = true;
                         mb.is_evaluating = false;
@@ -404,7 +404,7 @@ impl Interpreter {
                 }
                 // Fallback: check module's exports directly
                 if let Some(ref module_path) = ns_data.module_path
-                    && let Some(module) = self.module_registry.get(module_path)
+                    && let Some(module) = self.module_registry_get(module_path)
                     && let Some(val) = module.borrow().exports.get(key)
                 {
                     return Completion::Normal(val.clone());
@@ -684,7 +684,7 @@ impl Interpreter {
             let mut stack = vec![];
             if let Err(ref e) = self.inner_module_evaluation(&resolved_canon, &mut stack, 0) {
                 for m_path in &stack {
-                    if let Some(m) = self.module_registry.get(m_path) {
+                    if let Some(m) = self.module_registry_get(m_path) {
                         let mut mb = m.borrow_mut();
                         mb.evaluated = true;
                         mb.is_evaluating = false;
@@ -721,7 +721,7 @@ impl Interpreter {
                             interp.inner_module_evaluation(&resolved_canon, &mut stack, 0)
                         {
                             for m_path in &stack {
-                                if let Some(m) = interp.module_registry.get(m_path) {
+                                if let Some(m) = interp.module_registry_get(m_path) {
                                     let mut mb = m.borrow_mut();
                                     mb.evaluated = true;
                                     mb.is_evaluating = false;
@@ -810,9 +810,7 @@ impl Interpreter {
                 .unwrap_or_else(|| m.path.canonicalize().unwrap_or_else(|_| m.path.clone()))
         };
         let root_module = self
-            .module_registry
-            .get(&root_path)
-            .cloned()
+            .module_registry_get(&root_path)
             .unwrap_or_else(|| module.clone());
 
         {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -70,7 +70,7 @@ pub struct Interpreter {
         Box<dyn FnOnce(&mut Interpreter) -> Completion>,
     )>,
     cached_has_instance_key: Option<String>,
-    module_registry: HashMap<PathBuf, Rc<RefCell<LoadedModule>>>,
+    module_registry: HashMap<(usize, PathBuf), Rc<RefCell<LoadedModule>>>,
     synthetic_module_registry: HashMap<(PathBuf, ImportModuleType), Rc<RefCell<LoadedModule>>>,
     current_module_path: Option<PathBuf>,
     loading_deferred: bool,
@@ -1474,6 +1474,17 @@ impl Interpreter {
         }
     }
 
+    fn module_registry_get(&self, path: &Path) -> Option<Rc<RefCell<LoadedModule>>> {
+        self.module_registry
+            .get(&(self.current_realm_id, path.to_path_buf()))
+            .cloned()
+    }
+
+    fn module_registry_insert(&mut self, path: PathBuf, module: Rc<RefCell<LoadedModule>>) {
+        self.module_registry
+            .insert((self.current_realm_id, path), module);
+    }
+
     fn run_module(&mut self, program: &Program, module_path: Option<PathBuf>) -> Completion {
         let prev_module_path = self.current_module_path.take();
         self.current_module_path = module_path.clone();
@@ -1517,8 +1528,7 @@ impl Interpreter {
         }));
         if let Some(ref path) = module_path {
             let canon_path = path.canonicalize().unwrap_or_else(|_| path.clone());
-            self.module_registry
-                .insert(canon_path, loaded_module.clone());
+            self.module_registry_insert(canon_path, loaded_module.clone());
         }
         // Note: is_evaluating is managed by inner_module_evaluation
 
@@ -1668,7 +1678,7 @@ impl Interpreter {
             Self::cache_module_error(&loaded_module, e);
             // Per spec §16.2.1.5.3 step 9: mark all modules on stack as evaluated with error
             for m_path in &stack {
-                if let Some(m) = self.module_registry.get(m_path) {
+                if let Some(m) = self.module_registry_get(m_path) {
                     let mut mb = m.borrow_mut();
                     mb.evaluated = true;
                     mb.is_evaluating = false;
@@ -1685,7 +1695,7 @@ impl Interpreter {
         self.drain_microtasks();
 
         // Check if the entry module has an error (e.g. from rejected TLA await)
-        if let Some(module) = self.module_registry.get(&canon_path_entry).cloned()
+        if let Some(module) = self.module_registry_get(&canon_path_entry)
             && let Some(err) = module.borrow().error.clone()
         {
             self.current_module_path = prev_module_path;
@@ -1766,7 +1776,7 @@ impl Interpreter {
                     env.borrow_mut().initialize_binding(local, ns);
                     if let Some(ref mp) = self.current_module_path {
                         let canon = mp.canonicalize().unwrap_or_else(|_| mp.clone());
-                        if let Some(current_mod) = self.module_registry.get(&canon) {
+                        if let Some(current_mod) = self.module_registry_get(&canon) {
                             current_mod
                                 .borrow_mut()
                                 .namespace_imports
@@ -1977,7 +1987,7 @@ impl Interpreter {
         let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
         // Check if module is already loaded
-        if let Some(existing) = self.module_registry.get(&canon_path).cloned() {
+        if let Some(existing) = self.module_registry_get(&canon_path) {
             // If the module previously errored, re-throw the same error
             if let Some(ref err) = existing.borrow().error.clone() {
                 return Err(err.clone());
@@ -2049,8 +2059,7 @@ impl Interpreter {
             module_env
                 .borrow_mut()
                 .initialize_binding("*default*", parsed);
-            self.module_registry
-                .insert(canon_path.clone(), loaded_module.clone());
+            self.module_registry_insert(canon_path.clone(), loaded_module.clone());
             return Ok(loaded_module);
         }
 
@@ -2114,8 +2123,7 @@ impl Interpreter {
             dfs_index: None,
             dfs_ancestor_index: None,
         }));
-        self.module_registry
-            .insert(canon_path.clone(), loaded_module.clone());
+        self.module_registry_insert(canon_path.clone(), loaded_module.clone());
 
         // Collect export names and bindings first (before processing imports) for namespace objects
         for item in &program.module_items {
@@ -2293,7 +2301,7 @@ impl Interpreter {
     fn load_module_no_eval(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
         let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
-        if let Some(existing) = self.module_registry.get(&canon_path) {
+        if let Some(existing) = self.module_registry_get(&canon_path) {
             // Propagate parse/link errors (module never finished loading) eagerly.
             // Let evaluation errors surface via ensure_deferred_namespace_evaluation
             // when the deferred namespace is accessed, so identity is preserved
@@ -2372,8 +2380,7 @@ impl Interpreter {
             dfs_index: None,
             dfs_ancestor_index: None,
         }));
-        self.module_registry
-            .insert(canon_path.clone(), loaded_module.clone());
+        self.module_registry_insert(canon_path.clone(), loaded_module.clone());
 
         // Collect export names and bindings
         for item in &program.module_items {
@@ -2629,7 +2636,7 @@ impl Interpreter {
 
     /// Execute a module's body synchronously (no DFS into dependencies).
     fn execute_module_body_sync(&mut self, module_path: &Path) -> Result<(), JsValue> {
-        let module = match self.module_registry.get(module_path).cloned() {
+        let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return Ok(()),
         };
@@ -2675,7 +2682,7 @@ impl Interpreter {
     }
 
     fn collect_all_exports(&mut self, module_path: &Path) {
-        let module = match self.module_registry.get(module_path).cloned() {
+        let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return,
         };
@@ -2728,7 +2735,7 @@ impl Interpreter {
     }
 
     fn execute_async_module(&mut self, module_path: &Path) {
-        let module = match self.module_registry.get(module_path).cloned() {
+        let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return,
         };
@@ -2818,7 +2825,7 @@ impl Interpreter {
         let canon = module_path
             .canonicalize()
             .unwrap_or_else(|_| module_path.to_path_buf());
-        let module = match self.module_registry.get(&canon).cloned() {
+        let module = match self.module_registry_get(&canon) {
             Some(m) => m,
             None => return Ok(index),
         };
@@ -2866,7 +2873,7 @@ impl Interpreter {
         // Evaluate each dep and set up async parent relationships (spec §16.2.1.5.3.1 step 11)
         for dep_canon in evaluation_list.into_iter() {
             idx = self.inner_module_evaluation(&dep_canon, stack, idx)?;
-            let dep_mod = match self.module_registry.get(&dep_canon).cloned() {
+            let dep_mod = match self.module_registry_get(&dep_canon) {
                 Some(m) => m,
                 None => continue,
             };
@@ -2888,9 +2895,7 @@ impl Interpreter {
                 let cycle_root_path = dep.cycle_root.clone().unwrap_or_else(|| dep_canon.clone());
                 drop(dep);
                 let root_mod = self
-                    .module_registry
-                    .get(&cycle_root_path)
-                    .cloned()
+                    .module_registry_get(&cycle_root_path)
                     .unwrap_or_else(|| dep_mod.clone());
                 let root = root_mod.borrow();
                 if let Some(ref err) = root.error {
@@ -2930,7 +2935,7 @@ impl Interpreter {
         if my_dfs == my_ancestor {
             let has_async = module.borrow().async_evaluation_order.is_some();
             while let Some(popped) = stack.pop() {
-                if let Some(popped_mod) = self.module_registry.get(&popped).cloned() {
+                if let Some(popped_mod) = self.module_registry_get(&popped) {
                     popped_mod.borrow_mut().cycle_root = Some(canon.clone());
                     if !has_async {
                         let mut pm = popped_mod.borrow_mut();
@@ -2947,8 +2952,8 @@ impl Interpreter {
     }
 
     fn get_module_dep_paths(&self, canon_path: &Path) -> Vec<(PathBuf, bool)> {
-        let module = match self.module_registry.get(canon_path) {
-            Some(m) => m.clone(),
+        let module = match self.module_registry_get(canon_path) {
+            Some(m) => m,
             None => return Vec::new(),
         };
         let program = match module.borrow().program_ast.clone() {
@@ -2988,13 +2993,13 @@ impl Interpreter {
     }
 
     fn gather_available_ancestors(&mut self, module_path: &Path) -> Vec<PathBuf> {
-        let parents = match self.module_registry.get(module_path) {
+        let parents = match self.module_registry_get(module_path) {
             Some(m) => m.borrow().async_parent_modules.clone(),
             None => return Vec::new(),
         };
         let mut result = Vec::new();
         for parent_path in parents {
-            let parent = match self.module_registry.get(&parent_path).cloned() {
+            let parent = match self.module_registry_get(&parent_path) {
                 Some(m) => m,
                 None => continue,
             };
@@ -3010,8 +3015,7 @@ impl Interpreter {
             }
         }
         result.sort_by_key(|p| {
-            self.module_registry
-                .get(p)
+            self.module_registry_get(p)
                 .and_then(|m| m.borrow().async_evaluation_order)
                 .unwrap_or(u64::MAX)
         });
@@ -3019,7 +3023,7 @@ impl Interpreter {
     }
 
     fn async_module_execution_rejected(&mut self, module_path: &Path, error: &JsValue) {
-        let module = match self.module_registry.get(module_path).cloned() {
+        let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return,
         };
@@ -3042,7 +3046,7 @@ impl Interpreter {
     }
 
     fn async_module_execution_fulfilled(&mut self, module_path: &Path) {
-        let module = match self.module_registry.get(module_path).cloned() {
+        let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return,
         };
@@ -3064,8 +3068,7 @@ impl Interpreter {
             let ancestor = exec_list[i].clone();
             i += 1;
             let ancestor_has_tla = self
-                .module_registry
-                .get(&ancestor)
+                .module_registry_get(&ancestor)
                 .map(|m| m.borrow().has_tla)
                 .unwrap_or(false);
             if ancestor_has_tla {
@@ -3073,12 +3076,12 @@ impl Interpreter {
             } else {
                 match self.execute_module_body_sync(&ancestor) {
                     Ok(()) => {
-                        if let Some(m) = self.module_registry.get(&ancestor) {
+                        if let Some(m) = self.module_registry_get(&ancestor) {
                             let mut mb = m.borrow_mut();
                             mb.evaluated = true;
                             mb.is_evaluating = false;
                         }
-                        if let Some(m) = self.module_registry.get(&ancestor).cloned()
+                        if let Some(m) = self.module_registry_get(&ancestor)
                             && let Some((_p, resolve, _r)) = m.borrow().top_level_capability.clone()
                         {
                             let _ = self.call_function(
@@ -3268,7 +3271,7 @@ impl Interpreter {
         self.gather_async_transitive_deps(deferred_path, &mut to_eval, &mut seen);
 
         for path in to_eval {
-            if let Some(module) = self.module_registry.get(&path).cloned()
+            if let Some(module) = self.module_registry_get(&path)
                 && !module.borrow().evaluated
             {
                 let mut stack = vec![];
@@ -3290,8 +3293,8 @@ impl Interpreter {
             return;
         }
 
-        let module = match self.module_registry.get(&canon) {
-            Some(m) => m.clone(),
+        let module = match self.module_registry_get(&canon) {
+            Some(m) => m,
             None => return,
         };
 
@@ -3371,8 +3374,8 @@ impl Interpreter {
             return true; // cycle — spec says return true
         }
 
-        let module = match self.module_registry.get(&canon) {
-            Some(m) => m.clone(),
+        let module = match self.module_registry_get(&canon) {
+            Some(m) => m,
             None => return true,
         };
 
@@ -3983,9 +3986,12 @@ impl Interpreter {
     }
 
     fn create_namespace_for_env(&mut self, target_env: &EnvRef) -> JsValue {
+        let realm_id = self.current_realm_id;
         let found = self
             .module_registry
-            .values()
+            .iter()
+            .filter(|((rid, _), _)| *rid == realm_id)
+            .map(|(_, module)| module)
             .find(|m| Rc::ptr_eq(&m.borrow().env, target_env))
             .cloned();
         if let Some(module) = found {

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -359,9 +359,10 @@ fn transitive_module_import_link_error_aborts_parent_before_evaluation() {
     assert!(interp.realm().global_env.borrow().get("marker").is_none());
 
     let broken_canon = broken_path.canonicalize().unwrap_or(broken_path.clone());
+    let realm_id = interp.current_realm_id;
     let cached = interp
         .module_registry
-        .get(&broken_canon)
+        .get(&(realm_id, broken_canon))
         .expect("broken module registry entry")
         .borrow()
         .error
@@ -521,9 +522,11 @@ fn gc_keeps_module_exports_alive_until_registry_entry_is_removed() {
 
     let mut interp = run_module_with_path(&fs::read_to_string(&main_path).unwrap(), &main_path);
     let canon = main_path.canonicalize().unwrap_or(main_path.clone());
+    let realm_id = interp.current_realm_id;
+    let key = (realm_id, canon.clone());
     let module = interp
         .module_registry
-        .get(&canon)
+        .get(&key)
         .expect("module registry entry")
         .clone();
     let export_val = module
@@ -540,7 +543,7 @@ fn gc_keeps_module_exports_alive_until_registry_entry_is_removed() {
     interp.gc_safepoint();
     assert!(interp.get_object(obj_ref.id).is_some());
 
-    interp.module_registry.remove(&canon);
+    interp.module_registry.remove(&key);
     interp.gc_requested = true;
     interp.gc_safepoint();
     assert!(interp.get_object(obj_ref.id).is_none());


### PR DESCRIPTION
### Motivation
- Fix a cross-realm isolation bug where `Interpreter::module_registry` was shared across realms causing a module loaded in one realm to be reused (with its original module environment) in other realms. 
- This leak allows one realm to observe or modify another realm's module state and globals, violating realm isolation guarantees.

### Description
- Change `module_registry` keys from `PathBuf` to `(usize, PathBuf)` so entries are scoped by `(realm_id, canonical_module_path)` and thus per-realm. 
- Add helper accessors `module_registry_get` and `module_registry_insert` that perform lookups/inserts using the current realm id so all module operations are realm-local. 
- Update module lifecycle and evaluation code paths in `src/interpreter/mod.rs` to use the new helpers and to restrict namespace lookups to modules in the current realm. 
- Update module-related lookups in `src/interpreter/eval.rs` (e.g., `import.meta`, export resolution, deferred evaluation and dynamic import handling) to use the realm-scoped accessors so reads/writes target the active realm only. 

### Testing
- Ran `cargo fmt` successfully. 
- Ran `cargo test -q` and all tests passed (`48` tests passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b33a6124d88332a00c88594cb9ab35)