### PR TITLE
[perf] Inline caching for property lookups and call sites (#71)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,8 +1,11 @@
 /// AST node types for ECMAScript.
 /// Each node represents a syntactic element from the spec.
+use std::cell::Cell;
 use std::fmt;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::interpreter::ic::{CallIcSlot, PropIcSlot};
 
 static NEXT_TEMPLATE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -190,9 +193,26 @@ pub enum Expression {
     Update(UpdateOp, bool, Box<Expression>), // op, prefix, argument
     Assign(AssignOp, Box<Expression>, Box<Expression>),
     Conditional(Box<Expression>, Box<Expression>, Box<Expression>),
-    Call(Box<Expression>, Vec<Expression>),
-    New(Box<Expression>, Vec<Expression>),
-    Member(Box<Expression>, MemberProperty),
+    /// Function call `f(args)` / `obj.method(args)`. Third field is a
+    /// per-site call IC slot (issue #71, Phase 3).
+    Call(Box<Expression>, Vec<Expression>, Cell<CallIcSlot>),
+    /// Constructor invocation `new F(args)`. Carries its own call IC slot —
+    /// the slot is allocated for forward compatibility but is not yet read
+    /// in Phase-3 v1 (constructor invocation is statistically rarer than
+    /// regular calls; probe wiring lands in a follow-up cycle).
+    New(
+        Box<Expression>,
+        Vec<Expression>,
+        #[allow(dead_code)] Cell<CallIcSlot>,
+    ),
+    /// Property access `obj.x` / `obj[key]`. The third field is a per-site
+    /// inline-cache slot (issue #71). `Cell<PropIcSlot>` works because
+    /// `PropIcSlot` is `Copy`. At parse time the slot is `Empty`; the
+    /// `eval_member` probe and `get_object_property` slow path mutate it
+    /// through `Cell::get`/`Cell::set`. Slot state is per-AST-node, not
+    /// per-execution; generator/async replay is safe because the slot is
+    /// shape-keyed and re-fetches on every hit.
+    Member(Box<Expression>, MemberProperty, Cell<PropIcSlot>),
     OptionalChain(Box<Expression>, Box<Expression>),
     #[allow(dead_code)]
     Comma(Vec<Expression>),
@@ -637,15 +657,15 @@ fn expr_uses_arguments(expr: &Expression) -> bool {
         Expression::Conditional(t, c, a) => {
             expr_uses_arguments(t) || expr_uses_arguments(c) || expr_uses_arguments(a)
         }
-        Expression::Call(callee, args) => {
+        Expression::Call(callee, args, _) => {
             matches!(&**callee, Expression::Identifier(name) if name == "eval")
                 || expr_uses_arguments(callee)
                 || args.iter().any(expr_uses_arguments)
         }
-        Expression::New(callee, args) => {
+        Expression::New(callee, args, _) => {
             expr_uses_arguments(callee) || args.iter().any(expr_uses_arguments)
         }
-        Expression::Member(obj, prop) => {
+        Expression::Member(obj, prop, _) => {
             expr_uses_arguments(obj)
                 || matches!(prop, MemberProperty::Computed(e) if expr_uses_arguments(e))
         }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -409,9 +409,13 @@ impl Interpreter {
                     self.eval_expr(alt, env)
                 }
             }
-            Expression::Call(callee, args) => self.eval_call(callee, args, env),
-            Expression::New(callee, args) => self.eval_new(callee, args, env),
-            Expression::Member(obj, prop) => self.eval_member(obj, prop, env),
+            Expression::Call(callee, args, ic_cell) => {
+                self.eval_call(callee, args, env, Some(ic_cell))
+            }
+            Expression::New(callee, args, _) => self.eval_new(callee, args, env),
+            Expression::Member(obj, prop, ic_cell) => {
+                self.eval_member(obj, prop, env, Some(ic_cell))
+            }
             Expression::Array(elements, _) => self.eval_array_literal(elements, env),
             Expression::Object(props) => self.eval_object_literal(props, env),
             Expression::Function(f) => {
@@ -561,7 +565,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             }
             Expression::Delete(expr) => match expr.as_ref() {
-                Expression::Member(obj_expr, prop) => {
+                Expression::Member(obj_expr, prop, _) => {
                     // §13.5.1.2 step 5a: delete on SuperReference is always ReferenceError.
                     // §13.3.7.1: SuperProperty evaluation calls GetThisBinding() (step 2)
                     // before evaluating the key expression (step 3).
@@ -1220,7 +1224,7 @@ impl Interpreter {
                 let saved_tail = self.in_tail_position;
                 self.in_tail_position = false;
                 let (func_val, this_val) = match tag_expr.as_ref() {
-                    Expression::Member(obj_expr, prop) => {
+                    Expression::Member(obj_expr, prop, _) => {
                         let obj_val = match self.eval_expr(obj_expr, env) {
                             Completion::Normal(v) => v,
                             other => return other,
@@ -2368,7 +2372,7 @@ impl Interpreter {
                 other => return other,
             }
             Completion::Normal(if prefix { new_val } else { old_val })
-        } else if let Expression::Member(obj_expr, prop) = arg {
+        } else if let Expression::Member(obj_expr, prop, _) = arg {
             // §13.3.7.1: super[expr]++ — special evaluation order
             if matches!(obj_expr.as_ref(), Expression::Super)
                 && !matches!(prop, MemberProperty::Private(_))
@@ -2515,7 +2519,7 @@ impl Interpreter {
                 return Completion::Throw(e);
             }
             Completion::Normal(if prefix { new_val } else { old_val })
-        } else if let Expression::Call(_, _) = arg {
+        } else if let Expression::Call(_, _, _) = arg {
             match self.eval_expr(arg, env) {
                 Completion::Normal(_) => {}
                 other => return other,
@@ -2537,7 +2541,7 @@ impl Interpreter {
         env: &EnvRef,
     ) -> Result<(), JsValue> {
         match expr {
-            Expression::Member(obj_expr, prop) => {
+            Expression::Member(obj_expr, prop, _) => {
                 // Handle super.prop / super[expr] assignment
                 if matches!(obj_expr.as_ref(), Expression::Super) {
                     let key = match prop {
@@ -2898,7 +2902,7 @@ impl Interpreter {
                 };
                 self.put_value_by_ref(name, final_val, &id_ref, env)
             }
-            Expression::Member(obj_expr, prop) => {
+            Expression::Member(obj_expr, prop, _) => {
                 // §13.3.7.1: super[expr] = val — special evaluation order
                 if matches!(obj_expr.as_ref(), Expression::Super)
                     && !matches!(prop, MemberProperty::Private(_))
@@ -3455,7 +3459,7 @@ impl Interpreter {
                     other => other,
                 }
             }
-            Expression::Call(_, _) => {
+            Expression::Call(_, _, _) => {
                 match self.eval_expr(left, env) {
                     Completion::Normal(_) => {}
                     other => return other,
@@ -3554,7 +3558,7 @@ impl Interpreter {
                 }
                 self.put_value_by_ref(name, rval, &id_ref, env)
             }
-            Expression::Member(obj_expr, MemberProperty::Private(name)) => {
+            Expression::Member(obj_expr, MemberProperty::Private(name), _) => {
                 let branded = self.resolve_private_name(name, env);
                 let obj_val = match self.eval_expr(obj_expr, env) {
                     Completion::Normal(v) => v,
@@ -3652,7 +3656,7 @@ impl Interpreter {
                 }
                 Completion::Normal(rval)
             }
-            Expression::Member(obj_expr, prop) => {
+            Expression::Member(obj_expr, prop, _) => {
                 // Super property logical assignment: super.p &&= / ||= / ??=
                 if matches!(obj_expr.as_ref(), Expression::Super)
                     && !matches!(prop, MemberProperty::Private(_))
@@ -4383,7 +4387,7 @@ impl Interpreter {
                     other => other,
                 }
             }
-            Expression::Member(obj_expr, prop) => {
+            Expression::Member(obj_expr, prop, _) => {
                 match self.set_member_property(obj_expr, prop, val, env) {
                     Ok(()) => Completion::Normal(JsValue::Undefined),
                     Err(e) => Completion::Throw(e),
@@ -4430,7 +4434,7 @@ impl Interpreter {
         env: &EnvRef,
         yield_val: &mut Option<JsValue>,
     ) -> Result<Option<DestructLRef>, JsValue> {
-        let Expression::Member(obj_expr, prop) = target else {
+        let Expression::Member(obj_expr, prop, _) = target else {
             return Ok(None);
         };
 
@@ -4936,7 +4940,13 @@ impl Interpreter {
         Completion::Normal(JsValue::Undefined)
     }
 
-    fn eval_call(&mut self, callee: &Expression, args: &[Expression], env: &EnvRef) -> Completion {
+    fn eval_call(
+        &mut self,
+        callee: &Expression,
+        args: &[Expression],
+        env: &EnvRef,
+        ic_cell: Option<&std::cell::Cell<crate::interpreter::ic::CallIcSlot>>,
+    ) -> Completion {
         let saved_tail = self.in_tail_position;
         self.in_tail_position = false;
 
@@ -5005,7 +5015,7 @@ impl Interpreter {
 
         // Handle member calls: obj.method()
         let (func_val, this_val) = match callee {
-            Expression::Member(obj_expr, prop) => {
+            Expression::Member(obj_expr, prop, _) => {
                 let is_super_call = matches!(obj_expr.as_ref(), Expression::Super);
                 let obj_val = match self.eval_expr(obj_expr, env) {
                     Completion::Normal(v) => v,
@@ -5258,9 +5268,96 @@ impl Interpreter {
                 args: evaluated_args,
             };
         }
+        // Phase 3 call-IC probe + record. Issue #71. v1 scope:
+        //  - Probe HIT increments call_ic_hit_count; dispatch is unchanged
+        //    (the fast path that skips proxy/wrapped/class-ctor checks is a
+        //    follow-up — see plan Step 15).
+        //  - Probe MISS classifies the callable; if it's a plain native or
+        //    user function (no proxy, no wrapped, not a class ctor without
+        //    `new`, not bound), records Mono. Otherwise transitions to
+        //    Megamorphic. State machine identical to PropIcSlot.
+        if let Some(cell) = ic_cell
+            && self.with_scope_depth == 0
+            && let JsValue::Object(o) = &func_val
+        {
+            use crate::interpreter::ic::CallIcSlot;
+            let slot = cell.get();
+            let mut probe_hit = false;
+            if let CallIcSlot::Mono {
+                callee_obj_id,
+                callee_shape_id,
+                ..
+            } = slot
+                && o.id == callee_obj_id
+                && let Some(obj_rc) = self.get_object(o.id)
+                && obj_rc.borrow().shape_id == callee_shape_id
+            {
+                self.call_ic_hit_count.set(self.call_ic_hit_count.get() + 1);
+                probe_hit = true;
+            }
+            if !probe_hit {
+                self.call_ic_slow_path_count
+                    .set(self.call_ic_slow_path_count.get() + 1);
+            }
+            let result = self.call_function(&func_val, &this_val, &evaluated_args);
+            // Record only on success to avoid caching error-paths.
+            if !probe_hit && matches!(result, Completion::Normal(_)) {
+                let new_slot = self.classify_for_call_ic(o.id);
+                let next = match (slot, new_slot) {
+                    (_, None) => CallIcSlot::Empty,
+                    (CallIcSlot::Empty, Some(s)) => s,
+                    (
+                        CallIcSlot::Mono {
+                            callee_obj_id: prev,
+                            ..
+                        },
+                        Some(
+                            s @ CallIcSlot::Mono {
+                                callee_obj_id: new, ..
+                            },
+                        ),
+                    ) if prev == new => s,
+                    (CallIcSlot::Mono { .. }, Some(_)) => CallIcSlot::Megamorphic,
+                    (CallIcSlot::Megamorphic, _) => CallIcSlot::Megamorphic,
+                };
+                cell.set(next);
+            }
+            self.gc_unroot_frame(gc_frame);
+            return result;
+        }
         let result = self.call_function(&func_val, &this_val, &evaluated_args);
         self.gc_unroot_frame(gc_frame);
         result
+    }
+
+    /// Classifies the post-call state of `callee_obj_id` into a
+    /// `CallIcSlot::Mono { kind: ... }` ready for caching, or `None` if the
+    /// site is not IC-able under the v1 narrow scope (proxy, wrapped, bound,
+    /// or class-ctor-without-new). Phase 3, plan Step 14.
+    fn classify_for_call_ic(
+        &self,
+        callee_obj_id: u64,
+    ) -> Option<crate::interpreter::ic::CallIcSlot> {
+        use crate::interpreter::ic::{CallIcKind, CallIcSlot};
+        let obj_rc = self.get_object(callee_obj_id)?;
+        let obj = obj_rc.borrow();
+        if obj.proxy_target_id.is_some()
+            || obj.proxy_revoked
+            || obj.wrapped_target_function_id.is_some()
+            || obj.bound_target_function.is_some()
+            || obj.is_class_constructor
+        {
+            return None;
+        }
+        let kind = match obj.callable.as_ref()? {
+            JsFunction::Native(..) => CallIcKind::NativeFn,
+            JsFunction::User { .. } => CallIcKind::UserFn,
+        };
+        Some(CallIcSlot::Mono {
+            callee_obj_id,
+            callee_shape_id: obj.shape_id,
+            kind,
+        })
     }
 
     pub(crate) fn generator_next(&mut self, this: &JsValue, sent_value: JsValue) -> Completion {
@@ -12558,11 +12655,11 @@ impl Interpreter {
                 Self::expr_contains_arguments(&p.value)
                     || matches!(&p.key, PropertyKey::Computed(e) if Self::expr_contains_arguments(e))
             }),
-            Expression::Member(obj, prop) => {
+            Expression::Member(obj, prop, _) => {
                 Self::expr_contains_arguments(obj)
                     || matches!(prop, MemberProperty::Computed(e) if Self::expr_contains_arguments(e))
             }
-            Expression::Call(callee, args) | Expression::New(callee, args) => {
+            Expression::Call(callee, args, _) | Expression::New(callee, args, _) => {
                 Self::expr_contains_arguments(callee)
                     || args.iter().any(Self::expr_contains_arguments)
             }
@@ -12630,7 +12727,7 @@ impl Interpreter {
     fn expr_contains_super_call(expr: &Expression) -> bool {
         use crate::ast::*;
         match expr {
-            Expression::Call(callee, args) => {
+            Expression::Call(callee, args, _) => {
                 matches!(**callee, Expression::Super)
                     || Self::expr_contains_super_call(callee)
                     || args.iter().any(Self::expr_contains_super_call)
@@ -12655,11 +12752,11 @@ impl Interpreter {
                 ArrowBody::Expression(e) => Self::expr_contains_super_call(e),
                 ArrowBody::Block(stmts) => Self::stmts_contain_super_call(stmts),
             },
-            Expression::New(callee, args) => {
+            Expression::New(callee, args, _) => {
                 Self::expr_contains_super_call(callee)
                     || args.iter().any(Self::expr_contains_super_call)
             }
-            Expression::Member(obj, prop) => {
+            Expression::Member(obj, prop, _) => {
                 Self::expr_contains_super_call(obj)
                     || matches!(prop, MemberProperty::Computed(e) if Self::expr_contains_super_call(e))
             }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -5299,7 +5299,15 @@ impl Interpreter {
                 self.call_ic_slow_path_count
                     .set(self.call_ic_slow_path_count.get() + 1);
             }
-            let result = self.call_function(&func_val, &this_val, &evaluated_args);
+            // Phase-3 follow-up: route IC hits through the fast dispatch
+            // entry that skips proxy/wrapped/class-ctor checks. Misses use
+            // the slow path so the entry checks correctly classify novel
+            // callables (proxies, bound, class ctors) before IC recording.
+            let result = if probe_hit {
+                self.call_function_ic_validated(&func_val, &this_val, &evaluated_args)
+            } else {
+                self.call_function(&func_val, &this_val, &evaluated_args)
+            };
             // Record only on success to avoid caching error-paths.
             if !probe_hit && matches!(result, Completion::Normal(_)) {
                 let new_slot = self.classify_for_call_ic(o.id);
@@ -11803,7 +11811,7 @@ impl Interpreter {
         this_val: &JsValue,
         args: &[JsValue],
     ) -> Completion {
-        let mut result = self.call_function_inner(func_val, this_val, args);
+        let mut result = self.call_function_inner(func_val, this_val, args, false);
         loop {
             match result {
                 Completion::TailCall {
@@ -11811,7 +11819,34 @@ impl Interpreter {
                     this,
                     args: tc_args,
                 } => {
-                    result = self.call_function_inner(&func, &this, &tc_args);
+                    result = self.call_function_inner(&func, &this, &tc_args, false);
+                }
+                other => return other,
+            }
+        }
+    }
+
+    /// Issue #71 Phase-3 follow-up: call_function variant for IC-validated
+    /// hits. The first dispatch skips the proxy/wrapped/class-ctor entry
+    /// checks (the IC's `Mono` state guarantees the callable is a plain
+    /// native or user function). Tail-call recursion falls back to the
+    /// slow path because the tail-called function is a different callable
+    /// not validated by the originating IC slot.
+    pub(crate) fn call_function_ic_validated(
+        &mut self,
+        func_val: &JsValue,
+        this_val: &JsValue,
+        args: &[JsValue],
+    ) -> Completion {
+        let mut result = self.call_function_inner(func_val, this_val, args, true);
+        loop {
+            match result {
+                Completion::TailCall {
+                    func,
+                    this,
+                    args: tc_args,
+                } => {
+                    result = self.call_function_inner(&func, &this, &tc_args, false);
                 }
                 other => return other,
             }
@@ -11823,12 +11858,19 @@ impl Interpreter {
         func_val: &JsValue,
         _this_val: &JsValue,
         args: &[JsValue],
+        skip_entry_checks: bool,
     ) -> Completion {
         if let JsValue::Object(o) = func_val
             && let Some(obj) = self.get_object(o.id)
         {
-            // Single borrow to check proxy/wrapped/class-ctor status
-            let (is_proxy_or_revoked, has_wrapped_target, is_class_ctor) = {
+            // Single borrow to check proxy/wrapped/class-ctor status. Skipped
+            // when an IC hit already validated the callable category — see
+            // `call_function_ic_validated`.
+            let (is_proxy_or_revoked, has_wrapped_target, is_class_ctor) = if skip_entry_checks {
+                self.call_ic_fast_dispatch_count
+                    .set(self.call_ic_fast_dispatch_count.get() + 1);
+                (false, false, false)
+            } else {
                 let b = obj.borrow();
                 (
                     b.is_proxy() || b.proxy_revoked,

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -24,7 +24,7 @@ impl Interpreter {
         env: &EnvRef,
     ) -> Result<(JsValue, JsValue), Completion> {
         match base {
-            Expression::Member(obj_expr, member_prop) => {
+            Expression::Member(obj_expr, member_prop, _) => {
                 if matches!(obj_expr.as_ref(), Expression::Super) {
                     // §13.3.7.1: super property in optional chain — use HomeObject.__proto__
                     let this_val = env.borrow().get("this").unwrap_or(JsValue::Undefined);
@@ -216,7 +216,7 @@ impl Interpreter {
                     Ok((val, base_val.clone()))
                 }
             }
-            Expression::Call(callee, args) => {
+            Expression::Call(callee, args, _) => {
                 let (func_val, this_val) =
                     self.eval_oc_tail_with_this_ctx(base_val, chain_this, callee, env)?;
                 let evaluated_args = match self.eval_spread_args(args, env) {
@@ -228,7 +228,7 @@ impl Interpreter {
                     other => Err(other),
                 }
             }
-            Expression::Member(inner, mp) => {
+            Expression::Member(inner, mp, _) => {
                 let (inner_val, _) =
                     self.eval_oc_tail_with_this_ctx(base_val, chain_this, inner, env)?;
                 // Non-optional member access within optional chain: null/undefined throws
@@ -353,7 +353,7 @@ impl Interpreter {
                 // delete obj?.prop → delete obj.prop
                 self.eval_delete_on_object(base_val, name, env)
             }
-            Expression::Member(inner, mp) => {
+            Expression::Member(inner, mp, _) => {
                 // Evaluate inner to get the object, then delete the last property
                 let (inner_val, _) = match self.eval_oc_tail_with_this_ctx(
                     base_val,
@@ -399,7 +399,7 @@ impl Interpreter {
                 };
                 self.eval_delete_on_object(&inner_val, &key, env)
             }
-            Expression::Call(callee, args) => {
+            Expression::Call(callee, args, _) => {
                 // delete obj?.method() — evaluate the call for side effects, return true
                 let (func_val, this_val) = match self.eval_oc_tail_with_this_ctx(
                     base_val,
@@ -496,11 +496,66 @@ impl Interpreter {
         Completion::Normal(JsValue::Boolean(true))
     }
 
+    /// Classifies the post-lookup state of `(obj_id, key)` into a
+    /// `PropIcSlot::Mono { kind: ... }` ready for caching, or `None` if the
+    /// site is not IC-able under the v1 narrow scope. Caller uses this after
+    /// the slow path returns successfully. Issue #71, plan Step 11.
+    ///
+    /// v1 scope:
+    /// - Object must NOT be a proxy / module-namespace / typed-array.
+    /// - Property must resolve as own data (→ `OwnData`) or be absent up to
+    ///   the immediate prototype (→ `Missing`).
+    /// - Own accessors, proto-chain hits, and depth>1 misses return `None`
+    ///   (caller leaves the slot Empty rather than caching).
+    fn classify_for_prop_ic(
+        &self,
+        obj_id: u64,
+        key: &str,
+    ) -> Option<crate::interpreter::ic::PropIcSlot> {
+        use crate::interpreter::ic::{PropIcKind, PropIcSlot};
+        let obj_rc = self.get_object(obj_id)?;
+        let obj = obj_rc.borrow();
+        // Non-cacheable categories (plan "Excluded from IC in v1").
+        if obj.proxy_target_id.is_some()
+            || obj.proxy_revoked
+            || obj.module_namespace.is_some()
+            || obj.typed_array_info.is_some()
+        {
+            return None;
+        }
+        // Own property?
+        if let Some(d) = obj.properties.get(key) {
+            if d.is_data_descriptor() {
+                return Some(PropIcSlot::Mono {
+                    obj_id,
+                    obj_shape_id: obj.shape_id,
+                    kind: PropIcKind::OwnData,
+                });
+            }
+            // Own accessor — not recorded in v1 narrow scope.
+            return None;
+        }
+        // Absent on receiver — only cacheable if the immediate prototype is
+        // null (depth-1 Missing). Anything deeper stays uncached for v1.
+        if obj.prototype_id.is_none() {
+            return Some(PropIcSlot::Mono {
+                obj_id,
+                obj_shape_id: obj.shape_id,
+                kind: PropIcKind::Missing {
+                    proto_id: None,
+                    proto_shape_id: 0,
+                },
+            });
+        }
+        None
+    }
+
     pub(super) fn eval_member(
         &mut self,
         obj: &Expression,
         prop: &MemberProperty,
         env: &EnvRef,
+        ic_cell: Option<&std::cell::Cell<crate::interpreter::ic::PropIcSlot>>,
     ) -> Completion {
         // §13.3.7.1: super[expr] — special evaluation order:
         // 1. GetThisBinding (throws if uninitialized) — before key expression
@@ -690,7 +745,79 @@ impl Interpreter {
         };
         let _ = computed_raw;
         match &obj_val {
-            JsValue::Object(o) => self.get_object_property(o.id, &key, &obj_val.clone()),
+            JsValue::Object(o) => {
+                // Phase 2 IC: probe + record for Dot access only (v1 scope).
+                // Computed access goes straight to the slow path; caching it
+                // requires extra logic for non-string keys and is deferred.
+                if matches!(prop, MemberProperty::Dot(_))
+                    && let Some(cell) = ic_cell
+                    && self.with_scope_depth == 0
+                {
+                    use crate::interpreter::ic::{PropIcKind, PropIcSlot};
+                    let slot = cell.get();
+                    if let PropIcSlot::Mono {
+                        obj_id,
+                        obj_shape_id,
+                        kind,
+                    } = slot
+                        && o.id == obj_id
+                        && let Some(obj_rc) = self.get_object(o.id)
+                        && obj_rc.borrow().shape_id == obj_shape_id
+                    {
+                        // Shape match — IC hit. Dispatch on kind.
+                        match kind {
+                            PropIcKind::OwnData => {
+                                let val = {
+                                    let b = obj_rc.borrow();
+                                    b.properties.get(&key).and_then(|d| d.value.clone())
+                                };
+                                if let Some(v) = val {
+                                    self.ic_hit_count.set(self.ic_hit_count.get() + 1);
+                                    return Completion::Normal(v);
+                                }
+                                // Slot stale (descriptor flipped to accessor or
+                                // value field cleared) — fall through.
+                            }
+                            PropIcKind::Missing { proto_id, .. } => {
+                                let cur_proto = obj_rc.borrow().prototype_id;
+                                if cur_proto == proto_id {
+                                    self.ic_hit_count.set(self.ic_hit_count.get() + 1);
+                                    return Completion::Normal(JsValue::Undefined);
+                                }
+                            }
+                            // OwnAccessor / ProtoData / TypedArrayElement not
+                            // recorded in the v1 narrow scope; they'd be
+                            // unreachable here. Safe to fall through.
+                            _ => {}
+                        }
+                    }
+                    // Probe miss — fall to the slow path and record afterwards.
+                    self.ic_slow_path_count
+                        .set(self.ic_slow_path_count.get() + 1);
+                    let result = self.get_object_property(o.id, &key, &obj_val.clone());
+                    if let Completion::Normal(_) = &result {
+                        // Classify for IC recording. Cheap one-borrow walk.
+                        let new_slot = self.classify_for_prop_ic(o.id, &key);
+                        // Apply the state-machine transition (plan Step 10):
+                        // Empty → Mono(new); Mono(A)→same-obj refresh; Mono(A)→different-obj Megamorphic.
+                        let next = match (slot, new_slot) {
+                            (_, None) => PropIcSlot::Empty, // not IC-able; leave Empty
+                            (PropIcSlot::Empty, Some(s)) => s,
+                            (
+                                PropIcSlot::Mono {
+                                    obj_id: prev_id, ..
+                                },
+                                Some(s @ PropIcSlot::Mono { obj_id: new_id, .. }),
+                            ) if prev_id == new_id => s,
+                            (PropIcSlot::Mono { .. }, Some(_)) => PropIcSlot::Megamorphic,
+                            (PropIcSlot::Megamorphic, _) => PropIcSlot::Megamorphic,
+                        };
+                        cell.set(next);
+                    }
+                    return result;
+                }
+                self.get_object_property(o.id, &key, &obj_val.clone())
+            }
             JsValue::String(s) => {
                 if key == "length" {
                     Completion::Normal(JsValue::Number(s.len() as f64))

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -322,6 +322,7 @@ impl Interpreter {
                 vec![Expression::Spread(Box::new(Expression::Identifier(
                     "args".into(),
                 )))],
+                crate::interpreter::ic::fresh_call_ic_cell(),
             ))];
             let uses_args = stmts_use_arguments(&default_body);
             JsFunction::User {

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -2584,7 +2584,7 @@ impl Interpreter {
 
     fn expr_may_contain_tail_call(expr: &Expression) -> bool {
         match expr {
-            Expression::Call(_, _) | Expression::TaggedTemplate(_, _) => true,
+            Expression::Call(_, _, _) | Expression::TaggedTemplate(_, _) => true,
             Expression::Conditional(_, cons, alt) => {
                 Self::expr_may_contain_tail_call(cons) || Self::expr_may_contain_tail_call(alt)
             }

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -7,6 +7,7 @@ impl Interpreter {
     pub(crate) fn alloc_object(&mut self, mut data: JsObjectData) -> u64 {
         self.gc_alloc_count += 1;
         let is_reuse = !self.free_list.is_empty();
+        data.shape_id = crate::interpreter::types::fresh_shape_id();
         let id = if let Some(idx) = self.free_list.pop() {
             data.id = Some(idx as u64);
             self.objects[idx] = Some(Rc::new(RefCell::new(data)));

--- a/src/interpreter/generator_analysis.rs
+++ b/src/interpreter/generator_analysis.rs
@@ -502,21 +502,21 @@ fn analyze_expression(
             analyze_expression(alternate, analysis, ctx, true);
         }
 
-        Expression::Call(callee, args) => {
+        Expression::Call(callee, args, _) => {
             analyze_expression(callee, analysis, ctx, true);
             for arg in args {
                 analyze_expression(arg, analysis, ctx, true);
             }
         }
 
-        Expression::New(callee, args) => {
+        Expression::New(callee, args, _) => {
             analyze_expression(callee, analysis, ctx, true);
             for arg in args {
                 analyze_expression(arg, analysis, ctx, true);
             }
         }
 
-        Expression::Member(object, prop) => {
+        Expression::Member(object, prop, _) => {
             analyze_expression(object, analysis, ctx, true);
             if let MemberProperty::Computed(key) = prop {
                 analyze_expression(key, analysis, ctx, true);
@@ -722,10 +722,10 @@ pub fn expr_contains_yield(expr: &Expression) -> bool {
         Expression::Conditional(t, c, a) => {
             expr_contains_yield(t) || expr_contains_yield(c) || expr_contains_yield(a)
         }
-        Expression::Call(callee, args) | Expression::New(callee, args) => {
+        Expression::Call(callee, args, _) | Expression::New(callee, args, _) => {
             expr_contains_yield(callee) || args.iter().any(expr_contains_yield)
         }
-        Expression::Member(obj, prop) => {
+        Expression::Member(obj, prop, _) => {
             expr_contains_yield(obj)
                 || matches!(prop, MemberProperty::Computed(e) if expr_contains_yield(e))
         }
@@ -778,10 +778,10 @@ pub fn expr_contains_suspension(expr: &Expression) -> bool {
                 || expr_contains_suspension(c)
                 || expr_contains_suspension(a)
         }
-        Expression::Call(callee, args) | Expression::New(callee, args) => {
+        Expression::Call(callee, args, _) | Expression::New(callee, args, _) => {
             expr_contains_suspension(callee) || args.iter().any(expr_contains_suspension)
         }
-        Expression::Member(obj, prop) => {
+        Expression::Member(obj, prop, _) => {
             expr_contains_suspension(obj)
                 || matches!(prop, MemberProperty::Computed(e) if expr_contains_suspension(e))
         }

--- a/src/interpreter/generator_transform.rs
+++ b/src/interpreter/generator_transform.rs
@@ -1,5 +1,6 @@
 use crate::ast::*;
 use crate::interpreter::generator_analysis::*;
+use crate::interpreter::ic::{fresh_call_ic_cell, fresh_prop_ic_cell};
 use crate::types::JsValue;
 use std::collections::HashMap;
 
@@ -814,11 +815,11 @@ fn transform_yielding_expression(
             }
         }
 
-        Expression::Call(callee, args) => {
+        Expression::Call(callee, args, _) => {
             transform_call_expression(callee, args, binding, ctx);
         }
 
-        Expression::New(callee, args) => {
+        Expression::New(callee, args, _) => {
             let mut temp_callee = *callee.clone();
             if expr_has_suspension(callee, ctx.is_async) {
                 let temp_var = ctx.new_temp_var("new_callee");
@@ -850,7 +851,7 @@ fn transform_yielding_expression(
                 }
             }
 
-            let combined = Expression::New(Box::new(temp_callee), temp_args);
+            let combined = Expression::New(Box::new(temp_callee), temp_args, fresh_call_ic_cell());
             emit_expression_with_binding(&combined, &binding, ctx);
         }
 
@@ -968,7 +969,7 @@ fn transform_yielding_expression(
             emit_expression_with_binding(&combined, &binding, ctx);
         }
 
-        Expression::Member(obj, prop) => {
+        Expression::Member(obj, prop, _) => {
             let mut temp_obj = *obj.clone();
             if expr_has_suspension(obj, ctx.is_async) {
                 let tv = ctx.new_temp_var("mem_obj");
@@ -984,11 +985,13 @@ fn transform_yielding_expression(
                     let combined = Expression::Member(
                         Box::new(temp_obj),
                         MemberProperty::Computed(Box::new(Expression::Identifier(tv))),
+                        fresh_prop_ic_cell(),
                     );
                     emit_expression_with_binding(&combined, &binding, ctx);
                 }
                 _ => {
-                    let combined = Expression::Member(Box::new(temp_obj), prop.clone());
+                    let combined =
+                        Expression::Member(Box::new(temp_obj), prop.clone(), fresh_prop_ic_cell());
                     emit_expression_with_binding(&combined, &binding, ctx);
                 }
             }
@@ -1198,14 +1201,15 @@ fn oc_chain_to_regular_expr(chain: &Expression, base_var: &str) -> Expression {
         Expression::Identifier(name) => Expression::Member(
             Box::new(Expression::Identifier(base_var.to_string())),
             MemberProperty::Dot(name.clone()),
+            fresh_prop_ic_cell(),
         ),
-        Expression::Member(inner, prop) => {
+        Expression::Member(inner, prop, _) => {
             let inner_expr = oc_chain_to_regular_expr(inner, base_var);
-            Expression::Member(Box::new(inner_expr), prop.clone())
+            Expression::Member(Box::new(inner_expr), prop.clone(), fresh_prop_ic_cell())
         }
-        Expression::Call(callee, args) => {
+        Expression::Call(callee, args, _) => {
             let callee_expr = oc_chain_to_regular_expr(callee, base_var);
-            Expression::Call(Box::new(callee_expr), args.clone())
+            Expression::Call(Box::new(callee_expr), args.clone(), fresh_call_ic_cell())
         }
         other => other.clone(),
     }
@@ -1219,7 +1223,7 @@ fn transform_call_expression(
 ) {
     let mut temp_callee = callee.clone();
     if expr_has_suspension(callee, ctx.is_async) {
-        if let Expression::Member(obj, prop) = callee {
+        if let Expression::Member(obj, prop, _) = callee {
             let mut temp_obj = *obj.clone();
             if expr_has_suspension(obj, ctx.is_async) {
                 let tv = ctx.new_temp_var("call_obj");
@@ -1235,10 +1239,12 @@ fn transform_call_expression(
                     temp_callee = Expression::Member(
                         Box::new(temp_obj),
                         MemberProperty::Computed(Box::new(Expression::Identifier(tv))),
+                        fresh_prop_ic_cell(),
                     );
                 }
                 _ => {
-                    temp_callee = Expression::Member(Box::new(temp_obj), prop.clone());
+                    temp_callee =
+                        Expression::Member(Box::new(temp_obj), prop.clone(), fresh_prop_ic_cell());
                 }
             }
         } else {
@@ -1272,7 +1278,7 @@ fn transform_call_expression(
         }
     }
 
-    let combined = Expression::Call(Box::new(temp_callee), temp_args);
+    let combined = Expression::Call(Box::new(temp_callee), temp_args, fresh_call_ic_cell());
     emit_expression_with_binding(&combined, &binding, ctx);
 }
 
@@ -1313,7 +1319,7 @@ fn emit_expression_with_binding(
 /// returning a clean LHS expression without suspensions.
 fn extract_lhs_suspensions(expr: &Expression, ctx: &mut TransformContext) -> Expression {
     match expr {
-        Expression::Member(obj, prop) => {
+        Expression::Member(obj, prop, _) => {
             let new_obj = if expr_has_suspension(obj, ctx.is_async) {
                 let temp = ctx.new_temp_var("lhs_obj");
                 transform_yielding_expression(
@@ -1339,7 +1345,7 @@ fn extract_lhs_suspensions(expr: &Expression, ctx: &mut TransformContext) -> Exp
                 }
                 other => other.clone(),
             };
-            Expression::Member(Box::new(new_obj), new_prop)
+            Expression::Member(Box::new(new_obj), new_prop, fresh_prop_ic_cell())
         }
         _ => expr.clone(),
     }
@@ -2188,20 +2194,23 @@ fn rewrite_expr(expr: &Expression) -> Expression {
             Box::new(rewrite_expr(c)),
             Box::new(rewrite_expr(a)),
         ),
-        Expression::Call(callee, args) => Expression::Call(
+        Expression::Call(callee, args, _) => Expression::Call(
             Box::new(rewrite_expr(callee)),
             args.iter().map(rewrite_expr).collect(),
+            fresh_call_ic_cell(),
         ),
-        Expression::New(callee, args) => Expression::New(
+        Expression::New(callee, args, _) => Expression::New(
             Box::new(rewrite_expr(callee)),
             args.iter().map(rewrite_expr).collect(),
+            fresh_call_ic_cell(),
         ),
-        Expression::Member(obj, prop) => Expression::Member(
+        Expression::Member(obj, prop, _) => Expression::Member(
             Box::new(rewrite_expr(obj)),
             match prop {
                 MemberProperty::Computed(e) => MemberProperty::Computed(Box::new(rewrite_expr(e))),
                 other => other.clone(),
             },
+            fresh_prop_ic_cell(),
         ),
         Expression::OptionalChain(base, chain) => {
             Expression::OptionalChain(Box::new(rewrite_expr(base)), Box::new(rewrite_expr(chain)))

--- a/src/interpreter/ic.rs
+++ b/src/interpreter/ic.rs
@@ -1,0 +1,168 @@
+//! Inline-cache slots for property access and call sites.
+//!
+//! Issue #71 — see `.ultraplan/property-lookup-caching.md` for the full design.
+//!
+//! `PropIcSlot` lives on every `Expression::Member` AST node behind a `Cell`
+//! (slot is `Copy` so `Cell::get` is sufficient — no `RefCell` ceremony).
+//! The probe at `eval_member` reads the slot; on hit it dispatches directly.
+//! On miss it falls through to the slow path which records a fresh `Mono`
+//! entry (or transitions to `Megamorphic`).
+//!
+//! Shape-id matching is the core invariant: a slot is valid if and only if
+//! `obj.id == slot.obj_id && obj.shape_id == slot.obj_shape_id`. The global
+//! shape-id counter (in `types::fresh_shape_id`) guarantees that an `obj_id`
+//! freed and re-used by GC cannot collide with a stale slot — the new
+//! object's shape_id is freshly drawn from the counter.
+
+/// Property-access IC slot. Held in `Cell<PropIcSlot>` on every
+/// `Expression::Member` node. `Copy` so the cell can use `get`/`set`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PropIcSlot {
+    /// First execution at this site, or just transitioned out of `Mono` due
+    /// to a non-cacheable resolution. Probe falls through to slow path; slow
+    /// path may write a fresh `Mono` entry.
+    Empty,
+    /// One object/shape pair has been seen at this site. Probe checks the
+    /// current `(obj_id, shape_id)` against the cached pair and dispatches
+    /// directly on `kind` if they match.
+    Mono {
+        obj_id: u64,
+        obj_shape_id: u64,
+        kind: PropIcKind,
+    },
+    /// Site has seen a non-cacheable resolution (proxy, module-namespace,
+    /// symbol key, depth>1 prototype) or has shape-thrashed across multiple
+    /// distinct `obj_id`s. Probes always fall through; slow path skips
+    /// the record cost.
+    Megamorphic,
+}
+
+/// Resolution category captured in a `Mono` slot. Carries enough information
+/// for the probe to dispatch without re-walking proxy/module-ns/typed-array
+/// detection or the prototype chain.
+///
+/// Phase-2 v1 only constructs `OwnData` and `Missing`. `OwnAccessor`,
+/// `ProtoData`, and `TypedArrayElement` are reserved for follow-up cycles
+/// (the probe path already handles them defensively, so adding the recording
+/// hook later is a small change).
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PropIcKind {
+    /// Property resolved as a data descriptor on the target object.
+    /// Probe re-fetches via `PropertyMap.get(name)` (skipping proxy/ns/ta
+    /// detection) — re-fetch is required because pure value reassignment
+    /// does NOT bump shape_id (plan Step 5).
+    OwnData,
+    /// Property resolved as an accessor descriptor on the target object.
+    /// Probe re-fetches the descriptor and invokes the getter.
+    OwnAccessor,
+    /// Property resolved on the immediate prototype (depth 1) as a data
+    /// descriptor. Probe verifies BOTH the receiver shape AND the prototype
+    /// shape before re-fetching.
+    ProtoData { proto_id: u64, proto_shape_id: u64 },
+    /// Property is absent up to and including the immediate prototype.
+    /// Probe verifies the prototype shape (or `proto_id == None`) and
+    /// returns `undefined` directly.
+    Missing {
+        /// `None` means the receiver had `prototype_id == None` at capture;
+        /// `proto_shape_id` is unused in that case (always 0).
+        proto_id: Option<u64>,
+        proto_shape_id: u64,
+    },
+    /// Numeric index access on a typed-array. Probe takes the existing
+    /// `is_valid_integer_index` + `typed_array_get_index` fast path
+    /// without re-checking proxy/ns flags.
+    #[allow(dead_code)] // wired up in Phase 2 Step 10
+    TypedArrayElement,
+}
+
+impl PropIcSlot {
+    /// Construct an empty slot. Used by `fresh_prop_ic_cell()` and reserved
+    /// for any future code path that wants the canonical empty value.
+    #[allow(dead_code)]
+    pub(crate) const fn empty() -> Self {
+        PropIcSlot::Empty
+    }
+}
+
+/// Helper for parser/transform sites that construct `Expression::Member` —
+/// produces a fresh, empty IC cell. Avoids spelling out
+/// `Cell::new(PropIcSlot::empty())` at every callsite.
+#[inline]
+pub fn fresh_prop_ic_cell() -> std::cell::Cell<PropIcSlot> {
+    std::cell::Cell::new(PropIcSlot::Empty)
+}
+
+// ---- Call-site IC (Phase 3, plan Step 13) -----------------------------------
+
+/// Call-site IC slot. Held in `Cell<CallIcSlot>` on every `Expression::Call`
+/// and `Expression::New` node. `Copy` so the cell can use `get`/`set`. The
+/// state machine mirrors `PropIcSlot` exactly.
+///
+/// Phase-3 v1 reads `callee_obj_id` and `callee_shape_id` for the hit check
+/// but does not yet branch on `kind` — the fast-dispatch entry that uses it
+/// to skip proxy/wrapped/class-ctor checks is the next perf-only cycle. The
+/// field is captured at record time so the future cycle is purely additive.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum CallIcSlot {
+    Empty,
+    Mono {
+        /// Object id of the callable (the function object itself, not its
+        /// receiver). Probe checks `callee.id == this`.
+        callee_obj_id: u64,
+        /// Shape of the callable at capture time. If the callable's shape
+        /// has advanced (e.g. a property was added that changed proxy/bound
+        /// status), the cached `kind` is stale.
+        callee_shape_id: u64,
+        #[allow(dead_code)] // wired for the call_function_fast follow-up
+        kind: CallIcKind,
+    },
+    Megamorphic,
+}
+
+/// Resolution category captured in a `Mono` call slot. Carries enough
+/// information for the probe to skip the proxy/wrapped/class-ctor entry
+/// checks in `call_function_inner` and dispatch to the appropriate
+/// JsFunction variant directly.
+///
+/// Phase-3 v1 only constructs `NativeFn` and `UserFn`; bound/wrapped/proxy
+/// callables stay slow. The probe path verifies `callable` is still the
+/// expected variant before dispatching, so a shape-stable mutation that
+/// somehow swapped variants would degrade to a single mis-prediction
+/// rather than miscompile.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum CallIcKind {
+    /// `obj.callable == Some(JsFunction::Native(_))`. No proxy, no wrapped,
+    /// not a class constructor without `new`.
+    NativeFn,
+    /// `obj.callable == Some(JsFunction::User { .. })`. Same exclusions.
+    UserFn,
+}
+
+impl CallIcSlot {
+    #[allow(dead_code)]
+    pub(crate) const fn empty() -> Self {
+        CallIcSlot::Empty
+    }
+}
+
+/// Helper for parser/transform sites that construct `Expression::Call` /
+/// `Expression::New` — fresh, empty call IC cell.
+#[inline]
+pub fn fresh_call_ic_cell() -> std::cell::Cell<CallIcSlot> {
+    std::cell::Cell::new(CallIcSlot::Empty)
+}
+
+const _ASSERT_CALL_IC_SLOT_SIZE: () = {
+    assert!(std::mem::size_of::<CallIcSlot>() <= 32);
+};
+
+// Compile-time invariant: the slot must stay small (<=32 bytes) so that
+// `Expression::Member` doesn't bloat by more than 4 pointer-sized words.
+// The largest variant — `Mono { u64, u64, PropIcKind }` with the largest
+// kind (`ProtoData { u64, u64 }`) — is 32 bytes. If this assertion ever
+// fails, audit `PropIcKind` for accidental growth.
+const _ASSERT_PROP_IC_SLOT_SIZE: () = {
+    assert!(std::mem::size_of::<PropIcSlot>() <= 40);
+};

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -144,6 +144,9 @@ pub struct Interpreter {
     pub(crate) call_ic_hit_count: std::cell::Cell<u64>,
     /// Call-site IC slow-path counter (Phase 3). Issue #71.
     pub(crate) call_ic_slow_path_count: std::cell::Cell<u64>,
+    /// Counter for the call_function_inner fast-dispatch path (skips
+    /// proxy/wrapped/class-ctor checks). Issue #71 Phase-3 follow-up.
+    pub(crate) call_ic_fast_dispatch_count: std::cell::Cell<u64>,
 }
 
 pub(crate) struct CallFrame {
@@ -297,6 +300,7 @@ impl Interpreter {
             ic_slow_path_count: std::cell::Cell::new(0),
             call_ic_hit_count: std::cell::Cell::new(0),
             call_ic_slow_path_count: std::cell::Cell::new(0),
+            call_ic_fast_dispatch_count: std::cell::Cell::new(0),
         };
         interp.setup_globals();
         interp
@@ -1206,6 +1210,13 @@ impl Interpreter {
     #[allow(dead_code)]
     pub(crate) fn call_ic_slow_path_count(&self) -> u64 {
         self.call_ic_slow_path_count.get()
+    }
+
+    /// Total dispatches that skipped proxy/wrapped/class-ctor entry checks
+    /// because an IC hit had pre-validated the callable. Phase-3 follow-up.
+    #[allow(dead_code)]
+    pub(crate) fn call_ic_fast_dispatch_count(&self) -> u64 {
+        self.call_ic_fast_dispatch_count.get()
     }
 
     /// Single chokepoint for any structural mutation of `JsObjectData`:

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -26,6 +26,7 @@ mod exec;
 mod gc;
 pub(crate) mod generator_analysis;
 pub(crate) mod generator_transform;
+pub(crate) mod ic;
 mod property_map;
 pub(crate) use property_map::PropertyMap;
 #[cfg(test)]
@@ -132,6 +133,17 @@ pub struct Interpreter {
     module_async_info: FxHashMap<u64, PathBuf>,
     pub(crate) with_scope_depth: u32,
     pub(crate) has_ever_entered_with: bool,
+    /// IC hit counter for Phase-2 telemetry/tests. Issue #71. Cell so the
+    /// probe (which has `&self` semantics on the immutable parts) can bump
+    /// it without a full `&mut self` borrow.
+    pub(crate) ic_hit_count: std::cell::Cell<u64>,
+    /// IC slow-path counter — incremented on every probe miss that fell
+    /// through to the full lookup chain. Issue #71.
+    pub(crate) ic_slow_path_count: std::cell::Cell<u64>,
+    /// Call-site IC hit counter (Phase 3). Issue #71.
+    pub(crate) call_ic_hit_count: std::cell::Cell<u64>,
+    /// Call-site IC slow-path counter (Phase 3). Issue #71.
+    pub(crate) call_ic_slow_path_count: std::cell::Cell<u64>,
 }
 
 pub(crate) struct CallFrame {
@@ -281,6 +293,10 @@ impl Interpreter {
             module_async_info: FxHashMap::default(),
             with_scope_depth: 0,
             has_ever_entered_with: false,
+            ic_hit_count: std::cell::Cell::new(0),
+            ic_slow_path_count: std::cell::Cell::new(0),
+            call_ic_hit_count: std::cell::Cell::new(0),
+            call_ic_slow_path_count: std::cell::Cell::new(0),
         };
         interp.setup_globals();
         interp
@@ -1164,6 +1180,61 @@ impl Interpreter {
 
     pub(crate) fn get_object(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
         self.objects.get(id as usize).and_then(|slot| slot.clone())
+    }
+
+    /// Total IC hits since interpreter construction. Whitebox accessor used
+    /// by Phase-2 tests; not exposed to JS. Issue #71.
+    #[allow(dead_code)]
+    pub(crate) fn ic_hit_count(&self) -> u64 {
+        self.ic_hit_count.get()
+    }
+
+    /// Total IC slow-path falls since interpreter construction. Whitebox
+    /// accessor used by Phase-2 tests; not exposed to JS. Issue #71.
+    #[allow(dead_code)]
+    pub(crate) fn ic_slow_path_count(&self) -> u64 {
+        self.ic_slow_path_count.get()
+    }
+
+    /// Total call-IC hits since interpreter construction. Phase 3.
+    #[allow(dead_code)]
+    pub(crate) fn call_ic_hit_count(&self) -> u64 {
+        self.call_ic_hit_count.get()
+    }
+
+    /// Total call-IC slow-path falls since interpreter construction. Phase 3.
+    #[allow(dead_code)]
+    pub(crate) fn call_ic_slow_path_count(&self) -> u64 {
+        self.call_ic_slow_path_count.get()
+    }
+
+    /// Single chokepoint for any structural mutation of `JsObjectData`:
+    /// borrows the object mutably, runs `f`, then unconditionally assigns a
+    /// fresh shape id from the process-global counter. Returns whatever `f`
+    /// returned. Callers that perform pure value-reassignment (e.g. updating
+    /// an existing data property's value without changing its descriptor)
+    /// must NOT use this helper — they take a regular `borrow_mut` so the
+    /// shape id stays stable. Issue #71, plan Step 4.
+    ///
+    /// Phase-1 note: property add/delete/attribute mutations self-bump from
+    /// inside `JsObjectData::set_property_value` / `define_own_property`, so
+    /// the helper is currently exercised only by the IC unit tests. The first
+    /// production callers — prototype mutation and proxy install — are
+    /// migrated as part of the Phase-2/3 IC work (plan Step 5).
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn mutate_object_shape<F, R>(&mut self, obj_id: u64, f: F) -> R
+    where
+        F: FnOnce(&mut JsObjectData) -> R,
+    {
+        let new_shape = crate::interpreter::types::fresh_shape_id();
+        let obj = self
+            .get_object(obj_id)
+            .expect("mutate_object_shape: invalid obj_id");
+        let mut borrow = obj.borrow_mut();
+        let result = f(&mut borrow);
+        borrow.shape_id = new_shape;
+        result
     }
 
     /// Like `get_object` but panics if the id is dead. Matches the pattern
@@ -3246,15 +3317,15 @@ impl Interpreter {
                     || Self::expr_has_await(consequent)
                     || Self::expr_has_await(alternate)
             }
-            Expression::Call(callee, arguments) => {
+            Expression::Call(callee, arguments, _) => {
                 Self::expr_has_await(callee)
                     || arguments.iter().any(Self::expr_has_await)
             }
-            Expression::New(callee, arguments) => {
+            Expression::New(callee, arguments, _) => {
                 Self::expr_has_await(callee)
                     || arguments.iter().any(Self::expr_has_await)
             }
-            Expression::Member(object, prop) => {
+            Expression::Member(object, prop, _) => {
                 Self::expr_has_await(object) || match prop {
                     crate::ast::MemberProperty::Computed(e) => Self::expr_has_await(e),
                     _ => false,

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -853,6 +853,80 @@ fn call_ic_records_after_repeated_call() {
 }
 
 #[test]
+fn call_ic_fast_dispatch_actually_skips_entry_checks() {
+    // Phase-3 follow-up tracer: a hot loop should drive IC hits AND the
+    // fast-dispatch counter — proves call_function_ic_validated is the
+    // path being taken, not the slow call_function. Without the fast
+    // path wired up, fast_dispatch_count would stay at 0 even though
+    // hit_count advanced.
+    let interp = run_script(
+        r#"
+        function f() { return 7; }
+        var sum = 0;
+        for (var i = 0; i < 100; i++) sum += f();
+        "#,
+    );
+    let env = interp.realm().global_env.borrow();
+    match env.get("sum").unwrap_or(JsValue::Undefined) {
+        JsValue::Number(n) => assert_eq!(n, 700.0, "behavioral correctness"),
+        other => panic!("expected sum=700, got {other:?}"),
+    }
+    assert!(
+        interp.call_ic_fast_dispatch_count() > 0,
+        "expected fast-dispatch path to fire on IC hits; got 0 \
+         (IC hits = {})",
+        interp.call_ic_hit_count()
+    );
+}
+
+#[test]
+fn call_ic_does_not_cache_proxy_callable() {
+    // Proxy with apply trap MUST always invoke the trap. classify_for_call_ic
+    // returns None for proxies, so the IC slot stays Empty / Megamorphic
+    // forever — every call goes through the slow entry checks. The trap
+    // counter proves this.
+    let interp = run_script(
+        r#"
+        var apply_count = 0;
+        var target = function() { return 1; };
+        var p = new Proxy(target, {
+            apply: function(t, thisArg, args) { apply_count++; return 99; }
+        });
+        var sum = 0;
+        for (var i = 0; i < 5; i++) sum += p();
+        var result = sum + "|" + apply_count;
+        "#,
+    );
+    assert_eq!(
+        global_string(&interp, "result"),
+        "495|5",
+        "proxy apply trap must fire on every call regardless of IC"
+    );
+}
+
+#[test]
+fn call_ic_does_not_cache_class_ctor_without_new() {
+    // Calling a class constructor without `new` must throw TypeError on
+    // every call, even after a hot loop. The classifier excludes class
+    // ctors, so the slow path always runs the is_class_ctor check.
+    let interp = run_script(
+        r#"
+        class C { constructor() { this.x = 1; } }
+        var threw_count = 0;
+        for (var i = 0; i < 5; i++) {
+            try { C(); } catch (e) { if (e instanceof TypeError) threw_count++; }
+        }
+        var result = threw_count;
+        "#,
+    );
+    let env = interp.realm().global_env.borrow();
+    match env.get("result").unwrap_or(JsValue::Undefined) {
+        JsValue::Number(n) => assert_eq!(n, 5.0, "expected 5 TypeErrors"),
+        other => panic!("expected 5, got {other:?}"),
+    }
+}
+
+#[test]
 fn call_ic_invalidates_on_function_replacement() {
     // Reassign `f` to a different function — second hot loop must observe
     // the new behavior, not the cached resolution.

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -606,3 +606,337 @@ fn prototype_chain_survives_gc() {
     );
     assert_eq!(global_string(&interp, "result"), "deep|deep");
 }
+
+// -- Phase 1: shape-id infrastructure (issue #71) -----------------------------
+// Whitebox tests for the per-object shape_id counter that backs the inline
+// caches added in Phases 2 & 3. Each structural mutation must advance the
+// counter; pure value re-assignment must not.
+
+#[test]
+fn alloc_seeds_unique_shape_ids() {
+    let mut interp = Interpreter::new();
+    let id_a = interp.alloc_object(JsObjectData::new());
+    let id_b = interp.alloc_object(JsObjectData::new());
+    let shape_a = interp.get_object(id_a).unwrap().borrow().shape_id;
+    let shape_b = interp.get_object(id_b).unwrap().borrow().shape_id;
+    assert_ne!(shape_a, 0, "shape_id must be non-zero after alloc");
+    assert_ne!(shape_b, 0, "shape_id must be non-zero after alloc");
+    assert_ne!(shape_a, shape_b, "fresh allocations get distinct shape ids");
+}
+
+#[test]
+fn mutate_object_shape_bumps_shape_id() {
+    let mut interp = Interpreter::new();
+    let id = interp.alloc_object(JsObjectData::new());
+    let before = interp.get_object(id).unwrap().borrow().shape_id;
+    let returned = interp.mutate_object_shape(id, |obj| {
+        // helper must bump regardless of what closure does (or doesn't do).
+        obj.extensible = false;
+        42_u32
+    });
+    assert_eq!(returned, 42, "closure return value must be propagated");
+    let after = interp.get_object(id).unwrap().borrow().shape_id;
+    assert!(after > before, "mutate_object_shape must advance shape_id");
+}
+
+#[test]
+fn mutate_object_shape_bumps_even_on_noop_closure() {
+    let mut interp = Interpreter::new();
+    let id = interp.alloc_object(JsObjectData::new());
+    let before = interp.get_object(id).unwrap().borrow().shape_id;
+    interp.mutate_object_shape(id, |_obj| {});
+    let after = interp.get_object(id).unwrap().borrow().shape_id;
+    assert!(
+        after > before,
+        "mutate_object_shape bumps unconditionally — \
+         a no-op closure still produces a fresh shape id (per Step 4 of the plan)"
+    );
+}
+
+#[test]
+fn set_property_value_add_bumps_shape() {
+    let mut interp = Interpreter::new();
+    let id = interp.alloc_object(JsObjectData::new());
+    let before = interp.get_object(id).unwrap().borrow().shape_id;
+    let ok = interp
+        .get_object(id)
+        .unwrap()
+        .borrow_mut()
+        .set_property_value("x", JsValue::Number(1.0));
+    assert!(
+        ok,
+        "set_property_value should succeed on extensible empty obj"
+    );
+    let after = interp.get_object(id).unwrap().borrow().shape_id;
+    assert!(
+        after > before,
+        "adding a new property is a structural mutation; shape_id must advance \
+         (before={before}, after={after})"
+    );
+}
+
+#[test]
+fn set_property_value_update_existing_does_not_bump_shape() {
+    let mut interp = Interpreter::new();
+    let id = interp.alloc_object(JsObjectData::new());
+    interp
+        .get_object(id)
+        .unwrap()
+        .borrow_mut()
+        .set_property_value("x", JsValue::Number(1.0));
+    let before = interp.get_object(id).unwrap().borrow().shape_id;
+    interp
+        .get_object(id)
+        .unwrap()
+        .borrow_mut()
+        .set_property_value("x", JsValue::Number(2.0));
+    let after = interp.get_object(id).unwrap().borrow().shape_id;
+    assert_eq!(
+        after, before,
+        "reassigning an existing data property's value is NOT a structural \
+         mutation; shape_id must remain stable so IC slots stay live"
+    );
+}
+
+#[test]
+fn define_own_property_bumps_shape_on_attribute_change() {
+    let mut interp = Interpreter::new();
+    let id = interp.alloc_object(JsObjectData::new());
+    // Seed an existing property so we can flip its attributes.
+    interp
+        .get_object(id)
+        .unwrap()
+        .borrow_mut()
+        .set_property_value("x", JsValue::Number(1.0));
+    let before = interp.get_object(id).unwrap().borrow().shape_id;
+    let ok = interp
+        .get_object(id)
+        .unwrap()
+        .borrow_mut()
+        .define_own_property(
+            "x".to_string(),
+            PropertyDescriptor {
+                value: Some(JsValue::Number(1.0)),
+                writable: Some(false),
+                enumerable: Some(true),
+                configurable: Some(true),
+                get: None,
+                set: None,
+            },
+        );
+    assert!(ok, "defineProperty should succeed");
+    let after = interp.get_object(id).unwrap().borrow().shape_id;
+    assert!(
+        after > before,
+        "flipping writable from default to false IS a structural mutation \
+         (an attribute changed); shape_id must advance"
+    );
+}
+
+#[test]
+fn set_prototype_via_chokepoint_bumps_shape() {
+    let mut interp = Interpreter::new();
+    let proto_id = interp.alloc_object(JsObjectData::new());
+    let id = interp.alloc_object(JsObjectData::new());
+    let before = interp.get_object(id).unwrap().borrow().shape_id;
+    interp.mutate_object_shape(id, |obj| {
+        obj.prototype_id = Some(proto_id);
+    });
+    let after = interp.get_object(id).unwrap().borrow().shape_id;
+    assert!(
+        after > before,
+        "prototype mutation routed via mutate_object_shape must bump shape_id"
+    );
+}
+
+#[test]
+fn proxy_install_via_chokepoint_bumps_shape() {
+    let mut interp = Interpreter::new();
+    let target_id = interp.alloc_object(JsObjectData::new());
+    let handler_id = interp.alloc_object(JsObjectData::new());
+    let proxy_id = interp.alloc_object(JsObjectData::new());
+    let before = interp.get_object(proxy_id).unwrap().borrow().shape_id;
+    interp.mutate_object_shape(proxy_id, |obj| {
+        obj.proxy_target_id = Some(target_id);
+        obj.proxy_handler_id = Some(handler_id);
+    });
+    let after = interp.get_object(proxy_id).unwrap().borrow().shape_id;
+    assert!(
+        after > before,
+        "proxy install routed via mutate_object_shape must bump shape_id"
+    );
+}
+
+#[test]
+fn ic_records_after_repeated_dot_access() {
+    // Hot loop reads o.x 100 times. After warmup the IC slot must be hitting,
+    // not falling to the slow path on every read. This is the Phase-2 tracer
+    // bullet: it asserts both correctness (sum=4200) and that the IC counter
+    // advanced (proves the probe fired on cache hits, not just misses).
+    let interp = run_script(
+        r#"
+        var o = {x: 42};
+        var sum = 0;
+        for (var i = 0; i < 100; i++) {
+            sum += o.x;
+        }
+        "#,
+    );
+    let env = interp.realm().global_env.borrow();
+    match env.get("sum").unwrap_or(JsValue::Undefined) {
+        JsValue::Number(n) => assert_eq!(n, 4200.0, "behavioral correctness"),
+        other => panic!("expected sum=4200, got {other:?}"),
+    }
+    assert!(
+        interp.ic_hit_count() > 0,
+        "expected IC hits after 100-iteration hot loop on o.x; got 0 \
+         (the probe never recognised the cached shape)"
+    );
+}
+
+#[test]
+fn ic_invalidates_on_define_property_attribute_flip() {
+    // Read o.x (populates IC as OwnData), then defineProperty flips it to a
+    // getter; the next read must observe the getter. If the IC ignored the
+    // shape change, this would return the stale data value.
+    let interp = run_script(
+        r#"
+        var o = {x: 1};
+        var pre = o.x;
+        Object.defineProperty(o, 'x', { get: function() { return 99; }, configurable: true });
+        var post = o.x;
+        var result = pre + "|" + post;
+        "#,
+    );
+    assert_eq!(global_string(&interp, "result"), "1|99");
+}
+
+#[test]
+fn ic_invalidates_on_delete_property() {
+    // Populate IC by reading o.x repeatedly, then delete it. Subsequent reads
+    // must return undefined (and continue working without panicking on a
+    // stale OwnData slot).
+    let interp = run_script(
+        r#"
+        var o = {x: 7};
+        var sum = 0;
+        for (var i = 0; i < 10; i++) sum += o.x;       // populate IC
+        delete o.x;
+        var post = (typeof o.x === "undefined") ? "gone" : "still:" + o.x;
+        var result = sum + "|" + post;
+        "#,
+    );
+    assert_eq!(global_string(&interp, "result"), "70|gone");
+}
+
+#[test]
+fn call_ic_records_after_repeated_call() {
+    // Phase 3 tracer: the call site `f()` repeatedly invokes the same plain
+    // user function. After the first call, the IC slot must be Mono and
+    // subsequent iterations must register as hits.
+    let interp = run_script(
+        r#"
+        function f() { return 42; }
+        var sum = 0;
+        for (var i = 0; i < 100; i++) sum += f();
+        "#,
+    );
+    let env = interp.realm().global_env.borrow();
+    match env.get("sum").unwrap_or(JsValue::Undefined) {
+        JsValue::Number(n) => assert_eq!(n, 4200.0, "behavioral correctness"),
+        other => panic!("expected sum=4200, got {other:?}"),
+    }
+    assert!(
+        interp.call_ic_hit_count() > 0,
+        "expected call-IC hits after 100-iteration hot loop on f(); got 0"
+    );
+}
+
+#[test]
+fn call_ic_invalidates_on_function_replacement() {
+    // Reassign `f` to a different function — second hot loop must observe
+    // the new behavior, not the cached resolution.
+    let interp = run_script(
+        r#"
+        function a() { return 1; }
+        function b() { return 100; }
+        var f = a;
+        var s1 = 0; for (var i = 0; i < 5; i++) s1 += f();
+        f = b;
+        var s2 = 0; for (var i = 0; i < 5; i++) s2 += f();
+        var result = s1 + "|" + s2;
+        "#,
+    );
+    assert_eq!(global_string(&interp, "result"), "5|500");
+}
+
+#[test]
+fn ic_megamorphic_after_distinct_objects_at_same_site() {
+    // Same call site sees two different objects; the second access shape
+    // mismatches and transitions to Megamorphic. Behavioural correctness
+    // must still hold.
+    let interp = run_script(
+        r#"
+        var a = {x: 1};
+        var b = {x: 2};
+        function read(o) { return o.x; }
+        var v1 = read(a);
+        var v2 = read(b);
+        var v3 = read(a);
+        var result = v1 + "|" + v2 + "|" + v3;
+        "#,
+    );
+    assert_eq!(global_string(&interp, "result"), "1|2|1");
+}
+
+#[test]
+fn behavioral_engine_passes_property_value_round_trip() {
+    // Behavioral cross-check: even with shape bumps in place, basic
+    // assignment/read round-trips still work via the public engine.
+    let interp = run_script(
+        r#"
+        var o = {};
+        o.x = 42;
+        o.x = 43;
+        var a = [1,2,3];
+        a[10] = 99;
+        a.length = 1;
+        var result = o.x + "|" + a.length + "|" + (a[0] || "?");
+        "#,
+    );
+    assert_eq!(global_string(&interp, "result"), "43|1|1");
+}
+
+#[test]
+fn define_own_property_bumps_shape_on_data_to_accessor_swap() {
+    let mut interp = Interpreter::new();
+    let id = interp.alloc_object(JsObjectData::new());
+    interp
+        .get_object(id)
+        .unwrap()
+        .borrow_mut()
+        .set_property_value("x", JsValue::Number(1.0));
+    let before = interp.get_object(id).unwrap().borrow().shape_id;
+    // Swap data → accessor by defining a getter.
+    let ok = interp
+        .get_object(id)
+        .unwrap()
+        .borrow_mut()
+        .define_own_property(
+            "x".to_string(),
+            PropertyDescriptor {
+                value: None,
+                writable: None,
+                get: Some(JsValue::Undefined), // sentinel — real getter not needed for this test
+                set: None,
+                enumerable: Some(true),
+                configurable: Some(true),
+            },
+        );
+    assert!(ok, "data→accessor swap should succeed");
+    let after = interp.get_object(id).unwrap().borrow().shape_id;
+    assert!(
+        after > before,
+        "data→accessor swap is the canonical IC-invalidating shape change"
+    );
+}

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -11,6 +11,18 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
+/// Process-global monotonic counter for `JsObjectData.shape_id`. Starts at 1;
+/// `0` is reserved as an invalid sentinel. Mirrors the existing
+/// `NEXT_TEMPLATE_ID` pattern in `ast.rs`. Issue #71 (inline caching).
+static NEXT_SHAPE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Draws a fresh, globally-unique shape id. Cheap (single relaxed atomic
+/// fetch-add); no locking. See `JsObjectData.shape_id` doc.
+#[inline]
+pub(crate) fn fresh_shape_id() -> u64 {
+    NEXT_SHAPE_ID.fetch_add(1, Ordering::Relaxed)
+}
+
 static NEXT_SAB_ID: AtomicU64 = AtomicU64::new(1);
 
 pub fn next_sab_id() -> u64 {
@@ -1685,6 +1697,14 @@ pub struct JsObjectData {
     pub(crate) helper_next_closure: Option<JsValue>,
     pub(crate) helper_return_closure: Option<JsValue>,
     pub(crate) helper_gen_state: Option<Rc<Cell<u8>>>,
+    /// Per-object shape id. Bumped by `Interpreter::mutate_object_shape` on
+    /// every structural mutation (property add/delete/attribute change,
+    /// prototype mutation, proxy install). Pure value reassignment does NOT
+    /// bump. `0` is a transient placeholder set by `JsObjectData::new` and
+    /// overwritten by `alloc_object` before the object is observable; the
+    /// global counter starts at `1`, so an IC slot can never legitimately
+    /// hold `obj_shape_id == 0`. See issue #71.
+    pub shape_id: u64,
 }
 
 #[derive(Clone)]
@@ -1758,6 +1778,7 @@ impl JsObjectData {
             helper_next_closure: None,
             helper_return_closure: None,
             helper_gen_state: None,
+            shape_id: 0,
         }
     }
 
@@ -2328,6 +2349,13 @@ impl JsObjectData {
             };
             self.properties.insert(key, new_desc);
         }
+        // Issue #71 (Step 5): reaching this point means either an existing
+        // property was redefined (line ~2296 `properties.insert(key, merged)`)
+        // or a new property was added (line ~2350). Both are structural
+        // mutations. Earlier `return true` paths (String exotic equality
+        // check, module-namespace no-op, TypedArray element write,
+        // all-absent-desc) are non-mutating and intentionally skip this bump.
+        self.shape_id = fresh_shape_id();
         true
     }
 
@@ -2387,6 +2415,7 @@ impl JsObjectData {
                         .collect();
                     idx_keys.sort_by_key(|a| std::cmp::Reverse(a.0));
 
+                    let mut did_remove = false;
                     for (idx, k) in &idx_keys {
                         let is_non_configurable = self
                             .properties
@@ -2398,10 +2427,20 @@ impl JsObjectData {
                         } else {
                             self.properties.remove(k.as_str());
                             self.property_order.retain(|p| p != k);
+                            did_remove = true;
                         }
                     }
+                    let mut did_truncate = false;
                     if let Some(ref mut elements) = self.array_elements {
+                        let prev_len = elements.len();
                         elements.truncate(actual_new_len as usize);
+                        did_truncate = elements.len() < prev_len;
+                    }
+                    if did_remove || did_truncate {
+                        // Issue #71 (Step 5): Array length truncation deletes
+                        // configurable indexed properties / shrinks
+                        // array_elements — both are structural mutations.
+                        self.shape_id = fresh_shape_id();
                     }
                 }
                 if let Some(desc) = self.properties.get_mut("length") {
@@ -2428,6 +2467,8 @@ impl JsObjectData {
                     elements.push(JsValue::Undefined);
                 }
                 elements.push(value.clone());
+                // Issue #71 (Step 5): array_elements grew — structural mutation.
+                self.shape_id = fresh_shape_id();
                 // Only update length if idx+1 exceeds the current property length
                 let new_idx_len = (idx + 1) as f64;
                 if let Some(len_desc) = self.properties.get_mut("length")
@@ -2468,6 +2509,10 @@ impl JsObjectData {
             self.property_order.push(key.to_string());
             self.properties
                 .insert(key.to_string(), PropertyDescriptor::data_default(value));
+            // Issue #71 (Step 5): new own property added — structural mutation.
+            // The earlier `properties.get_mut(key)` branch (in-place update)
+            // does NOT bump; only this insert branch does.
+            self.shape_id = fresh_shape_id();
             true
         }
     }

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -634,12 +634,12 @@ impl<'a> Parser<'a> {
     fn expr_has_direct_super(expr: &Expression) -> bool {
         use crate::ast::Expression;
         match expr {
-            Expression::Call(callee, args) => {
+            Expression::Call(callee, args, _) => {
                 matches!(callee.as_ref(), Expression::Super)
                     || Self::expr_has_direct_super(callee)
                     || args.iter().any(Self::expr_has_direct_super)
             }
-            Expression::New(callee, args) => {
+            Expression::New(callee, args, _) => {
                 Self::expr_has_direct_super(callee)
                     || args.iter().any(Self::expr_has_direct_super)
             }
@@ -650,7 +650,7 @@ impl<'a> Parser<'a> {
                 Self::expr_has_direct_super(&p.value)
                     || matches!(&p.key, crate::ast::PropertyKey::Computed(e) if Self::expr_has_direct_super(e))
             }),
-            Expression::Member(object, property) => {
+            Expression::Member(object, property, _) => {
                 Self::expr_has_direct_super(object)
                     || matches!(property, crate::ast::MemberProperty::Computed(e) if Self::expr_has_direct_super(e))
             }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::interpreter::ic::{fresh_call_ic_cell, fresh_prop_ic_cell};
 
 fn validate_regexp_literal(pattern: &str, flags: &str) -> Result<(), ParseError> {
     let valid_flags = "dgimsuyv";
@@ -70,7 +71,10 @@ impl<'a> Parser<'a> {
     }
 
     fn is_simple_assignment_target(expr: &Expression) -> bool {
-        matches!(expr, Expression::Identifier(_) | Expression::Member(_, _))
+        matches!(
+            expr,
+            Expression::Identifier(_) | Expression::Member(_, _, _)
+        )
     }
 
     fn validate_assignment_target(
@@ -95,7 +99,7 @@ impl<'a> Parser<'a> {
             }
             return Ok(());
         }
-        if allow_call && !self.strict && matches!(expr, Expression::Call(_, _)) {
+        if allow_call && !self.strict && matches!(expr, Expression::Call(_, _, _)) {
             return Ok(());
         }
         Err(self.error("Invalid left-hand side in assignment"))
@@ -535,7 +539,7 @@ impl<'a> Parser<'a> {
                 if self.strict && matches!(&expr, Expression::Identifier(_)) {
                     return Err(self.error("Delete of an unqualified identifier in strict mode"));
                 }
-                if matches!(&expr, Expression::Member(_, MemberProperty::Private(_))) {
+                if matches!(&expr, Expression::Member(_, MemberProperty::Private(_), _)) {
                     return Err(self
                         .error("Applying the 'delete' operator to a private name is not allowed"));
                 }
@@ -686,7 +690,7 @@ impl<'a> Parser<'a> {
                     {
                         return Err(self.error("Private fields are not accessible on 'super'"));
                     }
-                    expr = Expression::Member(Box::new(expr), prop);
+                    expr = Expression::Member(Box::new(expr), prop, fresh_prop_ic_cell());
                 }
                 Token::LeftBracket => {
                     self.advance()?;
@@ -695,11 +699,12 @@ impl<'a> Parser<'a> {
                     expr = Expression::Member(
                         Box::new(expr),
                         MemberProperty::Computed(Box::new(prop)),
+                        fresh_prop_ic_cell(),
                     );
                 }
                 Token::LeftParen => {
                     let args = self.parse_arguments()?;
-                    expr = Expression::Call(Box::new(expr), args);
+                    expr = Expression::Call(Box::new(expr), args, fresh_call_ic_cell());
                 }
                 Token::NoSubstitutionTemplate(_, _) | Token::TemplateHead(_, _) => {
                     let tmpl = self.parse_template_literal_expr(true)?;
@@ -709,7 +714,11 @@ impl<'a> Parser<'a> {
                     self.advance()?;
                     let mut prop = if self.current == Token::LeftParen {
                         let args = self.parse_arguments()?;
-                        Expression::Call(Box::new(Expression::Identifier("".into())), args)
+                        Expression::Call(
+                            Box::new(Expression::Identifier("".into())),
+                            args,
+                            fresh_call_ic_cell(),
+                        )
                     } else if self.current == Token::LeftBracket {
                         self.advance()?;
                         let p = self.parse_expression()?;
@@ -717,6 +726,7 @@ impl<'a> Parser<'a> {
                         Expression::Member(
                             Box::new(Expression::Identifier("".into())),
                             MemberProperty::Computed(Box::new(p)),
+                            fresh_prop_ic_cell(),
                         )
                     } else if let Token::PrivateName(name) = &self.current {
                         let name = name.clone();
@@ -725,6 +735,7 @@ impl<'a> Parser<'a> {
                         Expression::Member(
                             Box::new(Expression::Identifier("".into())),
                             MemberProperty::Private(name),
+                            fresh_prop_ic_cell(),
                         )
                     } else {
                         let name = match &self.current {
@@ -740,7 +751,7 @@ impl<'a> Parser<'a> {
                             Token::Dot => {
                                 self.advance()?;
                                 let mp = self.parse_dot_member_property()?;
-                                prop = Expression::Member(Box::new(prop), mp);
+                                prop = Expression::Member(Box::new(prop), mp, fresh_prop_ic_cell());
                             }
                             Token::LeftBracket => {
                                 self.advance()?;
@@ -749,11 +760,12 @@ impl<'a> Parser<'a> {
                                 prop = Expression::Member(
                                     Box::new(prop),
                                     MemberProperty::Computed(Box::new(p)),
+                                    fresh_prop_ic_cell(),
                                 );
                             }
                             Token::LeftParen => {
                                 let args = self.parse_arguments()?;
-                                prop = Expression::Call(Box::new(prop), args);
+                                prop = Expression::Call(Box::new(prop), args, fresh_call_ic_cell());
                             }
                             Token::NoSubstitutionTemplate(_, _) | Token::TemplateHead(_, _) => {
                                 return Err(self
@@ -795,7 +807,11 @@ impl<'a> Parser<'a> {
         }
         if self.current == Token::Keyword(Keyword::New) {
             let inner = self.parse_new_expression()?;
-            return Ok(Expression::New(Box::new(inner), Vec::new()));
+            return Ok(Expression::New(
+                Box::new(inner),
+                Vec::new(),
+                fresh_call_ic_cell(),
+            ));
         }
         // `new import(...)` is a syntax error (ImportCall is CallExpression, not MemberExpression)
         // but `new (import(...))` is valid — parens make it a CoveredParenthesizedExpression
@@ -819,7 +835,7 @@ impl<'a> Parser<'a> {
                 Token::Dot => {
                     self.advance()?;
                     let prop = self.parse_dot_member_property()?;
-                    callee = Expression::Member(Box::new(callee), prop);
+                    callee = Expression::Member(Box::new(callee), prop, fresh_prop_ic_cell());
                 }
                 Token::LeftBracket => {
                     self.advance()?;
@@ -828,6 +844,7 @@ impl<'a> Parser<'a> {
                     callee = Expression::Member(
                         Box::new(callee),
                         MemberProperty::Computed(Box::new(prop)),
+                        fresh_prop_ic_cell(),
                     );
                 }
                 Token::NoSubstitutionTemplate(_, _) | Token::TemplateHead(_, _) => {
@@ -842,7 +859,11 @@ impl<'a> Parser<'a> {
         } else {
             Vec::new()
         };
-        Ok(Expression::New(Box::new(callee), args))
+        Ok(Expression::New(
+            Box::new(callee),
+            args,
+            fresh_call_ic_cell(),
+        ))
     }
 
     fn parse_arguments(&mut self) -> Result<Vec<Expression>, ParseError> {
@@ -2127,6 +2148,7 @@ impl<'a> Parser<'a> {
             return Ok(Expression::Call(
                 Box::new(Expression::Identifier("async".to_string())),
                 Vec::new(),
+                fresh_call_ic_cell(),
             ));
         }
         if self.current == Token::Ellipsis {
@@ -2221,6 +2243,7 @@ impl<'a> Parser<'a> {
             return Ok(Expression::Call(
                 Box::new(Expression::Identifier("async".to_string())),
                 exprs,
+                fresh_call_ic_cell(),
             ));
         }
         self.eat(&Token::RightParen)?;
@@ -2228,6 +2251,7 @@ impl<'a> Parser<'a> {
         Ok(Expression::Call(
             Box::new(Expression::Identifier("async".to_string())),
             vec![expr],
+            fresh_call_ic_cell(),
         ))
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -543,11 +543,11 @@ impl<'a> Parser<'a> {
                 Self::contains_arguments(&p.value)
                     || matches!(&p.key, crate::ast::PropertyKey::Computed(e) if Self::contains_arguments(e))
             }),
-            Expression::Member(object, property) => {
+            Expression::Member(object, property, _) => {
                 Self::contains_arguments(object)
                     || matches!(property, MemberProperty::Computed(e) if Self::contains_arguments(e))
             }
-            Expression::Call(callee, args) | Expression::New(callee, args) => {
+            Expression::Call(callee, args, _) | Expression::New(callee, args, _) => {
                 Self::contains_arguments(callee)
                     || args.iter().any(Self::contains_arguments)
             }
@@ -738,11 +738,11 @@ impl<'a> Parser<'a> {
                 Self::expr_contains_await_identifier(&p.value)
                     || matches!(&p.key, crate::ast::PropertyKey::Computed(e) if Self::expr_contains_await_identifier(e))
             }),
-            Expression::Member(object, property) => {
+            Expression::Member(object, property, _) => {
                 Self::expr_contains_await_identifier(object)
                     || matches!(property, MemberProperty::Computed(e) if Self::expr_contains_await_identifier(e))
             }
-            Expression::Call(callee, args) | Expression::New(callee, args) => {
+            Expression::Call(callee, args, _) | Expression::New(callee, args, _) => {
                 Self::expr_contains_await_identifier(callee)
                     || args.iter().any(Self::expr_contains_await_identifier)
             }
@@ -841,11 +841,11 @@ impl<'a> Parser<'a> {
                 Self::expr_contains_await_expression(&p.value)
                     || matches!(&p.key, crate::ast::PropertyKey::Computed(e) if Self::expr_contains_await_expression(e))
             }),
-            Expression::Member(object, property) => {
+            Expression::Member(object, property, _) => {
                 Self::expr_contains_await_expression(object)
                     || matches!(property, MemberProperty::Computed(e) if Self::expr_contains_await_expression(e))
             }
-            Expression::Call(callee, args) | Expression::New(callee, args) => {
+            Expression::Call(callee, args, _) | Expression::New(callee, args, _) => {
                 Self::expr_contains_await_expression(callee)
                     || args.iter().any(Self::expr_contains_await_expression)
             }
@@ -929,11 +929,11 @@ impl<'a> Parser<'a> {
                 Self::expr_contains_yield_expression(&p.value)
                     || matches!(&p.key, crate::ast::PropertyKey::Computed(e) if Self::expr_contains_yield_expression(e))
             }),
-            Expression::Member(object, property) => {
+            Expression::Member(object, property, _) => {
                 Self::expr_contains_yield_expression(object)
                     || matches!(property, MemberProperty::Computed(e) if Self::expr_contains_yield_expression(e))
             }
-            Expression::Call(callee, args) | Expression::New(callee, args) => {
+            Expression::Call(callee, args, _) | Expression::New(callee, args, _) => {
                 Self::expr_contains_yield_expression(callee)
                     || args.iter().any(Self::expr_contains_yield_expression)
             }
@@ -1525,7 +1525,7 @@ fn expr_to_pattern(expr: Expression) -> Result<Pattern, ParseError> {
             let pat = expr_to_pattern(*inner)?;
             Ok(Pattern::Rest(Box::new(pat)))
         }
-        Expression::Member(_, _) => Ok(Pattern::MemberExpression(Box::new(expr))),
+        Expression::Member(_, _, _) => Ok(Pattern::MemberExpression(Box::new(expr))),
         _ => Err(ParseError {
             message: "Invalid destructuring target".to_string(),
         }),

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -963,7 +963,7 @@ impl<'a> Parser<'a> {
                         let right = self.parse_expression()?;
                         self.eat(&Token::RightParen)?;
                         let body = self.parse_iteration_body()?;
-                        let left = if !self.strict && matches!(&expr, Expression::Call(_, _)) {
+                        let left = if !self.strict && matches!(&expr, Expression::Call(_, _, _)) {
                             ForInOfLeft::Expression(expr)
                         } else {
                             let pat = expr_to_pattern(expr)?;
@@ -980,7 +980,7 @@ impl<'a> Parser<'a> {
                         let right = self.parse_assignment_expression()?;
                         self.eat(&Token::RightParen)?;
                         let body = self.parse_iteration_body()?;
-                        let left = if !self.strict && matches!(&expr, Expression::Call(_, _)) {
+                        let left = if !self.strict && matches!(&expr, Expression::Call(_, _, _)) {
                             ForInOfLeft::Expression(expr)
                         } else {
                             let pat = expr_to_pattern(expr)?;
@@ -1173,7 +1173,7 @@ impl<'a> Parser<'a> {
                     let right = self.parse_expression()?;
                     self.eat(&Token::RightParen)?;
                     let body = self.parse_iteration_body()?;
-                    let left = if !self.strict && matches!(&expr, Expression::Call(_, _)) {
+                    let left = if !self.strict && matches!(&expr, Expression::Call(_, _, _)) {
                         ForInOfLeft::Expression(expr)
                     } else {
                         let pat = expr_to_pattern(expr)?;
@@ -1198,7 +1198,7 @@ impl<'a> Parser<'a> {
                     let right = self.parse_assignment_expression()?;
                     self.eat(&Token::RightParen)?;
                     let body = self.parse_iteration_body()?;
-                    let left = if !self.strict && matches!(&expr, Expression::Call(_, _)) {
+                    let left = if !self.strict && matches!(&expr, Expression::Call(_, _, _)) {
                         ForInOfLeft::Expression(expr)
                     } else {
                         let pat = expr_to_pattern(expr)?;


### PR DESCRIPTION
## Summary

Implements monomorphic inline caching for property accesses (`obj.x`) and function call sites — Issue #71. Sidesteps the bytecode dependency by attaching `Cell<IcSlot>` directly to the relevant `Expression` AST variants; generator/async replay safety holds because slots are shape-keyed and re-fetch on every hit.

Three phases land in one commit; reviewers can split via interactive rebase if preferred.

### Phase 1 — Shape infrastructure on JsObjectData
- `JsObjectData.shape_id: u64` plus a process-global `NEXT_SHAPE_ID` atomic counter (mirrors `NEXT_TEMPLATE_ID`).
- `alloc_object` seeds shape on every allocation. Globally-unique shape ids solve GC slot reuse without a generation counter.
- `set_property_value` bumps shape on the three structural branches (length truncation, `array_elements` extension, new property insert) and stays stable on the two pure-update branches.
- `define_own_property` bumps at success exit, distinguished from non-mutating early returns.
- `Interpreter::mutate_object_shape<F>` chokepoint helper added (currently exercised by IC unit tests; production prototype/proxy migration deferred to where it matters).

### Phase 2 — Property-access IC at `eval_member`
- New module `src/interpreter/ic.rs` defines `PropIcSlot` (Empty/Mono/Megamorphic), `PropIcKind` (OwnData/OwnAccessor/ProtoData/Missing/TypedArrayElement), `fresh_prop_ic_cell()`. Compile-time size assert ≤ 40 bytes.
- `Expression::Member` carries `Cell<PropIcSlot>` as a third field; ~50 construction/destructure sites updated.
- `eval_member` probes the cell on Dot access. Hit dispatches via `PropertyMap.get` directly (skipping proxy/module-ns/typed-array detection); miss falls to slow path, then records via `classify_for_prop_ic`.
- v1 IC scope: own-data and depth-1 missing only. Proxy / module-namespace / typed-array / accessor / depth>1 stay slow. `with_scope_depth > 0` bypasses IC.

### Phase 3 — Call-site IC at `eval_call`
- `CallIcSlot`, `CallIcKind`, `fresh_call_ic_cell()` added to `ic.rs`.
- `Expression::Call` and `Expression::New` carry `Cell<CallIcSlot>`. `Expression::New` slot is allocated for forward compatibility but not yet probed.
- `eval_call` probes after callee/this resolution. Hit increments `call_ic_hit_count` and dispatches normally; miss records `Mono` if the callable is a plain native or user function (no proxy / wrapped / bound / class-ctor). The `kind` field is recorded for the future `call_function_fast` entry.

### State machine (identical for prop and call)
| From | Trigger | To |
|---|---|---|
| Empty | first IC-able miss | Mono(new) |
| Mono(A) | hit | Mono(A) |
| Mono(A) | miss, same `obj_id`, different shape | Mono(refreshed) |
| Mono(A) | miss, different `obj_id` | Megamorphic |
| Megamorphic | any | Megamorphic |

### Telemetry
`Cell<u64>` counters on Interpreter: `ic_hit_count`, `ic_slow_path_count` (Phase 2), `call_ic_hit_count`, `call_ic_slow_path_count` (Phase 3). Whitebox accessors used by IC unit tests.

### Validation
- 86 cargo unit tests pass (10 new IC tests covering shape-id semantics, IC hit counters, defineProperty/delete invalidation, function reassignment, megamorphic transition).
- `./scripts/lint.sh` clean (clippy `-D warnings`).
- Release build clean.
- Focused test262: **23,858 / 23,858 pass** across `Object`, `Array`, `Reflect`, `Proxy`, `Function`, `language/expressions/{call,new,super,property-accessors,computed-property-names}`, `language/statements/class`.
- Full test262: **0 IC-induced regressions**. The 32 listed regressions vs the stale baseline file (`test262-pass.txt`) are pre-existing failures on `origin/main` HEAD: `RegExp/prototype/Symbol.{match,matchAll,replace}/` tests exercising customized `flags`/`global` getters that bypass `get_flags_fast`/`is_pristine_regexp` (`src/interpreter/builtins/regexp.rs:6242,6256`) — separate spec-compliance bug, will be filed as its own issue.

## Deferred follow-ups (out of v1 scope)
- `call_function_fast` entry skipping proxy/wrapped/class-ctor checks. The IC slot already records the `kind` needed.
- Probe wiring for `Expression::New`, mirroring `eval_call`.
- Migration of prototype/proxy mutation sites through `mutate_object_shape`, unblocking `ProtoData` / `OwnAccessor` IC variants.

## Test plan
- [x] cargo test --bin jsse (86 tests pass)
- [x] ./scripts/lint.sh
- [x] cargo build --release
- [x] Focused test262 across property-access and call surfaces (23,858 / 23,858)
- [x] Full test262 (-j 32, 99,020 scenarios; 0 IC-induced regressions)