### PR TITLE
Reduce function call overhead

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -552,8 +552,16 @@ fn stmt_uses_arguments(stmt: &Statement) -> bool {
                 || f.update.as_ref().is_some_and(expr_uses_arguments)
                 || stmt_uses_arguments(&f.body)
         }
-        Statement::ForIn(f) => expr_uses_arguments(&f.right) || stmt_uses_arguments(&f.body),
-        Statement::ForOf(f) => expr_uses_arguments(&f.right) || stmt_uses_arguments(&f.body),
+        Statement::ForIn(f) => {
+            for_in_of_left_uses_arguments(&f.left)
+                || expr_uses_arguments(&f.right)
+                || stmt_uses_arguments(&f.body)
+        }
+        Statement::ForOf(f) => {
+            for_in_of_left_uses_arguments(&f.left)
+                || expr_uses_arguments(&f.right)
+                || stmt_uses_arguments(&f.body)
+        }
         Statement::Return(e) => e.as_ref().is_some_and(expr_uses_arguments),
         Statement::Throw(e) => expr_uses_arguments(e),
         Statement::Try(t) => {
@@ -572,8 +580,13 @@ fn stmt_uses_arguments(stmt: &Statement) -> bool {
         }
         Statement::Labeled(_, s) => stmt_uses_arguments(s),
         Statement::With(e, s) => expr_uses_arguments(e) || stmt_uses_arguments(s),
-        // Don't recurse into nested function declarations (they have their own arguments)
-        Statement::FunctionDeclaration(_) | Statement::ClassDeclaration(_) => false,
+        // Nested function declarations have their own `arguments`; classes have
+        // their own scope for method bodies, but `extends` and computed element
+        // keys evaluate in the enclosing scope and may reference `arguments`.
+        Statement::FunctionDeclaration(_) => false,
+        Statement::ClassDeclaration(c) => {
+            class_extends_or_computed_keys_use_arguments(c.super_class.as_deref(), &c.body)
+        }
         Statement::Empty | Statement::Break(_) | Statement::Continue(_) | Statement::Debugger => {
             false
         }
@@ -589,8 +602,13 @@ fn expr_uses_arguments(expr: &Expression) -> bool {
         | Expression::ImportMeta
         | Expression::NewTarget
         | Expression::PrivateIdentifier(_) => false,
-        // Don't recurse into regular functions or classes (they have own arguments)
-        Expression::Function(_) | Expression::Class(_) => false,
+        // Regular functions have their own `arguments`. Classes have their own
+        // scope for method bodies, but `extends` and computed class element keys
+        // evaluate in the enclosing scope and may reference `arguments`.
+        Expression::Function(_) => false,
+        Expression::Class(c) => {
+            class_extends_or_computed_keys_use_arguments(c.super_class.as_deref(), &c.body)
+        }
         // DO recurse into arrow functions (they inherit arguments)
         Expression::ArrowFunction(a) => match &a.body {
             ArrowBody::Expression(e) => expr_uses_arguments(e),
@@ -659,13 +677,44 @@ fn pattern_uses_arguments(pat: &Pattern) -> bool {
             })
         }),
         Pattern::Object(props) => props.iter().any(|p| match p {
-            ObjectPatternProperty::KeyValue(_, pat) | ObjectPatternProperty::Rest(pat) => {
-                pattern_uses_arguments(pat)
+            ObjectPatternProperty::KeyValue(key, pat) => {
+                matches!(key, PropertyKey::Computed(e) if expr_uses_arguments(e))
+                    || pattern_uses_arguments(pat)
             }
+            ObjectPatternProperty::Rest(pat) => pattern_uses_arguments(pat),
             ObjectPatternProperty::Shorthand(name) => name == "arguments",
         }),
         Pattern::Assign(pat, expr) => pattern_uses_arguments(pat) || expr_uses_arguments(expr),
         Pattern::Rest(pat) => pattern_uses_arguments(pat),
         Pattern::MemberExpression(e) => expr_uses_arguments(e),
     }
