### PR TITLE
Optimize string concatenation

### DIFF
--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -98,9 +98,7 @@ fn create_segment_object(
     obj.borrow_mut().insert_property(
         "segment".to_string(),
         PropertyDescriptor::data(
-            JsValue::String(JsString {
-                code_units: segment.to_vec(),
-            }),
+            JsValue::String(JsString::from_vec(segment.to_vec())),
             true,
             true,
             true,
@@ -113,9 +111,7 @@ fn create_segment_object(
     obj.borrow_mut().insert_property(
         "input".to_string(),
         PropertyDescriptor::data(
-            JsValue::String(JsString {
-                code_units: input.to_vec(),
-            }),
+            JsValue::String(JsString::from_vec(input.to_vec())),
             true,
             true,
             true,
@@ -389,7 +385,7 @@ impl Interpreter {
                         iter_obj.borrow_mut().iterator_state =
                             Some(IteratorState::SegmentIterator {
                                 segments: seg_data,
-                                input: std::rc::Rc::new(input_clone.clone()),
+                                input: std::rc::Rc::new(input_clone.as_ref().clone()),
                                 position: 0,
                                 done: false,
                             });

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -1231,9 +1231,7 @@ impl Interpreter {
                                 position: position + advance,
                                 done: false,
                             });
-                            let result_js_str = JsString {
-                                code_units: result_units,
-                            };
+                            let result_js_str = JsString::from_vec(result_units);
                             Completion::Normal(
                                 interp.create_iter_result_object(
                                     JsValue::String(result_js_str),

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -1820,13 +1820,11 @@ impl Interpreter {
             JsFunction::native("decodeURI".to_string(), 1, |interp, _this, args| {
                 let val = args.first().cloned().unwrap_or(JsValue::Undefined);
                 let code_units = match interp.to_js_string(&val) {
-                    Ok(s) => s.code_units,
+                    Ok(s) => s.code_units.to_vec(),
                     Err(e) => return Completion::Throw(e),
                 };
                 match decode_uri_string(&code_units, true) {
-                    Ok(decoded) => Completion::Normal(JsValue::String(JsString {
-                        code_units: decoded,
-                    })),
+                    Ok(decoded) => Completion::Normal(JsValue::String(JsString::from_vec(decoded))),
                     Err(msg) => Completion::Throw(interp.create_error("URIError", &msg)),
                 }
             }),
@@ -1841,13 +1839,13 @@ impl Interpreter {
                 |interp, _this, args| {
                     let val = args.first().cloned().unwrap_or(JsValue::Undefined);
                     let code_units = match interp.to_js_string(&val) {
-                        Ok(s) => s.code_units,
+                        Ok(s) => s.code_units.to_vec(),
                         Err(e) => return Completion::Throw(e),
                     };
                     match decode_uri_string(&code_units, false) {
-                        Ok(decoded) => Completion::Normal(JsValue::String(JsString {
-                            code_units: decoded,
-                        })),
+                        Ok(decoded) => {
+                            Completion::Normal(JsValue::String(JsString::from_vec(decoded)))
+                        }
                         Err(msg) => Completion::Throw(interp.create_error("URIError", &msg)),
                     }
                 },
@@ -1937,7 +1935,7 @@ impl Interpreter {
                     }
                     i += 1;
                 }
-                Completion::Normal(JsValue::String(JsString { code_units: result }))
+                Completion::Normal(JsValue::String(JsString::from_vec(result)))
             }),
         );
 
@@ -3739,7 +3737,7 @@ impl Interpreter {
                             };
                             code_units.push(cu);
                         }
-                        Completion::Normal(JsValue::String(JsString { code_units }))
+                        Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
                     },
                 ));
                 let from_code_point = self.create_function(JsFunction::native(
@@ -3777,7 +3775,7 @@ impl Interpreter {
                                 code_units.push(cp as u16);
                             }
                         }
-                        Completion::Normal(JsValue::String(JsString { code_units }))
+                        Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
                     },
                 ));
                 if let Some(obj) = self.get_object(o.id) {
@@ -8676,9 +8674,7 @@ impl Interpreter {
                             "getOwnPropertyDescriptor",
                             vec![
                                 interp.get_proxy_target_val(o.id),
-                                JsValue::String(crate::types::JsString {
-                                    code_units: "length".encode_utf16().collect(),
-                                }),
+                                JsValue::String(crate::types::JsString::from_str("length")),
                             ],
                         ) {
                             Ok(Some(v)) => !matches!(v, JsValue::Undefined),

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -195,7 +195,7 @@ pub(crate) fn regex_output_to_js_string(s: &str) -> JsString {
             code_units.extend_from_slice(encoded);
         }
     }
-    JsString { code_units }
+    JsString::from_vec(code_units)
 }
 
 /// Convert UTF-16 code units that may contain PUA-encoded surrogates back to
