### PR TITLE
[perf] Intern JsObjectData.proxy_target / proxy_handler to _id: u64 (#66, PR 1b.3)

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -5,8 +5,8 @@ fn is_array_check(interp: &mut Interpreter, obj_id: u64) -> Result<bool, JsValue
     if let Some(obj) = interp.get_object(obj_id) {
         let (is_revoked, is_proxy, target_id, class) = {
             let b = obj.borrow();
-            let tid = b.proxy_target.as_ref().and_then(|t| t.borrow().id);
-            // is_proxy() checks proxy_target.is_some(), but revoked proxies have proxy_target=None
+            let tid = b.proxy_target_id;
+            // is_proxy() checks proxy_target_id.is_some(), but revoked proxies have proxy_target_id=None
             // Use proxy_revoked flag to also detect revoked proxies
             (
                 b.proxy_revoked,

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -8468,12 +8468,10 @@ impl Interpreter {
                     if callable.is_some() {
                         proxy_obj.borrow_mut().callable = callable;
                     }
-                    proxy_obj.borrow_mut().proxy_target = Some(target_rc);
+                    proxy_obj.borrow_mut().proxy_target_id = Some(t.id);
                 }
-                if let JsValue::Object(ref h) = handler
-                    && let Some(handler_rc) = interp.get_object(h.id)
-                {
-                    proxy_obj.borrow_mut().proxy_handler = Some(handler_rc);
+                if let JsValue::Object(ref h) = handler {
+                    proxy_obj.borrow_mut().proxy_handler_id = Some(h.id);
                 }
                 let proxy_id = proxy_obj.borrow().id.unwrap();
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: proxy_id }))
@@ -8521,12 +8519,10 @@ impl Interpreter {
                         if callable.is_some() {
                             proxy_obj.borrow_mut().callable = callable;
                         }
-                        proxy_obj.borrow_mut().proxy_target = Some(target_rc);
+                        proxy_obj.borrow_mut().proxy_target_id = Some(t.id);
                     }
-                    if let JsValue::Object(ref h) = handler
-                        && let Some(handler_rc) = interp.get_object(h.id)
-                    {
-                        proxy_obj.borrow_mut().proxy_handler = Some(handler_rc);
+                    if let JsValue::Object(ref h) = handler {
+                        proxy_obj.borrow_mut().proxy_handler_id = Some(h.id);
                     }
                     let proxy_id = proxy_obj.borrow().id.unwrap();
                     let proxy_val = JsValue::Object(crate::types::JsObject { id: proxy_id });
@@ -8539,8 +8535,8 @@ impl Interpreter {
                             if let Some(p) = interp2.get_object(proxy_id) {
                                 let mut pm = p.borrow_mut();
                                 pm.proxy_revoked = true;
-                                pm.proxy_target = None;
-                                pm.proxy_handler = None;
+                                pm.proxy_target_id = None;
+                                pm.proxy_handler_id = None;
                             }
                             Completion::Normal(JsValue::Undefined)
                         },

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -13959,8 +13959,8 @@ impl Interpreter {
         if let Some(obj) = self.get_object(obj_id) {
             let b = obj.borrow();
             if b.is_proxy() || b.proxy_revoked {
-                let target_id = b.proxy_target.as_ref().and_then(|t| t.borrow().id);
-                let handler_id = b.proxy_handler.as_ref().and_then(|h| h.borrow().id);
+                let target_id = b.proxy_target_id;
+                let handler_id = b.proxy_handler_id;
                 return Some((b.proxy_revoked, target_id, handler_id));
             }
         }
@@ -14010,13 +14010,10 @@ impl Interpreter {
     }
 
     pub(crate) fn get_proxy_target_val(&self, proxy_id: u64) -> JsValue {
-        if let Some(obj) = self.get_object(proxy_id) {
-            let b = obj.borrow();
-            if let Some(ref target) = b.proxy_target
-                && let Some(tid) = target.borrow().id
-            {
-                return JsValue::Object(crate::types::JsObject { id: tid });
-            }
+        if let Some(obj) = self.get_object(proxy_id)
+            && let Some(tid) = obj.borrow().proxy_target_id
+        {
+            return JsValue::Object(crate::types::JsObject { id: tid });
         }
         JsValue::Undefined
     }

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -261,7 +261,7 @@ impl Interpreter {
         // Single-borrow fast path: classify object and check own property in one borrow
         if let Some(obj) = self.get_object(obj_id) {
             let b = obj.borrow();
-            let is_proxy = b.proxy_target.is_some() || b.proxy_revoked;
+            let is_proxy = b.proxy_target_id.is_some() || b.proxy_revoked;
             let has_module_ns = b.module_namespace.is_some();
 
             if !is_proxy && !has_module_ns {

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -364,14 +364,10 @@ impl Interpreter {
                 Self::collect_value_roots(val, worklist);
             }
         }
-        if let Some(ref target) = obj.proxy_target
-            && let Some(tid) = target.borrow().id
-        {
+        if let Some(tid) = obj.proxy_target_id {
             worklist.push(tid);
         }
-        if let Some(ref handler) = obj.proxy_handler
-            && let Some(hid) = handler.borrow().id
-        {
+        if let Some(hid) = obj.proxy_handler_id {
             worklist.push(hid);
         }
         if let Some(ref pd) = obj.promise_data {

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -251,7 +251,7 @@ pub(crate) fn is_array_value(interp: &mut Interpreter, obj_id: u64) -> Result<bo
         let (is_revoked, is_proxy, target_id, class) = {
             let b = obj.borrow();
             let tid = if b.is_proxy() {
-                b.proxy_target.as_ref().and_then(|t| t.borrow().id)
+                b.proxy_target_id
             } else {
                 None
             };

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -757,8 +757,7 @@ impl Interpreter {
                 drop(obj_ref);
                 return Err(self.create_type_error("Cannot perform operation on a revoked proxy"));
             }
-            if let Some(ref target) = obj_ref.proxy_target {
-                let target_id = target.borrow().id.unwrap();
+            if let Some(target_id) = obj_ref.proxy_target_id {
                 drop(obj_ref);
                 return self.get_function_realm(&JsValue::Object(crate::types::JsObject {
                     id: target_id,

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1668,8 +1668,8 @@ pub struct JsObjectData {
     pub parameter_map: Option<HashMap<String, (EnvRef, String)>>,
     pub map_data: Option<Vec<Option<(JsValue, JsValue)>>>,
     pub set_data: Option<Vec<Option<JsValue>>>,
-    pub proxy_target: Option<Rc<RefCell<JsObjectData>>>,
-    pub proxy_handler: Option<Rc<RefCell<JsObjectData>>>,
+    pub proxy_target_id: Option<u64>,
+    pub proxy_handler_id: Option<u64>,
     pub proxy_revoked: bool,
     pub arraybuffer_data: Option<Rc<RefCell<BufferData>>>,
     pub arraybuffer_detached: Option<Rc<Cell<bool>>>,
@@ -1741,8 +1741,8 @@ impl JsObjectData {
             parameter_map: None,
             map_data: None,
             set_data: None,
-            proxy_target: None,
-            proxy_handler: None,
+            proxy_target_id: None,
+            proxy_handler_id: None,
             proxy_revoked: false,
             arraybuffer_data: None,
             arraybuffer_detached: None,
@@ -1783,7 +1783,7 @@ impl JsObjectData {
     }
 
     pub fn is_proxy(&self) -> bool {
-        self.proxy_target.is_some()
+        self.proxy_target_id.is_some()
     }
 
     fn string_exotic_value(&self, key: &str) -> Option<JsValue> {


### PR DESCRIPTION
Closes #106. Continues object-arena groundwork from PR 1a (#103), 1b.1 (#104), 1b.2 (#109).

## Summary

- `JsObjectData.proxy_target` → `proxy_target_id: Option<u64>`
- `JsObjectData.proxy_handler` → `proxy_handler_id: Option<u64>`
- These are the last two object-typed `Rc<RefCell<JsObjectData>>` fields on `JsObjectData`. PR 2 (slab → arena) is now unblocked.

## Changes (8 files, +26 / −38)

- `types.rs` — fields, defaults, `is_proxy()` body.
- `gc.rs` — trace pushes the `Option<u64>` directly (no `borrow().id` chase).
- `eval.rs` — `get_proxy_info` and `get_proxy_target_val` simplified.
- `mod.rs` — `get_function_realm` proxy branch reads `Option<u64>` directly.
- `eval/modules.rs` — proxy-classifier read.
- `helpers.rs` — `is_array_value` proxy-aware branch.
- `builtins/array.rs` — `is_array_check` + comment.
- `builtins/mod.rs` — Proxy ctor / `Proxy.revocable` / revoke. Drop the now-unnecessary `get_object(h.id)` guard in the handler arm; keep the `get_object(t.id)` guard in the target arm because `target_rc.borrow().callable` is still read for callable proxies.

## Re-entrancy

Slab storage (`Vec<Option<Rc<RefCell<JsObjectData>>>>`) and all borrow lifetimes are unchanged, so the Proxy re-entrancy paths (`eval/modules.rs`, `eval.rs` receiver branches) are preserved by construction. Per the issue, `built-ins/Proxy/` would surface any accidentally shifted borrow scope — see test plan.

## Test plan

- [x] `cargo build --release` clean
- [x] `./scripts/lint.sh` (rustfmt + clippy clean)
- [x] `run-test262.py test262/test/built-ins/Proxy/` — 607 / 607
- [x] `run-test262.py test262/test/built-ins/Reflect/` — 306 / 306
- [x] `run-test262.py test262/test/built-ins/Array/isArray/` — 58 / 58
- [x] `run-custom-tests.py` — 3 / 3
- [x] `run-acorn-tests.sh` — 13 537 / 13 537
- [x] `run-test262.py -j 16` — **98 426 / 98 426 (100.00 %), 0 regressions, +64 new passes** (carry-over from PR 1b.2 baseline)