+}
+
+fn for_in_of_left_uses_arguments(left: &ForInOfLeft) -> bool {
+    match left {
+        ForInOfLeft::Variable(d) => d.declarations.iter().any(|d| {
+            pattern_uses_arguments(&d.pattern) || d.init.as_ref().is_some_and(expr_uses_arguments)
+        }),
+        ForInOfLeft::Pattern(p) => pattern_uses_arguments(p),
+        ForInOfLeft::Expression(e) => expr_uses_arguments(e),
+    }
+}
+
+fn class_extends_or_computed_keys_use_arguments(
+    super_class: Option<&Expression>,
+    body: &[ClassElement],
+) -> bool {
+    if super_class.is_some_and(expr_uses_arguments) {
+        return true;
+    }
+    body.iter().any(|el| match el {
+        ClassElement::Method(m) => {
+            matches!(&m.key, PropertyKey::Computed(e) if expr_uses_arguments(e))
+        }
+        ClassElement::Property(p) | ClassElement::AutoAccessor(p) => {
+            matches!(&p.key, PropertyKey::Computed(e) if expr_uses_arguments(e))
+        }
+        // Static blocks have their own scope per spec §15.7.13 — do not recurse.
+        ClassElement::StaticBlock(_) => false,
+    })
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -509,3 +509,163 @@ pub struct TemplateLiteral {
     pub raw_quasis: Vec<String>,
     pub expressions: Vec<Expression>,
 }
+
+/// Check if a function (body + params) references the `arguments` identifier.
+/// Also checks parameter default expressions (which can reference arguments).
+pub fn func_uses_arguments(params: &[Pattern], body: &[Statement]) -> bool {
+    params_use_arguments(params) || stmts_use_arguments(body)
+}
+
+fn params_use_arguments(params: &[Pattern]) -> bool {
+    params.iter().any(pattern_uses_arguments)
+}
+
+/// Check if a function body references the `arguments` identifier.
+/// Recurses into arrow functions (they inherit arguments) but not into
+/// regular functions, generators, or class methods (they have their own).
+pub fn stmts_use_arguments(stmts: &[Statement]) -> bool {
+    stmts.iter().any(stmt_uses_arguments)
+}
+
+fn stmt_uses_arguments(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Expression(e) => expr_uses_arguments(e),
+        Statement::Block(stmts) => stmts.iter().any(stmt_uses_arguments),
+        Statement::Variable(decl) => decl.declarations.iter().any(|d| {
+            pattern_uses_arguments(&d.pattern) || d.init.as_ref().is_some_and(expr_uses_arguments)
+        }),
+        Statement::If(i) => {
+            expr_uses_arguments(&i.test)
+                || stmt_uses_arguments(&i.consequent)
+                || i.alternate.as_ref().is_some_and(|s| stmt_uses_arguments(s))
+        }
+        Statement::While(w) => expr_uses_arguments(&w.test) || stmt_uses_arguments(&w.body),
+        Statement::DoWhile(d) => stmt_uses_arguments(&d.body) || expr_uses_arguments(&d.test),
+        Statement::For(f) => {
+            f.init.as_ref().is_some_and(|i| match i {
+                ForInit::Expression(e) => expr_uses_arguments(e),
+                ForInit::Variable(d) => d.declarations.iter().any(|d| {
+                    pattern_uses_arguments(&d.pattern)
+                        || d.init.as_ref().is_some_and(expr_uses_arguments)
+                }),
+            }) || f.test.as_ref().is_some_and(expr_uses_arguments)
+                || f.update.as_ref().is_some_and(expr_uses_arguments)
+                || stmt_uses_arguments(&f.body)
+        }
+        Statement::ForIn(f) => expr_uses_arguments(&f.right) || stmt_uses_arguments(&f.body),
+        Statement::ForOf(f) => expr_uses_arguments(&f.right) || stmt_uses_arguments(&f.body),
+        Statement::Return(e) => e.as_ref().is_some_and(expr_uses_arguments),
+        Statement::Throw(e) => expr_uses_arguments(e),
+        Statement::Try(t) => {
+            stmts_use_arguments(&t.block)
+                || t.handler
+                    .as_ref()
+                    .is_some_and(|h| stmts_use_arguments(&h.body))
+                || t.finalizer.as_ref().is_some_and(|f| stmts_use_arguments(f))
+        }
+        Statement::Switch(s) => {
+            expr_uses_arguments(&s.discriminant)
+                || s.cases.iter().any(|c| {
+                    c.test.as_ref().is_some_and(expr_uses_arguments)
+                        || stmts_use_arguments(&c.consequent)
+                })
+        }
+        Statement::Labeled(_, s) => stmt_uses_arguments(s),
+        Statement::With(e, s) => expr_uses_arguments(e) || stmt_uses_arguments(s),
+        // Don't recurse into nested function declarations (they have their own arguments)
+        Statement::FunctionDeclaration(_) | Statement::ClassDeclaration(_) => false,
+        Statement::Empty | Statement::Break(_) | Statement::Continue(_) | Statement::Debugger => {
+            false
+        }
+    }
+}
+
+fn expr_uses_arguments(expr: &Expression) -> bool {
+    match expr {
+        Expression::Identifier(name) => name == "arguments",
+        Expression::Literal(_)
+        | Expression::This
+        | Expression::Super
+        | Expression::ImportMeta
+        | Expression::NewTarget
+        | Expression::PrivateIdentifier(_) => false,
+        // Don't recurse into regular functions or classes (they have own arguments)
+        Expression::Function(_) | Expression::Class(_) => false,
+        // DO recurse into arrow functions (they inherit arguments)
+        Expression::ArrowFunction(a) => match &a.body {
+            ArrowBody::Expression(e) => expr_uses_arguments(e),
+            ArrowBody::Block(stmts) => stmts_use_arguments(stmts),
+        },
+        Expression::Array(elems, _) => elems
+            .iter()
+            .any(|e| e.as_ref().is_some_and(expr_uses_arguments)),
+        Expression::Object(props) => props.iter().any(|p| {
+            expr_uses_arguments(&p.value)
+                || matches!(&p.key, PropertyKey::Computed(e) if expr_uses_arguments(e))
+        }),
+        Expression::Unary(_, e)
+        | Expression::Update(_, _, e)
+        | Expression::Spread(e)
+        | Expression::Yield(Some(e), _)
+        | Expression::Await(e)
+        | Expression::Typeof(e)
+        | Expression::Void(e)
+        | Expression::Delete(e) => expr_uses_arguments(e),
+        Expression::Yield(None, _) => false,
+        Expression::Binary(_, l, r)
+        | Expression::Logical(_, l, r)
+        | Expression::Assign(_, l, r) => expr_uses_arguments(l) || expr_uses_arguments(r),
+        Expression::Conditional(t, c, a) => {
+            expr_uses_arguments(t) || expr_uses_arguments(c) || expr_uses_arguments(a)
+        }
+        Expression::Call(callee, args) => {
+            matches!(&**callee, Expression::Identifier(name) if name == "eval")
+                || expr_uses_arguments(callee)
+                || args.iter().any(expr_uses_arguments)
+        }
+        Expression::New(callee, args) => {
+            expr_uses_arguments(callee) || args.iter().any(expr_uses_arguments)
+        }
+        Expression::Member(obj, prop) => {
+            expr_uses_arguments(obj)
+                || matches!(prop, MemberProperty::Computed(e) if expr_uses_arguments(e))
+        }
+        Expression::OptionalChain(base, chain) => {
+            expr_uses_arguments(base) || expr_uses_arguments(chain)
+        }
+        Expression::Comma(exprs) | Expression::Sequence(exprs) => {
+            exprs.iter().any(expr_uses_arguments)
+        }
+        Expression::TaggedTemplate(tag, tpl) => {
+            expr_uses_arguments(tag) || tpl.expressions.iter().any(expr_uses_arguments)
+        }
+        Expression::Template(tpl) => tpl.expressions.iter().any(expr_uses_arguments),
+        Expression::Import(spec, opts)
+        | Expression::ImportDefer(spec, opts)
+        | Expression::ImportSource(spec, opts) => {
+            expr_uses_arguments(spec) || opts.as_ref().is_some_and(|e| expr_uses_arguments(e))
+        }
+    }
+}
+
+fn pattern_uses_arguments(pat: &Pattern) -> bool {
+    match pat {
+        Pattern::Identifier(name) => name == "arguments",
+        Pattern::Array(elems) => elems.iter().any(|e| {
+            e.as_ref().is_some_and(|e| match e {
+                ArrayPatternElement::Pattern(p) | ArrayPatternElement::Rest(p) => {
+                    pattern_uses_arguments(p)
+                }
+            })
+        }),
+        Pattern::Object(props) => props.iter().any(|p| match p {
+            ObjectPatternProperty::KeyValue(_, pat) | ObjectPatternProperty::Rest(pat) => {
+                pattern_uses_arguments(pat)
+            }
+            ObjectPatternProperty::Shorthand(name) => name == "arguments",
+        }),
+        Pattern::Assign(pat, expr) => pattern_uses_arguments(pat) || expr_uses_arguments(expr),
+        Pattern::Rest(pat) => pattern_uses_arguments(pat),
+        Pattern::MemberExpression(e) => expr_uses_arguments(e),
+    }
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -566,9 +566,10 @@ fn stmt_uses_arguments(stmt: &Statement) -> bool {
         Statement::Throw(e) => expr_uses_arguments(e),
         Statement::Try(t) => {
             stmts_use_arguments(&t.block)
-                || t.handler
-                    .as_ref()
-                    .is_some_and(|h| stmts_use_arguments(&h.body))
+                || t.handler.as_ref().is_some_and(|h| {
+                    h.param.as_ref().is_some_and(pattern_uses_arguments)
+                        || stmts_use_arguments(&h.body)
+                })
                 || t.finalizer.as_ref().is_some_and(|f| stmts_use_arguments(f))
         }
         Statement::Switch(s) => {

--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -1386,6 +1386,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
+                let gc_frame = interp.gc_root_frame();
                 interp.gc_root_value(&a);
                 let mut n: usize = 0;
                 let items: Vec<JsValue> = std::iter::once(o).chain(args.iter().cloned()).collect();
@@ -1418,12 +1419,12 @@ impl Interpreter {
                         let len = match length_of_array_like(interp, item) {
                             Ok(v) => v,
                             Err(c) => {
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return c;
                             }
                         };
                         if (n as u64) + (len as u64) > 9007199254740991 {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(
                                 interp
                                     .create_type_error("Array length exceeds the allowed maximum"),
@@ -1434,7 +1435,7 @@ impl Interpreter {
                             let exists = match obj_has_throw(interp, item, &pk) {
                                 Ok(b) => b,
                                 Err(e) => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return Completion::Throw(e);
                                 }
                             };
@@ -1443,11 +1444,11 @@ impl Interpreter {
                                     match interp.get_object_property(obj_ref.id, &pk, item) {
                                         Completion::Normal(v) => v,
                                         Completion::Throw(e) => {
-                                            interp.gc_unroot_value(&a);
+                                            interp.gc_unroot_frame(gc_frame);
                                             return Completion::Throw(e);
                                         }
                                         other => {
-                                            interp.gc_unroot_value(&a);
+                                            interp.gc_unroot_frame(gc_frame);
                                             return other;
                                         }
                                     }
@@ -1455,7 +1456,7 @@ impl Interpreter {
                                     match obj_get(interp, item, &pk) {
                                         Ok(v) => v,
                                         Err(c) => {
-                                            interp.gc_unroot_value(&a);
+                                            interp.gc_unroot_frame(gc_frame);
                                             return c;
                                         }
                                     }
@@ -1463,7 +1464,7 @@ impl Interpreter {
                                 if let Err(e) =
                                     create_data_property_or_throw(interp, &a, &n.to_string(), val)
                                 {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return Completion::Throw(e);
                                 }
                             }
@@ -1471,7 +1472,7 @@ impl Interpreter {
                         }
                     } else {
                         if n as u64 >= 9007199254740991 {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(
                                 interp
                                     .create_type_error("Array length exceeds the allowed maximum"),
@@ -1480,17 +1481,17 @@ impl Interpreter {
                         if let Err(e) =
                             create_data_property_or_throw(interp, &a, &n.to_string(), item.clone())
                         {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                         n += 1;
                     }
                 }
                 if let Err(e) = obj_set_throw(interp, &a, "length", JsValue::Number(n as f64)) {
-                    interp.gc_unroot_value(&a);
+                    interp.gc_unroot_frame(gc_frame);
                     return Completion::Throw(e);
                 }
-                interp.gc_unroot_value(&a);
+                interp.gc_unroot_frame(gc_frame);
                 Completion::Normal(a)
             },
         ));
@@ -1546,6 +1547,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
+                let gc_frame = interp.gc_root_frame();
                 interp.gc_root_value(&a);
                 let mut n: usize = 0;
                 for i in k..fin {
@@ -1555,19 +1557,19 @@ impl Interpreter {
                             let val = match obj_get(interp, &o, &pk) {
                                 Ok(v) => v,
                                 Err(c) => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return c;
                                 }
                             };
                             if let Err(e) =
                                 create_data_property_or_throw(interp, &a, &n.to_string(), val)
                             {
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         }
                         Err(e) => {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                         _ => {}
@@ -1575,10 +1577,10 @@ impl Interpreter {
                     n += 1;
                 }
                 if let Err(e) = obj_set_throw(interp, &a, "length", JsValue::Number(n as f64)) {
-                    interp.gc_unroot_value(&a);
+                    interp.gc_unroot_frame(gc_frame);
                     return Completion::Throw(e);
                 }
-                interp.gc_unroot_value(&a);
+                interp.gc_unroot_frame(gc_frame);
                 Completion::Normal(a)
             },
         ));
@@ -1760,6 +1762,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
+                let gc_frame = interp.gc_root_frame();
                 interp.gc_root_value(&a);
                 for k in 0..len {
                     let pk = k.to_string();
@@ -1768,7 +1771,7 @@ impl Interpreter {
                             let kvalue = match obj_get(interp, &o, &pk) {
                                 Ok(v) => v,
                                 Err(c) => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return c;
                                 }
                             };
@@ -1781,24 +1784,24 @@ impl Interpreter {
                                     if let Err(e) =
                                         create_data_property_or_throw(interp, &a, &pk, v)
                                     {
-                                        interp.gc_unroot_value(&a);
+                                        interp.gc_unroot_frame(gc_frame);
                                         return Completion::Throw(e);
                                     }
                                 }
                                 other => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return other;
                                 }
                             }
                         }
                         Err(e) => {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                         _ => {}
                     }
                 }
-                interp.gc_unroot_value(&a);
+                interp.gc_unroot_frame(gc_frame);
                 Completion::Normal(a)
             },
         ));