@@ -398,12 +398,12 @@ fn to_regex_input_with_units(
     match val {
         JsValue::String(s) => Ok((
             js_string_to_regex_input(&s.code_units),
-            s.code_units.clone(),
+            s.code_units.to_vec(),
         )),
         _ => {
             let s = interp.to_string_value(val)?;
             let js = JsString::from_str(&s);
-            Ok((js_string_to_regex_input(&js.code_units), js.code_units))
+            Ok((js_string_to_regex_input(&js.code_units), js.into_vec()))
         }
     }
 }
@@ -474,7 +474,7 @@ fn escape_regexp_pattern_code_units(code_units: &[u16]) -> JsString {
             }
         }
     }
-    JsString { code_units: result }
+    JsString::from_vec(result)
 }
 
 // ECMAScript binary Unicode properties (with aliases) — §Table 67
@@ -6368,9 +6368,7 @@ fn regexp_exec_abstract(
         let result = interp.call_function(
             &exec_val,
             &rx_val,
-            &[JsValue::String(JsString {
-                code_units: code_units.to_vec(),
-            })],
+            &[JsValue::String(JsString::from_vec(code_units.to_vec()))],
         );
         match result {
             Completion::Normal(ref v) => {
@@ -9198,9 +9196,7 @@ impl Interpreter {
                     }
                     is_first = false;
                 }
-                Completion::Normal(JsValue::String(JsString {
-                    code_units: result_units,
-                }))
+                Completion::Normal(JsValue::String(JsString::from_vec(result_units)))
             },
         ));
 

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -163,9 +163,9 @@ impl Interpreter {
                     if idx < 0 || idx as usize >= units.len() {
                         return Completion::Normal(JsValue::String(JsString::from_str("")));
                     }
-                    Completion::Normal(JsValue::String(JsString {
-                        code_units: vec![units[idx as usize]],
-                    }))
+                    Completion::Normal(JsValue::String(JsString::from_vec(vec![
+                        units[idx as usize],
+                    ])))
                 }),
             ),
             (
@@ -480,9 +480,9 @@ impl Interpreter {
                     if from >= to {
                         return Completion::Normal(JsValue::String(JsString::from_str("")));
                     }
-                    Completion::Normal(JsValue::String(JsString {
-                        code_units: units[from..to].to_vec(),
-                    }))
+                    Completion::Normal(JsValue::String(JsString::from_vec(
+                        units[from..to].to_vec(),
+                    )))
                 }),
             ),
             (
@@ -684,7 +684,7 @@ impl Interpreter {
                     let pad: Vec<u16> = fill_units.iter().copied().cycle().take(fill_len).collect();
                     let mut result = pad;
                     result.extend_from_slice(&s_units);
-                    Completion::Normal(JsValue::String(JsString { code_units: result }))
+                    Completion::Normal(JsValue::String(JsString::from_vec(result)))
                 }),
             ),
             (
@@ -720,7 +720,7 @@ impl Interpreter {
                     let pad: Vec<u16> = fill_units.iter().copied().cycle().take(fill_len).collect();
                     let mut result = s_units;
                     result.extend_from_slice(&pad);
-                    Completion::Normal(JsValue::String(JsString { code_units: result }))
+                    Completion::Normal(JsValue::String(JsString::from_vec(result)))
                 }),
             ),
             (
@@ -1138,9 +1138,9 @@ impl Interpreter {
                     if actual < 0 || actual >= len {
                         return Completion::Normal(JsValue::Undefined);
                     }
-                    Completion::Normal(JsValue::String(JsString {
-                        code_units: vec![units[actual as usize]],
-                    }))
+                    Completion::Normal(JsValue::String(JsString::from_vec(vec![
+                        units[actual as usize],
+                    ])))
                 }),
             ),
             (
@@ -1469,7 +1469,7 @@ impl Interpreter {
                             i += 1;
                         }
                     }
