### PR TITLE
[modules] Close the last 3 test262 failures (import-defer + source-phase)

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2084,6 +2084,28 @@ impl Interpreter {
             }
         }
 
+        // Host-resolve pre-pass (spec LoadRequestedModules): surface unresolvable
+        // specifier errors before any transitive Link-phase SyntaxError fires.
+        for item in &program.module_items {
+            let specifier = match item {
+                ModuleItem::ImportDeclaration(import) => Some(import.source.as_str()),
+                ModuleItem::ExportDeclaration(ExportDeclaration::All { source, .. }) => {
+                    Some(source.as_str())
+                }
+                ModuleItem::ExportDeclaration(ExportDeclaration::Named {
+                    source: Some(s), ..
+                }) => Some(s.as_str()),
+                _ => None,
+            };
+            if let Some(spec) = specifier
+                && let Err(e) = self.resolve_module_specifier(spec, Some(&canon_path))
+            {
+                Self::cache_module_error(&loaded_module, &e);
+                self.current_module_path = prev_path;
+                return Err(e);
+            }
+        }
+
         // Pre-load pass: load ALL referenced modules in source order (§16.2.1.6.2 step 6)
         // For deferred imports, load without evaluation.
         // For non-deferred, load normally (which includes evaluation).
@@ -2188,8 +2210,16 @@ impl Interpreter {
         let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
         if let Some(existing) = self.module_registry.get(&canon_path) {
-            if let Some(ref err) = existing.borrow().error.clone() {
-                return Err(err.clone());
+            // Propagate parse/link errors (module never finished loading) eagerly.
+            // Let evaluation errors surface via ensure_deferred_namespace_evaluation
+            // when the deferred namespace is accessed, so identity is preserved
+            // per spec §16.2.1.5.3 (EnsureDeferredNamespaceEvaluation).
+            let (has_error, evaluated, err_clone) = {
+                let b = existing.borrow();
+                (b.error.is_some(), b.evaluated, b.error.clone())
+            };
+            if has_error && !evaluated {
+                return Err(err_clone.unwrap());
             }
             return Ok(existing.clone());
         }


### PR DESCRIPTION
Closes #91.

## Summary
- `load_module_no_eval` at `src/interpreter/mod.rs:2190-2205` now only propagates cached errors when the target module was never evaluated. For already-evaluated-with-error modules it returns `Ok(existing)` so the deferred namespace re-throws on access via `EnsureDeferredNamespaceEvaluation` (spec §16.2.1.5.3). Fixes `defer-import-after-evaluation.js` and preserves error identity across `import defer * as`.
- `load_module_inner` gains a host-resolve pre-pass after hoisting and before the existing pre-load pass. Unresolvable specifiers reject the module before any transitive Link-phase `SyntaxError` can fire, matching spec `LoadRequestedModules`-before-`Link` ordering. Fixes both `import-source.js` scenarios.

## Result
- Non-staging: **99,020 / 99,020 (100.00%)**, 0 regressions, +67 net new passes (3 targets plus previously flaky tests that settled).
- Full `import-defer/` subtree: 103 / 103.
- No parser, AST, or builtin changes — scaffolding for both TC39 proposals was already in place; this PR only fixes the module-loader semantics around cached errors and error ordering.

## Test plan
- [x] `cargo build --release`
- [x] `./scripts/lint.sh`
- [x] `uv run python scripts/run-test262.py test262/test/language/import/import-defer/errors/module-throws/`
- [x] `uv run python scripts/run-test262.py test262/test/language/module-code/source-phase-import/`
- [x] `uv run python scripts/run-test262.py test262/test/language/import/import-defer/` (full subtree — no regressions)
- [x] Full non-staging `uv run python scripts/run-test262.py -j 32` — 0 regressions
- [x] Baseline refreshed via `--update-baseline`