### PR TITLE
[perf] Centralise object allocation behind alloc_object (#66, PR 1a)

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -3912,8 +3912,7 @@ impl Interpreter {
             PropertyDescriptor::data(JsValue::Number(values.len() as f64), true, false, false),
         );
         obj_data.array_elements = Some(values);
-        let obj = Rc::new(RefCell::new(obj_data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(obj_data);
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -3944,8 +3943,7 @@ impl Interpreter {
             PropertyDescriptor::data(JsValue::Number(len as f64), true, false, false),
         );
         obj_data.array_elements = Some(array_elements);
-        let obj = Rc::new(RefCell::new(obj_data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(obj_data);
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -3963,8 +3961,7 @@ impl Interpreter {
         );
         // Use a small Vec for sparse arrays — don't pre-allocate huge arrays
         obj_data.array_elements = Some(Vec::new());
-        let obj = Rc::new(RefCell::new(obj_data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(obj_data);
         JsValue::Object(crate::types::JsObject { id })
     }
 }

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -123,8 +123,7 @@ impl Interpreter {
                 kind,
                 done: false,
             });
-            let obj = Rc::new(RefCell::new(obj_data));
-            let id = interp.allocate_object_slot(obj);
+            let id = interp.alloc_object(obj_data);
             JsValue::Object(crate::types::JsObject { id })
         }
 
@@ -970,8 +969,7 @@ impl Interpreter {
                 kind,
                 done: false,
             });
-            let obj = Rc::new(RefCell::new(obj_data));
-            let id = interp.allocate_object_slot(obj);
+            let id = interp.alloc_object(obj_data);
             JsValue::Object(crate::types::JsObject { id })
         }
 

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -3575,8 +3575,7 @@ impl Interpreter {
             kind,
             done: false,
         });
-        let obj = Rc::new(RefCell::new(obj_data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(obj_data);
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -3599,8 +3598,7 @@ impl Interpreter {
             kind,
             done: false,
         });
-        let obj = Rc::new(RefCell::new(obj_data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(obj_data);
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -3618,8 +3616,7 @@ impl Interpreter {
             position: 0,
             done: false,
         });
-        let obj = Rc::new(RefCell::new(obj_data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(obj_data);
         JsValue::Object(crate::types::JsObject { id })
     }
 

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -752,8 +752,7 @@ impl Interpreter {
         data.prototype = self.realm().promise_prototype.clone();
         data.class_name = "Promise".to_string();
         data.promise_data = Some(PromiseData::new());
-        let obj = Rc::new(RefCell::new(data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(data);
         JsValue::Object(crate::types::JsObject { id })
     }
 

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -8668,8 +8668,7 @@ impl Interpreter {
                     "lastIndex".to_string(),
                     PropertyDescriptor::data(JsValue::Number(0.0), true, false, false),
                 );
-                let rc = Rc::new(RefCell::new(obj));
-                let id = interp.allocate_object_slot(rc);
+                let id = interp.alloc_object(obj);
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
             },
         ));

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1438,8 +1438,7 @@ impl Interpreter {
                 if obj_data.prototype.is_none() {
                     obj_data.prototype = self.realm().object_prototype.clone();
                 }
-                let obj = Rc::new(RefCell::new(obj_data));
-                let id = self.allocate_object_slot(obj);
+                let id = self.alloc_object(obj_data);
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
             }
             JsValue::Object(_) => Completion::Normal(val.clone()),

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -65,8 +65,7 @@ impl Interpreter {
         );
         obj_data.array_elements = Some(values);
         obj_data.extensible = false;
-        let obj = Rc::new(RefCell::new(obj_data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(obj_data);
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -113,8 +112,7 @@ impl Interpreter {
                     "lastIndex".to_string(),
                     PropertyDescriptor::data(JsValue::Number(0.0), true, false, false),
                 );
-                let rc = Rc::new(RefCell::new(obj));
-                let id = self.allocate_object_slot(rc);
+                let id = self.alloc_object(obj);
                 JsValue::Object(crate::types::JsObject { id })
             }
         }
@@ -157,8 +155,7 @@ impl Interpreter {
             "lastIndex".to_string(),
             PropertyDescriptor::data(JsValue::Number(0.0), true, false, false),
         );
-        let rc = Rc::new(RefCell::new(obj));
-        let id = self.allocate_object_slot(rc);
+        let id = self.alloc_object(obj);
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -1342,8 +1339,7 @@ impl Interpreter {
                 }
             }
         }
