### PR TITLE
[perf] Intern Environment.global_object and WithObject._object (#66, PR 1b.4)

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -828,7 +828,13 @@ fn array_species_create(
             Err(e) => return Err(Completion::Throw(e)),
         };
         if c_realm != interp.current_realm_id {
-            let realm_array = interp.realms[c_realm].global_env.borrow().get("Array");
+            // Look up "Array" from the c_realm's global object (its env.bindings
+            // had "Array" stripped at setup_globals; the binding now lives only
+            // on the global object).
+            let realm_array = interp.realms[c_realm]
+                .global_object
+                .and_then(|gid| interp.get_object(gid))
+                .and_then(|go| go.borrow().own_property_lookup("Array"));
             if let Some(ref ra) = realm_array
                 && same_value(&c, ra)
             {
@@ -3811,7 +3817,7 @@ impl Interpreter {
         ));
 
         // Set Array statics on the Array constructor
-        let array_val = self.realm().global_env.borrow().get("Array");
+        let array_val = self.get_global_var("Array");
         if let Some(array_val) = array_val
             && let JsValue::Object(o) = &array_val
             && let Some(obj) = self.get_object(o.id)

--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -208,7 +208,7 @@ impl Interpreter {
                             Err(e) => return Completion::Throw(e),
                         };
                         let args = [prim];
-                        let bigint_fn = interp.realm().global_env.borrow().get("BigInt");
+                        let bigint_fn = interp.get_global_var("BigInt");
                         if let Some(bigint_fn) = bigint_fn {
                             return interp.call_function(&bigint_fn, &JsValue::Undefined, &args);
                         }
@@ -302,7 +302,7 @@ impl Interpreter {
             },
         ));
 
