### PR TITLE
Limit v-flag class nesting depth in RegExp validator

### DIFF
--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -3343,12 +3343,22 @@ fn is_v_flag_reserved_double_punctuator(a: char, b: char) -> bool {
         )
 }
 
+const MAX_V_FLAG_CLASS_NESTING_DEPTH: usize = 256;
+
 fn validate_v_flag_class_inner(
     chars: &[char],
     i: &mut usize,
     source: &str,
     negated: bool,
+    depth: usize,
 ) -> Result<(), String> {
+    if depth > MAX_V_FLAG_CLASS_NESTING_DEPTH {
+        return Err(format!(
+            "Invalid regular expression: /{}/ : Character class nesting too deep",
+            source
+        ));
+    }
+
     let len = chars.len();
     let err = |msg: &str| -> Result<(), String> {
         Err(format!(
@@ -3402,7 +3412,7 @@ fn validate_v_flag_class_inner(
             } else {
                 false
             };
-            validate_v_flag_class_inner(chars, i, source, nested_negated)?;
+            validate_v_flag_class_inner(chars, i, source, nested_negated, depth + 1)?;
             has_operand = true;
             continue;
         }
@@ -3802,7 +3812,7 @@ pub(crate) fn validate_js_pattern(source: &str, _flags: &str) -> Result<(), Stri
             };
 
             if v_flag {
-                validate_v_flag_class_inner(&chars, &mut i, source, class_negated)?;
+                validate_v_flag_class_inner(&chars, &mut i, source, class_negated, 0)?;
             } else {
                 let mut prev_value: Option<u32> = None;
                 let mut prev_is_class_escape = false;


### PR DESCRIPTION
### Motivation
- The v-flag character class validator (`validate_v_flag_class_inner`) recursed on every nested `[` with no bound, allowing attacker-controlled patterns to cause unbounded recursion and crash the process (DoS).
- Introduce a safe limit to prevent stack exhaustion while preserving normal parsing behavior for valid patterns.

### Description
- Add `const MAX_V_FLAG_CLASS_NESTING_DEPTH: usize = 256;` in `src/interpreter/builtins/regexp.rs` to cap nesting depth.
- Thread a `depth: usize` parameter through `validate_v_flag_class_inner` and increment it on each recursive entry.
- Return an `Err` with `"Character class nesting too deep"` when `depth` exceeds the configured maximum.
- Start v-flag validation calls with `depth` set to `0` from the v-flag parse path in `validate_js_pattern`.

### Testing
- Ran `cargo test -q`, all unit tests passed (`48 passed; 0 failed`).
- Ran `cargo fmt -- --check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b34215abc48332bfe9a9c0bf65ee50)