-                    Completion::Normal(JsValue::String(JsString { code_units: result }))
+                    Completion::Normal(JsValue::String(JsString::from_vec(result)))
                 }),
             ),
         ];
@@ -1644,9 +1644,9 @@ impl Interpreter {
                         _ => units.len(),
                     };
                     let end = (start + result_len).min(units.len());
-                    Completion::Normal(JsValue::String(JsString {
-                        code_units: units[start..end].to_vec(),
-                    }))
+                    Completion::Normal(JsValue::String(JsString::from_vec(
+                        units[start..end].to_vec(),
+                    )))
                 }),
                 false,
             ));

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -365,6 +365,28 @@ impl Interpreter {
                 if *op == BinaryOp::Instanceof {
                     return self.eval_instanceof(&lval, &rval);
                 }
+                // Fast path for string + on owned primitive values:
+                // skip eval_binary → to_primitive → js_value_to_code_units clone chain.
+                if *op == BinaryOp::Add
+                    && !matches!(&lval, JsValue::Object(_))
+                    && !matches!(&rval, JsValue::Object(_))
+                    && (matches!(&lval, JsValue::String(_)) || matches!(&rval, JsValue::String(_)))
+                {
+                    if matches!(&lval, JsValue::Symbol(_)) || matches!(&rval, JsValue::Symbol(_)) {
+                        return Completion::Throw(
+                            self.create_type_error("Cannot convert a Symbol value to a string"),
+                        );
+                    }
+                    let mut code_units = match lval {
+                        JsValue::String(s) => s.into_vec(),
+                        ref other => js_value_to_code_units(other),
+                    };
+                    match rval {
+                        JsValue::String(s) => code_units.extend_from_slice(&s.code_units),
+                        ref other => code_units.extend(js_value_to_code_units(other)),
+                    };
+                    return Completion::Normal(JsValue::String(JsString::from_vec(code_units)));
+                }
                 self.eval_binary(*op, &lval, &rval)
             }
             Expression::Logical(op, left, right) => self.eval_logical(*op, left, right, env),
@@ -1176,7 +1198,7 @@ impl Interpreter {
                         code_units.extend(str_val.encode_utf16());
                     }
                 }