@@ -1828,6 +1831,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
+                let gc_frame = interp.gc_root_frame();
                 interp.gc_root_value(&a);
                 let mut to: usize = 0;
                 for k in 0..len {
@@ -1837,7 +1841,7 @@ impl Interpreter {
                             let kvalue = match obj_get(interp, &o, &pk) {
                                 Ok(v) => v,
                                 Err(c) => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return c;
                                 }
                             };
@@ -1854,26 +1858,26 @@ impl Interpreter {
                                             &to.to_string(),
                                             kvalue,
                                         ) {
-                                            interp.gc_unroot_value(&a);
+                                            interp.gc_unroot_frame(gc_frame);
                                             return Completion::Throw(e);
                                         }
                                         to += 1;
                                     }
                                 }
                                 other => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return other;
                                 }
                             }
                         }
                         Err(e) => {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                         _ => {}
                     }
                 }
-                interp.gc_unroot_value(&a);
+                interp.gc_unroot_frame(gc_frame);
                 Completion::Normal(a)
             },
         ));
@@ -2378,6 +2382,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
+                let gc_frame = interp.gc_root_frame();
                 interp.gc_root_value(&a);
                 for i in 0..actual_delete_count {
                     let from = (actual_start + i).to_string();
@@ -2386,19 +2391,19 @@ impl Interpreter {
                             let val = match obj_get(interp, &o, &from) {
                                 Ok(v) => v,
                                 Err(c) => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return c;
                                 }
                             };
                             if let Err(e) =
                                 create_data_property_or_throw(interp, &a, &i.to_string(), val)
                             {
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         }
                         Err(e) => {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                         _ => {}
@@ -2411,7 +2416,7 @@ impl Interpreter {
                     "length",
                     JsValue::Number(actual_delete_count as f64),
                 ) {
-                    interp.gc_unroot_value(&a);
+                    interp.gc_unroot_frame(gc_frame);
                     return Completion::Throw(e);
                 }
                 let items: Vec<JsValue> = args.iter().skip(2).cloned().collect();
@@ -2422,7 +2427,7 @@ impl Interpreter {
                         let from_present = match obj_has_throw(interp, &o, &from) {
                             Ok(v) => v,
                             Err(e) => {
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
@@ -2430,16 +2435,16 @@ impl Interpreter {
                             let val = match obj_get(interp, &o, &from) {
                                 Ok(v) => v,
                                 Err(c) => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return c;
                                 }
                             };
                             if let Err(e) = obj_set_throw(interp, &o, &to, val) {
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         } else if let Err(e) = obj_delete_throw(interp, &o, &to) {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                     }
@@ -2447,7 +2452,7 @@ impl Interpreter {
                         ((len as usize - actual_delete_count + insert_count)..(len as usize)).rev()
                     {
                         if let Err(e) = obj_delete_throw(interp, &o, &k.to_string()) {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                     }
@@ -2458,7 +2463,7 @@ impl Interpreter {
                         let from_present = match obj_has_throw(interp, &o, &from) {
                             Ok(v) => v,
                             Err(e) => {
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
@@ -2466,16 +2471,16 @@ impl Interpreter {
                             let val = match obj_get(interp, &o, &from) {
                                 Ok(v) => v,
                                 Err(c) => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return c;
                                 }
                             };
                             if let Err(e) = obj_set_throw(interp, &o, &to, val) {
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         } else if let Err(e) = obj_delete_throw(interp, &o, &to) {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                     }
@@ -2483,16 +2488,16 @@ impl Interpreter {
                 for (j, item) in items.into_iter().enumerate() {
                     if let Err(e) = obj_set_throw(interp, &o, &(actual_start + j).to_string(), item)
                     {
-                        interp.gc_unroot_value(&a);
+                        interp.gc_unroot_frame(gc_frame);
                         return Completion::Throw(e);
                     }
                 }
                 let new_len = (len as usize) - actual_delete_count + insert_count;
                 if let Err(e) = set_length_throw(interp, &o, new_len) {
-                    interp.gc_unroot_value(&a);
+                    interp.gc_unroot_frame(gc_frame);
                     return Completion::Throw(e);
                 }
-                interp.gc_unroot_value(&a);
+                interp.gc_unroot_frame(gc_frame);
                 Completion::Normal(a)
             },
         ));
@@ -2890,6 +2895,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
+                let gc_frame = interp.gc_root_frame();
                 interp.gc_root_value(&a);
                 fn flatten_into(
                     interp: &mut Interpreter,
@@ -2943,10 +2949,10 @@ impl Interpreter {
                 }
                 let mut target_index = 0usize;
                 if let Err(c) = flatten_into(interp, &a, &mut target_index, &o, len, depth) {
-                    interp.gc_unroot_value(&a);
+                    interp.gc_unroot_frame(gc_frame);
                     return c;
                 }
-                interp.gc_unroot_value(&a);
+                interp.gc_unroot_frame(gc_frame);
                 Completion::Normal(a)
             },
         ));
@@ -2979,6 +2985,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
+                let gc_frame = interp.gc_root_frame();
                 interp.gc_root_value(&a);
                 let mut target_index = 0usize;
                 for k in 0..len {
@@ -2988,7 +2995,7 @@ impl Interpreter {
                             let kvalue = match obj_get(interp, &o, &pk) {
                                 Ok(v) => v,
                                 Err(c) => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return c;
                                 }
                             };
@@ -3003,7 +3010,7 @@ impl Interpreter {
                                         match is_array_check(interp, mo.id) {
                                             Ok(b) => b,
                                             Err(e) => {
-                                                interp.gc_unroot_value(&a);
+                                                interp.gc_unroot_frame(gc_frame);
                                                 return Completion::Throw(e);
                                             }
                                         }
@@ -3014,7 +3021,7 @@ impl Interpreter {
                                         let mlen = match length_of_array_like(interp, &v) {
                                             Ok(l) => l,
                                             Err(c) => {
-                                                interp.gc_unroot_value(&a);
+                                                interp.gc_unroot_frame(gc_frame);
                                                 return c;
                                             }
                                         };
@@ -3025,7 +3032,7 @@ impl Interpreter {
                                                     let jval = match obj_get(interp, &v, &jpk) {
                                                         Ok(v) => v,
                                                         Err(c) => {
-                                                            interp.gc_unroot_value(&a);
+                                                            interp.gc_unroot_frame(gc_frame);
                                                             return c;
                                                         }
                                                     };
@@ -3035,13 +3042,13 @@ impl Interpreter {
                                                         &target_index.to_string(),
                                                         jval,
                                                     ) {
-                                                        interp.gc_unroot_value(&a);
+                                                        interp.gc_unroot_frame(gc_frame);
                                                         return Completion::Throw(e);
                                                     }
                                                     target_index += 1;
                                                 }
                                                 Err(e) => {
-                                                    interp.gc_unroot_value(&a);
+                                                    interp.gc_unroot_frame(gc_frame);
                                                     return Completion::Throw(e);
                                                 }
                                                 _ => {}
@@ -3054,26 +3061,26 @@ impl Interpreter {
                                             &target_index.to_string(),
                                             v,
                                         ) {
-                                            interp.gc_unroot_value(&a);
+                                            interp.gc_unroot_frame(gc_frame);
                                             return Completion::Throw(e);
                                         }
                                         target_index += 1;
                                     }
                                 }
                                 other => {
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return other;
                                 }
                             }
                         }
                         Err(e) => {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                         _ => {}
                     }
                 }
-                interp.gc_unroot_value(&a);
+                interp.gc_unroot_frame(gc_frame);
                 Completion::Normal(a)
             },
         ));
@@ -3347,16 +3354,17 @@ impl Interpreter {
                     } else {
                         interp.create_array(Vec::new())
                     };
+                    let gc_frame = interp.gc_root_frame();
                     interp.gc_root_value(&a);
 
                     let iterator = match interp.call_function(&iter_method, &source, &[]) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                         other => {
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return other;
                         }
                     };
