### PR TITLE
Fix Intl.Segmenter iterator input memory amplification

### DIFF
--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -4,7 +4,6 @@ use icu::segmenter::{GraphemeClusterSegmenter, SentenceSegmenter, WordSegmenter}
 struct SegmentInfo {
     segment: Vec<u16>,
     index: usize, // UTF-16 code unit index
-    input: Vec<u16>,
     is_word_like: Option<bool>,
 }
 
@@ -24,7 +23,6 @@ fn compute_segments(input: &[u16], granularity: &str) -> Vec<SegmentInfo> {
                 segments.push(SegmentInfo {
                     segment: input[prev..pos].to_vec(),
                     index: prev,
-                    input: input.to_vec(),
                     is_word_like: Some(is_word_like),
                 });
                 prev = pos;
@@ -37,7 +35,6 @@ fn compute_segments(input: &[u16], granularity: &str) -> Vec<SegmentInfo> {
                 segments.push(SegmentInfo {
                     segment: input[w[0]..w[1]].to_vec(),
                     index: w[0],
-                    input: input.to_vec(),
                     is_word_like: None,
                 });
             }
@@ -49,7 +46,6 @@ fn compute_segments(input: &[u16], granularity: &str) -> Vec<SegmentInfo> {
                 segments.push(SegmentInfo {
                     segment: input[w[0]..w[1]].to_vec(),
                     index: w[0],
-                    input: input.to_vec(),
                     is_word_like: None,
                 });
             }
@@ -374,9 +370,9 @@ impl Interpreter {
                     0,
                     move |interp, _this, _args| {
                         let segs = compute_segments(&input_clone, &granularity_clone);
-                        let seg_data: Vec<(Vec<u16>, usize, Vec<u16>, bool)> = segs
+                        let seg_data: Vec<(Vec<u16>, usize, bool)> = segs
                             .into_iter()
-                            .map(|s| (s.segment, s.index, s.input, s.is_word_like.unwrap_or(false)))
+                            .map(|s| (s.segment, s.index, s.is_word_like.unwrap_or(false)))
                             .collect();
 
                         let iter_obj = interp.create_object();
@@ -390,6 +386,7 @@ impl Interpreter {
                         iter_obj.borrow_mut().iterator_state =
                             Some(IteratorState::SegmentIterator {
                                 segments: seg_data,
+                                input: std::rc::Rc::new(input_clone.clone()),
                                 position: 0,
                                 done: false,
                             });
@@ -411,30 +408,24 @@ impl Interpreter {
                                 if let JsValue::Object(o) = this
                                     && let Some(obj) = interp.get_object(o.id)
                                 {
-                                    let (state, has_word_like) = {
+                                    let has_word_like = {
                                         let b = obj.borrow();
-                                        let hwl = b
-                                            .properties
+                                        b.properties
                                             .get("[[HasWordLike]]")
                                             .and_then(|pd| pd.value.as_ref())
                                             .map(|v| matches!(v, JsValue::Boolean(true)))
-                                            .unwrap_or(false);
-                                        (b.iterator_state.clone(), hwl)
+                                            .unwrap_or(false)
                                     };
 
                                     if let Some(IteratorState::SegmentIterator {
-                                        ref segments,
-                                        position,
-                                        done,
-                                    }) = state
+                                        ref mut segments,
+                                        ref input,
+                                        ref mut position,
+                                        ref mut done,
+                                    }) = obj.borrow_mut().iterator_state
                                     {
-                                        if done || position >= segments.len() {
-                                            obj.borrow_mut().iterator_state =
-                                                Some(IteratorState::SegmentIterator {
-                                                    segments: segments.clone(),
-                                                    position,
-                                                    done: true,
-                                                });
+                                        if *done || *position >= segments.len() {
+                                            *done = true;
                                             return Completion::Normal(
                                                 interp.create_iter_result_object(
                                                     JsValue::Undefined,
@@ -443,23 +434,18 @@ impl Interpreter {
                                             );
                                         }
 
-                                        let (ref seg, idx, ref inp, wl) = segments[position];
+                                        let (seg, idx, wl) = segments[*position].clone();
+                                        *position += 1;
+
                                         let is_word_like =
                                             if has_word_like { Some(wl) } else { None };
                                         let seg_obj = create_segment_object(
                                             interp,
-                                            seg,
+                                            &seg,
                                             idx,
-                                            inp,
+                                            input,
                                             is_word_like,
                                         );
-
-                                        obj.borrow_mut().iterator_state =
-                                            Some(IteratorState::SegmentIterator {
-                                                segments: segments.clone(),
-                                                position: position + 1,
-                                                done: false,
-                                            });
 
                                         return Completion::Normal(
                                             interp.create_iter_result_object(seg_obj, false),

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1267,7 +1267,8 @@ pub enum IteratorState {
         done: bool,
     },
     SegmentIterator {
-        segments: Vec<(Vec<u16>, usize, Vec<u16>, bool)>, // (segment, index, input, isWordLike)
+        segments: Vec<(Vec<u16>, usize, bool)>, // (segment, index, isWordLike)
+        input: Rc<Vec<u16>>,
         position: usize,
         done: bool,
     },


### PR DESCRIPTION
### Motivation
- The Intl.Segmenter iterator was duplicating the entire UTF-16 input per segment, producing O(n^2) memory growth for long inputs and enabling memory-exhaustion DoS. 
- The goal is to remove per-segment input cloning while preserving Segmenter API behavior and result objects. 

### Description
- Removed the per-segment `input: Vec<u16>` field from `SegmentInfo` and stopped cloning `input` in `compute_segments`, so each segment now only holds its slice and metadata. 
- Changed `IteratorState::SegmentIterator` to store a single shared `Rc<Vec<u16>>` `input` buffer and reduced per-segment tuples to `(Vec<u16>, usize, bool)`. 
- Updated the `[Symbol.iterator]` constructor and the iterator `next()` implementation to reference the shared `input` buffer when creating segment result objects without retaining a full copy per segment. 

### Testing
- Ran code formatting with `cargo fmt -- src/interpreter/builtins/intl/segmenter.rs src/interpreter/types.rs`, which completed successfully. 
- Ran `cargo check` and observed compilation progress through dependencies and crates, but the environment exhibited file-locking/streaming behavior that prevented a deterministic final status from being captured. 
- Attempted `cargo test` (and `cargo test -q`), but the test/run invocation did not produce a reliable completion in this environment due to long-running compiler tasks; no automated test failures were observed in the visible output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b33a11c8108332a402bc8b6392202a)