-                Completion::Normal(JsValue::String(JsString { code_units }))
+                Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
             }
             Expression::OptionalChain(base, prop) => {
                 let (base_val, base_this) = match self.eval_oc_base(base, prop, env) {
@@ -1264,9 +1286,9 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(s.len() as f64))
                 } else if let Ok(idx) = name.parse::<usize>() {
                     if idx < s.code_units.len() {
-                        Completion::Normal(JsValue::String(JsString {
-                            code_units: vec![s.code_units[idx]],
-                        }))
+                        Completion::Normal(JsValue::String(JsString::from_vec(vec![
+                            s.code_units[idx],
+                        ])))
                     } else {
                         Completion::Normal(JsValue::Undefined)
                     }
@@ -1955,9 +1977,15 @@ impl Interpreter {
                     );
                 }
                 if is_string(&lprim) || is_string(&rprim) {
-                    let mut code_units = js_value_to_code_units(&lprim);
-                    code_units.extend(js_value_to_code_units(&rprim));
-                    Completion::Normal(JsValue::String(JsString { code_units }))
+                    let mut code_units = match lprim {
+                        JsValue::String(s) => s.into_vec(),
+                        ref other => js_value_to_code_units(other),
+                    };
+                    match rprim {
+                        JsValue::String(s) => code_units.extend_from_slice(&s.code_units),
+                        ref other => code_units.extend(js_value_to_code_units(other)),
+                    };
+                    Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
                 } else if let (JsValue::BigInt(a), JsValue::BigInt(b)) = (&lprim, &rprim) {
                     Completion::Normal(JsValue::BigInt(JsBigInt {
                         value: bigint_ops::add(&a.value, &b.value),
@@ -2808,7 +2836,7 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        let final_val = match self.apply_compound_assign(op, &lval, &rval) {
+                        let final_val = match self.apply_compound_assign(op, lval, rval) {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
@@ -2858,7 +2886,7 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                let final_val = match self.apply_compound_assign(op, &lval, &rval) {
+                let final_val = match self.apply_compound_assign(op, lval, rval) {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
@@ -2933,7 +2961,7 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        let final_val = match self.apply_compound_assign(op, &lval, &rval) {
+                        let final_val = match self.apply_compound_assign(op, lval, rval) {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
@@ -2966,7 +2994,7 @@ impl Interpreter {
                                             } else {
                                                 JsValue::Undefined
                                             };
-                                            match self.apply_compound_assign(op, &lval, &rval) {
+                                            match self.apply_compound_assign(op, lval, rval) {
                                                 Completion::Normal(v) => v,
                                                 other => return other,
                                             }
@@ -2994,7 +3022,7 @@ impl Interpreter {
                                                 } else {
                                                     JsValue::Undefined
                                                 };
-                                                match self.apply_compound_assign(op, &lval, &rval) {
+                                                match self.apply_compound_assign(op, lval, rval) {
                                                     Completion::Normal(v) => v,
                                                     other => return other,
                                                 }
@@ -3124,7 +3152,7 @@ impl Interpreter {
                     let final_val = if op == AssignOp::Assign {
                         rval
                     } else {
-                        match self.apply_compound_assign(op, &lval_for_compound.unwrap(), &rval) {
+                        match self.apply_compound_assign(op, lval_for_compound.unwrap(), rval) {
                             Completion::Normal(v) => v,
                             other => return other,
                         }
@@ -3341,7 +3369,7 @@ impl Interpreter {
                 let final_val = if op == AssignOp::Assign {
                     rval
                 } else {
-                    match self.apply_compound_assign(op, &lval_for_compound.unwrap(), &rval) {
+                    match self.apply_compound_assign(op, lval_for_compound.unwrap(), rval) {
                         Completion::Normal(v) => v,
                         other => return other,
                     }
@@ -3919,26 +3947,44 @@ impl Interpreter {
         }
     }
 
-    fn apply_compound_assign(
-        &mut self,
-        op: AssignOp,
-        lval: &JsValue,
-        rval: &JsValue,
-    ) -> Completion {
+    fn apply_compound_assign(&mut self, op: AssignOp, lval: JsValue, rval: JsValue) -> Completion {
         match op {
-            AssignOp::AddAssign => self.eval_binary(BinaryOp::Add, lval, rval),
-            AssignOp::SubAssign => self.eval_binary(BinaryOp::Sub, lval, rval),
-            AssignOp::MulAssign => self.eval_binary(BinaryOp::Mul, lval, rval),
-            AssignOp::DivAssign => self.eval_binary(BinaryOp::Div, lval, rval),
-            AssignOp::ModAssign => self.eval_binary(BinaryOp::Mod, lval, rval),
-            AssignOp::ExpAssign => self.eval_binary(BinaryOp::Exp, lval, rval),
-            AssignOp::LShiftAssign => self.eval_binary(BinaryOp::LShift, lval, rval),
-            AssignOp::RShiftAssign => self.eval_binary(BinaryOp::RShift, lval, rval),
-            AssignOp::URShiftAssign => self.eval_binary(BinaryOp::URShift, lval, rval),
-            AssignOp::BitAndAssign => self.eval_binary(BinaryOp::BitAnd, lval, rval),
-            AssignOp::BitOrAssign => self.eval_binary(BinaryOp::BitOr, lval, rval),
-            AssignOp::BitXorAssign => self.eval_binary(BinaryOp::BitXor, lval, rval),
-            _ => Completion::Normal(rval.clone()),
+            AssignOp::AddAssign => {
+                // Fast path: both primitives and at least one is a string — avoid
+                // to_primitive/js_value_to_code_units clones in eval_binary.
+                if !matches!(&lval, JsValue::Object(_))
+                    && !matches!(&rval, JsValue::Object(_))
+                    && (matches!(&lval, JsValue::String(_)) || matches!(&rval, JsValue::String(_)))
+                {
+                    if matches!(&lval, JsValue::Symbol(_)) || matches!(&rval, JsValue::Symbol(_)) {
+                        return Completion::Throw(
+                            self.create_type_error("Cannot convert a Symbol value to a string"),
+                        );
+                    }
+                    let mut code_units = match lval {
+                        JsValue::String(s) => s.into_vec(),
+                        ref other => js_value_to_code_units(other),
+                    };
+                    match rval {
+                        JsValue::String(s) => code_units.extend_from_slice(&s.code_units),
+                        ref other => code_units.extend(js_value_to_code_units(other)),
+                    };
+                    return Completion::Normal(JsValue::String(JsString::from_vec(code_units)));
+                }
+                self.eval_binary(BinaryOp::Add, &lval, &rval)
+            }
+            AssignOp::SubAssign => self.eval_binary(BinaryOp::Sub, &lval, &rval),
+            AssignOp::MulAssign => self.eval_binary(BinaryOp::Mul, &lval, &rval),
+            AssignOp::DivAssign => self.eval_binary(BinaryOp::Div, &lval, &rval),
+            AssignOp::ModAssign => self.eval_binary(BinaryOp::Mod, &lval, &rval),
+            AssignOp::ExpAssign => self.eval_binary(BinaryOp::Exp, &lval, &rval),
+            AssignOp::LShiftAssign => self.eval_binary(BinaryOp::LShift, &lval, &rval),
+            AssignOp::RShiftAssign => self.eval_binary(BinaryOp::RShift, &lval, &rval),
+            AssignOp::URShiftAssign => self.eval_binary(BinaryOp::URShift, &lval, &rval),
+            AssignOp::BitAndAssign => self.eval_binary(BinaryOp::BitAnd, &lval, &rval),
+            AssignOp::BitOrAssign => self.eval_binary(BinaryOp::BitOr, &lval, &rval),
+            AssignOp::BitXorAssign => self.eval_binary(BinaryOp::BitXor, &lval, &rval),
+            _ => Completion::Normal(rval),
         }
     }
 

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -696,9 +696,9 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(s.len() as f64))
                 } else if let Ok(idx) = key.parse::<usize>() {
                     if idx < s.code_units.len() {
-                        Completion::Normal(JsValue::String(JsString {
-                            code_units: vec![s.code_units[idx]],
-                        }))
+                        Completion::Normal(JsValue::String(JsString::from_vec(vec![
+                            s.code_units[idx],
+                        ])))
                     } else {
                         Completion::Normal(JsValue::Undefined)
                     }

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -13,9 +13,7 @@ impl Interpreter {
             .quasis
             .iter()
             .map(|q| match q {
-                Some(cu) => JsValue::String(JsString {
-                    code_units: cu.clone(),
-                }),
+                Some(cu) => JsValue::String(JsString::from_vec(cu.clone())),
                 None => JsValue::Undefined,
             })
             .collect();
@@ -76,7 +74,7 @@ impl Interpreter {
             Literal::String(s) => {
                 let code_units =
                     crate::interpreter::builtins::regexp::pua_code_units_to_surrogates(s);
-                JsValue::String(JsString { code_units })
+                JsValue::String(JsString::from_vec(code_units))
             }
             Literal::BigInt(s) => {
                 use num_bigint::BigInt;

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -104,7 +104,7 @@ pub(crate) fn to_js_string(val: &JsValue) -> String {
 /// Convert a JsValue to UTF-16 code units, preserving lone surrogates for strings.
 pub(crate) fn js_value_to_code_units(val: &JsValue) -> Vec<u16> {
     match val {
-        JsValue::String(s) => s.code_units.clone(),
+        JsValue::String(s) => s.code_units.to_vec(),
         _ => to_js_string(val).encode_utf16().collect(),
     }
 }

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1799,9 +1799,9 @@ impl JsObjectData {
             if let Ok(idx) = key.parse::<usize>()
                 && idx < units.len()
             {
-                return Some(JsValue::String(crate::types::JsString {
-                    code_units: vec![units[idx]],
-                }));
+                return Some(JsValue::String(crate::types::JsString::from_vec(vec![
+                    units[idx],
+                ])));
             }
         }
         None
@@ -1872,9 +1872,9 @@ impl JsObjectData {
                 && idx < units.len()
             {
                 return Some(PropertyDescriptor {
-                    value: Some(JsValue::String(crate::types::JsString {
-                        code_units: vec![units[idx]],
-                    })),
+                    value: Some(JsValue::String(crate::types::JsString::from_vec(vec![
+                        units[idx],
+                    ]))),
                     writable: Some(false),
                     enumerable: Some(true),
                     configurable: Some(false),
@@ -1966,9 +1966,7 @@ impl JsObjectData {
                 && idx < s.code_units.len()
             {
                 return Some(PropertyDescriptor::data(
-                    JsValue::String(JsString {
-                        code_units: vec![s.code_units[idx]],
-                    }),
+                    JsValue::String(JsString::from_vec(vec![s.code_units[idx]])),
                     false,
                     true,
                     false,
@@ -2034,9 +2032,8 @@ impl JsObjectData {
                 return false;
             }
             if let Some(ref v) = desc.value {
-                let char_val = JsValue::String(crate::types::JsString {
-                    code_units: vec![s.code_units[idx]],
-                });
+                let char_val =
+                    JsValue::String(crate::types::JsString::from_vec(vec![s.code_units[idx]]));
                 if !same_value(v, &char_val) {
                     return false;
                 }
@@ -2645,9 +2642,9 @@ impl JsObjectData {
                 && idx < units.len()
             {
                 return Some(PropertyDescriptor {
-                    value: Some(JsValue::String(crate::types::JsString {
-                        code_units: vec![units[idx]],
-                    })),
+                    value: Some(JsValue::String(crate::types::JsString::from_vec(vec![
+                        units[idx],
+                    ]))),
                     writable: Some(false),
                     enumerable: Some(true),
                     configurable: Some(false),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub enum JsValue {
@@ -13,15 +14,22 @@ pub enum JsValue {
 }
 
 // UTF-16 code unit string per spec §6.1.4
+// Uses Arc<Vec<u16>> so cloning (e.g. env.get) is O(1).
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct JsString {
-    pub code_units: Vec<u16>,
+    pub code_units: Arc<Vec<u16>>,
 }
 
 impl JsString {
     pub fn from_str(s: &str) -> Self {
         Self {
-            code_units: s.encode_utf16().collect(),
+            code_units: Arc::new(s.encode_utf16().collect()),
+        }
+    }
+
+    pub fn from_vec(v: Vec<u16>) -> Self {
+        Self {
+            code_units: Arc::new(v),
         }
     }
 
@@ -35,6 +43,12 @@ impl JsString {
 
     pub fn to_rust_string(&self) -> String {
         String::from_utf16_lossy(&self.code_units)
+    }
+
+    /// Get mutable access to code_units, cloning only if shared.
+    /// Take ownership of the inner Vec (clones if shared).
+    pub fn into_vec(self) -> Vec<u16> {
+        Arc::try_unwrap(self.code_units).unwrap_or_else(|arc| (*arc).clone())
     }
 }
 


### PR DESCRIPTION
Extracted from PR #44 commit de28cce and ported onto current main after the regex-cache recovery. This PR keeps only the runtime/code changes for Arc-backed JsString and fast string concat paths; it intentionally excludes the stale performance plan and test262 baseline changes from the original branch.\n\nValidation:\n- cargo fmt --check\n- CARGO_TARGET_DIR=/tmp/jsse-port-pr44-string-target cargo build --release\n- ./scripts/lint.sh\n- /tmp/jsse-port-pr44-string-target/release/jsse -e 'let a="foo"; let b="bar"; console.log(a + b); let c="x"; c += "y"; console.log(c); console.log(("ab" + 12 + true).slice(0, 8));'\n- /tmp/jsse-port-pr44-string-target/release/jsse -e 'let s = Object("abc"); console.log(s.length); console.log(s[1]); console.log(JSON.stringify(Intl.Segmenter ? Array.from(new Intl.Segmenter("en", {granularity:"word"}).segment("hello world"), x => x.segment) : []));'