-        if let Some(bigint_val) = self.realm().global_env.borrow().get("BigInt")
+        if let Some(bigint_val) = self.get_global_var("BigInt")
             && let JsValue::Object(o) = &bigint_val
             && let Some(bigint_obj) = self.get_object(o.id)
         {
@@ -322,7 +322,7 @@ impl Interpreter {
         }
 
         // Set constructor property on prototype
-        if let Some(bigint_val) = self.realm().global_env.borrow().get("BigInt") {
+        if let Some(bigint_val) = self.get_global_var("BigInt") {
             proto.borrow_mut().insert_property(
                 "constructor".to_string(),
                 PropertyDescriptor::data(bigint_val, true, false, true),

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -1255,7 +1255,7 @@ impl Interpreter {
                 Completion::Throw(e)
             },
         ));
-        if let Some(sym_val) = self.realm().global_env.borrow().get("Symbol")
+        if let Some(sym_val) = self.get_global_var("Symbol")
             && let JsValue::Object(sym_obj) = &sym_val
         {
             let tp_key = to_js_string(&self.get_property_on_id(sym_obj.id, "toPrimitive"));
@@ -1587,8 +1587,8 @@ impl Interpreter {
     }
 
     pub(crate) fn create_error(&mut self, name: &str, msg: &str) -> JsValue {
-        let env = self.realm().global_env.borrow();
-        let error_proto_id: Option<u64> = env.get(name).and_then(|v| {
+        let ctor = self.get_global_var(name);
+        let error_proto_id: Option<u64> = ctor.and_then(|v| {
             if let JsValue::Object(o) = &v {
                 let pv = self.get_property_on_id(o.id, "prototype");
                 if let JsValue::Object(p) = &pv {
@@ -1600,7 +1600,6 @@ impl Interpreter {
                 None
             }
         });
-        drop(env);
         let obj = self.create_object();
         {
             let mut o = obj.borrow_mut();

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -700,12 +700,17 @@ impl Interpreter {
                 }
                 // If new_target is the Iterator constructor itself, throw TypeError
                 // (abstract class cannot be instantiated directly)
-                if let Some(JsValue::Object(nt)) = &interp.new_target {
+                let nt_id = if let Some(JsValue::Object(nt)) = &interp.new_target {
+                    Some(nt.id)
+                } else {
+                    None
+                };
+                if let Some(nt_id) = nt_id {
                     // Check if new.target is the Iterator constructor by checking if
                     // looking up "Iterator" from global gives the same object
-                    let global_iter = interp.realm().global_env.borrow().get("Iterator");
+                    let global_iter = interp.get_global_var("Iterator");
                     if let Some(JsValue::Object(gi)) = global_iter
-                        && gi.id == nt.id
+                        && gi.id == nt_id
                     {
                         let err = interp.create_type_error(
                             "Abstract class Iterator not directly constructable",
@@ -3718,7 +3723,7 @@ impl Interpreter {
 
         // [[Prototype]] = Function.prototype_id
         // Get Function.prototype from global Function
-        if let Some(func_val) = self.realm().global_env.borrow().get("Function")
+        if let Some(func_val) = self.get_global_var("Function")
             && let JsValue::Object(func_obj) = func_val
             && let JsValue::Object(func_proto_obj) =
                 self.get_property_on_id(func_obj.id, "prototype")

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -1080,7 +1080,7 @@ impl Interpreter {
                 // the active function (Object), return OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%")
                 if let Some(ref nt) = interp.new_target.clone() {
                     // Check if new_target is different from the Object constructor itself
-                    let object_fn = interp.realm().global_env.borrow().get("Object").unwrap_or(JsValue::Undefined);
+                    let object_fn = interp.get_global_var("Object").unwrap_or(JsValue::Undefined);
                     let nt_is_object = matches!((&object_fn, nt), (JsValue::Object(a), JsValue::Object(b)) if a.id == b.id);
                     if !nt_is_object {
                         // OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%")
@@ -1494,7 +1494,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::Boolean(result))
                 },
             ));
-            if let Some(num_val) = self.realm().global_env.borrow().get("Number")
+            if let Some(num_val) = self.get_global_var("Number")
                 && let JsValue::Object(o) = &num_val
                 && let Some(num_obj) = self.get_object(o.id)
             {
@@ -1732,9 +1732,9 @@ impl Interpreter {
 
         // Attach parseInt/parseFloat to Number constructor (must be after global registration)
         {
-            let parse_int = self.realm().global_env.borrow().get("parseInt");
-            let parse_float = self.realm().global_env.borrow().get("parseFloat");
-            if let Some(num_val) = self.realm().global_env.borrow().get("Number")
+            let parse_int = self.get_global_var("parseInt");
+            let parse_float = self.get_global_var("parseFloat");
+            if let Some(num_val) = self.get_global_var("Number")
                 && let JsValue::Object(o) = &num_val
                 && let Some(num_obj) = self.get_object(o.id)
             {
@@ -2593,7 +2593,7 @@ impl Interpreter {
                     );
                 }
             } else {
-                let func_val = self.realm().global_env.borrow().get("Function");
+                let func_val = self.get_global_var("Function");
                 if let Some(JsValue::Object(fo)) = func_val {
                     let pv = self.get_property_on_id(fo.id, "prototype");
                     if let JsValue::Object(pr) = pv
@@ -2624,7 +2624,7 @@ impl Interpreter {
 
         // Store Function.prototype for use as [[Prototype]] of all function objects
         {
-            let func_val = self.realm().global_env.borrow().get("Function");
+            let func_val = self.get_global_var("Function");
             if let Some(JsValue::Object(fo)) = func_val
                 && let Some(func_data) = self.get_object(fo.id)
             {
@@ -2971,7 +2971,7 @@ impl Interpreter {
                     "SuppressedError",
                     "AggregateError",
                 ] {
-                    let ctor_val = self.realm().global_env.borrow().get(name);
+                    let ctor_val = self.get_global_var(name);
                     if let Some(JsValue::Object(o)) = ctor_val
                         && let Some(ctor_obj) = self.get_object(o.id)
                     {
@@ -2988,7 +2988,7 @@ impl Interpreter {
             af_proto.borrow_mut().class_name = "AsyncFunction".to_string();
 
             // [[Prototype]] = Function.prototype_id
-            if let Some(func_val) = self.realm().global_env.borrow().get("Function")
+            if let Some(func_val) = self.get_global_var("Function")
                 && let JsValue::Object(func_obj) = func_val
                 && let JsValue::Object(func_proto_obj) =
                     self.get_property_on_id(func_obj.id, "prototype")
@@ -3713,7 +3713,7 @@ impl Interpreter {
 
         // String.fromCharCode
         {
-            let string_ctor = self.realm().global_env.borrow().get("String");
+            let string_ctor = self.get_global_var("String");
             if let Some(JsValue::Object(ref o)) = string_ctor {
                 let from_char_code = self.create_function(JsFunction::native(
                     "fromCharCode".to_string(),
@@ -3984,8 +3984,13 @@ impl Interpreter {
         // Per spec §9.1.1.4, the Global Environment Record has an Object Environment
         // Record whose binding object is the global object. Variable lookups in global
         // scope should check global object properties.
-        self.realm().global_env.borrow_mut().global_object = Some(global_obj.clone());
-        self.realm_mut().global_object = Some(global_obj.borrow().id.unwrap());
+        let gid = global_obj.borrow().id.unwrap();
+        {
+            let mut env = self.realm().global_env.borrow_mut();
+            env.global_object_id = Some(gid);
+            env.global_object_rc = Some(global_obj.clone());
+        }
+        self.realm_mut().global_object = Some(gid);
 
         // Per §9.1.1.4, built-in global names live on the global object (Object
         // Environment Record), not as declarative bindings. Remove the bootstrapping
@@ -6673,17 +6678,13 @@ impl Interpreter {
     }
 
     pub(crate) fn get_symbol_iterator_key(&self) -> Option<String> {
-        self.realm()
-            .global_env
-            .borrow()
-            .get("Symbol")
-            .and_then(|sv| {
-                if let JsValue::Object(so) = sv {
-                    Some(to_js_string(&self.get_property_on_id(so.id, "iterator")))
-                } else {
-                    None
-                }
-            })
+        self.get_global_var_ref("Symbol").and_then(|sv| {
+            if let JsValue::Object(so) = sv {
+                Some(to_js_string(&self.get_property_on_id(so.id, "iterator")))
+            } else {
+                None
+            }
+        })
     }
 
     pub(crate) fn create_iter_result_object(&mut self, value: JsValue, done: bool) -> JsValue {
@@ -7013,12 +7014,7 @@ impl Interpreter {
         let done_bool = matches!(done, JsValue::Boolean(true));
 
         // Step 5: valueWrapper = PromiseResolve(%Promise%, value)
-        let promise_ctor = self
-            .realm()
-            .global_env
-            .borrow()
-            .get("Promise")
-            .unwrap_or(JsValue::Undefined);
+        let promise_ctor = self.get_global_var("Promise").unwrap_or(JsValue::Undefined);
         let value_wrapper = match self.promise_resolve_with_constructor(&promise_ctor, &value) {
             Ok(w) => w,
             Err(e) => {

--- a/src/interpreter/builtins/number.rs
+++ b/src/interpreter/builtins/number.rs
@@ -361,7 +361,7 @@ impl Interpreter {
             false,
         ));
         // Get the @@toPrimitive well-known symbol key
-        if let Some(sym_val) = self.realm().global_env.borrow().get("Symbol")
+        if let Some(sym_val) = self.get_global_var("Symbol")
             && let JsValue::Object(sym_obj) = &sym_val
         {
             let to_prim_sym = self.get_property_on_id(sym_obj.id, "toPrimitive");
@@ -381,7 +381,7 @@ impl Interpreter {
         }
 
         // [Symbol.toStringTag] = "Symbol"
-        if let Some(sym_val) = self.realm().global_env.borrow().get("Symbol")
+        if let Some(sym_val) = self.get_global_var("Symbol")
             && let JsValue::Object(sym_obj) = &sym_val
         {
             let tag_sym = self.get_property_on_id(sym_obj.id, "toStringTag");
@@ -406,7 +406,7 @@ impl Interpreter {
         }
 
         // Set Symbol.prototype on the Symbol constructor
-        if let Some(sym_val) = self.realm().global_env.borrow().get("Symbol")
+        if let Some(sym_val) = self.get_global_var("Symbol")
             && let JsValue::Object(o) = &sym_val
             && let Some(sym_obj) = self.get_object(o.id)
         {
@@ -669,7 +669,7 @@ impl Interpreter {
         }
 
         // Set Number.prototype on the Number constructor
-        if let Some(num_val) = self.realm().global_env.borrow().get("Number")
+        if let Some(num_val) = self.get_global_var("Number")
             && let JsValue::Object(o) = &num_val
             && let Some(num_obj) = self.get_object(o.id)
         {
@@ -752,7 +752,7 @@ impl Interpreter {
         }
 
         // Set Boolean.prototype on the Boolean constructor
-        if let Some(bool_val) = self.realm().global_env.borrow().get("Boolean")
+        if let Some(bool_val) = self.get_global_var("Boolean")
             && let JsValue::Object(o) = &bool_val
             && let Some(bool_obj) = self.get_object(o.id)
         {

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -27,7 +27,7 @@ impl Interpreter {
         }
 
         // Check if C is the built-in Promise constructor - fast path
-        let promise_ctor = self.realm().global_env.borrow().get("Promise");
+        let promise_ctor = self.get_global_var("Promise");
         if let Some(ref ctor_val) = promise_ctor
             && same_value(constructor, ctor_val)
         {
@@ -252,10 +252,7 @@ impl Interpreter {
 
                 // Step 3: Let C = ? SpeciesConstructor(promise, %Promise%).
                 let promise_ctor = interp
-                    .realm()
-                    .global_env
-                    .borrow()
-                    .get("Promise")
+                    .get_global_var("Promise")
                     .unwrap_or(JsValue::Undefined);
                 let c = match interp.species_constructor(this, &promise_ctor) {
                     Ok(c) => c,
@@ -1118,12 +1115,7 @@ impl Interpreter {
         };
 
         // SpeciesConstructor(promise, %Promise%)
-        let promise_ctor = self
-            .realm()
-            .global_env
-            .borrow()
-            .get("Promise")
-            .unwrap_or(JsValue::Undefined);
+        let promise_ctor = self.get_global_var("Promise").unwrap_or(JsValue::Undefined);
         let c = match self.species_constructor(promise_val, &promise_ctor) {
             Ok(c) => c,
             Err(e) => return Completion::Throw(e),
@@ -1209,7 +1201,7 @@ impl Interpreter {
         {
             match self.get_object_property(o.id, "constructor", value) {
                 Completion::Normal(ctor) => {
-                    let promise_ctor = self.realm().global_env.borrow().get("Promise");
+                    let promise_ctor = self.get_global_var("Promise");
                     if let Some(ref pc) = promise_ctor
                         && strict_equality(&ctor, pc)
                     {

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -6908,18 +6908,13 @@ fn regexp_exec_raw(
 }
 
 fn get_symbol_key(interp: &Interpreter, name: &str) -> Option<String> {
-    interp
-        .realm()
-        .global_env
-        .borrow()
-        .get("Symbol")
-        .and_then(|sv| {
-            if let JsValue::Object(so) = sv {
-                Some(to_js_string(&interp.get_property_on_id(so.id, name)))
-            } else {
-                None
-            }
-        })
+    interp.get_global_var_ref("Symbol").and_then(|sv| {
+        if let JsValue::Object(so) = sv {
+            Some(to_js_string(&interp.get_property_on_id(so.id, name)))
+        } else {
+            None
+        }
+    })
 }
 
 impl Interpreter {

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -1694,7 +1694,7 @@ impl Interpreter {
         }
 
         // Set String.prototype on the String constructor and wire constructor back
-        if let Some(str_val) = self.realm().global_env.borrow().get("String")
+        if let Some(str_val) = self.get_global_var("String")
             && let JsValue::Object(o) = &str_val
             && let Some(str_obj) = self.get_object(o.id)
         {

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -4333,7 +4333,7 @@ impl Interpreter {
 
     fn setup_uint8array_base64_hex(&mut self) {
         // Get Uint8Array constructor from global env
-        let uint8_ctor = self.realm().global_env.borrow().get("Uint8Array").unwrap();
+        let uint8_ctor = self.get_global_var("Uint8Array").unwrap();
         let uint8_proto = self.get_object_expect(self.realm().uint8array_prototype.unwrap());
 
         // --- Static methods on Uint8Array constructor ---

--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -1,0 +1,298 @@
+//! Interpreter-side wrappers around the slim `Environment` methods. They
+//! re-introduce the global-object mirroring that PR 1b.4 removed from
+//! `Environment::set/get/has/declare_global_*` so those methods could be
+//! free of `Rc<RefCell<JsObjectData>>` field access.
+//!
+//! Borrow-ordering rule: every wrapper drops all `RefCell` borrows on `env`
+//! before invoking `proxy_set` / `set_property_value` on the global object.
+//! A re-entrant `set` trap that calls back into `env_set` would otherwise
+//! double-borrow the same env.
+
+use super::types::*;
+use super::*;
+use crate::types::{JsString, JsValue};
+
+impl Interpreter {
+    /// Read a name from the current realm's global env, falling through to
+    /// the global object's own properties when env.bindings doesn't carry the
+    /// name (which is the case for built-ins after `setup_globals` strips them
+    /// from env.bindings — see builtins/mod.rs:3995-4004).
+    pub(crate) fn get_global_var(&mut self, name: &str) -> Option<JsValue> {
+        let env = self.realm().global_env.clone();
+        self.env_get(&env, name)
+    }
+
+    /// `&self` variant of `get_global_var` for read-only call sites that don't
+    /// have a `&mut Interpreter` (e.g. helpers like `get_symbol_iterator_key`).
+    /// Skips Proxy traps on the global object — sufficient for built-in name
+    /// lookups that should resolve via own properties.
+    pub(crate) fn get_global_var_ref(&self, name: &str) -> Option<JsValue> {
+        let env = self.realm().global_env.borrow();
+        if let Some(v) = env.get(name) {
+            return Some(v);
+        }
+        let gid = env.global_object_id?;
+        drop(env);
+        self.get_object(gid)
+            .and_then(|go| go.borrow().own_property_lookup(name))
+    }
+
+    /// Mirrors `Environment::set`'s old chain walk + global-object mirror,
+    /// preserving sloppy-mode implicit globals and the var-binding mirror at
+    /// the global env.
+    pub(crate) fn env_set(
+        &mut self,
+        env: &EnvRef,
+        name: &str,
+        value: JsValue,
+    ) -> Result<(), JsValue> {
+        let mut current = env.clone();
+        loop {
+            // Inspect this frame without mutating; capture the next action.
+            let action = {
+                let e = current.borrow();
+                if e.is_indirect_binding(name) {
+                    return Err(JsValue::String(JsString::from_str(
+                        "Assignment to constant variable.",
+                    )));
+                }
+                if let Some(binding) = e.bindings.get(name) {
+                    if !binding.initialized
+                        && matches!(binding.kind, BindingKind::Let | BindingKind::Const)
+                    {
+                        return Err(JsValue::String(JsString::from_str(&format!(
+                            "Cannot access '{name}' before initialization"
+                        ))));
+                    }
+                    if binding.kind == BindingKind::Const && binding.initialized {
+                        return Err(JsValue::String(JsString::from_str(
+                            "Assignment to constant variable.",
+                        )));
+                    }
+                    if (binding.kind == BindingKind::FunctionName
+                        || binding.kind == BindingKind::ImmutableValue)
+                        && binding.initialized
+                    {
+                        if e.strict {
+                            return Err(JsValue::String(JsString::from_str(
+                                "Assignment to constant variable.",
+                            )));
+                        }
+                        return Ok(());
+                    }
+                    let mirror = if binding.kind == BindingKind::Var {
+                        e.global_object_id
+                    } else {
+                        None
+                    };
+                    EnvSetAction::WriteBinding {
+                        mirror_gid: mirror,
+                        strict: e.strict,
+                    }
+                } else if e.parent.is_some() {
+                    EnvSetAction::Recurse(e.parent.clone().unwrap())
+                } else if let Some(gid) = e.global_object_id {
+                    EnvSetAction::ImplicitGlobal { gid }
+                } else {
+                    EnvSetAction::CreateBinding
+                }
+            };
+
+            match action {
+                EnvSetAction::WriteBinding { mirror_gid, strict } => {
+                    if let Some(gid) = mirror_gid {
+                        // Borrow on `current` is dropped above; safe to call
+                        // out to the slab (re-entrant set traps OK).
+                        if let Some(go) = self.get_object(gid) {
+                            let ok = go.borrow_mut().set_property_value(name, value.clone());
+                            if !ok {
+                                if strict {
+                                    return Err(JsValue::String(JsString::from_str(&format!(
+                                        "Cannot assign to read only property '{name}' of object '#<Object>'"
+                                    ))));
+                                }
+                                return Ok(());
+                            }
+                        }
+                    }
+                    let mut e = current.borrow_mut();
+                    if let Some(b) = e.bindings.get_mut(name) {
+                        b.value = value;
+                        b.initialized = true;
+                    }
+                    return Ok(());
+                }
+                EnvSetAction::Recurse(parent) => {
+                    current = parent;
+                }
+                EnvSetAction::ImplicitGlobal { gid } => {
+                    let already_on_global = self
+                        .get_object(gid)
+                        .is_some_and(|go| go.borrow().has_own_property(name));
+                    let ok = self
+                        .get_object(gid)
+                        .is_some_and(|go| go.borrow_mut().set_property_value(name, value.clone()));
+                    if !ok {
+                        return Ok(());
+                    }
+                    if already_on_global {
+                        return Ok(());
+                    }
+                    current.borrow_mut().bindings.insert(
+                        name.to_string(),
+                        Binding::new(value, BindingKind::Var, true),
+                    );
+                    return Ok(());
+                }
+                EnvSetAction::CreateBinding => {
+                    current.borrow_mut().bindings.insert(
+                        name.to_string(),
+                        Binding::new(value, BindingKind::Var, true),
+                    );
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    /// Lookup a name, falling through to the global object's own properties
+    /// when the chain bottoms out at the global env.
+    pub(crate) fn env_get(&mut self, env: &EnvRef, name: &str) -> Option<JsValue> {
+        // First try slim Environment::get.
+        if let Some(v) = env.borrow().get(name) {
+            return Some(v);
+        }
+        // Walk to find an env with global_object_id set; fall through.
+        let mut current = Some(env.clone());
+        while let Some(e_ref) = current {
+            let e = e_ref.borrow();
+            if e.bindings.contains_key(name) || e.is_indirect_binding(name) {
+                return None;
+            }
+            if let Some(gid) = e.global_object_id {
+                drop(e);
+                if let Some(go) = self.get_object(gid)
+                    && let Some(v) = go.borrow().own_property_lookup(name)
+                {
+                    return Some(v);
+                }
+                return None;
+            }
+            current = e.parent.clone();
+        }
+        None
+    }
+
+    /// `Environment::has` with global-object fall-through.
+    pub(crate) fn env_has(&mut self, env: &EnvRef, name: &str) -> bool {
+        if env.borrow().has(name) {
+            return true;
+        }
+        let mut current = Some(env.clone());
+        while let Some(e_ref) = current {
+            let e = e_ref.borrow();
+            if e.bindings.contains_key(name) || e.is_indirect_binding(name) {
+                return true;
+            }
+            if let Some(gid) = e.global_object_id {
+                drop(e);
+                if let Some(go) = self.get_object(gid) {
+                    return go.borrow().own_has_property(name).unwrap_or(false);
+                }
+                return false;
+            }
+            current = e.parent.clone();
+        }
+        false
+    }
+
+    /// CreateGlobalVarBinding (§9.1.1.4.17): declare a non-configurable Var
+    /// on the global object when env is the global env, otherwise just declare
+    /// in env.bindings.
+    pub(crate) fn env_declare_global_var(&mut self, env: &EnvRef, name: &str) {
+        let gid = env.borrow().global_object_id;
+        if let Some(gid) = gid {
+            if let Some(go) = self.get_object(gid) {
+                let mut g = go.borrow_mut();
+                if !g.properties.contains_key(name) {
+                    g.property_order.push(name.to_string());
+                    g.properties.insert(
+                        name.to_string(),
+                        PropertyDescriptor::data(JsValue::Undefined, true, true, false),
+                    );
+                }
+            }
+        } else {
+            env.borrow_mut().declare_global_var(name);
+        }
+    }
+
+    /// CreateGlobalVarBinding with configurable=true (eval-declared vars).
+    pub(crate) fn env_declare_global_var_configurable(&mut self, env: &EnvRef, name: &str) {
+        let gid = env.borrow().global_object_id;
+        if let Some(gid) = gid {
+            if !env.borrow().bindings.contains_key(name) {
+                let has_global_prop = self
+                    .get_object(gid)
+                    .is_some_and(|g| g.borrow().properties.contains_key(name));
+                if !has_global_prop {
+                    env.borrow_mut().declare(name, BindingKind::Var);
+                }
+            }
+            if let Some(go) = self.get_object(gid) {
+                let mut g = go.borrow_mut();
+                if !g.properties.contains_key(name) {
+                    g.property_order.push(name.to_string());
+                    g.properties.insert(
+                        name.to_string(),
+                        PropertyDescriptor::data(JsValue::Undefined, true, true, true),
+                    );
+                }
+            }
+        } else {
+            env.borrow_mut().declare_global_var_configurable(name);
+        }
+    }
+
+    /// CreateGlobalFunctionBinding (eval-declared functions).
+    pub(crate) fn env_declare_global_function_binding(
+        &mut self,
+        env: &EnvRef,
+        name: &str,
+        value: JsValue,
+        configurable: bool,
+    ) {
+        env.borrow_mut()
+            .declare_global_function_binding(name, value.clone(), configurable);
+        let gid = env.borrow().global_object_id;
+        if let Some(gid) = gid
+            && let Some(go) = self.get_object(gid)
+        {
+            let mut g = go.borrow_mut();
+            let existing = g.properties.get(name);
+            let need_full_desc =
+                existing.is_none() || existing.is_some_and(|d| d.configurable == Some(true));
+            if need_full_desc {
+                let desc = PropertyDescriptor::data(value, true, true, configurable);
+                if !g.properties.contains_key(name) {
+                    g.property_order.push(name.to_string());
+                }
+                g.properties.insert(name.to_string(), desc);
+            } else {
+                g.set_property_value(name, value);
+            }
+        }
+    }
+}
+
+enum EnvSetAction {
+    WriteBinding {
+        mirror_gid: Option<u64>,
+        strict: bool,
+    },
+    Recurse(EnvRef),
+    ImplicitGlobal {
+        gid: u64,
+    },
+    CreateBinding,
+}

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -424,7 +424,8 @@ impl Interpreter {
                         is_arrow_scope: false,
                         with_object: None,
                         dispose_stack: None,
-                        global_object: None,
+                        global_object_id: None,
+                        global_object_rc: None,
                         annexb_function_names: None,
                         class_private_names: None,
                         is_field_initializer: false,
@@ -775,8 +776,10 @@ impl Interpreter {
                     }
 
                     // At global level — check global object property descriptor
-                    let global_obj = self.realm().global_env.borrow().global_object.clone();
-                    if let Some(ref global) = global_obj {
+                    let global_id = self.realm().global_env.borrow().global_object_id;
+                    if let Some(gid) = global_id
+                        && let Some(global) = self.get_object(gid)
+                    {
                         let gb = global.borrow();
                         if let Some(desc) = gb.properties.get(name) {
                             if desc.configurable == Some(false) {
@@ -11459,12 +11462,7 @@ impl Interpreter {
         // For Promise values, check if PromiseResolve would throw (e.g. broken .constructor)
         // Skip for non-promise values to avoid spurious "then" getter access
         if self.is_promise(&value) {
-            let promise_ctor = self
-                .realm()
-                .global_env
-                .borrow()
-                .get("Promise")
-                .unwrap_or(JsValue::Undefined);
+            let promise_ctor = self.get_global_var("Promise").unwrap_or(JsValue::Undefined);
             if let Err(e) = self.promise_resolve_with_constructor(&promise_ctor, &value) {
                 obj_rc.borrow_mut().iterator_state =
                     Some(IteratorState::StateMachineAsyncGenerator {
@@ -12706,11 +12704,8 @@ impl Interpreter {
             let mut found_derived_constructor = false;
             let mut function_boundary_count: u32 = 0;
             let mut env_walk = Some(caller_env.clone());
-            loop {
-                let e = match env_walk {
-                    Some(ref e) => e.clone(),
-                    None => break,
-                };
+            while let Some(ref e) = env_walk {
+                let e = e.clone();
                 let borrowed = e.borrow();
                 if borrowed.is_field_initializer {
                     in_field_initializer = true;
@@ -12959,7 +12954,7 @@ impl Interpreter {
         direct: bool,
         caller_env: &EnvRef,
     ) -> Result<(), JsValue> {
-        let is_global = var_env.borrow().global_object.is_some();
+        let is_global = var_env.borrow().global_object_id.is_some();
 
         // Collect function declarations to initialize
         let functions_to_init = Self::collect_eval_function_decls(body);
@@ -13023,8 +13018,9 @@ impl Interpreter {
                     .chain(declared_var_names.iter())
                     .cloned()
                     .collect();
+                let global_id = var_env.borrow().global_object_id;
+                let global_obj = global_id.and_then(|id| self.get_object(id));
                 let env_b = var_env.borrow();
-                let global_obj = env_b.global_object.clone();
                 for name in &all_names {
                     if let Some(binding) = env_b.bindings.get(name)
                         && matches!(binding.kind, BindingKind::Let | BindingKind::Const)
@@ -13096,7 +13092,8 @@ impl Interpreter {
 
         // Check CanDeclareGlobalFunction / CanDeclareGlobalVar for global context
         if is_global {
-            let global_obj = var_env.borrow().global_object.clone();
+            let global_id = var_env.borrow().global_object_id;
+            let global_obj = global_id.and_then(|id| self.get_object(id));
             if let Some(ref gobj) = global_obj {
                 let gb = gobj.borrow();
                 let extensible = gb.extensible;
@@ -13150,16 +13147,14 @@ impl Interpreter {
             };
             let val = self.create_function(func);
             if is_global {
-                var_env
-                    .borrow_mut()
-                    .declare_global_function_binding(&f.name, val, true);
+                self.env_declare_global_function_binding(var_env, &f.name, val, true);
             } else {
                 if !var_env.borrow().bindings.contains_key(&f.name) {
                     var_env
                         .borrow_mut()
                         .declare_deletable(&f.name, BindingKind::Var);
                 }
-                let _ = var_env.borrow_mut().set(&f.name, val);
+                let _ = self.env_set(var_env, &f.name, val);
             }
         }
 
@@ -13208,7 +13203,7 @@ impl Interpreter {
         for name in &declared_var_names {
             if !var_env.borrow().bindings.contains_key(name) {
                 if is_global {
-                    var_env.borrow_mut().declare_global_var_configurable(name);
+                    self.env_declare_global_var_configurable(var_env, name);
                 } else {
                     var_env
                         .borrow_mut()
@@ -13275,7 +13270,7 @@ impl Interpreter {
 
                         if is_global {
                             if !var_env.borrow().bindings.contains_key(&name) {
-                                var_env.borrow_mut().declare_global_var_configurable(&name);
+                                self.env_declare_global_var_configurable(var_env, &name);
                             }
                         } else if !var_env.borrow().bindings.contains_key(&name) {
                             var_env
@@ -14326,10 +14321,11 @@ impl Interpreter {
                 let in_bindings = e.bindings.contains_key(name) || e.is_indirect_binding(name);
                 if in_bindings {
                     (true, None)
-                } else if let Some(ref global_obj) = e.global_object {
-                    let own = global_obj.borrow().properties.contains_key(name);
-                    let gid = global_obj.borrow().id;
-                    (own, if !own { gid } else { None })
+                } else if let Some(gid) = e.global_object_id {
+                    let own = self
+                        .get_object(gid)
+                        .is_some_and(|g| g.borrow().properties.contains_key(name));
+                    (own, if !own { Some(gid) } else { None })
                 } else {
                     (false, None)
                 }
@@ -14360,7 +14356,7 @@ impl Interpreter {
                 .borrow_mut()
                 .declare_deletable(name, BindingKind::Var);
         }
-        match global_env.borrow_mut().set(name, value.clone()) {
+        match self.env_set(&global_env, name, value.clone()) {
             Ok(()) => Completion::Normal(value),
             Err(_) => Completion::Throw(self.create_type_error("Assignment to constant variable.")),
         }
@@ -14416,11 +14412,7 @@ impl Interpreter {
                     }
                     SetBindingCheck::Unresolvable => {
                         let strict = env.borrow().strict || specific_env.borrow().strict;
-                        let global_obj_id = specific_env
-                            .borrow()
-                            .global_object
-                            .as_ref()
-                            .and_then(|obj| obj.borrow().id);
+                        let global_obj_id = specific_env.borrow().global_object_id;
                         if let Some(gid) = global_obj_id {
                             // §9.1.1.2.5 SetMutableBinding: check HasProperty
                             let still_exists = self.proxy_has_property(gid, name);
@@ -14451,11 +14443,7 @@ impl Interpreter {
                         // has_property (prototype chain), use [[Set]] to respect setters/proxies
                         let in_bindings = specific_env.borrow().bindings.contains_key(name);
                         if !in_bindings {
-                            let global_obj_id = specific_env
-                                .borrow()
-                                .global_object
-                                .as_ref()
-                                .and_then(|obj| obj.borrow().id);
+                            let global_obj_id = specific_env.borrow().global_object_id;
                             if let Some(gid) = global_obj_id {
                                 // §9.1.1.2.5 SetMutableBinding: check HasProperty again
                                 let still_exists = self.proxy_has_property(gid, name);
@@ -14482,7 +14470,7 @@ impl Interpreter {
                                 }
                             }
                         }
-                        match specific_env.borrow_mut().set(name, value.clone()) {
+                        match self.env_set(specific_env, name, value.clone()) {
                             Ok(()) => Completion::Normal(value),
                             Err(_) => Completion::Throw(
                                 self.create_type_error("Assignment to constant variable."),
@@ -14561,11 +14549,9 @@ impl Interpreter {
             }
 
             // 4. Check global object (at the bottom of the scope chain)
-            if let Some(ref global_obj) = env_borrow.global_object {
-                let global_obj_clone = global_obj.clone();
-                let global_id = global_obj_clone.borrow().id;
+            if let Some(gid) = env_borrow.global_object_id {
                 drop(env_borrow);
-                if let Some(gid) = global_id {
+                {
                     // Check own property first
                     let own_prop = self
                         .get_object(gid)
@@ -14616,33 +14602,32 @@ impl Interpreter {
             if env_borrow.bindings.contains_key(name) {
                 return None;
             }
-            if let Some(ref global_obj) = env_borrow.global_object {
-                let global_obj_clone = global_obj.clone();
-                let global_id = global_obj_clone.borrow().id;
+            if let Some(gid) = env_borrow.global_object_id {
                 drop(env_borrow);
-                if let Some(gid) = global_id {
-                    // Check own property first (fast path)
-                    let own_prop = self
-                        .get_object(gid)
-                        .and_then(|o| o.borrow().get_own_property(name));
-                    if let Some(ref desc) = own_prop {
-                        if desc.get.is_some() {
-                            let this_val = JsValue::Object(crate::types::JsObject { id: gid });
-                            return Some(self.get_object_property(gid, name, &this_val));
-                        }
-                        return None;
+                // Check own property first (fast path)
+                let own_prop = self
+                    .get_object(gid)
+                    .and_then(|o| o.borrow().get_own_property(name));
+                if let Some(ref desc) = own_prop {
+                    if desc.get.is_some() {
+                        let this_val = JsValue::Object(crate::types::JsObject { id: gid });
+                        return Some(self.get_object_property(gid, name, &this_val));
                     }
-                    // Not own — check prototype chain (handles Proxy has/get traps)
-                    match self.proxy_has_property(gid, name) {
-                        Ok(true) => {
-                            let this_val = JsValue::Object(crate::types::JsObject { id: gid });
-                            return Some(self.get_object_property(gid, name, &this_val));
-                        }
-                        Ok(false) => return None,
-                        Err(e) => return Some(Completion::Throw(e)),
-                    }
+                    // Data property — slim Environment::get no longer falls
+                    // through to the global object, so return the value here.
+                    return Some(Completion::Normal(
+                        desc.value.clone().unwrap_or(JsValue::Undefined),
+                    ));
                 }
-                return None;
+                // Not own — check prototype chain (handles Proxy has/get traps)
+                match self.proxy_has_property(gid, name) {
+                    Ok(true) => {
+                        let this_val = JsValue::Object(crate::types::JsObject { id: gid });
+                        return Some(self.get_object_property(gid, name, &this_val));
+                    }
+                    Ok(false) => return None,
+                    Err(e) => return Some(Completion::Throw(e)),
+                }
             }
             current = env_borrow.parent.clone();
         }

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -577,7 +577,7 @@ impl Interpreter {
             if env_borrow.bindings.contains_key(name) {
                 return Ok(None);
             }
-            if env_borrow.global_object.is_some() {
+            if env_borrow.global_object_id.is_some() {
                 return Ok(None);
             }
             current = env_borrow.parent.clone();

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -4,7 +4,7 @@ impl Interpreter {
     pub(crate) fn exec_statements(&mut self, stmts: &[Statement], env: &EnvRef) -> Completion {
         // Hoist var and function declarations
         let var_scope = Environment::find_var_scope(env);
-        let is_global = var_scope.borrow().global_object.is_some();
+        let is_global = var_scope.borrow().global_object_id.is_some();
         let is_block_scope = !Rc::ptr_eq(env, &var_scope);
 
         // §16.1.7 GlobalDeclarationInstantiation: pre-check CanDeclareGlobalFunction
@@ -93,7 +93,7 @@ impl Interpreter {
                     }
                     if !env.borrow().bindings.contains_key(&name) {
                         if is_global {
-                            env.borrow_mut().declare_global_var(&name);
+                            self.env_declare_global_var(env, &name);
                         } else {
                             env.borrow_mut().declare(&name, BindingKind::Var);
                         }
@@ -212,8 +212,8 @@ impl Interpreter {
         stmts: &[Statement],
         env: &EnvRef,
     ) -> Option<Completion> {
-        let global_obj = env.borrow().global_object.clone();
-        let global_obj = global_obj?;
+        let gid = env.borrow().global_object_id?;
+        let global_obj = self.get_object(gid)?;
 
         // §16.1.7 step 3: Check lexical names
         let lex_names = Self::collect_lex_names(stmts);
@@ -313,8 +313,7 @@ impl Interpreter {
         let val = self.create_function(func);
         if is_global {
             // §16.1.7 step 17c: CreateGlobalFunctionBinding(fn, fo, false)
-            env.borrow_mut()
-                .declare_global_function_binding(&f.name, val, false);
+            self.env_declare_global_function_binding(env, &f.name, val, false);
         } else {
             env.borrow_mut().declare(&f.name, BindingKind::Var);
             let _ = env.borrow_mut().set(&f.name, val);
@@ -381,12 +380,12 @@ impl Interpreter {
         }
     }
 
-    pub(crate) fn hoist_pattern(&self, pat: &Pattern, env: &EnvRef, is_global: bool) {
+    pub(crate) fn hoist_pattern(&mut self, pat: &Pattern, env: &EnvRef, is_global: bool) {
         match pat {
             Pattern::Identifier(name) => {
                 if !env.borrow().bindings.contains_key(name) {
                     if is_global {
-                        env.borrow_mut().declare_global_var(name);
+                        self.env_declare_global_var(env, name);
                     } else {
                         env.borrow_mut().declare(name, BindingKind::Var);
                     }
@@ -410,7 +409,7 @@ impl Interpreter {
                         ObjectPatternProperty::Shorthand(name) => {
                             if !env.borrow().bindings.contains_key(name) {
                                 if is_global {
-                                    env.borrow_mut().declare_global_var(name);
+                                    self.env_declare_global_var(env, name);
                                 } else {
                                     env.borrow_mut().declare(name, BindingKind::Var);
                                 }
@@ -427,7 +426,7 @@ impl Interpreter {
     }
 
     pub(crate) fn hoist_vars_from_stmt(
-        &self,
+        &mut self,
         stmt: &Statement,
         var_scope: &EnvRef,
         is_global: bool,
@@ -942,19 +941,17 @@ impl Interpreter {
                     other => return other,
                 };
                 if let JsValue::Object(obj_ref) = &obj_val {
-                    if let Some(obj_data) = self.get_object(obj_ref.id) {
+                    if self.get_object(obj_ref.id).is_some() {
                         let with_env = Rc::new(RefCell::new(Environment {
                             bindings: HashMap::new(),
                             parent: Some(env.clone()),
                             strict: env.borrow().strict,
                             is_function_scope: false,
                             is_arrow_scope: false,
-                            with_object: Some(WithObject {
-                                _object: obj_data,
-                                obj_id: obj_ref.id,
-                            }),
+                            with_object: Some(WithObject { obj_id: obj_ref.id }),
                             dispose_stack: None,
-                            global_object: None,
+                            global_object_id: None,
+                            global_object_rc: None,
                             annexb_function_names: None,
                             class_private_names: None,
                             is_field_initializer: false,
@@ -994,7 +991,7 @@ impl Interpreter {
                 // Only for regular functions (not generators or async)
                 if !f.is_generator && !f.is_async && !env.borrow().strict {
                     let is_block =
-                        !env.borrow().is_function_scope && env.borrow().global_object.is_none();
+                        !env.borrow().is_function_scope && env.borrow().global_object_id.is_none();
                     if is_block {
                         let var_scope = Environment::find_var_scope(env);
                         let is_registered = var_scope
@@ -1165,11 +1162,11 @@ impl Interpreter {
                 if kind == BindingKind::Var {
                     let var_scope = Environment::find_var_scope(env);
                     let already_declared = {
+                        let gid = var_scope.borrow().global_object_id;
                         let vs = var_scope.borrow();
                         vs.bindings.contains_key(name)
-                            || vs
-                                .global_object
-                                .as_ref()
+                            || gid
+                                .and_then(|id| self.get_object(id))
                                 .is_some_and(|g| g.borrow().properties.contains_key(name))
                     };
                     if !already_declared {
@@ -1182,11 +1179,11 @@ impl Interpreter {
                                 let strict = env.borrow().strict;
                                 self.with_set_mutable_binding(obj_id, name, val, strict)
                             }
-                            Ok(None) => env.borrow_mut().set(name, val),
+                            Ok(None) => self.env_set(env, name, val),
                             Err(e) => Err(e),
                         }
                     } else {
-                        env.borrow_mut().set(name, val)
+                        self.env_set(env, name, val)
                     }
                 } else {
                     env.borrow_mut().declare(name, kind);
@@ -1419,9 +1416,10 @@ impl Interpreter {
                                 // Step 2: ResolveBinding(bindingId, environment)
                                 let var_scope = Environment::find_var_scope(env);
                                 let already = {
+                                    let gid = var_scope.borrow().global_object_id;
                                     let vs = var_scope.borrow();
                                     vs.bindings.contains_key(binding_name)
-                                        || vs.global_object.as_ref().is_some_and(|g| {
+                                        || gid.and_then(|id| self.get_object(id)).is_some_and(|g| {
                                             g.borrow().properties.contains_key(binding_name)
                                         })
                                 };
@@ -1903,12 +1901,12 @@ impl Interpreter {
                         }
                         ForInOfLeft::Pattern(pat) => match pat {
                             Pattern::Identifier(name) => {
-                                if !env.borrow().has(name) && env.borrow().strict {
+                                if !self.env_has(env, name) && env.borrow().strict {
                                     break 'unroot Completion::Throw(self.create_reference_error(
                                         &format!("{name} is not defined"),
                                     ));
                                 }
-                                let _ = env.borrow_mut().set(name, key_val);
+                                let _ = self.env_set(env, name, key_val);
                             }
                             Pattern::MemberExpression(expr) => {
                                 if let Err(e) = self.assign_to_expr(expr, key_val, env) {

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -1,26 +1,22 @@
 use super::*;
 
 impl Interpreter {
-    /// Allocate a fresh object slot for `data` and return its id.
-    /// Centralises the `Rc::new(RefCell::new(..))` + `allocate_object_slot`
-    /// pattern used at every object creation site.
-    pub(crate) fn alloc_object(&mut self, data: JsObjectData) -> u64 {
-        let rc = Rc::new(RefCell::new(data));
-        self.allocate_object_slot(rc)
-    }
-
-    pub(crate) fn allocate_object_slot(&mut self, obj: Rc<RefCell<JsObjectData>>) -> u64 {
+    /// Allocate a fresh object slot for `data` and return its id. The id is
+    /// written to `data.id` *before* wrapping in `Rc<RefCell<>>`, so the field
+    /// is set exactly once at allocation and never reassigned.
+    pub(crate) fn alloc_object(&mut self, mut data: JsObjectData) -> u64 {
         self.gc_alloc_count += 1;
         let is_reuse = !self.free_list.is_empty();
         let id = if let Some(idx) = self.free_list.pop() {
-            self.objects[idx] = Some(obj.clone());
+            data.id = Some(idx as u64);
+            self.objects[idx] = Some(Rc::new(RefCell::new(data)));
             idx as u64
         } else {
             let idx = self.objects.len();
-            self.objects.push(Some(obj.clone()));
+            data.id = Some(idx as u64);
+            self.objects.push(Some(Rc::new(RefCell::new(data))));
             idx as u64
         };
-        obj.borrow_mut().id = Some(id);
         let cost = if is_reuse {
             GC_OBJECT_OVERHEAD / 2
         } else {
@@ -483,6 +479,12 @@ impl Interpreter {
             let borrowed = e.borrow();
             for binding in borrowed.bindings.values() {
                 Self::collect_value_roots(&binding.value, worklist);
+            }
+            // The with-target is interned (id-only) — root it explicitly so
+            // identifier resolution inside `with(o) { ... }` keeps `o` alive
+            // across GC.
+            if let Some(ref w) = borrowed.with_object {
+                worklist.push(w.obj_id);
             }
             current = borrowed.parent.clone();
         }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -20,6 +20,7 @@ mod helpers;
 pub(crate) use helpers::*;
 mod builtins;
 pub(crate) use builtins::regexp::validate_js_pattern;
+mod env_helpers;
 mod eval;
 mod exec;
 mod gc;
@@ -359,9 +360,7 @@ impl Interpreter {
 
         // $262.global — reference to the realm's global object
         let global_env = self.realms[realm_id].global_env.clone();
-        let global_obj = global_env.borrow().global_object.clone();
-        if let Some(ref go) = global_obj {
-            let go_id = go.borrow().id.unwrap();
+        if let Some(go_id) = global_env.borrow().global_object_id {
             dollar_262.borrow_mut().insert_builtin(
                 "global".to_string(),
                 JsValue::Object(crate::types::JsObject { id: go_id }),
@@ -837,7 +836,7 @@ impl Interpreter {
         let val = self.create_function(func);
         let global_env = self.realm().global_env.clone();
         global_env.borrow_mut().declare(name, kind);
-        let _ = global_env.borrow_mut().set(name, val);
+        let _ = self.env_set(&global_env, name, val);
     }
 
     #[allow(clippy::wrong_self_convention)]
@@ -1415,13 +1414,13 @@ impl Interpreter {
 
     /// Convert a symbol property key string (e.g. "Symbol(Symbol.toStringTag)" or "Symbol(desc)#42")
     /// back to a JsValue::Symbol.
-    pub(crate) fn symbol_key_to_jsvalue(&self, key: &str) -> JsValue {
+    pub(crate) fn symbol_key_to_jsvalue(&mut self, key: &str) -> JsValue {
         // Well-known symbols: "Symbol(Symbol.xyz)" — look up from Symbol constructor
         if key.starts_with("Symbol(Symbol.") && key.ends_with(')') && !key.contains('#') {
             // Extract the well-known name (e.g. "toStringTag" from "Symbol(Symbol.toStringTag)")
             let inner = &key[7..key.len() - 1]; // "Symbol.toStringTag"
             let name = &inner[7..]; // "toStringTag"
-            if let Some(sym_val) = self.realm().global_env.borrow().get("Symbol")
+            if let Some(sym_val) = self.get_global_var("Symbol")
                 && let JsValue::Object(so) = sym_val
             {
                 let val = self.get_property_on_id(so.id, name);

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -612,7 +612,14 @@ pub struct Environment {
     pub(crate) is_arrow_scope: bool,
     pub(crate) with_object: Option<WithObject>,
     pub(crate) dispose_stack: Option<Vec<DisposableResource>>,
-    pub(crate) global_object: Option<Rc<RefCell<JsObjectData>>>,
+    /// Slab id of the realm's global object. The canonical identity reference.
+    pub(crate) global_object_id: Option<u64>,
+    /// Rc handle to the same global object kept in sync with `global_object_id`.
+    /// Used only by `Environment` methods that need property access without an
+    /// `Interpreter` reference (e.g. `Environment::get/set/has/declare_global_*`).
+    /// `setup_globals` writes both fields atomically; nothing else mutates them.
+    /// PR 2 will drop this field when the slab itself loses `Rc<RefCell<>>`.
+    pub(crate) global_object_rc: Option<Rc<RefCell<JsObjectData>>>,
     // Annex B.3.3: names registered for block-level function var hoisting
     pub(crate) annexb_function_names: Option<Vec<String>>,
     pub(crate) class_private_names: Option<HashMap<String, String>>,
@@ -652,7 +659,6 @@ impl std::fmt::Debug for Environment {
 }
 
 pub(crate) struct WithObject {
-    pub(crate) _object: Rc<RefCell<JsObjectData>>,
     pub(crate) obj_id: u64,
 }
 
@@ -706,7 +712,8 @@ impl Environment {
             is_arrow_scope: false,
             with_object: None,
             dispose_stack: None,
-            global_object: None,
+            global_object_id: None,
+            global_object_rc: None,
             annexb_function_names: None,
             class_private_names: None,
             is_field_initializer: false,
@@ -730,7 +737,8 @@ impl Environment {
             is_arrow_scope: false,
             with_object: None,
             dispose_stack: None,
-            global_object: None,
+            global_object_id: None,
+            global_object_rc: None,
             annexb_function_names: None,
             class_private_names: None,
             is_field_initializer: false,
@@ -757,7 +765,7 @@ impl Environment {
     /// Find the nearest function scope (for var hoisting).
     /// Returns self if this is a function scope, otherwise traverses up.
     pub fn find_var_scope(env: &EnvRef) -> EnvRef {
-        if env.borrow().is_function_scope || env.borrow().global_object.is_some() {
+        if env.borrow().is_function_scope || env.borrow().global_object_id.is_some() {
             return env.clone();
         }
         if let Some(ref parent) = env.borrow().parent {
@@ -850,10 +858,7 @@ impl Environment {
     /// Per §9.1.1.4.17 CreateGlobalVarBinding: var declarations in global scope
     /// create non-configurable properties on the global object.
     pub fn declare_global_var(&mut self, name: &str) {
-        // Per §9.1.1.4.17 CreateGlobalVarBinding: global vars are stored as
-        // properties on the global object, not in the environment bindings map.
-        // This ensures `this.x = val` and `x` reference the same storage.
-        if let Some(ref global_obj) = self.global_object {
+        if let Some(ref global_obj) = self.global_object_rc {
             let mut gb = global_obj.borrow_mut();
             if !gb.properties.contains_key(name) {
                 gb.property_order.push(name.to_string());
@@ -870,16 +875,15 @@ impl Environment {
     /// CreateGlobalVarBinding with configurable:true (for eval-declared vars).
     pub fn declare_global_var_configurable(&mut self, name: &str) {
         if !self.bindings.contains_key(name) {
-            // Check if the global object has ANY property (data or accessor)
             let has_global_prop = self
-                .global_object
+                .global_object_rc
                 .as_ref()
                 .is_some_and(|g| g.borrow().properties.contains_key(name));
             if !has_global_prop {
                 self.declare(name, BindingKind::Var);
             }
         }
-        if let Some(ref global_obj) = self.global_object {
+        if let Some(ref global_obj) = self.global_object_rc {
             let mut gb = global_obj.borrow_mut();
             if !gb.properties.contains_key(name) {
                 gb.property_order.push(name.to_string());
@@ -903,7 +907,7 @@ impl Environment {
             binding.value = value.clone();
             binding.initialized = true;
         }
-        if let Some(ref global_obj) = self.global_object {
+        if let Some(ref global_obj) = self.global_object_rc {
             let mut gb = global_obj.borrow_mut();
             let existing = gb.properties.get(name);
             let need_full_desc =
@@ -952,7 +956,7 @@ impl Environment {
                 return Ok(());
             }
             if binding.kind == BindingKind::Var
-                && let Some(ref global_obj) = self.global_object
+                && let Some(ref global_obj) = self.global_object_rc
             {
                 let ok = global_obj
                     .borrow_mut()
@@ -973,7 +977,7 @@ impl Environment {
             parent.borrow_mut().set(name, value)
         } else {
             // Global implicit declaration (sloppy mode)
-            if let Some(ref global_obj) = self.global_object {
+            if let Some(ref global_obj) = self.global_object_rc {
                 let already_on_global = global_obj.borrow().has_own_property(name);
                 let ok = global_obj
                     .borrow_mut()
@@ -1005,48 +1009,16 @@ impl Environment {
             Some(binding.value.clone())
         } else if let Some(parent) = &self.parent {
             parent.borrow().get(name)
-        } else if let Some(ref global_obj) = self.global_object {
-            if Self::global_obj_has_property(global_obj, name) {
-                Some(Self::global_obj_get_property(global_obj, name))
+        } else if let Some(ref global_obj) = self.global_object_rc {
+            let b = global_obj.borrow();
+            if let Some(true) = b.own_has_property(name) {
+                b.own_property_lookup(name)
             } else {
                 None
             }
         } else {
             None
         }
-    }
-
-    /// Rc-based prototype-chain walk used by `Environment::{get, check_set_binding, has}`
-    /// to probe the global object without needing an `Interpreter` reference.
-    /// Once `Environment.global_object` becomes `Option<u64>` (PR 1b.4), these
-    /// helpers must be replaced by `Interpreter::{has_property_on_id, get_property_on_id}`.
-    fn global_obj_has_property(obj_rc: &Rc<RefCell<JsObjectData>>, name: &str) -> bool {
-        // NOTE: after PR 1b.4 converts `Environment.global_object` to `Option<u64>`,
-        // this helper should route through `Interpreter::has_property_on_id` instead.
-        // Today we still have an Rc here, but the inner `prototype_id` is a u64 —
-        // we'd need the interpreter's object table to follow it. As a stopgap, we
-        // emulate the walk by borrowing the realm's object slab via the Rc chain.
-        // Since this helper only walks the GLOBAL object's chain (which the realm
-        // roots keep alive), the simplest correct path is: check the first frame's
-        // own property, then fall through. The global object's prototype chain is
-        // either Object.prototype (always own-resolves) or null — so this is safe.
-        // The properly iterative form lives in `Interpreter::has_property_on_id`.
-        let b = obj_rc.borrow();
-        if let Some(r) = b.own_has_property(name) {
-            return r;
-        }
-        // Global object inherits from Object.prototype; without Interpreter access
-        // here we cannot safely walk further. In practice the next step is a single
-        // hop to Object.prototype. Conservative: report absent.
-        false
-    }
-
-    fn global_obj_get_property(obj_rc: &Rc<RefCell<JsObjectData>>, name: &str) -> JsValue {
-        let b = obj_rc.borrow();
-        if let Some(v) = b.own_property_lookup(name) {
-            return v;
-        }
-        JsValue::Undefined
     }
 
     /// Check if a binding exists but is uninitialized (in TDZ).
@@ -1085,8 +1057,8 @@ impl Environment {
             }
             return SetBindingCheck::Ok;
         }
-        if let Some(ref global_obj) = e.global_object {
-            if Self::global_obj_has_property(global_obj, name) {
+        if let Some(ref global_obj) = e.global_object_rc {
+            if matches!(global_obj.borrow().own_has_property(name), Some(true)) {
                 return SetBindingCheck::Ok;
             }
             return SetBindingCheck::Unresolvable;
@@ -1102,8 +1074,8 @@ impl Environment {
             true
         } else if let Some(parent) = &self.parent {
             parent.borrow().has(name)
-        } else if let Some(ref global_obj) = self.global_object {
-            Self::global_obj_has_property(global_obj, name)
+        } else if let Some(ref global_obj) = self.global_object_rc {
+            matches!(global_obj.borrow().own_has_property(name), Some(true))
         } else {
             false
         }
@@ -1114,7 +1086,7 @@ impl Environment {
         if e.is_indirect_binding(name) || e.bindings.contains_key(name) {
             return Some(env.clone());
         }
-        if e.global_object.is_some() {
+        if e.global_object_id.is_some() {
             return Some(env.clone());
         }
         if let Some(ref parent) = e.parent {
@@ -1658,6 +1630,8 @@ pub(crate) enum TemporalData {
 }
 
 pub struct JsObjectData {
+    /// Slab index of this object. Set exactly once by
+    /// `Interpreter::alloc_object` at allocation time and never reassigned.
     pub id: Option<u64>,
     pub properties: PropertyMap,
     pub property_order: Vec<String>,

--- a/test262-extra/with-gc-root.js
+++ b/test262-extra/with-gc-root.js
@@ -1,0 +1,43 @@
+// Tests that the with-statement target object stays live across a GC
+// triggered inside the with-block.
+// Spec: ECMAScript 2024 §14.11 (The with Statement) — the binding object
+// must remain reachable for the duration of the with-block. Regression test
+// for PR 1b.4 (issue #66 / #107) where WithObject._object was dropped and
+// the obj_id is now rooted only via Interpreter::collect_env_roots.
+
+var probe = { sentinel: 0xdeadbeef, marker: "with-target" };
+
+with (probe) {
+  // Allocate enough garbage to push the GC over the threshold, then force a
+  // collection while we're still inside the with-scope.
+  for (var i = 0; i < 5000; i++) {
+    var tmp = { idx: i, payload: "filler" };
+  }
+  $262.gc();
+
+  // Property reads on the with-target should still resolve correctly.
+  if (sentinel !== 0xdeadbeef) {
+    throw new Error("with-target collected: sentinel=" + sentinel);
+  }
+  if (marker !== "with-target") {
+    throw new Error("with-target collected: marker=" + marker);
+  }
+
+  // Writes inside the with-block must mutate the original object, not leak
+  // to the surrounding scope.
+  sentinel = 1;
+}
+
+if (probe.sentinel !== 1) {
+  throw new Error("with-block write did not reach probe: " + probe.sentinel);
+}
+// `sentinel` must be unresolvable outside the with-block.
+var threw = false;
+try {
+  sentinel;
+} catch (e) {
+  threw = e instanceof ReferenceError;
+}
+if (!threw) {
+  throw new Error("with-binding leaked outside with-block");
+}


### PR DESCRIPTION
Closes #107. Final field-interning step from issue #66, continuing PR 1a (#103), PR 1b.1 (#104), PR 1b.2 (#109), PR 1b.3 (#117).

## Summary

- `Environment.global_object: Rc<RefCell<JsObjectData>>` → canonical `global_object_id: Option<u64>` with a transitional `global_object_rc` retained for in-`Environment` binding-resolution methods. Both fields written atomically in `setup_globals`.
- `WithObject._object` dropped. The with-target is now rooted via `Interpreter::collect_env_roots` through `WithObject.obj_id` — single GC root, no Rc.
- `alloc_object()` writes `JsObjectData.id` before wrapping in `Rc<RefCell<>>`; the post-construction backfill in `allocate_object_slot` is removed and `allocate_object_slot` is folded into `alloc_object`.

## Plumbing

New `src/interpreter/env_helpers.rs` with `env_set` / `env_get` / `env_has` / `env_declare_global_*` / `get_global_var` / `get_global_var_ref`. All builtin-name lookups (`Symbol`, `Promise`, `Function`, `RegExp`, error constructors) route through these so they survive `setup_globals` stripping the bootstrap bindings. `set_global_implicit` / `register_global_fn` / `put_value_by_ref` / var initialisers / for-in identifier targets / function-decl hoisting use `env_set` so the var-binding mirror to the global obj is preserved.

`resolve_global_getter` now returns the resolved value for data properties on the global obj — slim `Environment::get` no longer falls through on its own.

## Caveat

The strict "no `Rc<RefCell<JsObjectData>>` field anywhere" goal in #107 is not fully met. `Environment.global_object_rc` remains as a transitional handle because `Environment::set/get/has/check_set_binding/declare_global_*` have no `&mut Interpreter` and therefore no way to resolve an id through the slab. PR 2 (which drops `Rc` from the slab itself) will replace this handle with the new slab-cursor type — no callers outside `Environment` hold an `Rc` to the global object anymore. Documented inline in `types.rs`.

## Test plan

- [x] `cargo build --release` clean
- [x] `./scripts/lint.sh` rustfmt + clippy clean
- [x] `uv run python scripts/run-test262.py -j 32` — 40 flaky failures under load, all pre-existing on `origin/main` (verified by stash + rerun)
- [x] `uv run python scripts/run-test262.py -j 100` — same flaky pattern (40)
- [x] `test262/test/language/statements/with/` — 100% green
- [x] `./scripts/run-acorn-tests.sh` — 13,537 / 13,537
- [x] `uv run python scripts/run-custom-tests.py` — 3 / 3
- [x] `test262-extra/` — 13 / 13 including new `with-gc-root.js`
- [x] JetStream `proxy-mobx` — 1140ms vs main's 1139ms (perf-neutral, within noise)

## References

- Issue: #107
- Plan: `.ultraplan/intern-env-with-ids.md`
- Predecessors: #103, #104, #109, #117