@@ -3366,8 +3374,7 @@ impl Interpreter {
                         let next = match interp.iterator_step(&iterator) {
                             Ok(v) => v,
                             Err(e) => {
-                                interp.gc_unroot_value(&iterator);
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
@@ -3375,22 +3382,19 @@ impl Interpreter {
                             Some(result) => result,
                             None => {
                                 if let Err(e) = set_length_throw(interp, &a, k) {
-                                    interp.gc_unroot_value(&iterator);
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return Completion::Throw(e);
                                 }
-                                interp.gc_unroot_value(&iterator);
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Normal(a);
                             }
                         };
+                        let gc_frame_next = interp.gc_root_frame();
                         interp.gc_root_value(&next);
                         let value = match interp.iterator_value(&next) {
                             Ok(v) => v,
                             Err(e) => {
-                                interp.gc_unroot_value(&next);
-                                interp.gc_unroot_value(&iterator);
-                                interp.gc_unroot_value(&a);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
@@ -3402,10 +3406,8 @@ impl Interpreter {
                             ) {
                                 Completion::Normal(v) => v,
                                 other => {
-                                    interp.gc_unroot_value(&next);
                                     let _ = interp.iterator_close(&iterator, JsValue::Undefined);
-                                    interp.gc_unroot_value(&iterator);
-                                    interp.gc_unroot_value(&a);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return other;
                                 }
                             }
@@ -3415,17 +3417,16 @@ impl Interpreter {
                         if let Err(e) =
                             create_data_property_or_throw(interp, &a, &k.to_string(), mapped_value)
                         {
-                            interp.gc_unroot_value(&next);
                             let _ = interp.iterator_close(&iterator, JsValue::Undefined);
-                            interp.gc_unroot_value(&iterator);
-                            interp.gc_unroot_value(&a);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
-                        interp.gc_unroot_value(&next);
+                        interp.gc_unroot_frame(gc_frame_next);
                         k += 1;
                     }
                 } else {
                     // Array-like path
+                    let gc_frame = interp.gc_root_frame();
                     let array_like = match to_object_val(interp, &source) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -3434,7 +3435,7 @@ impl Interpreter {
                     let len = match length_of_array_like(interp, &array_like) {
                         Ok(v) => v,
                         Err(c) => {
-                            interp.gc_unroot_value(&array_like);
+                            interp.gc_unroot_frame(gc_frame);
                             return c;
                         }
                     };
@@ -3443,11 +3444,11 @@ impl Interpreter {
                         match interp.construct(&c, &[JsValue::Number(len as f64)]) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
-                                interp.gc_unroot_value(&array_like);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                             other => {
-                                interp.gc_unroot_value(&array_like);
+                                interp.gc_unroot_frame(gc_frame);
                                 return other;
                             }
                         }
@@ -3460,8 +3461,7 @@ impl Interpreter {
                         let kvalue = match obj_get(interp, &array_like, &k.to_string()) {
                             Ok(v) => v,
                             Err(c) => {
-                                interp.gc_unroot_value(&a);
-                                interp.gc_unroot_value(&array_like);
+                                interp.gc_unroot_frame(gc_frame);
                                 return c;
                             }
                         };
@@ -3473,8 +3473,7 @@ impl Interpreter {
                             ) {
                                 Completion::Normal(v) => v,
                                 other => {
-                                    interp.gc_unroot_value(&a);
-                                    interp.gc_unroot_value(&array_like);
+                                    interp.gc_unroot_frame(gc_frame);
                                     return other;
                                 }
                             }
@@ -3484,18 +3483,15 @@ impl Interpreter {
                         if let Err(e) =
                             create_data_property_or_throw(interp, &a, &k.to_string(), mapped_value)
                         {
-                            interp.gc_unroot_value(&a);
-                            interp.gc_unroot_value(&array_like);
+                            interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
                     }
                     if let Err(e) = set_length_throw(interp, &a, len) {
-                        interp.gc_unroot_value(&a);
-                        interp.gc_unroot_value(&array_like);
+                        interp.gc_unroot_frame(gc_frame);
                         return Completion::Throw(e);
                     }
-                    interp.gc_unroot_value(&a);
-                    interp.gc_unroot_value(&array_like);
+                    interp.gc_unroot_frame(gc_frame);
                     Completion::Normal(a)
                 }
             },

--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -657,6 +657,7 @@ impl Interpreter {
                     let sab_info = get_sab_info(interp, &ta_val);
                     let (resolve_fn, _reject_fn, promise_val) = interp.create_promise_parts();
                     interp.gc_root_value(&resolve_fn);
+                    let gc_frame_promise = interp.gc_root_frame();
                     interp.gc_root_value(&promise_val);
 
                     if let Some((sab, _)) = sab_info {
@@ -745,7 +746,7 @@ impl Interpreter {
                         PropertyDescriptor::data(promise_val.clone(), true, true, true),
                     );
                     // resolve_fn stays rooted until completion callback runs
-                    interp.gc_unroot_value(&promise_val);
+                    interp.gc_unroot_frame(gc_frame_promise);
                 }
                 let id = result.borrow().id.unwrap();
                 Completion::Normal(JsValue::Object(JsObject { id }))

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2527,6 +2527,7 @@ impl Interpreter {
                             is_method: false,
                             source_text: Some(fn_source_text.into()),
                             captured_new_target: None,
+                            uses_arguments: true, // conservative for dynamic Function()
                         };
                         // Create function in the Function constructor's realm
                         let old_realm = interp.current_realm_id;
@@ -3111,6 +3112,7 @@ impl Interpreter {
                             is_method: false,
                             source_text: Some(fn_source_text.into()),
                             captured_new_target: None,
+                            uses_arguments: true, // conservative for dynamic AsyncFunction()
                         };
                         let fn_val = interp.create_function(js_func);
                         // Apply GetPrototypeFromConstructor(newTarget, "%AsyncFunction.prototype%")
@@ -3270,6 +3272,7 @@ impl Interpreter {
                             is_method: false,
                             source_text: Some(fn_source_text.into()),
                             captured_new_target: None,
+                            uses_arguments: true, // conservative for dynamic GeneratorFunction()
                         };
                         let fn_val = interp.create_function(js_func);
                         // Apply GetPrototypeFromConstructor(newTarget, "%GeneratorFunction.prototype%")
@@ -3431,6 +3434,7 @@ impl Interpreter {
                             is_method: false,
                             source_text: Some(fn_source_text.into()),
                             captured_new_target: None,
+                            uses_arguments: true, // conservative for dynamic AsyncGeneratorFunction()
                         };
                         let fn_val = interp.create_function(js_func);
                         // Apply GetPrototypeFromConstructor(newTarget, "%AsyncGeneratorFunction.prototype%")
@@ -6600,20 +6604,21 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
+                    let gc_frame = interp.gc_root_frame();
                     interp.gc_root_value(&iterator);
                     loop {
                         let step = match interp.iterator_step(&iterator) {
                             Ok(Some(result)) => result,
                             Ok(None) => break,
                             Err(e) => {
-                                interp.gc_unroot_value(&iterator);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
                         let next_item = match interp.iterator_value(&step) {
                             Ok(v) => v,
                             Err(e) => {
-                                interp.gc_unroot_value(&iterator);
+                                interp.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
@@ -6621,7 +6626,7 @@ impl Interpreter {
                         let item_id = if let JsValue::Object(ref vo) = next_item {
                             vo.id
                         } else {
-                            interp.gc_unroot_value(&iterator);
+                            interp.gc_unroot_frame(gc_frame);
                             let err = interp.create_type_error("Iterator value is not an object");
                             interp.iterator_close(&iterator, err.clone());
                             return Completion::Throw(err);
@@ -6630,7 +6635,7 @@ impl Interpreter {
                         let key_raw = match interp.get_object_property(item_id, "0", &next_item) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
-                                interp.gc_unroot_value(&iterator);
+                                interp.gc_unroot_frame(gc_frame);
                                 interp.iterator_close(&iterator, e.clone());
                                 return Completion::Throw(e);
                             }
@@ -6640,7 +6645,7 @@ impl Interpreter {
                         let value = match interp.get_object_property(item_id, "1", &next_item) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
-                                interp.gc_unroot_value(&iterator);
+                                interp.gc_unroot_frame(gc_frame);
                                 interp.iterator_close(&iterator, e.clone());
                                 return Completion::Throw(e);
                             }
@@ -6650,7 +6655,7 @@ impl Interpreter {
                         let key = match interp.to_property_key(&key_raw) {
                             Ok(k) => k,
                             Err(e) => {
-                                interp.gc_unroot_value(&iterator);
+                                interp.gc_unroot_frame(gc_frame);
                                 interp.iterator_close(&iterator, e.clone());
                                 return Completion::Throw(e);
                             }
@@ -6659,7 +6664,7 @@ impl Interpreter {
                             obj_data.borrow_mut().insert_value(key, value);
                         }
                     }
-                    interp.gc_unroot_value(&iterator);
+                    interp.gc_unroot_frame(gc_frame);
                     Completion::Normal(obj_val)
                 },
             ));

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -4906,9 +4906,10 @@ impl Interpreter {
         &mut self,
         val: &JsValue,
     ) -> Result<Vec<JsValue>, Completion> {
+        let gc_frame = self.gc_root_frame();
         self.gc_root_value(val);
         let result = self.collect_iterable_or_arraylike_inner(val);
-        self.gc_unroot_value(val);
+        self.gc_unroot_frame(gc_frame);
         result
     }
 

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -11749,7 +11749,6 @@ impl Interpreter {
                         if let Some(&fn_realm) = self.function_realm_map.get(&o.id) {
                             self.current_realm_id = fn_realm;
                         }
-                        let gc_frame = self.gc_root_frame();
                         self.gc_root_value(_this_val);
                         for a in args.iter() {
                             self.gc_root_value(a);
@@ -11758,7 +11757,15 @@ impl Interpreter {
                         let result = f(self, _this_val, args);
                         self.last_call_this_value = saved_this;
                         self.last_call_had_explicit_return = true;
-                        self.gc_unroot_frame(gc_frame);
+                        // Unroot only what we pushed. A bulk truncate would also
+                        // drop persistent roots pushed by the builtin itself
+                        // (e.g. Atomics.waitAsync / $262.agent.getReportAsync
+                        // root resolve_fn for an async completion that runs
+                        // after this call returns).
+                        for a in args.iter().rev() {
+                            self.gc_unroot_value(a);
+                        }
+                        self.gc_unroot_value(_this_val);
                         self.current_realm_id = caller_realm;
                         result
                     }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -4918,7 +4918,10 @@ impl Interpreter {
             let gc_frame = self.gc_root_frame();
             let arg_vals = match self.eval_spread_args(args, env) {
                 Ok(v) => v,
-                Err(e) => return Completion::Throw(e),
+                Err(e) => {
+                    self.gc_unroot_frame(gc_frame);
+                    return Completion::Throw(e);
+                }
             };
             let this_in_tdz = Self::this_is_in_tdz(env);
             if this_in_tdz {
@@ -5175,7 +5178,10 @@ impl Interpreter {
             let gc_frame = self.gc_root_frame();
             let evaluated_args = match self.eval_spread_args(args, env) {
                 Ok(args) => args,
-                Err(e) => return Completion::Throw(e),
+                Err(e) => {
+                    self.gc_unroot_frame(gc_frame);
+                    return Completion::Throw(e);
+                }
             };
             let caller_strict = env.borrow().strict;
             let result = self.perform_eval(&evaluated_args, caller_strict, true, env);

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -12208,8 +12208,13 @@ impl Interpreter {
                                     },
                                 );
                             }
-                            if uses_arguments {
-                                let env_strict = func_env.borrow().strict;
+                            let env_strict = func_env.borrow().strict;
+                            // Sloppy non-arrow functions need a real arguments object even
+                            // when the body doesn't reference it, because Annex B
+                            // `Function.prototype.arguments` (§B.3.7) observes the active
+                            // call frame's arguments_obj.
+                            let needs_args = uses_arguments || (!is_strict && !env_strict);
+                            if needs_args {
                                 let use_mapped = is_simple && !is_strict && !env_strict;
                                 let param_names: Vec<String> = if use_mapped {
                                     params

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -435,6 +435,7 @@ impl Interpreter {
                     is_method: force_method,
                     source_text: f.source_text.clone(),
                     captured_new_target: None,
+                    uses_arguments: func_uses_arguments(&f.params, &f.body),
                 };
                 let func_val = self.create_function(func);
                 if let Some(name) = &f.name {
@@ -462,6 +463,7 @@ impl Interpreter {
                     is_method: false,
                     source_text: af.source_text.clone(),
                     captured_new_target: self.new_target.clone(),
+                    uses_arguments: false, // arrows never have own arguments
                 };
                 Completion::Normal(self.create_function(func))
             }
@@ -823,6 +825,7 @@ impl Interpreter {
                             Err(e) => return Completion::Throw(e),
                         }
                     };
+                    let gc_frame = self.gc_root_frame();
                     if let JsValue::Object(o) = &iterator {
                         self.gc_temp_roots.push(o.id);
                     }
@@ -830,7 +833,7 @@ impl Interpreter {
                         let next_result = match self.iterator_next(&iterator) {
                             Ok(v) => v,
                             Err(e) => {
-                                self.gc_unroot_value(&iterator);
+                                self.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
@@ -838,11 +841,11 @@ impl Interpreter {
                             match self.await_value(&next_result) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => {
-                                    self.gc_unroot_value(&iterator);
+                                    self.gc_unroot_frame(gc_frame);
                                     return Completion::Throw(e);
                                 }
                                 other => {
-                                    self.gc_unroot_value(&iterator);
+                                    self.gc_unroot_frame(gc_frame);
                                     return other;
                                 }
                             }
@@ -852,14 +855,14 @@ impl Interpreter {
                         let done = match self.iterator_complete(&next_result) {
                             Ok(d) => d,
                             Err(e) => {
-                                self.gc_unroot_value(&iterator);
+                                self.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
                         let value = match self.iterator_value(&next_result) {
                             Ok(v) => v,
                             Err(e) => {
-                                self.gc_unroot_value(&iterator);
+                                self.gc_unroot_frame(gc_frame);
                                 return Completion::Throw(e);
                             }
                         };
@@ -875,26 +878,26 @@ impl Interpreter {
                             if current == ctx.target_yield {
                                 match &ctx.resume_kind {
                                     GeneratorResumeKind::Next => {
-                                        self.gc_unroot_value(&iterator);
+                                        self.gc_unroot_frame(gc_frame);
                                         return Completion::Yield(value);
                                     }
                                     GeneratorResumeKind::Return(v) => {
                                         let v = v.clone();
-                                        self.gc_unroot_value(&iterator);
+                                        self.gc_unroot_frame(gc_frame);
                                         return Completion::Return(v);
                                     }
                                     GeneratorResumeKind::Throw(e) => {
                                         let e = e.clone();
-                                        self.gc_unroot_value(&iterator);
+                                        self.gc_unroot_frame(gc_frame);
                                         return Completion::Throw(e);
                                     }
                                 }
                             }
                         }
-                        self.gc_unroot_value(&iterator);
+                        self.gc_unroot_frame(gc_frame);
                         return Completion::Yield(value);
                     };
-                    self.gc_unroot_value(&iterator);
+                    self.gc_unroot_frame(gc_frame);
                     result
                 } else {
                     let value = if let Some(e) = expr {
@@ -4912,38 +4915,33 @@ impl Interpreter {
             } else {
                 env.borrow().get("__super__").unwrap_or(JsValue::Undefined)
             };
+            let gc_frame = self.gc_root_frame();
             let arg_vals = match self.eval_spread_args(args, env) {
                 Ok(v) => v,
                 Err(e) => return Completion::Throw(e),
             };
             let this_in_tdz = Self::this_is_in_tdz(env);
             if this_in_tdz {
-                // Derived constructor: use Construct semantics
-                // Per spec §13.3.7.1: super() must forward the derived class's new.target
                 let current_new_target = self.new_target.clone().unwrap_or(super_ctor.clone());
                 let saved_new_target = self.new_target.clone();
                 let result =
                     self.construct_with_new_target(&super_ctor, &arg_vals, current_new_target);
                 self.new_target = saved_new_target;
-                self.gc_unroot_args(&arg_vals);
+                self.gc_unroot_frame(gc_frame);
                 if let Completion::Normal(ref v) = result {
-                    // Bind this in the function environment
                     Self::initialize_this_binding(env, v.clone());
-                    // Initialize instance elements (private/public fields) for the current class
                     if let Err(e) = self.initialize_instance_elements(v.clone(), env) {
                         return Completion::Throw(e);
                     }
                 }
                 return result;
             } else {
-                // this is already bound — second super() call in derived constructor
-                // Per spec: Construct runs first, then BindThisValue throws
                 let current_new_target = self.new_target.clone().unwrap_or(super_ctor.clone());
                 let saved_new_target = self.new_target.clone();
                 let result =
                     self.construct_with_new_target(&super_ctor, &arg_vals, current_new_target);
                 self.new_target = saved_new_target;
-                self.gc_unroot_args(&arg_vals);
+                self.gc_unroot_frame(gc_frame);
                 if let Completion::Throw(_) = result {
                     return result;
                 }
@@ -5174,32 +5172,31 @@ impl Interpreter {
         if matches!(callee, Expression::Identifier(n) if n == "eval")
             && self.is_builtin_eval(&func_val)
         {
+            let gc_frame = self.gc_root_frame();
             let evaluated_args = match self.eval_spread_args(args, env) {
                 Ok(args) => args,
                 Err(e) => return Completion::Throw(e),
             };
             let caller_strict = env.borrow().strict;
             let result = self.perform_eval(&evaluated_args, caller_strict, true, env);
-            self.gc_unroot_args(&evaluated_args);
+            self.gc_unroot_frame(gc_frame);
             return result;
         }
 
         // Root func_val and this_val before evaluating args (which may trigger GC)
+        let gc_frame = self.gc_root_frame();
         self.gc_root_value(&func_val);
         self.gc_root_value(&this_val);
         let evaluated_args = match self.eval_spread_args(args, env) {
             Ok(args) => args,
             Err(e) => {
-                self.gc_unroot_value(&this_val);
-                self.gc_unroot_value(&func_val);
+                self.gc_unroot_frame(gc_frame);
                 return Completion::Throw(e);
             }
         };
 
         if saved_tail && !self.is_builtin_eval(&func_val) {
-            self.gc_unroot_value(&this_val);
-            self.gc_unroot_value(&func_val);
-            self.gc_unroot_args(&evaluated_args);
+            self.gc_unroot_frame(gc_frame);
             return Completion::TailCall {
                 func: func_val,
                 this: this_val,
@@ -5207,9 +5204,7 @@ impl Interpreter {
             };
         }
         let result = self.call_function(&func_val, &this_val, &evaluated_args);
-        self.gc_unroot_value(&this_val);
-        self.gc_unroot_value(&func_val);
-        self.gc_unroot_args(&evaluated_args);
+        self.gc_unroot_frame(gc_frame);
         result
     }
 
@@ -11685,8 +11680,16 @@ impl Interpreter {
         if let JsValue::Object(o) = func_val
             && let Some(obj) = self.get_object(o.id)
         {
-            // Proxy apply trap (also check revoked proxy)
-            if obj.borrow().is_proxy() || obj.borrow().proxy_revoked {
+            // Single borrow to check proxy/wrapped/class-ctor status
+            let (is_proxy_or_revoked, has_wrapped_target, is_class_ctor) = {
+                let b = obj.borrow();
+                (
+                    b.is_proxy() || b.proxy_revoked,
+                    b.wrapped_target_function_id.is_some(),
+                    b.is_class_constructor,
+                )
+            };
+            if is_proxy_or_revoked {
                 let target_val = self.get_proxy_target_val(o.id);
                 let args_array = self.create_array(args.to_vec());
                 match self.invoke_proxy_trap(
@@ -11696,18 +11699,14 @@ impl Interpreter {
                 ) {
                     Ok(Some(v)) => return Completion::Normal(v),
                     Ok(None) => {
-                        // No trap, call target directly
                         return self.call_function(&target_val, _this_val, args);
                     }
                     Err(e) => return Completion::Throw(e),
                 }
             }
-            // Wrapped function [[Call]]
-            let has_wrapped_target = obj.borrow().wrapped_target_function_id.is_some();
             if has_wrapped_target {
                 return self.call_wrapped_function(o.id, _this_val, args);
             }
-            let is_class_ctor = obj.borrow().is_class_constructor;
             if is_class_ctor && self.new_target.is_none() {
                 let caller_realm = self.current_realm_id;
                 if let Some(&fn_realm) = self.function_realm_map.get(&o.id) {
@@ -11750,8 +11749,7 @@ impl Interpreter {
                         if let Some(&fn_realm) = self.function_realm_map.get(&o.id) {
                             self.current_realm_id = fn_realm;
                         }
-                        // Root args and this_val so GC doesn't collect them
-                        // during native function execution (e.g. Array.prototype.map callback)
+                        let gc_frame = self.gc_root_frame();
                         self.gc_root_value(_this_val);
                         for a in args.iter() {
                             self.gc_root_value(a);
@@ -11760,10 +11758,7 @@ impl Interpreter {
                         let result = f(self, _this_val, args);
                         self.last_call_this_value = saved_this;
                         self.last_call_had_explicit_return = true;
-                        for a in args.iter().rev() {
-                            self.gc_unroot_value(a);
-                        }
-                        self.gc_unroot_value(_this_val);
+                        self.gc_unroot_frame(gc_frame);
                         self.current_realm_id = caller_realm;
                         result
                     }
@@ -11775,6 +11770,7 @@ impl Interpreter {
                         is_strict,
                         is_generator,
                         is_async,
+                        uses_arguments,
                         ..
                     } => {
                         // §10.2.1.1 PrepareForOrdinaryCall: switch to function's realm
@@ -11793,6 +11789,7 @@ impl Interpreter {
                                 _this_val,
                                 args,
                                 func_val,
+                                uses_arguments,
                             );
                             self.current_realm_id = caller_realm;
                             return result;
@@ -11812,34 +11809,39 @@ impl Interpreter {
                             );
                             let is_simple_ag =
                                 params.iter().all(|p| matches!(p, Pattern::Identifier(_)));
-                            let env_strict_ag = func_env.borrow().strict;
-                            let use_mapped_ag = is_simple_ag && !is_strict && !env_strict_ag;
-                            let param_names_ag: Vec<String> = if use_mapped_ag {
-                                params
-                                    .iter()
-                                    .filter_map(|p| {
-                                        if let Pattern::Identifier(name) = p {
-                                            Some(name.clone())
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .collect()
+                            if uses_arguments {
+                                let env_strict_ag = func_env.borrow().strict;
+                                let use_mapped_ag = is_simple_ag && !is_strict && !env_strict_ag;
+                                let param_names_ag: Vec<String> = if use_mapped_ag {
+                                    params
+                                        .iter()
+                                        .filter_map(|p| {
+                                            if let Pattern::Identifier(name) = p {
+                                                Some(name.clone())
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .collect()
+                                } else {
+                                    Vec::new()
+                                };
+                                let mapped_env_ag =
+                                    if use_mapped_ag { Some(&func_env) } else { None };
+                                let arguments_obj = self.create_arguments_object(
+                                    args,
+                                    func_val.clone(),
+                                    is_strict,
+                                    mapped_env_ag,
+                                    &param_names_ag,
+                                );
+                                func_env.borrow_mut().declare("arguments", BindingKind::Var);
+                                let _ = func_env.borrow_mut().set("arguments", arguments_obj);
+                                if is_strict || !is_simple_ag {
+                                    func_env.borrow_mut().arguments_immutable = true;
+                                }
                             } else {
-                                Vec::new()
-                            };
-                            let mapped_env_ag = if use_mapped_ag { Some(&func_env) } else { None };
-                            let arguments_obj = self.create_arguments_object(
-                                args,
-                                func_val.clone(),
-                                is_strict,
-                                mapped_env_ag,
-                                &param_names_ag,
-                            );
-                            func_env.borrow_mut().declare("arguments", BindingKind::Var);
-                            let _ = func_env.borrow_mut().set("arguments", arguments_obj);
-                            if is_strict || !is_simple_ag {
-                                func_env.borrow_mut().arguments_immutable = true;
+                                func_env.borrow_mut().declare("arguments", BindingKind::Var);
                             }
                             if !is_simple_ag {
                                 func_env.borrow_mut().has_parameter_expressions = true;
@@ -11999,34 +12001,39 @@ impl Interpreter {
                             );
                             let is_simple_g =
                                 params.iter().all(|p| matches!(p, Pattern::Identifier(_)));
-                            let env_strict_g = func_env.borrow().strict;
-                            let use_mapped_g = is_simple_g && !is_strict && !env_strict_g;
-                            let param_names_g: Vec<String> = if use_mapped_g {
-                                params
-                                    .iter()
-                                    .filter_map(|p| {
-                                        if let Pattern::Identifier(name) = p {
-                                            Some(name.clone())
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .collect()
+                            if uses_arguments {
+                                let env_strict_g = func_env.borrow().strict;
+                                let use_mapped_g = is_simple_g && !is_strict && !env_strict_g;
+                                let param_names_g: Vec<String> = if use_mapped_g {
+                                    params
+                                        .iter()
+                                        .filter_map(|p| {
+                                            if let Pattern::Identifier(name) = p {
+                                                Some(name.clone())
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .collect()
+                                } else {
+                                    Vec::new()
+                                };
+                                let mapped_env_g =
+                                    if use_mapped_g { Some(&func_env) } else { None };
+                                let arguments_obj = self.create_arguments_object(
+                                    args,
+                                    func_val.clone(),
+                                    is_strict,
+                                    mapped_env_g,
+                                    &param_names_g,
+                                );
+                                func_env.borrow_mut().declare("arguments", BindingKind::Var);
+                                let _ = func_env.borrow_mut().set("arguments", arguments_obj);
+                                if is_strict || !is_simple_g {
+                                    func_env.borrow_mut().arguments_immutable = true;
+                                }
                             } else {
-                                Vec::new()
-                            };
-                            let mapped_env_g = if use_mapped_g { Some(&func_env) } else { None };
-                            let arguments_obj = self.create_arguments_object(
-                                args,
-                                func_val.clone(),
-                                is_strict,
-                                mapped_env_g,
-                                &param_names_g,
-                            );
-                            func_env.borrow_mut().declare("arguments", BindingKind::Var);
-                            let _ = func_env.borrow_mut().set("arguments", arguments_obj);
-                            if is_strict || !is_simple_g {
-                                func_env.borrow_mut().arguments_immutable = true;
+                                func_env.borrow_mut().declare("arguments", BindingKind::Var);
                             }
                             if !is_simple_g {
                                 func_env.borrow_mut().has_parameter_expressions = true;
@@ -12201,35 +12208,39 @@ impl Interpreter {
                                     },
                                 );
                             }
-                            let env_strict = func_env.borrow().strict;
-                            let use_mapped = is_simple && !is_strict && !env_strict;
-                            let param_names: Vec<String> = if use_mapped {
-                                params
-                                    .iter()
-                                    .filter_map(|p| {
-                                        if let Pattern::Identifier(name) = p {
-                                            Some(name.clone())
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .collect()
+                            if uses_arguments {
+                                let env_strict = func_env.borrow().strict;
+                                let use_mapped = is_simple && !is_strict && !env_strict;
+                                let param_names: Vec<String> = if use_mapped {
+                                    params
+                                        .iter()
+                                        .filter_map(|p| {
+                                            if let Pattern::Identifier(name) = p {
+                                                Some(name.clone())
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .collect()
+                                } else {
+                                    Vec::new()
+                                };
+                                let mapped_env = if use_mapped { Some(&func_env) } else { None };
+                                let arguments_obj = self.create_arguments_object(
+                                    args,
+                                    func_val.clone(),
+                                    is_strict,
+                                    mapped_env,
+                                    &param_names,
+                                );
+                                call_frame_args = arguments_obj.clone();
+                                func_env.borrow_mut().declare("arguments", BindingKind::Var);
+                                let _ = func_env.borrow_mut().set("arguments", arguments_obj);
+                                if is_strict || !is_simple {
+                                    func_env.borrow_mut().arguments_immutable = true;
+                                }
                             } else {
-                                Vec::new()
-                            };
-                            let mapped_env = if use_mapped { Some(&func_env) } else { None };
-                            let arguments_obj = self.create_arguments_object(
-                                args,
-                                func_val.clone(),
-                                is_strict,
-                                mapped_env,
-                                &param_names,
-                            );
-                            call_frame_args = arguments_obj.clone();
-                            func_env.borrow_mut().declare("arguments", BindingKind::Var);
-                            let _ = func_env.borrow_mut().set("arguments", arguments_obj);
-                            if is_strict || !is_simple {
-                                func_env.borrow_mut().arguments_immutable = true;
+                                func_env.borrow_mut().declare("arguments", BindingKind::Var);
                             }
                         }
                         // For arrows with non-simple params and "arguments" parameter,
@@ -12370,23 +12381,10 @@ impl Interpreter {
             if let Expression::Spread(inner) = arg {
                 let val = match self.eval_expr(inner, env) {
                     Completion::Normal(v) => v,
-                    Completion::Throw(e) => {
-                        for v in &evaluated {
-                            self.gc_unroot_value(v);
-                        }
-                        return Err(e);
-                    }
+                    Completion::Throw(e) => return Err(e),
                     _ => JsValue::Undefined,
                 };
-                let items = match self.iterate_to_vec(&val) {
-                    Ok(items) => items,
-                    Err(e) => {
-                        for v in &evaluated {
-                            self.gc_unroot_value(v);
-                        }
-                        return Err(e);
-                    }
-                };
+                let items = self.iterate_to_vec(&val)?;
                 for item in &items {
                     self.gc_root_value(item);
                 }
@@ -12394,19 +12392,13 @@ impl Interpreter {
             } else {
                 let val = match self.eval_expr(arg, env) {
                     Completion::Normal(v) => v,
-                    Completion::Throw(e) => {
-                        for v in &evaluated {
-                            self.gc_unroot_value(v);
-                        }
-                        return Err(e);
-                    }
+                    Completion::Throw(e) => return Err(e),
                     _ => JsValue::Undefined,
                 };
                 self.gc_root_value(&val);
                 evaluated.push(val);
             }
         }
-        // Args are returned still rooted — callers must call gc_unroot_args after consuming them
         Ok(evaluated)
     }
 
@@ -13090,6 +13082,7 @@ impl Interpreter {
                 is_method: false,
                 source_text: f.source_text.clone(),
                 captured_new_target: None,
+                uses_arguments: func_uses_arguments(&f.params, &f.body),
             };
             let val = self.create_function(func);
             if is_global {
@@ -13252,6 +13245,7 @@ impl Interpreter {
     }
 
     fn eval_new(&mut self, callee: &Expression, args: &[Expression], env: &EnvRef) -> Completion {
+        let gc_frame = self.gc_root_frame();
         let callee_val = match self.eval_expr(callee, env) {
             Completion::Normal(v) => v,
             other => return other,
@@ -13260,7 +13254,7 @@ impl Interpreter {
         let evaluated_args = match self.eval_spread_args(args, env) {
             Ok(args) => args,
             Err(e) => {
-                self.gc_unroot_value(&callee_val);
+                self.gc_unroot_frame(gc_frame);
                 return Completion::Throw(e);
             }
         };
@@ -13287,16 +13281,14 @@ impl Interpreter {
                         None => String::new(),
                     };
                     drop(b);
-                    self.gc_unroot_args(&evaluated_args);
-                    self.gc_unroot_value(&callee_val);
+                    self.gc_unroot_frame(gc_frame);
                     return Completion::Throw(
                         self.create_type_error(&format!("{} is not a constructor", name)),
                     );
                 }
             }
         } else {
-            self.gc_unroot_args(&evaluated_args);
-            self.gc_unroot_value(&callee_val);
+            self.gc_unroot_frame(gc_frame);
             return Completion::Throw(
                 self.create_type_error(&format!("{:?} is not a constructor", callee_val)),
             );
@@ -13308,8 +13300,7 @@ impl Interpreter {
             let target_val = self.get_proxy_target_val(co.id);
             let args_array = self.create_array(evaluated_args.clone());
             let new_target = callee_val.clone();
-            self.gc_unroot_args(&evaluated_args);
-            self.gc_unroot_value(&callee_val);
+            self.gc_unroot_frame(gc_frame);
             match self.invoke_proxy_trap(
                 co.id,
                 "construct",
@@ -13339,8 +13330,7 @@ impl Interpreter {
             && let Some(func_obj) = self.get_object(co.id)
             && func_obj.borrow().bound_target_function.is_some()
         {
-            self.gc_unroot_args(&evaluated_args);
-            self.gc_unroot_value(&callee_val);
+            self.gc_unroot_frame(gc_frame);
             return self.construct_with_new_target(
                 &callee_val,
                 &evaluated_args,
@@ -13381,8 +13371,7 @@ impl Interpreter {
                 };
                 let prev_new_target = self.new_target.take();
                 self.new_target = Some(callee_val.clone());
-                self.gc_unroot_args(&evaluated_args);
-                self.gc_unroot_value(&callee_val);
+                self.gc_unroot_frame(gc_frame);
                 let result = self.construct_with_new_target(
                     &super_ctor,
                     &evaluated_args,
@@ -13411,8 +13400,7 @@ impl Interpreter {
             self.constructing_derived = true;
             self.calling_as_construct = true;
             let result = self.call_function(&callee_val, &JsValue::Undefined, &evaluated_args);
-            self.gc_unroot_args(&evaluated_args);
-            self.gc_unroot_value(&callee_val);
+            self.gc_unroot_frame(gc_frame);
             self.constructing_derived = prev_constructing_derived;
             let had_explicit_return = self.last_call_had_explicit_return;
             let final_this = self.last_call_this_value.take();
@@ -13623,8 +13611,7 @@ impl Interpreter {
             self.last_call_this_value = None;
             self.calling_as_construct = true;
             let result = self.call_function(&callee_val, &this_val, &evaluated_args);
-            self.gc_unroot_args(&evaluated_args);
-            self.gc_unroot_value(&callee_val);
+            self.gc_unroot_frame(gc_frame);
             let had_explicit_return = self.last_call_had_explicit_return;
             let final_this = self.last_call_this_value.take().unwrap_or(this_val.clone());
             self.new_target = prev_new_target;
@@ -15949,7 +15936,9 @@ impl Interpreter {
         this_val: &JsValue,
         args: &[JsValue],
         func_val: &JsValue,
+        uses_arguments: bool,
     ) -> Completion {
+        let gc_frame = self.gc_root_frame();
         let promise = self.create_promise_object();
         let promise_id = if let JsValue::Object(ref o) = promise {
             o.id
@@ -15996,35 +15985,39 @@ impl Interpreter {
                     deletable: false,
                 },
             );
-            let is_simple = params.iter().all(|p| matches!(p, Pattern::Identifier(_)));
-            let env_strict = func_env.borrow().strict;
-            let use_mapped = is_simple && !is_strict && !env_strict;
-            let param_names: Vec<String> = if use_mapped {
-                params
-                    .iter()
-                    .filter_map(|p| {
-                        if let Pattern::Identifier(name) = p {
-                            Some(name.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
+            if uses_arguments {
+                let is_simple = params.iter().all(|p| matches!(p, Pattern::Identifier(_)));
+                let env_strict = func_env.borrow().strict;
+                let use_mapped = is_simple && !is_strict && !env_strict;
+                let param_names: Vec<String> = if use_mapped {
+                    params
+                        .iter()
+                        .filter_map(|p| {
+                            if let Pattern::Identifier(name) = p {
+                                Some(name.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                let mapped_env = if use_mapped { Some(&func_env) } else { None };
+                let arguments_obj = self.create_arguments_object(
+                    args,
+                    func_val.clone(),
+                    is_strict,
+                    mapped_env,
+                    &param_names,
+                );
+                func_env.borrow_mut().declare("arguments", BindingKind::Var);
+                let _ = func_env.borrow_mut().set("arguments", arguments_obj);
+                if is_strict || !is_simple {
+                    func_env.borrow_mut().arguments_immutable = true;
+                }
             } else {
-                Vec::new()
-            };
-            let mapped_env = if use_mapped { Some(&func_env) } else { None };
-            let arguments_obj = self.create_arguments_object(
-                args,
-                func_val.clone(),
-                is_strict,
-                mapped_env,
-                &param_names,
-            );
-            func_env.borrow_mut().declare("arguments", BindingKind::Var);
-            let _ = func_env.borrow_mut().set("arguments", arguments_obj);
-            if is_strict || !is_simple {
-                func_env.borrow_mut().arguments_immutable = true;
+                func_env.borrow_mut().declare("arguments", BindingKind::Var);
             }
         }
         {
@@ -16040,9 +16033,7 @@ impl Interpreter {
                 if let Err(e) = self.bind_pattern(inner, rest_arr, BindingKind::Var, &func_env) {
                     let _ = self.call_function(&reject_fn, &JsValue::Undefined, &[e]);
                     self.drain_microtasks();
-                    self.gc_unroot_value(&reject_fn);
-                    self.gc_unroot_value(&resolve_fn);
-                    self.gc_unroot_value(&promise);
+                    self.gc_unroot_frame(gc_frame);
                     return Completion::Normal(promise);
                 }
                 break;
@@ -16051,9 +16042,7 @@ impl Interpreter {
             if let Err(e) = self.bind_pattern(param, val, BindingKind::Var, &func_env) {
                 let _ = self.call_function(&reject_fn, &JsValue::Undefined, &[e]);
                 self.drain_microtasks();
-                self.gc_unroot_value(&reject_fn);
-                self.gc_unroot_value(&resolve_fn);
-                self.gc_unroot_value(&promise);
+                self.gc_unroot_frame(gc_frame);
                 return Completion::Normal(promise);
             }
         }
@@ -16098,7 +16087,7 @@ impl Interpreter {
 
         self.async_function_resume(async_id, JsValue::Undefined, false);
 
-        self.gc_unroot_value(&promise);
+        self.gc_unroot_frame(gc_frame);
         Completion::Normal(promise)
     }
 
@@ -17117,6 +17106,7 @@ impl Interpreter {
             0
         };
 
+        let gc_frame = self.gc_root_frame();
         self.gc_root_value(&promise);
 
         let done = Rc::new(Cell::new(false));
@@ -17199,7 +17189,7 @@ impl Interpreter {
                 }
             }
             None => {
-                self.gc_unroot_value(&promise);
+                self.gc_unroot_frame(gc_frame);
                 return Completion::Normal(val.clone());
             }
         }
@@ -17215,13 +17205,12 @@ impl Interpreter {
             }
             if !self.microtask_queue.is_empty() {
                 let (roots, job) = self.microtask_queue.remove(0);
+                let mt_frame = self.gc_root_frame();
                 for val in &roots {
                     self.gc_root_value(val);
                 }
                 let _ = job(self);
-                for val in &roots {
-                    self.gc_unroot_value(val);
-                }
+                self.gc_unroot_frame(mt_frame);
                 continue;
             }
             // Check agent async completions
@@ -17255,7 +17244,7 @@ impl Interpreter {
             break;
         }
 
-        self.gc_unroot_value(&promise);
+        self.gc_unroot_frame(gc_frame);
 
         match result.borrow_mut().take() {
             Some(Ok(v)) => Completion::Normal(v),

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -316,19 +316,22 @@ impl Interpreter {
                 is_method: false,
                 source_text: class_source_text.clone(),
                 captured_new_target: None,
+                uses_arguments: func_uses_arguments(&cm.value.params, &cm.value.body),
             }
         } else if super_val.is_some() {
+            let default_body = vec![Statement::Expression(Expression::Call(
+                Box::new(Expression::Super),
+                vec![Expression::Spread(Box::new(Expression::Identifier(
+                    "args".into(),
+                )))],
+            ))];
+            let uses_args = stmts_use_arguments(&default_body);
             JsFunction::User {
                 name: Some(name.to_string()),
                 params: Rc::new(vec![Pattern::Rest(Box::new(Pattern::Identifier(
                     "args".into(),
                 )))]),
-                body: Rc::new(vec![Statement::Expression(Expression::Call(
-                    Box::new(Expression::Super),
-                    vec![Expression::Spread(Box::new(Expression::Identifier(
-                        "args".into(),
-                    )))],
-                ))]),
+                body: Rc::new(default_body),
                 closure: class_env.clone(),
                 is_arrow: false,
                 is_strict: true,
@@ -337,6 +340,7 @@ impl Interpreter {
                 is_method: false,
                 source_text: class_source_text.clone(),
                 captured_new_target: None,
+                uses_arguments: uses_args,
             }
         } else {
             JsFunction::User {
@@ -351,6 +355,7 @@ impl Interpreter {
                 is_method: false,
                 source_text: class_source_text.clone(),
                 captured_new_target: None,
+                uses_arguments: false,
             }
         };
 
@@ -563,6 +568,7 @@ impl Interpreter {
                                 is_method: true,
                                 source_text: m.value.source_text.clone(),
                                 captured_new_target: None,
+                                uses_arguments: func_uses_arguments(&m.value.params, &m.value.body),
                             };
                             let method_val = self.create_function(method_func);
 
@@ -736,6 +742,7 @@ impl Interpreter {
                         is_method: true,
                         source_text: m.value.source_text.clone(),
                         captured_new_target: None,
+                        uses_arguments: func_uses_arguments(&m.value.params, &m.value.body),
                     };
                     let method_val = self.create_function(method_func);
 

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -308,6 +308,7 @@ impl Interpreter {
             is_method: false,
             source_text: f.source_text.clone(),
             captured_new_target: None,
+            uses_arguments: func_uses_arguments(&f.params, &f.body),
         };
         let val = self.create_function(func);
         if is_global {
@@ -2066,9 +2067,10 @@ impl Interpreter {
             }
         };
 
+        let gc_frame = self.gc_root_frame();
         self.gc_root_value(&iterator);
         let result = self.exec_for_of_loop(fo, env, &iterator, label);
-        self.gc_unroot_value(&iterator);
+        self.gc_unroot_frame(gc_frame);
         result
     }
 
@@ -2301,6 +2303,7 @@ impl Interpreter {
                         is_method: false,
                         source_text: f.source_text.clone(),
                         captured_new_target: None,
+                        uses_arguments: func_uses_arguments(&f.params, &f.body),
                     };
                     let val = self.create_function(func);
                     let _ = switch_env.borrow_mut().set(&f.name, val);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -720,6 +720,19 @@ impl Interpreter {
         }
     }
 
+    /// Save the current GC temp-root stack depth. Call gc_unroot_frame()
+    /// with the returned value to bulk-unroot everything pushed since.
+    #[inline(always)]
+    pub(crate) fn gc_root_frame(&self) -> usize {
+        self.gc_temp_roots.len()
+    }
+
+    /// Bulk-unroot: truncate temp roots back to a saved frame marker. O(1).
+    #[inline(always)]
+    pub(crate) fn gc_unroot_frame(&mut self, frame: usize) {
+        self.gc_temp_roots.truncate(frame);
+    }
+
     pub(crate) fn gc_unroot_value(&mut self, val: &JsValue) {
         if let JsValue::Object(o) = val
             && let Some(pos) = self.gc_temp_roots.iter().rposition(|&id| id == o.id)
@@ -728,6 +741,7 @@ impl Interpreter {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn gc_unroot_args(&mut self, args: &[JsValue]) {
         for v in args {
             self.gc_unroot_value(v);
@@ -4056,6 +4070,7 @@ impl Interpreter {
                     is_method: false,
                     source_text: f.source_text.clone(),
                     captured_new_target: None,
+                    uses_arguments: func_uses_arguments(&f.params, &f.body),
                 };
                 let val = self.create_function(func);
                 let _ = env.borrow_mut().set(&f.name, val);
@@ -4103,6 +4118,7 @@ impl Interpreter {
                     is_method: false,
                     source_text: f.source_text.clone(),
                     captured_new_target: None,
+                    uses_arguments: func_uses_arguments(&f.params, &f.body),
                 };
                 let val = self.create_function(func);
                 env.borrow_mut().initialize_binding(&name, val);
@@ -4281,6 +4297,7 @@ impl Interpreter {
                     is_method: false,
                     source_text: func.source_text.clone(),
                     captured_new_target: None,
+                    uses_arguments: func_uses_arguments(&func.params, &func.body),
                 };
                 let fn_obj = self.create_function(js_func);
                 if !func.name.is_empty() {
@@ -4330,13 +4347,12 @@ impl Interpreter {
         loop {
             if !self.microtask_queue.is_empty() {
                 let (roots, job) = self.microtask_queue.remove(0);
+                let mt_frame = self.gc_root_frame();
                 for val in &roots {
                     self.gc_root_value(val);
                 }
                 let _ = job(self);
-                for val in &roots {
-                    self.gc_unroot_value(val);
-                }
+                self.gc_unroot_frame(mt_frame);
                 iterations += 1;
                 // Periodically check agent async completions (e.g. waitAsync timeouts)
                 // so they get processed even when the microtask queue stays busy
@@ -4433,13 +4449,12 @@ impl Interpreter {
         loop {
             while !self.microtask_queue.is_empty() {
                 let (roots, job) = self.microtask_queue.remove(0);
+                let mt_frame = self.gc_root_frame();
                 for val in &roots {
                     self.gc_root_value(val);
                 }
                 let _ = job(self);
-                for val in &roots {
-                    self.gc_unroot_value(val);
-                }
+                self.gc_unroot_frame(mt_frame);
             }
             let completions: Vec<_> = {
                 let mut lock = self.agent_async_completions.0.lock().unwrap();

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1139,6 +1139,7 @@ pub enum JsFunction {
         is_method: bool,
         source_text: Option<SourceText>,
         captured_new_target: Option<JsValue>,
+        uses_arguments: bool,
     },
     Native(
         String,
@@ -1181,6 +1182,7 @@ impl Clone for JsFunction {
                 is_method,
                 source_text,
                 captured_new_target,
+                uses_arguments,
             } => JsFunction::User {
                 name: name.clone(),
                 params: params.clone(),
@@ -1193,6 +1195,7 @@ impl Clone for JsFunction {
                 is_method: *is_method,
                 source_text: source_text.clone(),
                 captured_new_target: captured_new_target.clone(),
+                uses_arguments: *uses_arguments,
             },
             JsFunction::Native(name, arity, f, is_ctor) => {
                 JsFunction::Native(name.clone(), *arity, f.clone(), *is_ctor)


### PR DESCRIPTION
Extracted from PR #44 commit 74cdaa9 and ported onto current main after the regex-cache recovery. This keeps the runtime optimization work only and excludes the stale benchmark report / performance plan artifacts from the original branch.\n\nPort notes:\n- Preserved current generator iterator cleanup behavior while resolving conflicts.\n- Added a conservative direct-eval guard so functions containing direct eval still create an arguments object for eval("arguments") semantics.\n\nValidation:\n- cargo fmt --check\n- CARGO_TARGET_DIR=/tmp/jsse-port-pr44-function-target cargo build --release\n- ./scripts/lint.sh\n- /tmp/jsse-port-pr44-function-target/release/jsse -e 'function f(a){ return a + 1; } console.log(f(4)); function g(a,b){ return arguments[0] + arguments.length; } console.log(g(5,6)); function h(a){ arguments[0] = 9; return a; } console.log(h(1)); function outer(){ return (() => arguments[0])(); } console.log(outer(42)); function ev(a){ return eval("arguments[0]"); } console.log(ev(77));'\n- /tmp/jsse-port-pr44-function-target/release/jsse -e 'function* g(){ yield* [1,2]; } let out=[]; for (let x of g()) out.push(x); console.log(JSON.stringify(out)); async function af(a){ return arguments[0]; } af(13).then(v => console.log(v));'