### PR TITLE
Bound proxy ownKeys trap result length

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -14074,9 +14074,19 @@ impl Interpreter {
         trap_result: &JsValue,
         target_val: &JsValue,
     ) -> Result<(), JsValue> {
+        const MAX_PROXY_OWNKEYS_RESULT_LEN: usize = 1_000_000;
+
         let trap_keys: Vec<String> = if let JsValue::Object(arr) = trap_result {
             let len = match self.get_property_on_id(arr.id, "length") {
-                JsValue::Number(n) => n as usize,
+                JsValue::Number(n) if n.is_finite() && n > 0.0 => {
+                    let len = n.floor() as usize;
+                    if len > MAX_PROXY_OWNKEYS_RESULT_LEN {
+                        return Err(self.create_type_error(
+                            "'ownKeys' on proxy: trap result length exceeds supported limit",
+                        ));
+                    }
+                    len
+                }
                 _ => 0,
             };
             let arr_id = arr.id;
@@ -15368,6 +15378,8 @@ impl Interpreter {
     /// Proxy-aware [[OwnPropertyKeys]] - checks proxy `ownKeys` trap, recurses on target if no trap.
     /// Returns all own property keys (for getOwnPropertyNames).
     pub(crate) fn proxy_own_keys(&mut self, obj_id: u64) -> Result<Vec<JsValue>, JsValue> {
+        const MAX_PROXY_OWNKEYS_RESULT_LEN: usize = 1_000_000;
+
         if self.get_proxy_info(obj_id).is_some() {
             let target_val = self.get_proxy_target_val(obj_id);
             match self.invoke_proxy_trap(obj_id, "ownKeys", vec![target_val.clone()]) {
@@ -15386,7 +15398,16 @@ impl Interpreter {
                             _ => JsValue::Undefined,
                         };
                         let len = match len_val {
-                            JsValue::Number(n) => n as usize,
+                            JsValue::Number(n) if n.is_finite() && n > 0.0 => {
+                                let len = n.floor() as usize;
+                                if len > MAX_PROXY_OWNKEYS_RESULT_LEN {
+                                    return Err(self.create_type_error(
+                                        "'ownKeys' on proxy: trap result length exceeds supported limit",
+                                    ));
+                                }
+                                len
+                            }
+                            JsValue::Number(_) => 0,
                             _ => {
                                 return Err(self.create_type_error(
                                     "ownKeys trap result length is not a number",

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -309,8 +309,17 @@ pub(crate) fn enumerable_own_keys(
                     interp.validate_ownkeys_invariant(&v, &target_val)?;
                     let mut keys = Vec::new();
                     if let JsValue::Object(arr) = &v {
+                        const MAX_PROXY_OWNKEYS_RESULT_LEN: usize = 1_000_000;
                         let len = match interp.get_property_on_id(arr.id, "length") {
-                            JsValue::Number(n) => n as usize,
+                            JsValue::Number(n) if n.is_finite() && n > 0.0 => {
+                                let len = n.floor() as usize;
+                                if len > MAX_PROXY_OWNKEYS_RESULT_LEN {
+                                    return Err(interp.create_type_error(
+                                        "'ownKeys' on proxy: trap result length exceeds supported limit",
+                                    ));
+                                }
+                                len
+                            }
                             _ => 0,
                         };
                         for i in 0..len {


### PR DESCRIPTION
### Motivation
- The proxy `ownKeys` invariant code trusted the trap result's `length` and directly allocated/iterated `0..length`, allowing a malicious proxy to request huge allocations and trigger OOM/DoS.
- The change aims to mitigate the availability risk by bounding work done for attacker-controlled `ownKeys` results while preserving normal behavior for reasonable key counts.

### Description
- Add a hard upper bound `MAX_PROXY_OWNKEYS_RESULT_LEN = 1_000_000` and apply it before converting the trap `length` into a `usize` to prevent unbounded allocations.
- Validate `length` with `is_finite()` and `n > 0.0` and use `n.floor() as usize` when converting to `usize` to follow `ToLength`-style semantics.
- Enforce the bound in three places: `validate_ownkeys_invariant`, `proxy_own_keys` (the main `[[OwnPropertyKeys]]` proxy path), and `enumerable_own_keys` in `helpers.rs` so all proxy-driven enumeration paths are protected.
- Return a `TypeError` when the trap `length` exceeds the supported limit or is not a valid numeric length, preserving existing error responses for invalid results.

### Testing
- Ran `cargo fmt -- src/interpreter/eval.rs src/interpreter/helpers.rs` which completed successfully.
- Ran `timeout 180 cargo check -q`, which completed successfully and emitted existing `dead_code` warnings; no new compile errors were introduced.
- No new unit tests were added; changes are minimal and focused on input validation to mitigate the reported DoS vector.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b34bc5ef348332872198020ec0d035)