### PR TITLE
[gc] Root completion accumulators across non-loop safepoints (#118)

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -12770,8 +12770,11 @@ impl Interpreter {
         self.call_stack_envs.push(lex_env.clone());
         let mut last = Completion::Empty;
         for stmt in &program.body {
+            self.gc_root_completion(&last);
             self.gc_safepoint();
-            match self.exec_statement(stmt, &lex_env) {
+            let comp = self.exec_statement(stmt, &lex_env);
+            self.gc_unroot_completion(&last);
+            match comp {
                 Completion::Normal(v) => last = Completion::Normal(v),
                 Completion::Empty => {}
                 other => {

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -1116,8 +1116,11 @@ impl Interpreter {
         self.call_stack_envs.push(lex_env.clone());
         let mut result = Completion::Empty;
         for stmt in &program.body {
+            self.gc_root_completion(&result);
             self.gc_safepoint();
-            match self.exec_statement(stmt, &lex_env) {
+            let comp = self.exec_statement(stmt, &lex_env);
+            self.gc_unroot_completion(&result);
+            match comp {
                 Completion::Normal(v) => result = Completion::Normal(v),
                 Completion::Empty => {}
                 other => {

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -109,8 +109,10 @@ impl Interpreter {
         self.call_stack_envs.push(env.clone());
         let mut result = Completion::Empty;
         for stmt in stmts {
+            self.gc_root_completion(&result);
             self.gc_safepoint();
             let comp = self.exec_statement(stmt, env);
+            self.gc_unroot_completion(&result);
             match comp {
                 Completion::Normal(val) => result = Completion::Normal(val),
                 Completion::Empty => {} // keep previous result (UpdateEmpty semantics)
@@ -1834,135 +1836,149 @@ impl Interpreter {
             _ => return Completion::Normal(JsValue::Undefined),
         };
         let mut v = JsValue::Undefined;
-        if let JsValue::Object(ref o) = obj_val {
-            let obj_id = o.id;
-            let keys = {
-                let needs_proxy_path = self
-                    .get_object(obj_id)
-                    .map(|obj| {
-                        let b = obj.borrow();
-                        b.is_proxy() || b.module_namespace.is_some()
-                    })
-                    .unwrap_or(false);
-                if needs_proxy_path {
-                    match self.proxy_enumerable_keys_with_proto(obj_id) {
-                        Ok(k) => k,
-                        Err(e) => return Completion::Throw(e),
+        // Root the iterable wrapper across the entire for-in body. Primitive
+        // iterables (e.g. `for (k in Object("abc"))`) get a fresh String wrapper
+        // from `to_object` that is held only by this Rust local; without rooting,
+        // a GC fired by an inner safepoint inside the body would free the wrapper
+        // and leave `obj_id` dangling. The labeled block lets every early exit
+        // funnel through a single `gc_unroot_value` call.
+        self.gc_root_value(&obj_val);
+        let loop_result: Completion = 'unroot: {
+            if let JsValue::Object(ref o) = obj_val {
+                let obj_id = o.id;
+                let keys = {
+                    let needs_proxy_path = self
+                        .get_object(obj_id)
+                        .map(|obj| {
+                            let b = obj.borrow();
+                            b.is_proxy() || b.module_namespace.is_some()
+                        })
+                        .unwrap_or(false);
+                    if needs_proxy_path {
+                        match self.proxy_enumerable_keys_with_proto(obj_id) {
+                            Ok(k) => k,
+                            Err(e) => break 'unroot Completion::Throw(e),
+                        }
+                    } else if self.get_object(obj_id).is_some() {
+                        self.enumerable_keys_with_proto_on_id(obj_id)
+                    } else {
+                        break 'unroot Completion::Normal(JsValue::Undefined);
                     }
-                } else if self.get_object(obj_id).is_some() {
-                    self.enumerable_keys_with_proto_on_id(obj_id)
-                } else {
-                    return Completion::Normal(JsValue::Undefined);
-                }
-            };
-            for key in keys {
-                self.gc_root_value(&v);
-                self.gc_safepoint();
-                self.gc_unroot_value(&v);
-                // Skip keys that have been deleted during iteration (proxy-aware)
-                let still_exists = match self.proxy_has_property(obj_id, &key) {
-                    Ok(b) => b,
-                    Err(e) => return Completion::Throw(e),
                 };
-                if !still_exists {
-                    continue;
-                }
-                let key_val = JsValue::String(JsString::from_str(&key));
-                let for_env = Environment::new(Some(env.clone()));
-                match &fi.left {
-                    ForInOfLeft::Variable(decl) => {
-                        let kind = match decl.kind {
-                            VarKind::Var => BindingKind::Var,
-                            VarKind::Let => BindingKind::Let,
-                            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => {
-                                BindingKind::Const
-                            }
-                        };
-                        let bind_env = if decl.kind == VarKind::Var {
-                            env
-                        } else {
-                            &for_env
-                        };
-                        if let Some(d) = decl.declarations.first()
-                            && let Err(e) = self.bind_pattern(&d.pattern, key_val, kind, bind_env)
-                        {
-                            return Completion::Throw(e);
-                        }
+                for key in keys {
+                    self.gc_root_value(&v);
+                    self.gc_safepoint();
+                    self.gc_unroot_value(&v);
+                    // Skip keys that have been deleted during iteration (proxy-aware)
+                    let still_exists = match self.proxy_has_property(obj_id, &key) {
+                        Ok(b) => b,
+                        Err(e) => break 'unroot Completion::Throw(e),
+                    };
+                    if !still_exists {
+                        continue;
                     }
-                    ForInOfLeft::Pattern(pat) => match pat {
-                        Pattern::Identifier(name) => {
-                            if !env.borrow().has(name) && env.borrow().strict {
-                                return Completion::Throw(
-                                    self.create_reference_error(&format!("{name} is not defined")),
-                                );
-                            }
-                            let _ = env.borrow_mut().set(name, key_val);
-                        }
-                        Pattern::MemberExpression(expr) => {
-                            if let Err(e) = self.assign_to_expr(expr, key_val, env) {
-                                return Completion::Throw(e);
-                            }
-                        }
-                        _ => {
-                            if let Err(e) =
-                                self.bind_pattern(pat, key_val, BindingKind::Let, &for_env)
-                            {
-                                return Completion::Throw(e);
-                            }
-                        }
-                    },
-                    ForInOfLeft::Expression(expr) => {
-                        match expr {
-                            Expression::Identifier(_) => {
-                                if let Err(e) = self.assign_to_expr(expr, key_val, env) {
-                                    return Completion::Throw(e);
+                    let key_val = JsValue::String(JsString::from_str(&key));
+                    let for_env = Environment::new(Some(env.clone()));
+                    match &fi.left {
+                        ForInOfLeft::Variable(decl) => {
+                            let kind = match decl.kind {
+                                VarKind::Var => BindingKind::Var,
+                                VarKind::Let => BindingKind::Let,
+                                VarKind::Const | VarKind::Using | VarKind::AwaitUsing => {
+                                    BindingKind::Const
                                 }
+                            };
+                            let bind_env = if decl.kind == VarKind::Var {
+                                env
+                            } else {
+                                &for_env
+                            };
+                            if let Some(d) = decl.declarations.first()
+                                && let Err(e) =
+                                    self.bind_pattern(&d.pattern, key_val, kind, bind_env)
+                            {
+                                break 'unroot Completion::Throw(e);
                             }
-                            Expression::Member(..) => {
+                        }
+                        ForInOfLeft::Pattern(pat) => match pat {
+                            Pattern::Identifier(name) => {
+                                if !env.borrow().has(name) && env.borrow().strict {
+                                    break 'unroot Completion::Throw(self.create_reference_error(
+                                        &format!("{name} is not defined"),
+                                    ));
+                                }
+                                let _ = env.borrow_mut().set(name, key_val);
+                            }
+                            Pattern::MemberExpression(expr) => {
                                 if let Err(e) = self.assign_to_expr(expr, key_val, env) {
-                                    return Completion::Throw(e);
+                                    break 'unroot Completion::Throw(e);
                                 }
                             }
                             _ => {
-                                // Evaluate for side effects, then throw ReferenceError
-                                match self.eval_expr(expr, env) {
-                                    Completion::Normal(_) => {}
-                                    other => return other,
+                                if let Err(e) =
+                                    self.bind_pattern(pat, key_val, BindingKind::Let, &for_env)
+                                {
+                                    break 'unroot Completion::Throw(e);
                                 }
-                                return Completion::Throw(self.create_reference_error(
-                                    "Invalid left-hand side in for-in loop",
-                                ));
+                            }
+                        },
+                        ForInOfLeft::Expression(expr) => {
+                            match expr {
+                                Expression::Identifier(_) => {
+                                    if let Err(e) = self.assign_to_expr(expr, key_val, env) {
+                                        break 'unroot Completion::Throw(e);
+                                    }
+                                }
+                                Expression::Member(..) => {
+                                    if let Err(e) = self.assign_to_expr(expr, key_val, env) {
+                                        break 'unroot Completion::Throw(e);
+                                    }
+                                }
+                                _ => {
+                                    // Evaluate for side effects, then throw ReferenceError
+                                    match self.eval_expr(expr, env) {
+                                        Completion::Normal(_) => {}
+                                        other => break 'unroot other,
+                                    }
+                                    break 'unroot Completion::Throw(self.create_reference_error(
+                                        "Invalid left-hand side in for-in loop",
+                                    ));
+                                }
                             }
                         }
                     }
-                }
-                let result = self.exec_statement(&fi.body, &for_env);
-                match result {
-                    Completion::Normal(val) => {
-                        v = val;
-                    }
-                    Completion::Empty => {}
-                    Completion::Continue(None, cont_val) => {
-                        if let Some(val) = cont_val {
+                    let result = self.exec_statement(&fi.body, &for_env);
+                    match result {
+                        Completion::Normal(val) => {
                             v = val;
                         }
-                    }
-                    Completion::Continue(Some(ref l), cont_val) if label == Some(l.as_str()) => {
-                        if let Some(val) = cont_val {
-                            v = val;
+                        Completion::Empty => {}
+                        Completion::Continue(None, cont_val) => {
+                            if let Some(val) = cont_val {
+                                v = val;
+                            }
                         }
-                    }
-                    Completion::Break(None, break_val) => {
-                        if let Some(val) = break_val {
-                            v = val;
+                        Completion::Continue(Some(ref l), cont_val)
+                            if label == Some(l.as_str()) =>
+                        {
+                            if let Some(val) = cont_val {
+                                v = val;
+                            }
                         }
-                        return Completion::Normal(v);
+                        Completion::Break(None, break_val) => {
+                            if let Some(val) = break_val {
+                                v = val;
+                            }
+                            break 'unroot Completion::Normal(v);
+                        }
+                        other => break 'unroot other,
                     }
-                    other => return other,
                 }
             }
-        }
-        Completion::Normal(v)
+            Completion::Normal(v)
+        };
+        self.gc_unroot_value(&obj_val);
+        loop_result
     }
 
     fn collect_for_decl_bound_names(left: &ForInOfLeft) -> Vec<String> {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -732,6 +732,18 @@ impl Interpreter {
         }
     }
 
+    pub(crate) fn gc_root_completion(&mut self, c: &Completion) {
+        if let Completion::Normal(v) = c {
+            self.gc_root_value(v);
+        }
+    }
+
+    pub(crate) fn gc_unroot_completion(&mut self, c: &Completion) {
+        if let Completion::Normal(v) = c {
+            self.gc_unroot_value(v);
+        }
+    }
+
     pub(crate) fn can_be_held_weakly(&self, val: &JsValue) -> bool {
         match val {
             JsValue::Object(_) => true,

--- a/test262-extra/GC-loop-completion-rooting.js
+++ b/test262-extra/GC-loop-completion-rooting.js
@@ -1,0 +1,57 @@
+// Tests GC rooting across non-loop safepoints.
+// Issue: https://github.com/pmatos/jsse/issues/118 (follow-up to PR #112).
+// Without rooting, GC pressure mid-iteration frees a heap value held only by a
+// Rust local (the iterable wrapper or the running completion accumulator).
+
+// --- Case 1: exec_for_in obj_val rooting ---
+// Object("ABCDE") creates a primitive String wrapper held only by exec_for_in's
+// `obj_val` Rust local. Allocations inside the body trip the adaptive
+// `gc_threshold_bytes`, and inner safepoints (e.g. the inner loop's backedge)
+// fire GC. Without rooting `obj_val`, the wrapper is freed and the bare
+// `obj_id` used by `proxy_has_property` either dangles or hits a reused slot.
+{
+  let count = 0;
+  for (var k in Object("ABCDE")) {
+    for (let i = 0; i < 2000; i++) ({});
+    count++;
+  }
+  if (count !== 5) {
+    throw new Test262Error(
+      "for-in over Object(\"ABCDE\") should yield 5 keys, got " + count
+    );
+  }
+}
+
+// --- Case 2: exec_statements completion accumulator ---
+// The eval program is a labeled block whose 3 inner statements run under
+// exec_statements:
+//   stmt 1: expression statement -> Completion::Normal({tag:"live"}) sets `result`.
+//   stmt 2: VariableStatement -> Completion::Empty (preserves `result`); its IIFE
+//           initializer runs ~30k allocations to trip gc_threshold_bytes, and
+//           inner safepoints fire GC while `result` is held only by the outer
+//           Rust local.
+//   stmt 3: `break outer` -> Completion::Break(Some("outer"), None);
+//           exec_statements captures `Some(result.value_or(Undefined))` into the
+//           Break value.
+// The Statement::Labeled handler unwraps that Break to
+// Completion::Normal({tag:"live"}). eval returns it.
+const sentinel = eval(`
+  outer: {
+    ({tag: "live", magic: 305419896});
+    var trigger = (function () {
+      for (let i = 0; i < 30000; i++) ({});
+      return 0;
+    })();
+    break outer;
+  }
+`);
+if (typeof sentinel !== "object" || sentinel === null) {
+  throw new Test262Error(
+    "eval completion lost identity (expected object, got " + typeof sentinel + ")"
+  );
+}
+if (sentinel.tag !== "live" || sentinel.magic !== 305419896) {
+  throw new Test262Error(
+    "eval completion corrupted: " + JSON.stringify(sentinel)
+  );
+}


### PR DESCRIPTION
## Summary
Follow-up to PR #112. Applies the same `gc_root_value` / `gc_unroot_value` pattern to the three non-loop safepoint sites that hold a `Completion` in a Rust local across `gc_safepoint()`, and roots the iterable wrapper in `exec_for_in` across the entire body so primitive iterables (e.g. `for (k in Object("abc"))`) cannot be freed mid-iteration. Adds a regression test that forces GC pressure mid-iteration while a heap-object completion value is live.

Closes #118.

### Sites bracketed
- `src/interpreter/exec.rs` — `exec_statements` (block / function body / program / switch case)
- `src/interpreter/eval.rs` — `perform_eval` (indirect/direct eval body driver)
- `src/interpreter/eval/modules.rs` — `perform_realm_eval` (ShadowRealm evaluate body, the issue calls this `run_module`)
- `src/interpreter/exec.rs` — `exec_for_in` `obj_val` rooting (pre-existing gap)

### Why broader rooting than PR #112 here
PR #112 wraps only the loop-backedge `gc_safepoint()` because the loop accumulator `v` is *overwritten* by the body (`v = val`) before the next read, so any inner-GC during body execution that frees `v`'s old content is harmless. The non-loop sites do **not** have that property — `result.value_or(...)` is read mid-iteration on Break / Continue (`exec.rs:118-130`), and `exec_statement(stmt)` itself can trigger inner GC via its own internal safepoints (e.g. an IIFE with an allocation-heavy body). The rooting therefore extends through the iteration body, not just the safepoint.

### `exec_for_in` single-exit refactor
`obj_val` is invariant across the loop, but the body has many early-return paths (proxy `enumerable_keys` error, missing-object short-circuit, binding errors, body abrupt completions, throw paths from `proxy_has_property` / `assign_to_expr`). Per-`return` unroot is fragile, so the body is restructured around a `'unroot: { ... }` labeled block — every prior `return Completion::X(..)` becomes `break 'unroot Completion::X(..)`, and the unroot runs once after the labeled block on every path. Compare `exec_for_of:2053`, which roots the iterator once before delegating.

### New helpers
`gc_root_completion(&Completion)` / `gc_unroot_completion(&Completion)` (in `src/interpreter/mod.rs`) wrap the existing value helpers and no-op on non-`Normal` completions, removing match-on-Completion boilerplate at each call site.

## Test plan
- [x] `cargo build --release` — succeeds.
- [x] `./scripts/lint.sh` — rustfmt + clippy pass.
- [x] `./target/release/jsse test262-extra/GC-loop-completion-rooting.js` — exits 0; ran 5 times for stability, all pass.
- [x] `uv run python scripts/run-test262.py -j 100` — 98,426 / 98,426 (100.00%), 0 regressions, 64 new passes.