### PR TITLE
Harden Claude workflow against untrusted comment triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
### Motivation
- The `claude` GitHub Actions workflow previously ran whenever a comment/issue contained `@claude` and granted sensitive `id-token: write` permission and a repository secret to a third‑party action, allowing untrusted users to trigger privileged execution.

### Description
- Restrict the `jobs.claude.if` expression in `.github/workflows/claude.yml` to require the comment/issue author's `author_association` be one of `OWNER`, `MEMBER`, or `COLLABORATOR` in addition to the existing `@claude` mention checks for `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events.
- Preserve existing behavior and permissions while adding the trust gating logic using `contains(fromJSON(...), ...)` checks so only trusted actors can trigger the job.

### Testing
- Ran `git diff --check` to verify no formatting/errors were introduced and it succeeded.
- Inspected the workflow diff with `git diff -- .github/workflows/claude.yml` to confirm the updated `if` expression was applied as intended.
- Listed the updated workflow file with `nl -ba .github/workflows/claude.yml` to validate the final contents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b56da37b788332813fd2cac84138ca)