-        let obj = Rc::new(RefCell::new(obj_data));
-        let id = self.allocate_object_slot(obj);
+        let id = self.alloc_object(obj_data);
         // Set __home_object__ for concise methods, getters, and setters
         let obj_val = JsValue::Object(crate::types::JsObject { id });
         {

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -1,6 +1,14 @@
 use super::*;
 
 impl Interpreter {
+    /// Allocate a fresh object slot for `data` and return its id.
+    /// Centralises the `Rc::new(RefCell::new(..))` + `allocate_object_slot`
+    /// pattern used at every object creation site.
+    pub(crate) fn alloc_object(&mut self, data: JsObjectData) -> u64 {
+        let rc = Rc::new(RefCell::new(data));
+        self.allocate_object_slot(rc)
+    }
+
     pub(crate) fn allocate_object_slot(&mut self, obj: Rc<RefCell<JsObjectData>>) -> u64 {
         self.gc_alloc_count += 1;
         let is_reuse = !self.free_list.is_empty();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -955,9 +955,8 @@ impl Interpreter {
     fn create_object(&mut self) -> Rc<RefCell<JsObjectData>> {
         let mut data = JsObjectData::new();
         data.prototype = self.realm().object_prototype.clone();
-        let obj = Rc::new(RefCell::new(data));
-        self.allocate_object_slot(obj.clone());
-        obj
+        let id = self.alloc_object(data);
+        self.get_object_expect(id)
     }
 
     fn create_thrower_function(&mut self) -> JsValue {
@@ -1122,15 +1121,17 @@ impl Interpreter {
                 PropertyDescriptor::data(proto_val.clone(), true, false, false),
             );
         }
-        let obj = Rc::new(RefCell::new(obj_data));
-        let func_id = self.allocate_object_slot(obj.clone());
+        let func_id = self.alloc_object(obj_data);
         self.function_realm_map
             .insert(func_id, self.current_realm_id);
         let func_val = JsValue::Object(crate::types::JsObject { id: func_id });
         // Set prototype.constructor = func (not for generators)
         if is_constructable
             && !is_gen
-            && let Some(JsValue::Object(proto_ref)) = obj.borrow().get_property_value("prototype")
+            && let Some(JsValue::Object(proto_ref)) = self
+                .get_object_expect(func_id)
+                .borrow()
+                .get_property_value("prototype")
             && let Some(proto_obj) = self.get_object(proto_ref.id)
         {
             proto_obj
@@ -1140,8 +1141,18 @@ impl Interpreter {
         func_val
     }
 
-    fn get_object(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
+    pub(crate) fn get_object(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
         self.objects.get(id as usize).and_then(|slot| slot.clone())
+    }
+
+    /// Like `get_object` but panics if the id is dead. Matches the pattern
+    /// `self.objects[id as usize].as_ref().unwrap().clone()` used at most
+    /// call sites where the id is known live (held by a live JsValue).
+    pub(crate) fn get_object_expect(&self, id: u64) -> Rc<RefCell<JsObjectData>> {
+        self.objects[id as usize]
+            .as_ref()
+            .expect("dead object id")
+            .clone()
     }
 
     pub(crate) fn set_function_name(&self, val: &JsValue, name: &str) {


### PR DESCRIPTION
## Summary
First of a planned series addressing issue #66 (arena allocator for JS objects). Introduces a single object-allocation chokepoint so follow-ups can swap the storage layer without rewriting every call site.

- New `Interpreter::alloc_object(data) -> u64` factory in `src/interpreter/gc.rs` wrapping the existing `Rc::new(RefCell::new(..)) + allocate_object_slot` pattern.
- Widen existing private `get_object(id)` accessor to `pub(crate)` and add a `get_object_expect(id)` variant that matches the ubiquitous `self.objects[id].as_ref().unwrap().clone()` call shape.
- Migrate all 17 direct `Rc::new(RefCell::new(JsObjectData ..))` allocation sites to the new factory (across `eval`, `eval/literals`, `builtins/{array,collections,iterators,promise,regexp}`, and the `create_object` / `create_function` factories in `interpreter/mod.rs`).
- Storage layout is **unchanged** — this PR is perf-neutral by design. The malloc reduction comes in follow-ups (PR 1b interns prototype / proxy / Realm references to `u64`; PR 2 replaces the slab with a chunked arena, per the plan in `.ultraplan/object-arena-allocator.md`).

`Rc::ptr_eq` audit also noted in passing: grep confirms no object-pointer identity comparisons exist in the codebase — all `Rc::ptr_eq` / `Rc::as_ptr` sites operate on `Environment`, `LoadedModule`, or `BufferData`.

## Test plan
- [x] `cargo build --release`
- [x] `./scripts/lint.sh` (clippy clean)
- [x] `uv run python scripts/run-test262.py -j 32` → 99 020 / 99 020, 0 regressions vs `origin/main:test262-pass.txt`
- [x] `uv run python scripts/run-custom-tests.py` → 2 / 2
- [x] `./scripts/run-acorn-tests.sh` → 13 537 / 13 537 (both normal + loose parsers)