### PR TITLE
Object slab arena (#66, PR 2 series)

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -2,19 +2,19 @@ use super::super::*;
 
 // §7.2.2 IsArray — Proxy-aware check
 fn is_array_check(interp: &mut Interpreter, obj_id: u64) -> Result<bool, JsValue> {
-    if let Some(obj) = interp.get_object(obj_id) {
-        let (is_revoked, is_proxy, target_id, class) = {
-            let b = obj.borrow();
-            let tid = b.proxy_target_id;
-            // is_proxy() checks proxy_target_id.is_some(), but revoked proxies have proxy_target_id=None
-            // Use proxy_revoked flag to also detect revoked proxies
-            (
-                b.proxy_revoked,
-                b.is_proxy() || b.proxy_revoked,
-                tid,
-                b.class_name.clone(),
-            )
-        };
+    let snapshot = interp.get_object_cell(obj_id).map(|cell| {
+        let b = cell.borrow();
+        let tid = b.proxy_target_id;
+        // is_proxy() checks proxy_target_id.is_some(), but revoked proxies have proxy_target_id=None
+        // Use proxy_revoked flag to also detect revoked proxies
+        (
+            b.proxy_revoked,
+            b.is_proxy() || b.proxy_revoked,
+            tid,
+            b.class_name.clone(),
+        )
+    });
+    if let Some((is_revoked, is_proxy, target_id, class)) = snapshot {
         if is_revoked {
             return Err(interp
                 .create_type_error("Cannot perform 'IsArray' on a proxy that has been revoked"));
@@ -59,9 +59,9 @@ fn length_of_array_like(interp: &mut Interpreter, o: &JsValue) -> Result<usize, 
     Ok(len.min(9007199254740991.0) as usize)
 }
 
-fn get_obj(interp: &Interpreter, o: &JsValue) -> Option<Rc<RefCell<JsObjectData>>> {
+fn get_obj<'a>(interp: &'a Interpreter, o: &JsValue) -> Option<&'a RefCell<JsObjectData>> {
     if let JsValue::Object(obj_ref) = o {
-        interp.get_object(obj_ref.id)
+        interp.get_object_cell(obj_ref.id)
     } else {
         None
     }
@@ -87,9 +87,11 @@ fn obj_set_throw(
 ) -> Result<(), JsValue> {
     if let JsValue::Object(obj_ref) = o {
         // Check for Proxy
-        if let Some(obj) = interp.get_object(obj_ref.id)
-            && (obj.borrow().is_proxy() || obj.borrow().proxy_revoked)
-        {
+        let is_proxy = interp.get_object_cell(obj_ref.id).is_some_and(|cell| {
+            let b = cell.borrow();
+            b.is_proxy() || b.proxy_revoked
+        });
+        if is_proxy {
             match interp.proxy_set(obj_ref.id, key, value, o) {
                 Ok(true) => return Ok(()),
                 Ok(false) => {
@@ -131,8 +133,8 @@ fn obj_set_throw(
         }
         // TypedArray [[Set]]: must call ToNumber/ToBigInt before writing (§10.4.5.5)
         {
-            let ta_info = interp.get_object(obj_ref.id).and_then(|obj| {
-                let b = obj.borrow();
+            let ta_info = interp.get_object_cell(obj_ref.id).and_then(|cell| {
+                let b = cell.borrow();
                 b.typed_array_info
                     .as_ref()
                     .map(|ta| (ta.kind.is_bigint(), ta.kind))
@@ -148,8 +150,8 @@ fn obj_set_throw(
                         Err(e) => return Err(e),
                     }
                 };
-                if let Some(obj) = interp.get_object(obj_ref.id)
-                    && let Some(ref ta) = obj.borrow().typed_array_info
+                if let Some(cell) = interp.get_object_cell(obj_ref.id)
+                    && let Some(ref ta) = cell.borrow().typed_array_info
                     && is_valid_integer_index(ta, index)
                 {
                     typed_array_set_index(ta, index as usize, &num_val);
@@ -158,14 +160,17 @@ fn obj_set_throw(
             }
         }
         // Normal set
-        if let Some(obj) = interp.get_object(obj_ref.id) {
-            let mut borrow = obj.borrow_mut();
-            if !borrow.extensible && !borrow.has_own_property(key) {
+        if let Some(cell) = interp.get_object_cell(obj_ref.id) {
+            let needs_error = {
+                let borrow = cell.borrow();
+                !borrow.extensible && !borrow.has_own_property(key)
+            };
+            if needs_error {
                 return Err(interp.create_type_error(&format!(
                     "Cannot add property {key}, object is not extensible"
                 )));
             }
-            borrow.set_property_value(key, value);
+            cell.borrow_mut().set_property_value(key, value);
         }
     }
     Ok(())
@@ -180,8 +185,8 @@ pub(crate) fn create_data_property_or_throw(
     if let JsValue::Object(obj_ref) = o {
         // Deferred namespace: trigger evaluation on [[DefineOwnProperty]]
         {
-            let is_deferred_ns = interp.get_object(obj_ref.id).is_some_and(|obj| {
-                obj.borrow()
+            let is_deferred_ns = interp.get_object_cell(obj_ref.id).is_some_and(|cell| {
+                cell.borrow()
                     .module_namespace
                     .as_ref()
                     .is_some_and(|ns| ns.deferred)
@@ -191,9 +196,10 @@ pub(crate) fn create_data_property_or_throw(
             }
         }
         // Check for Proxy defineProperty trap
-        if let Some(obj) = interp.get_object(obj_ref.id)
-            && obj.borrow().is_proxy()
-        {
+        let is_proxy = interp
+            .get_object_cell(obj_ref.id)
+            .is_some_and(|cell| cell.borrow().is_proxy());
+        if is_proxy {
             // Build descriptor object for proxy trap
             let desc_obj_id = interp.create_object_id();
             {
@@ -213,26 +219,29 @@ pub(crate) fn create_data_property_or_throw(
                 Err(e) => Err(e),
             };
         }
-        if let Some(obj) = interp.get_object(obj_ref.id) {
+        if interp.get_object_cell(obj_ref.id).is_some() {
             // Check extensibility — if object is not extensible and property doesn't exist, fail
-            let not_extensible = !obj.borrow().extensible;
+            let not_extensible = !interp
+                .get_object_cell_expect(obj_ref.id)
+                .borrow()
+                .extensible;
             if not_extensible && !interp.has_property_on_id(obj_ref.id, key) {
                 return Err(interp.create_type_error(&format!(
                     "Cannot add property {key}, object is not extensible"
                 )));
             }
-            {
-                let borrow = obj.borrow();
-                // Check for non-configurable existing property
-                if let Some(desc) = borrow.get_own_property(key)
-                    && desc.configurable == Some(false)
-                {
-                    return Err(
-                        interp.create_type_error(&format!("Cannot redefine property: {key}"))
-                    );
-                }
+            // Check for non-configurable existing property
+            let non_configurable = {
+                let borrow = interp.get_object_cell_expect(obj_ref.id).borrow();
+                borrow
+                    .get_own_property(key)
+                    .is_some_and(|desc| desc.configurable == Some(false))
+            };
+            if non_configurable {
+                return Err(interp.create_type_error(&format!("Cannot redefine property: {key}")));
             }
-            let mut borrow = obj.borrow_mut();
+            let cell = interp.get_object_cell_expect(obj_ref.id);
+            let mut borrow = cell.borrow_mut();
             if let Some(ref mut elems) = borrow.array_elements
                 && let Ok(idx) = key.parse::<usize>()
             {
@@ -442,8 +451,8 @@ fn from_async_attach_await(
                 },
             ));
 
-            if let Some(obj) = interp.get_object(promise_id) {
-                let mut ob = obj.borrow_mut();
+            if let Some(cell) = interp.get_object_cell(promise_id) {
+                let mut ob = cell.borrow_mut();
                 if let Some(ref mut pd) = ob.promise_data {
                     pd.is_handled = true;
                     pd.fulfill_reactions.push(PromiseReaction {
@@ -674,8 +683,8 @@ fn from_async_store_arraylike_and_continue(
 }
 
 fn obj_delete(interp: &mut Interpreter, o: &JsValue, key: &str) {
-    if let Some(obj) = get_obj(interp, o) {
-        let mut borrow = obj.borrow_mut();
+    if let Some(cell) = get_obj(interp, o) {
+        let mut borrow = cell.borrow_mut();
         borrow.properties.remove(key);
         borrow.property_order.retain(|k| k != key);
         if let Some(ref mut elems) = borrow.array_elements
@@ -691,9 +700,11 @@ fn obj_delete(interp: &mut Interpreter, o: &JsValue, key: &str) {
 fn obj_delete_throw(interp: &mut Interpreter, o: &JsValue, key: &str) -> Result<(), JsValue> {
     if let JsValue::Object(obj_ref) = o {
         // Check for Proxy deleteProperty trap
-        if let Some(obj) = interp.get_object(obj_ref.id)
-            && (obj.borrow().is_proxy() || obj.borrow().proxy_revoked)
-        {
+        let is_proxy = interp.get_object_cell(obj_ref.id).is_some_and(|cell| {
+            let b = cell.borrow();
+            b.is_proxy() || b.proxy_revoked
+        });
+        if is_proxy {
             match interp.proxy_delete_property(obj_ref.id, key) {
                 Ok(true) => return Ok(()),
                 Ok(false) => {
@@ -705,15 +716,15 @@ fn obj_delete_throw(interp: &mut Interpreter, o: &JsValue, key: &str) -> Result<
             }
         }
         // Check if property is non-configurable
-        if let Some(obj) = interp.get_object(obj_ref.id) {
-            let desc = obj.borrow().get_own_property(key);
-            if let Some(ref d) = desc
-                && d.configurable == Some(false)
-            {
-                return Err(
-                    interp.create_type_error(&format!("Cannot delete property '{key}' of object"))
-                );
-            }
+        let non_configurable = interp.get_object_cell(obj_ref.id).is_some_and(|cell| {
+            cell.borrow()
+                .get_own_property(key)
+                .is_some_and(|desc| desc.configurable == Some(false))
+        });
+        if non_configurable {
+            return Err(
+                interp.create_type_error(&format!("Cannot delete property '{key}' of object"))
+            );
         }
     }
     obj_delete(interp, o, key);
@@ -721,8 +732,8 @@ fn obj_delete_throw(interp: &mut Interpreter, o: &JsValue, key: &str) -> Result<
 }
 
 fn set_length(interp: &mut Interpreter, o: &JsValue, len: usize) {
-    if let Some(obj) = get_obj(interp, o) {
-        let mut borrow = obj.borrow_mut();
+    if let Some(cell) = get_obj(interp, o) {
+        let mut borrow = cell.borrow_mut();
         if let Some(ref mut elems) = borrow.array_elements
             && len <= elems.len()
         {
@@ -735,42 +746,41 @@ fn set_length(interp: &mut Interpreter, o: &JsValue, len: usize) {
 
 // Set(O, "length", len, true) — uses obj_set_throw for setter invocation
 fn set_length_throw(interp: &mut Interpreter, o: &JsValue, len: usize) -> Result<(), JsValue> {
-    if let Some(obj) = get_obj(interp, o)
-        && obj.borrow().array_elements.is_some()
-    {
+    let snapshot = get_obj(interp, o).and_then(|cell| {
+        let b = cell.borrow();
+        b.array_elements.as_ref()?;
+        let length_desc = b.get_own_property("length");
+        let length_writable_false = length_desc
+            .as_ref()
+            .is_some_and(|d| d.writable == Some(false));
+        let length_frozen = length_desc
+            .as_ref()
+            .is_some_and(|d| d.configurable == Some(false) && d.writable == Some(false));
+        Some((b.extensible, length_writable_false, length_frozen))
+    });
+    if let Some((extensible, length_writable_false, length_frozen)) = snapshot {
         // ArraySetLength §10.4.2.4: ToUint32(len) must equal ToNumber(len)
         let len_f64 = len as f64;
         let len_u32 = len_f64 as u32;
         if (len_u32 as f64) != len_f64 {
             return Err(interp.create_range_error("Invalid array length"));
         }
-        // Check if length is writable
-        let desc = obj.borrow().get_own_property("length");
-        if let Some(ref d) = desc
-            && d.writable == Some(false)
-        {
+        if length_writable_false {
             return Err(interp.create_type_error("Cannot assign to read only property 'length'"));
         }
-        // Check if frozen (not extensible + all props non-configurable)
-        if !obj.borrow().extensible {
-            let desc = obj.borrow().get_own_property("length");
-            if let Some(ref d) = desc
-                && d.configurable == Some(false)
-                && d.writable == Some(false)
+        if !extensible && length_frozen {
+            return Err(interp.create_type_error("Cannot assign to read only property 'length'"));
+        }
+        if let Some(cell) = get_obj(interp, o) {
+            let mut borrow = cell.borrow_mut();
+            if let Some(ref mut elems) = borrow.array_elements
+                && len <= elems.len()
             {
-                return Err(
-                    interp.create_type_error("Cannot assign to read only property 'length'")
-                );
+                elems.truncate(len);
             }
+            // Don't pre-allocate for sparse arrays
+            borrow.set_property_value("length", JsValue::Number(len as f64));
         }
-        let mut borrow = obj.borrow_mut();
-        if let Some(ref mut elems) = borrow.array_elements
-            && len <= elems.len()
-        {
-            elems.truncate(len);
-        }
-        // Don't pre-allocate for sparse arrays
-        borrow.set_property_value("length", JsValue::Number(len as f64));
         return Ok(());
     }
     obj_set_throw(interp, o, "length", JsValue::Number(len as f64))
@@ -833,8 +843,8 @@ fn array_species_create(
             // on the global object).
             let realm_array = interp.realms[c_realm]
                 .global_object
-                .and_then(|gid| interp.get_object(gid))
-                .and_then(|go| go.borrow().own_property_lookup("Array"));
+                .and_then(|gid| interp.get_object_cell(gid))
+                .and_then(|cell| cell.borrow().own_property_lookup("Array"));
             if let Some(ref ra) = realm_array
                 && same_value(&c, ra)
             {
@@ -3832,20 +3842,21 @@ impl Interpreter {
         let array_val = self.get_global_var("Array");
         if let Some(array_val) = array_val
             && let JsValue::Object(o) = &array_val
-            && let Some(obj) = self.get_object(o.id)
+            && self.get_object_cell(o.id).is_some()
         {
-            obj.borrow_mut()
-                .insert_builtin("isArray".to_string(), is_array_fn);
-            obj.borrow_mut()
-                .insert_builtin("from".to_string(), array_from);
-            obj.borrow_mut().insert_builtin("of".to_string(), array_of);
-            obj.borrow_mut()
-                .insert_builtin("fromAsync".to_string(), from_async_fn);
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val, false, false, false),
-            );
+            let array_id = o.id;
+            {
+                let mut borrow = self.get_object_cell_expect(array_id).borrow_mut();
+                borrow.insert_builtin("isArray".to_string(), is_array_fn);
+                borrow.insert_builtin("from".to_string(), array_from);
+                borrow.insert_builtin("of".to_string(), array_of);
+                borrow.insert_builtin("fromAsync".to_string(), from_async_fn);
+                let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+                borrow.insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val, false, false, false),
+                );
+            }
 
             // Array[Symbol.species] getter - returns `this`
             let species_getter = self.create_function(JsFunction::native(
@@ -3853,17 +3864,19 @@ impl Interpreter {
                 0,
                 |_interp, this_val, _args| Completion::Normal(this_val.clone()),
             ));
-            obj.borrow_mut().insert_property(
-                "Symbol(Symbol.species)".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(species_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            self.get_object_cell_expect(array_id)
+                .borrow_mut()
+                .insert_property(
+                    "Symbol(Symbol.species)".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        get: Some(species_getter),
+                        set: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                    },
+                );
 
             // Array.prototype.constructor = Array
             self.get_object_cell_expect(proto_id)

--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -195,15 +195,15 @@ pub(crate) fn create_data_property_or_throw(
             && obj.borrow().is_proxy()
         {
             // Build descriptor object for proxy trap
-            let desc_obj = interp.create_object();
+            let desc_obj_id = interp.create_object_id();
             {
-                let mut borrow = desc_obj.borrow_mut();
+                let mut borrow = interp.get_object_cell_expect(desc_obj_id).borrow_mut();
                 borrow.set_property_value("value", value);
                 borrow.set_property_value("writable", JsValue::Boolean(true));
                 borrow.set_property_value("enumerable", JsValue::Boolean(true));
                 borrow.set_property_value("configurable", JsValue::Boolean(true));
             }
-            let desc_id = desc_obj.borrow().id.unwrap();
+            let desc_id = desc_obj_id;
             let desc_val = JsValue::Object(crate::types::JsObject { id: desc_id });
             return match interp.proxy_define_own_property(obj_ref.id, key.to_string(), &desc_val) {
                 Ok(true) => Ok(()),
@@ -890,13 +890,19 @@ fn array_species_create(
 
 impl Interpreter {
     pub(crate) fn setup_array_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Array".to_string();
-        proto.borrow_mut().array_elements = Some(Vec::new());
-        proto.borrow_mut().insert_property(
-            "length".to_string(),
-            PropertyDescriptor::data(JsValue::Number(0.0), true, false, false),
-        );
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Array".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .array_elements = Some(Vec::new());
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "length".to_string(),
+                PropertyDescriptor::data(JsValue::Number(0.0), true, false, false),
+            );
 
         // Array.prototype.push
         let push_fn = self.create_function(JsFunction::native(
@@ -927,7 +933,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(len as f64))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("push".to_string(), push_fn);
 
@@ -964,7 +970,9 @@ impl Interpreter {
                 Completion::Normal(val)
             },
         ));
-        proto.borrow_mut().insert_builtin("pop".to_string(), pop_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("pop".to_string(), pop_fn);
 
         // Array.prototype.shift
         let shift_fn = self.create_function(JsFunction::native(
@@ -1017,7 +1025,7 @@ impl Interpreter {
                 Completion::Normal(first)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("shift".to_string(), shift_fn);
 
@@ -1073,7 +1081,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(new_len as f64))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("unshift".to_string(), unshift_fn);
 
@@ -1130,7 +1138,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(-1.0))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("indexOf".to_string(), indexof_fn);
 
@@ -1187,7 +1195,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(-1.0))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("lastIndexOf".to_string(), lastindexof_fn);
 
@@ -1234,7 +1242,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("includes".to_string(), includes_fn);
 
@@ -1281,7 +1289,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&parts.join(&sep))))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("join".to_string(), join_fn);
 
@@ -1309,7 +1317,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str("[object Array]")))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), tostring_fn);
 
@@ -1375,7 +1383,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&parts.join(separator))))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_string_fn);
 
@@ -1501,7 +1509,7 @@ impl Interpreter {
                 Completion::Normal(a)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("concat".to_string(), concat_fn);
 
@@ -1590,7 +1598,7 @@ impl Interpreter {
                 Completion::Normal(a)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("slice".to_string(), slice_fn);
 
@@ -1663,7 +1671,7 @@ impl Interpreter {
                 Completion::Normal(o)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("reverse".to_string(), reverse_fn);
 
@@ -1694,7 +1702,7 @@ impl Interpreter {
                 Completion::Normal(arr)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toReversed".to_string(), to_reversed_fn);
 
@@ -1740,7 +1748,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("forEach".to_string(), foreach_fn);
 
@@ -1811,7 +1819,9 @@ impl Interpreter {
                 Completion::Normal(a)
             },
         ));
-        proto.borrow_mut().insert_builtin("map".to_string(), map_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("map".to_string(), map_fn);
 
         // Array.prototype.filter
         let filter_fn = self.create_function(JsFunction::native(
@@ -1887,7 +1897,7 @@ impl Interpreter {
                 Completion::Normal(a)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("filter".to_string(), filter_fn);
 
@@ -1968,7 +1978,7 @@ impl Interpreter {
                 Completion::Normal(acc)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("reduce".to_string(), reduce_fn);
 
@@ -2048,7 +2058,7 @@ impl Interpreter {
                 Completion::Normal(acc)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("reduceRight".to_string(), reduce_right_fn);
 
@@ -2100,7 +2110,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("some".to_string(), some_fn);
 
@@ -2152,7 +2162,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(true))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("every".to_string(), every_fn);
 
@@ -2197,7 +2207,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("find".to_string(), find_fn);
 
@@ -2242,7 +2252,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(-1.0))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findIndex".to_string(), findindex_fn);
 
@@ -2287,7 +2297,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findLast".to_string(), findlast_fn);
 
@@ -2334,7 +2344,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(-1.0))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findLastIndex".to_string(), findlastidx_fn);
 
@@ -2507,7 +2517,7 @@ impl Interpreter {
                 Completion::Normal(a)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("splice".to_string(), splice_fn);
 
@@ -2578,7 +2588,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(result))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toSpliced".to_string(), to_spliced_fn);
 
@@ -2634,7 +2644,7 @@ impl Interpreter {
                 Completion::Normal(o)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("fill".to_string(), fill_fn);
 
@@ -2755,7 +2765,7 @@ impl Interpreter {
                 Completion::Normal(o)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("sort".to_string(), sort_fn);
 
@@ -2862,7 +2872,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(items))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toSorted".to_string(), to_sorted_fn);
 
@@ -2962,7 +2972,7 @@ impl Interpreter {
                 Completion::Normal(a)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("flat".to_string(), flat_fn);
 
@@ -3090,7 +3100,7 @@ impl Interpreter {
                 Completion::Normal(a)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("flatMap".to_string(), flatmap_fn);
 
@@ -3185,7 +3195,7 @@ impl Interpreter {
                 Completion::Normal(o)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("copyWithin".to_string(), copywithin_fn);
 
@@ -3224,7 +3234,9 @@ impl Interpreter {
                 }
             },
         ));
-        proto.borrow_mut().insert_builtin("at".to_string(), at_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("at".to_string(), at_fn);
 
         // Array.prototype.with
         let with_fn = self.create_function(JsFunction::native(
@@ -3273,7 +3285,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(result))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("with".to_string(), with_fn);
 
@@ -3550,7 +3562,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("entries called on non-object"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("entries".to_string(), entries_fn);
 
@@ -3571,7 +3583,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("keys called on non-object"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("keys".to_string(), keys_fn);
 
@@ -3592,13 +3604,13 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("values called on non-object"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("values".to_string(), values_fn.clone());
 
         // Array.prototype[@@iterator] is the same function as Array.prototype.values (spec §23.1.3.35)
         if let Some(key) = self.get_symbol_iterator_key() {
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(values_fn, true, false, true));
         }
@@ -3829,9 +3841,7 @@ impl Interpreter {
             obj.borrow_mut().insert_builtin("of".to_string(), array_of);
             obj.borrow_mut()
                 .insert_builtin("fromAsync".to_string(), from_async_fn);
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -3856,15 +3866,17 @@ impl Interpreter {
             );
 
             // Array.prototype.constructor = Array
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("constructor".to_string(), array_val);
         }
 
         // Array.prototype[@@unscopables] (§23.1.3.38)
         {
-            let unscopables_obj = self.create_object();
-            unscopables_obj.borrow_mut().prototype_id = None;
+            let unscopables_obj_id = self.create_object_id();
+            self.get_object_cell_expect(unscopables_obj_id)
+                .borrow_mut()
+                .prototype_id = None;
             let names = [
                 "at",
                 "copyWithin",
@@ -3884,19 +3896,21 @@ impl Interpreter {
                 "values",
             ];
             for name in names {
-                unscopables_obj
+                self.get_object_cell_expect(unscopables_obj_id)
                     .borrow_mut()
                     .insert_value(name.to_string(), JsValue::Boolean(true));
             }
-            let unscopables_id = unscopables_obj.borrow().id.unwrap();
+            let unscopables_id = unscopables_obj_id;
             let unscopables_val = JsValue::Object(crate::types::JsObject { id: unscopables_id });
-            proto.borrow_mut().insert_property(
-                "Symbol(Symbol.unscopables)".to_string(),
-                PropertyDescriptor::data(unscopables_val, false, false, true),
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "Symbol(Symbol.unscopables)".to_string(),
+                    PropertyDescriptor::data(unscopables_val, false, false, true),
+                );
         }
 
-        self.realm_mut().array_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().array_prototype = Some(proto_id);
     }
 
     pub(crate) fn create_array(&mut self, values: Vec<JsValue>) -> JsValue {

--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -15,22 +15,25 @@ static WAITER_MAP: LazyLock<Mutex<FxHashMap<(u64, usize), Vec<WaiterEntry>>>> =
     LazyLock::new(|| Mutex::new(FxHashMap::default()));
 
 fn check_ta_detached(interp: &mut Interpreter, ta_val: &JsValue) -> Result<(), JsValue> {
-    if let JsValue::Object(o) = ta_val
-        && let Some(obj) = interp.get_object(o.id)
-    {
-        let obj_ref = obj.borrow();
-        if let Some(ref info) = obj_ref.typed_array_info
-            && info.is_detached.get()
-        {
-            return Err(interp.create_type_error("typed array is detached"));
-        }
+    let detached = if let JsValue::Object(o) = ta_val {
+        interp.get_object_cell(o.id).is_some_and(|cell| {
+            cell.borrow()
+                .typed_array_info
+                .as_ref()
+                .is_some_and(|info| info.is_detached.get())
+        })
+    } else {
+        false
+    };
+    if detached {
+        return Err(interp.create_type_error("typed array is detached"));
     }
     Ok(())
 }
 
 fn get_sab_info(interp: &Interpreter, ta_val: &JsValue) -> Option<(Arc<SharedBufferInner>, usize)> {
     if let JsValue::Object(o) = ta_val
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let obj_ref = obj.borrow();
         let byte_offset = obj_ref
@@ -39,7 +42,7 @@ fn get_sab_info(interp: &Interpreter, ta_val: &JsValue) -> Option<(Arc<SharedBuf
             .map(|i| i.byte_offset)
             .unwrap_or(0);
         if let Some(buf_id) = obj_ref.view_buffer_object_id
-            && let Some(buf_obj) = interp.get_object(buf_id)
+            && let Some(buf_obj) = interp.get_object_cell(buf_id)
         {
             let buf_ref = buf_obj.borrow();
             if buf_ref.arraybuffer_is_shared
@@ -556,12 +559,12 @@ impl Interpreter {
                     };
                 // Step 3: IsSharedArrayBuffer check — before index/value/timeout
                 let buffer_is_shared = if let JsValue::Object(o) = &ta_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let obj_ref = obj.borrow();
                     if obj_ref.typed_array_info.is_some() {
                         if let Some(buf_id) = obj_ref.view_buffer_object_id
-                            && let Some(buf_obj) = interp.get_object(buf_id)
+                            && let Some(buf_obj) = interp.get_object_cell(buf_id)
                         {
                             buf_obj.borrow().arraybuffer_is_shared
                         } else {
@@ -1262,42 +1265,43 @@ fn validate_integer_typed_array(
     ),
     JsValue,
 > {
-    if let JsValue::Object(o) = ta_val
-        && let Some(obj) = interp.get_object(o.id)
-    {
-        let obj_ref = obj.borrow();
-        if let Some(ref info) = obj_ref.typed_array_info {
-            let kind = info.kind;
-            if waitable {
-                if !matches!(kind, TypedArrayKind::Int32 | TypedArrayKind::BigInt64) {
-                    return Err(interp.create_type_error(
-                        "Atomics.wait/notify requires Int32Array or BigInt64Array",
-                    ));
-                }
-            } else if matches!(
-                kind,
-                TypedArrayKind::Float16
-                    | TypedArrayKind::Float32
-                    | TypedArrayKind::Float64
-                    | TypedArrayKind::Uint8Clamped
-            ) {
-                return Err(
-                    interp.create_type_error("Atomics operations require integer typed arrays")
-                );
+    let info_snapshot = if let JsValue::Object(o) = ta_val {
+        interp.get_object_cell(o.id).and_then(|cell| {
+            let obj_ref = cell.borrow();
+            obj_ref.typed_array_info.as_ref().map(|info| {
+                (
+                    info.kind,
+                    info.buffer.clone(),
+                    info.byte_offset,
+                    info.is_detached.get(),
+                )
+            })
+        })
+    } else {
+        None
+    };
+    if let Some((kind, buffer, byte_offset, is_detached)) = info_snapshot {
+        if waitable {
+            if !matches!(kind, TypedArrayKind::Int32 | TypedArrayKind::BigInt64) {
+                return Err(interp.create_type_error(
+                    "Atomics.wait/notify requires Int32Array or BigInt64Array",
+                ));
             }
-            if info.is_detached.get() {
-                return Err(interp.create_type_error("typed array is detached"));
-            }
-            let element_size = kind.bytes_per_element();
-            let is_bigint = kind.is_bigint();
-            return Ok((
-                kind,
-                info.buffer.clone(),
-                info.byte_offset,
-                element_size,
-                is_bigint,
-            ));
+        } else if matches!(
+            kind,
+            TypedArrayKind::Float16
+                | TypedArrayKind::Float32
+                | TypedArrayKind::Float64
+                | TypedArrayKind::Uint8Clamped
+        ) {
+            return Err(interp.create_type_error("Atomics operations require integer typed arrays"));
         }
+        if is_detached {
+            return Err(interp.create_type_error("typed array is detached"));
+        }
+        let element_size = kind.bytes_per_element();
+        let is_bigint = kind.is_bigint();
+        return Ok((kind, buffer, byte_offset, element_size, is_bigint));
     }
     Err(interp.create_type_error("first argument must be a typed array"))
 }
@@ -1314,7 +1318,7 @@ fn validate_atomic_access(
         _ => 0,
     };
     let array_length = if let JsValue::Object(o) = ta_val
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let obj_ref = obj.borrow();
         if let Some(ref info) = obj_ref.typed_array_info {

--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -54,8 +54,8 @@ fn get_sab_info(interp: &Interpreter, ta_val: &JsValue) -> Option<(Arc<SharedBuf
 
 impl Interpreter {
     pub(crate) fn setup_atomics(&mut self) {
-        let atomics_obj = self.create_object();
-        let atomics_id = atomics_obj.borrow().id.unwrap();
+        let atomics_obj_id = self.create_object_id();
+        let atomics_id = atomics_obj_id;
 
         // Atomics.add
         let add_fn = self.create_function(JsFunction::native(
@@ -70,7 +70,7 @@ impl Interpreter {
                 )
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("add".to_string(), add_fn);
 
@@ -87,7 +87,7 @@ impl Interpreter {
                 )
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("sub".to_string(), sub_fn);
 
@@ -99,7 +99,7 @@ impl Interpreter {
                 atomics_rmw(interp, args, |old, val| old & val, |old, val| old & val)
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("and".to_string(), and_fn);
 
@@ -111,7 +111,7 @@ impl Interpreter {
                 atomics_rmw(interp, args, |old, val| old | val, |old, val| old | val)
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("or".to_string(), or_fn);
 
@@ -123,7 +123,7 @@ impl Interpreter {
                 atomics_rmw(interp, args, |old, val| old ^ val, |old, val| old ^ val)
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("xor".to_string(), xor_fn);
 
@@ -133,7 +133,7 @@ impl Interpreter {
             3,
             |interp, _this, args| atomics_rmw(interp, args, |_old, val| val, |_old, val| val),
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("exchange".to_string(), exchange_fn);
 
@@ -170,7 +170,7 @@ impl Interpreter {
                 })
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("load".to_string(), load_fn);
 
@@ -230,7 +230,7 @@ impl Interpreter {
                 Completion::Normal(return_val)
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("store".to_string(), store_fn);
 
@@ -307,7 +307,7 @@ impl Interpreter {
                 })
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("compareExchange".to_string(), cmpxchg_fn);
 
@@ -325,7 +325,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(result))
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("isLockFree".to_string(), is_lock_free_fn);
 
@@ -471,7 +471,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(result)))
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("wait".to_string(), wait_fn);
 
@@ -537,7 +537,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(woken as f64))
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("notify".to_string(), notify_fn);
 
@@ -624,35 +624,47 @@ impl Interpreter {
                     }
                 });
 
-                let result = interp.create_object();
+                let result_id = interp.create_object_id();
                 if !current_matches {
-                    result.borrow_mut().insert_property(
-                        "async".to_string(),
-                        PropertyDescriptor::data(JsValue::Boolean(false), true, true, true),
-                    );
-                    result.borrow_mut().insert_property(
-                        "value".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str("not-equal")),
-                            true,
-                            true,
-                            true,
-                        ),
-                    );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "async".to_string(),
+                            PropertyDescriptor::data(JsValue::Boolean(false), true, true, true),
+                        );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "value".to_string(),
+                            PropertyDescriptor::data(
+                                JsValue::String(JsString::from_str("not-equal")),
+                                true,
+                                true,
+                                true,
+                            ),
+                        );
                 } else if timeout <= 0.0 {
-                    result.borrow_mut().insert_property(
-                        "async".to_string(),
-                        PropertyDescriptor::data(JsValue::Boolean(false), true, true, true),
-                    );
-                    result.borrow_mut().insert_property(
-                        "value".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str("timed-out")),
-                            true,
-                            true,
-                            true,
-                        ),
-                    );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "async".to_string(),
+                            PropertyDescriptor::data(JsValue::Boolean(false), true, true, true),
+                        );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "value".to_string(),
+                            PropertyDescriptor::data(
+                                JsValue::String(JsString::from_str("timed-out")),
+                                true,
+                                true,
+                                true,
+                            ),
+                        );
                 } else {
                     let sab_info = get_sab_info(interp, &ta_val);
                     let (resolve_fn, _reject_fn, promise_val) = interp.create_promise_parts();
@@ -738,22 +750,28 @@ impl Interpreter {
                         });
                     }
 
-                    result.borrow_mut().insert_property(
-                        "async".to_string(),
-                        PropertyDescriptor::data(JsValue::Boolean(true), true, true, true),
-                    );
-                    result.borrow_mut().insert_property(
-                        "value".to_string(),
-                        PropertyDescriptor::data(promise_val.clone(), true, true, true),
-                    );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "async".to_string(),
+                            PropertyDescriptor::data(JsValue::Boolean(true), true, true, true),
+                        );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "value".to_string(),
+                            PropertyDescriptor::data(promise_val.clone(), true, true, true),
+                        );
                     // resolve_fn stays rooted until completion callback runs
                     interp.gc_unroot_frame(gc_frame_promise);
                 }
-                let id = result.borrow().id.unwrap();
+                let id = result_id;
                 Completion::Normal(JsValue::Object(JsObject { id }))
             },
         ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("waitAsync".to_string(), wait_async_fn);
 
@@ -782,7 +800,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::Undefined)
                 },
             ));
-        atomics_obj
+        self.get_object_cell_expect(atomics_obj_id)
             .borrow_mut()
             .insert_builtin("pause".to_string(), pause_fn);
 
@@ -791,11 +809,14 @@ impl Interpreter {
             let tag = JsValue::String(JsString::from_str("Atomics"));
             let sym_key = "Symbol(Symbol.toStringTag)".to_string();
             let desc = PropertyDescriptor::data(tag, false, false, true);
-            atomics_obj
+            self.get_object_cell_expect(atomics_obj_id)
                 .borrow_mut()
                 .property_order
                 .push(sym_key.clone());
-            atomics_obj.borrow_mut().properties.insert(sym_key, desc);
+            self.get_object_cell_expect(atomics_obj_id)
+                .borrow_mut()
+                .properties
+                .insert(sym_key, desc);
         }
 
         let atomics_val = JsValue::Object(crate::types::JsObject { id: atomics_id });

--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -32,8 +32,10 @@ pub fn f64_to_bigint(n: f64) -> num_bigint::BigInt {
 
 impl Interpreter {
     pub(crate) fn setup_bigint_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "BigInt".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "BigInt".to_string();
 
         fn this_bigint_value(interp: &Interpreter, this: &JsValue) -> Option<num_bigint::BigInt> {
             match this {
@@ -128,22 +130,26 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // @@toStringTag
         let tag_key = self
             .get_symbol_key("toStringTag")
             .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
-        proto.borrow_mut().insert_property(
-            tag_key,
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("BigInt")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                tag_key,
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("BigInt")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
         // BigInt() — is a constructor but throws TypeError when called with new
         self.register_global_fn(
@@ -306,9 +312,7 @@ impl Interpreter {
             && let JsValue::Object(o) = &bigint_val
             && let Some(bigint_obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             bigint_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -323,13 +327,15 @@ impl Interpreter {
 
         // Set constructor property on prototype
         if let Some(bigint_val) = self.get_global_var("BigInt") {
-            proto.borrow_mut().insert_property(
-                "constructor".to_string(),
-                PropertyDescriptor::data(bigint_val, true, false, true),
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "constructor".to_string(),
+                    PropertyDescriptor::data(bigint_val, true, false, true),
+                );
         }
 
-        self.realm_mut().bigint_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().bigint_prototype = Some(proto_id);
     }
 }
 

--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -40,8 +40,8 @@ impl Interpreter {
         fn this_bigint_value(interp: &Interpreter, this: &JsValue) -> Option<num_bigint::BigInt> {
             match this {
                 JsValue::BigInt(b) => Some(b.value.clone()),
-                JsValue::Object(o) => interp.get_object(o.id).and_then(|obj| {
-                    let b = obj.borrow();
+                JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|cell| {
+                    let b = cell.borrow();
                     if b.class_name == "BigInt"
                         && let Some(JsValue::BigInt(bi)) = &b.primitive_value
                     {
@@ -310,17 +310,17 @@ impl Interpreter {
 
         if let Some(bigint_val) = self.get_global_var("BigInt")
             && let JsValue::Object(o) = &bigint_val
-            && let Some(bigint_obj) = self.get_object(o.id)
+            && let Some(bigint_cell) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-            bigint_obj.borrow_mut().insert_property(
+            bigint_cell.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
-            bigint_obj
+            bigint_cell
                 .borrow_mut()
                 .insert_builtin("asIntN".to_string(), as_int_n);
-            bigint_obj
+            bigint_cell
                 .borrow_mut()
                 .insert_builtin("asUintN".to_string(), as_uint_n);
         }

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -2,23 +2,31 @@ use super::super::*;
 
 impl Interpreter {
     pub(crate) fn setup_map_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Map".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Map".to_string();
 
         // Map iterator prototype
-        let map_iter_proto = self.create_object();
-        map_iter_proto.borrow_mut().prototype_id = self.realm().iterator_prototype;
-        map_iter_proto.borrow_mut().class_name = "Map Iterator".to_string();
+        let map_iter_proto_id = self.create_object_id();
+        self.get_object_cell_expect(map_iter_proto_id)
+            .borrow_mut()
+            .prototype_id = self.realm().iterator_prototype;
+        self.get_object_cell_expect(map_iter_proto_id)
+            .borrow_mut()
+            .class_name = "Map Iterator".to_string();
 
-        map_iter_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Map Iterator")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(map_iter_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Map Iterator")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
         let map_iter_next = self.create_function(JsFunction::native(
             "next".to_string(),
@@ -85,7 +93,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        map_iter_proto
+        self.get_object_cell_expect(map_iter_proto_id)
             .borrow_mut()
             .insert_builtin("next".to_string(), map_iter_next);
 
@@ -95,13 +103,15 @@ impl Interpreter {
                 0,
                 |_interp, this, _args| Completion::Normal(this.clone()),
             ));
-            map_iter_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(iter_self_fn, true, false, true),
-            );
+            self.get_object_cell_expect(map_iter_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(iter_self_fn, true, false, true),
+                );
         }
 
-        self.realm_mut().map_iterator_prototype = Some(map_iter_proto.borrow().id.unwrap());
+        self.realm_mut().map_iterator_prototype = Some(map_iter_proto_id);
 
         // Helper to create map iterators
         fn create_map_iterator(
@@ -148,13 +158,13 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("entries".to_string(), entries_fn.clone());
 
         // Map.prototype[@@iterator] = entries
         if let Some(key) = self.get_symbol_iterator_key() {
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(entries_fn, true, false, true));
         }
@@ -181,7 +191,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("keys".to_string(), keys_fn);
 
@@ -207,7 +217,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("values".to_string(), values_fn);
 
@@ -241,7 +251,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("get".to_string(), get_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("get".to_string(), get_fn);
 
         // Map.prototype.set
         let set_fn = self.create_function(JsFunction::native(
@@ -281,7 +293,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("set".to_string(), set_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("set".to_string(), set_fn);
 
         // Map.prototype.has
         let has_fn = self.create_function(JsFunction::native(
@@ -313,7 +327,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("has".to_string(), has_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("has".to_string(), has_fn);
 
         // Map.prototype.delete
         let delete_fn = self.create_function(JsFunction::native(
@@ -346,7 +362,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("delete".to_string(), delete_fn);
 
@@ -371,7 +387,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("clear".to_string(), clear_fn);
 
@@ -411,7 +427,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("forEach".to_string(), foreach_fn);
 
@@ -440,17 +456,19 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_property(
-            "size".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(size_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "size".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(size_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // Map.prototype.getOrInsert
         let get_or_insert_fn = self.create_function(JsFunction::native(
@@ -495,7 +513,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getOrInsert".to_string(), get_or_insert_fn);
 
@@ -560,27 +578,29 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getOrInsertComputed".to_string(), get_or_insert_computed_fn);
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Map")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Map")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
         // constructor property
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // Map constructor
-        let map_proto_clone_id = proto.borrow().id.unwrap();
+        let map_proto_clone_id = proto_id;
         let map_ctor = self.create_function(JsFunction::constructor(
             "Map".to_string(),
             0,
@@ -597,11 +617,11 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(map_proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Map".to_string();
-                obj.borrow_mut().map_data = Some(Vec::new());
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = interp.create_object_id();
+                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
+                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "Map".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().map_data = Some(Vec::new());
+                let obj_id = obj_id;
                 let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
 
                 let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
@@ -690,10 +710,12 @@ impl Interpreter {
                 PropertyDescriptor::data(proto_val.clone(), false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(map_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(map_ctor.clone(), true, false, true),
+            );
 
         // Map[Symbol.species] getter
         if let JsValue::Object(ref ctor_ref) = map_ctor
@@ -721,7 +743,7 @@ impl Interpreter {
         if let JsValue::Object(ref ctor_ref) = map_ctor
             && let Some(ctor_obj) = self.get_object(ctor_ref.id)
         {
-            let map_proto_for_groupby = proto.clone();
+            let map_proto_for_groupby = proto_id;
             let group_by_fn = self.create_function(JsFunction::native(
                 "groupBy".to_string(),
                 2,
@@ -745,12 +767,20 @@ impl Interpreter {
                     };
 
                     // 3. Create result Map
-                    let result_map = interp.create_object();
-                    result_map.borrow_mut().prototype_id =
-                        Some(map_proto_for_groupby.borrow().id.unwrap());
-                    result_map.borrow_mut().class_name = "Map".to_string();
-                    result_map.borrow_mut().map_data = Some(Vec::new());
-                    let result_id = result_map.borrow().id.unwrap();
+                    let result_map_id = interp.create_object_id();
+                    interp
+                        .get_object_cell_expect(result_map_id)
+                        .borrow_mut()
+                        .prototype_id = Some(map_proto_for_groupby);
+                    interp
+                        .get_object_cell_expect(result_map_id)
+                        .borrow_mut()
+                        .class_name = "Map".to_string();
+                    interp
+                        .get_object_cell_expect(result_map_id)
+                        .borrow_mut()
+                        .map_data = Some(Vec::new());
+                    let result_id = result_map_id;
                     let result_val = JsValue::Object(crate::types::JsObject { id: result_id });
 
                     // 4. Iterate and group
@@ -848,27 +878,35 @@ impl Interpreter {
         let env = self.realm().global_env.clone();
         let _ = self.env_set(&env, "Map", map_ctor);
 
-        self.realm_mut().map_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().map_prototype = Some(proto_id);
     }
 
     pub(crate) fn setup_set_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Set".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Set".to_string();
 
         // Set iterator prototype
-        let set_iter_proto = self.create_object();
-        set_iter_proto.borrow_mut().prototype_id = self.realm().iterator_prototype;
-        set_iter_proto.borrow_mut().class_name = "Set Iterator".to_string();
+        let set_iter_proto_id = self.create_object_id();
+        self.get_object_cell_expect(set_iter_proto_id)
+            .borrow_mut()
+            .prototype_id = self.realm().iterator_prototype;
+        self.get_object_cell_expect(set_iter_proto_id)
+            .borrow_mut()
+            .class_name = "Set Iterator".to_string();
 
-        set_iter_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Set Iterator")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(set_iter_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Set Iterator")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
         let set_iter_next = self.create_function(JsFunction::native(
             "next".to_string(),
@@ -933,7 +971,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        set_iter_proto
+        self.get_object_cell_expect(set_iter_proto_id)
             .borrow_mut()
             .insert_builtin("next".to_string(), set_iter_next);
 
@@ -943,13 +981,15 @@ impl Interpreter {
                 0,
                 |_interp, this, _args| Completion::Normal(this.clone()),
             ));
-            set_iter_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(iter_self_fn, true, false, true),
-            );
+            self.get_object_cell_expect(set_iter_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(iter_self_fn, true, false, true),
+                );
         }
 
-        self.realm_mut().set_iterator_prototype = Some(set_iter_proto.borrow().id.unwrap());
+        self.realm_mut().set_iterator_prototype = Some(set_iter_proto_id);
 
         fn create_set_iterator(
             interp: &mut Interpreter,
@@ -995,18 +1035,18 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("values".to_string(), values_fn.clone());
 
         // Set.prototype.keys = Set.prototype.values
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("keys".to_string(), values_fn.clone());
 
         // Set.prototype[@@iterator] = values
         if let Some(key) = self.get_symbol_iterator_key() {
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(values_fn, true, false, true));
         }
@@ -1033,7 +1073,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("entries".to_string(), entries_fn);
 
@@ -1072,7 +1112,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("add".to_string(), add_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("add".to_string(), add_fn);
 
         // Set.prototype.has
         let has_fn = self.create_function(JsFunction::native(
@@ -1103,7 +1145,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("has".to_string(), has_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("has".to_string(), has_fn);
 
         // Set.prototype.delete
         let delete_fn = self.create_function(JsFunction::native(
@@ -1136,7 +1180,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("delete".to_string(), delete_fn);
 
@@ -1161,7 +1205,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("clear".to_string(), clear_fn);
 
@@ -1201,7 +1245,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("forEach".to_string(), foreach_fn);
 
@@ -1229,17 +1273,19 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_property(
-            "size".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(size_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "size".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(size_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // ES2025 Set methods
 
@@ -1369,11 +1415,20 @@ impl Interpreter {
         }
 
         fn make_result_set(interp: &mut Interpreter, entries: Vec<Option<JsValue>>) -> Completion {
-            let new_obj = interp.create_object();
-            new_obj.borrow_mut().prototype_id = interp.realm().set_prototype;
-            new_obj.borrow_mut().class_name = "Set".to_string();
-            new_obj.borrow_mut().set_data = Some(entries);
-            let id = new_obj.borrow().id.unwrap();
+            let new_obj_id = interp.create_object_id();
+            interp
+                .get_object_cell_expect(new_obj_id)
+                .borrow_mut()
+                .prototype_id = interp.realm().set_prototype;
+            interp
+                .get_object_cell_expect(new_obj_id)
+                .borrow_mut()
+                .class_name = "Set".to_string();
+            interp
+                .get_object_cell_expect(new_obj_id)
+                .borrow_mut()
+                .set_data = Some(entries);
+            let id = new_obj_id;
             Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
         }
 
@@ -1423,7 +1478,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("union".to_string(), union_fn);
 
@@ -1505,7 +1560,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("intersection".to_string(), intersection_fn);
 
@@ -1574,7 +1629,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("difference".to_string(), difference_fn);
 
@@ -1635,7 +1690,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("symmetricDifference".to_string(), sym_diff_fn);
 
@@ -1690,7 +1745,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("isSubsetOf".to_string(), is_subset_fn);
 
@@ -1739,7 +1794,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("isSupersetOf".to_string(), is_superset_fn);
 
@@ -1811,26 +1866,28 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("isDisjointFrom".to_string(), is_disjoint_fn);
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Set")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Set")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // Set constructor
-        let set_proto_clone_id = proto.borrow().id.unwrap();
+        let set_proto_clone_id = proto_id;
         let set_ctor = self.create_function(JsFunction::constructor(
             "Set".to_string(),
             0,
@@ -1847,11 +1904,11 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(set_proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Set".to_string();
-                obj.borrow_mut().set_data = Some(Vec::new());
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = interp.create_object_id();
+                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
+                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "Set".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().set_data = Some(Vec::new());
+                let obj_id = obj_id;
                 let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
 
                 let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
@@ -1936,10 +1993,12 @@ impl Interpreter {
                 PropertyDescriptor::data(proto_val.clone(), false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(set_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(set_ctor.clone(), true, false, true),
+            );
 
         // Set[Symbol.species] getter
         if let JsValue::Object(ref ctor_ref) = set_ctor
@@ -1970,7 +2029,7 @@ impl Interpreter {
         let env = self.realm().global_env.clone();
         let _ = self.env_set(&env, "Set", set_ctor);
 
-        self.realm_mut().set_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().set_prototype = Some(proto_id);
     }
 
     pub(crate) fn create_type_error(&mut self, msg: &str) -> JsValue {
@@ -1978,8 +2037,10 @@ impl Interpreter {
     }
 
     pub(crate) fn setup_weakmap_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "WeakMap".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "WeakMap".to_string();
 
         // WeakMap.prototype.get
         let get_fn = self.create_function(JsFunction::native(
@@ -2008,7 +2069,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("get".to_string(), get_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("get".to_string(), get_fn);
 
         // WeakMap.prototype.set
         let set_fn = self.create_function(JsFunction::native(
@@ -2043,7 +2106,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("set".to_string(), set_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("set".to_string(), set_fn);
 
         // WeakMap.prototype.has
         let has_fn = self.create_function(JsFunction::native(
@@ -2072,7 +2137,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("has".to_string(), has_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("has".to_string(), has_fn);
 
         // WeakMap.prototype.delete
         let delete_fn = self.create_function(JsFunction::native(
@@ -2106,7 +2173,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("delete".to_string(), delete_fn);
 
@@ -2148,7 +2215,7 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getOrInsert".to_string(), get_or_insert_fn);
 
@@ -2213,26 +2280,28 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getOrInsertComputed".to_string(), get_or_insert_computed_fn);
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("WeakMap")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("WeakMap")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // WeakMap constructor
-        let weakmap_proto_clone_id = proto.borrow().id.unwrap();
+        let weakmap_proto_clone_id = proto_id;
         let weakmap_ctor = self.create_function(JsFunction::constructor(
             "WeakMap".to_string(),
             0,
@@ -2249,11 +2318,11 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(weakmap_proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "WeakMap".to_string();
-                obj.borrow_mut().map_data = Some(Vec::new());
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = interp.create_object_id();
+                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
+                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "WeakMap".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().map_data = Some(Vec::new());
+                let obj_id = obj_id;
                 let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
 
                 let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
@@ -2373,10 +2442,12 @@ impl Interpreter {
                 PropertyDescriptor::data(proto_val.clone(), false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(weakmap_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(weakmap_ctor.clone(), true, false, true),
+            );
 
         self.realm()
             .global_env
@@ -2388,12 +2459,14 @@ impl Interpreter {
             .borrow_mut()
             .set("WeakMap", weakmap_ctor);
 
-        self.realm_mut().weakmap_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().weakmap_prototype = Some(proto_id);
     }
 
     pub(crate) fn setup_weakset_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "WeakSet".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "WeakSet".to_string();
 
         // WeakSet.prototype.add
         let add_fn = self.create_function(JsFunction::native(
@@ -2426,7 +2499,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("add".to_string(), add_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("add".to_string(), add_fn);
 
         // WeakSet.prototype.has
         let has_fn = self.create_function(JsFunction::native(
@@ -2455,7 +2530,9 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto.borrow_mut().insert_builtin("has".to_string(), has_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("has".to_string(), has_fn);
 
         // WeakSet.prototype.delete
         let delete_fn = self.create_function(JsFunction::native(
@@ -2489,26 +2566,28 @@ impl Interpreter {
                 Completion::Throw(err)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("delete".to_string(), delete_fn);
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("WeakSet")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("WeakSet")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // WeakSet constructor
-        let weakset_proto_clone_id = proto.borrow().id.unwrap();
+        let weakset_proto_clone_id = proto_id;
         let weakset_ctor = self.create_function(JsFunction::constructor(
             "WeakSet".to_string(),
             0,
@@ -2525,11 +2604,11 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(weakset_proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "WeakSet".to_string();
-                obj.borrow_mut().set_data = Some(Vec::new());
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = interp.create_object_id();
+                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
+                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "WeakSet".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().set_data = Some(Vec::new());
+                let obj_id = obj_id;
                 let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
 
                 let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
@@ -2622,10 +2701,12 @@ impl Interpreter {
                 PropertyDescriptor::data(proto_val.clone(), false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(weakset_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(weakset_ctor.clone(), true, false, true),
+            );
 
         self.realm()
             .global_env
@@ -2637,12 +2718,14 @@ impl Interpreter {
             .borrow_mut()
             .set("WeakSet", weakset_ctor);
 
-        self.realm_mut().weakset_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().weakset_prototype = Some(proto_id);
     }
 
     pub(crate) fn setup_weakref(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "WeakRef".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "WeakRef".to_string();
 
         // WeakRef.prototype.deref
         let deref_fn = self.create_function(JsFunction::native(
@@ -2666,7 +2749,7 @@ impl Interpreter {
                 )
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("deref".to_string(), deref_fn);
 
@@ -2681,8 +2764,14 @@ impl Interpreter {
                 set: None,
             };
             let key = "Symbol(Symbol.toStringTag)".to_string();
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // WeakRef constructor
@@ -2707,13 +2796,22 @@ impl Interpreter {
                     Ok(p) => p,
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().class_name = "WeakRef".to_string();
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "WeakRef".to_string();
                 if let Some(p) = proto {
-                    obj.borrow_mut().prototype_id = Some(p);
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(p);
                 }
-                obj.borrow_mut().primitive_value = Some(target);
-                let id = obj.borrow().id.unwrap();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .primitive_value = Some(target);
+                let id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
             },
         ));
@@ -2724,9 +2822,7 @@ impl Interpreter {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject {
-                        id: proto.borrow().id.unwrap(),
-                    }),
+                    JsValue::Object(crate::types::JsObject { id: proto_id }),
                     false,
                     false,
                     false,
@@ -2734,10 +2830,12 @@ impl Interpreter {
             );
         }
 
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(weakref_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(weakref_ctor.clone(), true, false, true),
+            );
 
         self.realm()
             .global_env
@@ -2749,12 +2847,14 @@ impl Interpreter {
             .borrow_mut()
             .set("WeakRef", weakref_ctor);
 
-        self.realm_mut().weakref_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().weakref_prototype = Some(proto_id);
     }
 
     pub(crate) fn setup_finalization_registry(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "FinalizationRegistry".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "FinalizationRegistry".to_string();
 
         // FinalizationRegistry.prototype.register
         let register_fn = self.create_function(JsFunction::native(
@@ -2815,7 +2915,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("register".to_string(), register_fn);
 
@@ -2870,7 +2970,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("unregister".to_string(), unregister_fn);
 
@@ -2895,7 +2995,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("cleanupSome".to_string(), cleanup_fn);
 
@@ -2910,8 +3010,14 @@ impl Interpreter {
                 set: None,
             };
             let key = "Symbol(Symbol.toStringTag)".to_string();
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // FinalizationRegistry constructor
@@ -2945,16 +3051,25 @@ impl Interpreter {
                     Ok(p) => p,
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().class_name = "FinalizationRegistry".to_string();
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "FinalizationRegistry".to_string();
                 if let Some(p) = proto {
-                    obj.borrow_mut().prototype_id = Some(p);
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(p);
                 }
-                obj.borrow_mut().primitive_value = Some(callback);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .primitive_value = Some(callback);
                 // Initialize [[Cells]] as empty - map_data for (target, heldValue), set_data for tokens
-                obj.borrow_mut().map_data = Some(Vec::new());
-                obj.borrow_mut().set_data = Some(Vec::new());
-                let id = obj.borrow().id.unwrap();
+                interp.get_object_cell_expect(obj_id).borrow_mut().map_data = Some(Vec::new());
+                interp.get_object_cell_expect(obj_id).borrow_mut().set_data = Some(Vec::new());
+                let id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
             },
         ));
@@ -2965,9 +3080,7 @@ impl Interpreter {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject {
-                        id: proto.borrow().id.unwrap(),
-                    }),
+                    JsValue::Object(crate::types::JsObject { id: proto_id }),
                     false,
                     false,
                     false,
@@ -2975,10 +3088,12 @@ impl Interpreter {
             );
         }
 
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(fr_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(fr_ctor.clone(), true, false, true),
+            );
 
         self.realm()
             .global_env
@@ -2990,6 +3105,6 @@ impl Interpreter {
             .borrow_mut()
             .set("FinalizationRegistry", fr_ctor);
 
-        self.realm_mut().finalization_registry_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().finalization_registry_prototype = Some(proto_id);
     }
 }

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -142,7 +142,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && {
                         let b = obj.borrow();
                         b.map_data.is_some() && b.class_name == "Map"
@@ -175,7 +175,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && {
                         let b = obj.borrow();
                         b.map_data.is_some() && b.class_name == "Map"
@@ -201,7 +201,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && {
                         let b = obj.borrow();
                         b.map_data.is_some() && b.class_name == "Map"
@@ -227,7 +227,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let borrowed = obj.borrow();
                     let is_map = borrowed.map_data.is_some() && borrowed.class_name == "Map";
@@ -261,7 +261,7 @@ impl Interpreter {
             2,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_map = {
                         let b = obj.borrow();
@@ -303,7 +303,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let borrowed = obj.borrow();
                     let is_map = borrowed.map_data.is_some() && borrowed.class_name == "Map";
@@ -337,7 +337,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_map = {
                         let b = obj.borrow();
@@ -372,7 +372,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_map = {
                         let b = obj.borrow();
@@ -437,7 +437,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let borrowed = obj.borrow();
                     let is_map = borrowed.map_data.is_some() && borrowed.class_name == "Map";
@@ -476,7 +476,7 @@ impl Interpreter {
             2,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_map = {
                         let borrowed = obj.borrow();
@@ -523,7 +523,7 @@ impl Interpreter {
             2,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_map = {
                         let borrowed = obj.borrow();
@@ -533,7 +533,7 @@ impl Interpreter {
                         let mut key = args.first().cloned().unwrap_or(JsValue::Undefined);
                         let callbackfn = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                         // Step 3: IsCallable check BEFORE anything else
-                        if !matches!(&callbackfn, JsValue::Object(co) if interp.get_object(co.id).is_some_and(|o| o.borrow().callable.is_some())) {
+                        if !matches!(&callbackfn, JsValue::Object(co) if interp.get_object_cell(co.id).is_some_and(|o| o.borrow().callable.is_some())) {
                             let err = interp.create_type_error("callbackfn is not a function");
                             return Completion::Throw(err);
                         }
@@ -559,7 +559,7 @@ impl Interpreter {
                         };
                         // Step 7: Re-check if key was inserted by callback
                         {
-                            let obj = interp.get_object(o.id).unwrap();
+                            let obj = interp.get_object_cell(o.id).unwrap();
                             let mut borrowed = obj.borrow_mut();
                             let entries = borrowed.map_data.as_mut().unwrap();
                             for entry in entries.iter_mut().flatten() {
@@ -629,7 +629,7 @@ impl Interpreter {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
+                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object_cell(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
                         let err = interp.create_type_error("Map.prototype.set is not a function");
                         return Completion::Throw(err);
                     }
@@ -701,7 +701,7 @@ impl Interpreter {
 
         // Set Map.prototype on ctor, ctor on prototype
         if let JsValue::Object(ctor_obj) = &map_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -750,7 +750,7 @@ impl Interpreter {
                     let callback = args.get(1).cloned().unwrap_or(JsValue::Undefined);
 
                     // 1. Validate callback is callable
-                    if !matches!(&callback, JsValue::Object(o) if interp.get_object(o.id)
+                    if !matches!(&callback, JsValue::Object(o) if interp.get_object_cell(o.id)
                         .map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
                     {
                         return Completion::Throw(
@@ -817,7 +817,7 @@ impl Interpreter {
                         };
 
                         // Add value to the group for this key (using Map's SameValueZero semantics)
-                        if let Some(map_obj) = interp.get_object(result_id) {
+                        if let Some(map_obj) = interp.get_object_cell(result_id) {
                             let mut borrowed = map_obj.borrow_mut();
                             let entries = borrowed.map_data.as_mut().unwrap();
 
@@ -851,7 +851,7 @@ impl Interpreter {
                                 // Create new array and add entry
                                 drop(borrowed);
                                 let new_arr = interp.create_array(vec![value]);
-                                if let Some(map_obj) = interp.get_object(result_id) {
+                                if let Some(map_obj) = interp.get_object_cell(result_id) {
                                     let mut borrowed = map_obj.borrow_mut();
                                     let entries = borrowed.map_data.as_mut().unwrap();
                                     entries.push(Some((key_val, new_arr)));
@@ -1017,7 +1017,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && {
                         let b = obj.borrow();
                         b.set_data.is_some() && b.class_name != "WeakSet"
@@ -1055,7 +1055,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && {
                         let b = obj.borrow();
                         b.set_data.is_some() && b.class_name != "WeakSet"
@@ -1081,7 +1081,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_set = {
                         let b = obj.borrow();
@@ -1120,7 +1120,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let (is_set, set_data) = {
                         let b = obj.borrow();
@@ -1153,7 +1153,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_set = {
                         let b = obj.borrow();
@@ -1188,7 +1188,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_set = {
                         let b = obj.borrow();
@@ -1253,7 +1253,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let (has_set, set_data) = {
                         let b = obj.borrow();
@@ -1914,7 +1914,7 @@ impl Interpreter {
                         Completion::Normal(v) => v,
                         c => return c,
                     };
-                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
+                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object_cell(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
                         let err = interp.create_type_error("Set.prototype.add is not a function");
                         return Completion::Throw(err);
                     }
@@ -1982,7 +1982,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ctor_obj) = &set_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -2044,7 +2044,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_weakmap = obj.borrow().class_name == "WeakMap";
                     let map_data = obj.borrow().map_data.clone();
@@ -2075,7 +2075,7 @@ impl Interpreter {
             2,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_map = obj.borrow().map_data.is_some();
                     if has_map && obj.borrow().class_name == "WeakMap" {
@@ -2112,7 +2112,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_weakmap = obj.borrow().class_name == "WeakMap";
                     let map_data = obj.borrow().map_data.clone();
@@ -2143,7 +2143,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_weakmap = obj.borrow().class_name == "WeakMap";
                     let has_map = obj.borrow().map_data.is_some();
@@ -2179,7 +2179,7 @@ impl Interpreter {
             2,
             |interp, this, args| {
                 if let JsValue::Object(o) = &this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_weakmap =
                         obj.borrow().map_data.is_some() && obj.borrow().class_name == "WeakMap";
@@ -2221,7 +2221,7 @@ impl Interpreter {
             2,
             |interp, this, args| {
                 if let JsValue::Object(o) = &this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_weakmap = obj.borrow().map_data.is_some()
                         && obj.borrow().class_name == "WeakMap";
@@ -2234,7 +2234,7 @@ impl Interpreter {
                             return Completion::Throw(err);
                         }
                         let is_callable = matches!(&callbackfn, JsValue::Object(co)
-                            if interp.get_object(co.id).is_some_and(|ob| ob.borrow().callable.is_some()));
+                            if interp.get_object_cell(co.id).is_some_and(|ob| ob.borrow().callable.is_some()));
                         if !is_callable {
                             let err = interp
                                 .create_type_error("callbackfn is not a function");
@@ -2257,7 +2257,7 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        let obj = interp.get_object(o.id).unwrap();
+                        let obj = interp.get_object_cell(o.id).unwrap();
                         let mut borrowed = obj.borrow_mut();
                         let entries = borrowed.map_data.as_mut().unwrap();
                         for entry in entries.iter_mut().flatten() {
@@ -2326,7 +2326,7 @@ impl Interpreter {
                         Completion::Normal(v) => v,
                         c => return c,
                     };
-                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
+                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object_cell(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
                         let err = interp.create_type_error("WeakMap.prototype.set is not a function");
                         return Completion::Throw(err);
                     }
@@ -2429,7 +2429,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ctor_obj) = &weakmap_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -2468,7 +2468,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_set =
                         obj.borrow().set_data.is_some() && obj.borrow().class_name == "WeakSet";
@@ -2503,7 +2503,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_weakset = obj.borrow().class_name == "WeakSet";
                     let set_data = obj.borrow().set_data.clone();
@@ -2534,7 +2534,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let is_weakset = obj.borrow().class_name == "WeakSet";
                     let has_set = obj.borrow().set_data.is_some();
@@ -2610,7 +2610,7 @@ impl Interpreter {
                         Completion::Normal(v) => v,
                         c => return c,
                     };
-                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
+                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object_cell(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
                         let err = interp.create_type_error("WeakSet.prototype.add is not a function");
                         return Completion::Throw(err);
                     }
@@ -2686,7 +2686,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ctor_obj) = &weakset_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -2727,7 +2727,7 @@ impl Interpreter {
                 // Require this to be an object with [[WeakRefTarget]] internal slot
                 // (indicated by class_name == "WeakRef" AND primitive_value.is_some())
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let b = obj.borrow();
                     if b.class_name == "WeakRef" && b.primitive_value.is_some() {
@@ -2809,7 +2809,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ref ctor_obj) = weakref_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -2854,7 +2854,7 @@ impl Interpreter {
             2,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     // Check [[Cells]] internal slot: class_name + map_data.is_some()
                     let has_cells = {
@@ -2890,7 +2890,7 @@ impl Interpreter {
                         } else {
                             Some(unregister_token)
                         };
-                        if let Some(obj_rc) = interp.get_object(o.id) {
+                        if let Some(obj_rc) = interp.get_object_cell(o.id) {
                             let mut b = obj_rc.borrow_mut();
                             if let Some(ref mut cells) = b.map_data {
                                 cells.push(Some((target, held_value)));
@@ -2917,7 +2917,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_cells = {
                         let b = obj.borrow();
@@ -2932,7 +2932,7 @@ impl Interpreter {
                         }
                         // Remove cells whose unregisterToken matches
                         let mut removed = false;
-                        if let Some(obj_rc) = interp.get_object(o.id) {
+                        if let Some(obj_rc) = interp.get_object_cell(o.id) {
                             let mut b = obj_rc.borrow_mut();
                             let len = b.map_data.as_ref().map(|c| c.len()).unwrap_or(0);
                             for i in 0..len {
@@ -2972,7 +2972,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let has_cells = {
                         let b = obj.borrow();
@@ -3029,7 +3029,7 @@ impl Interpreter {
                     ));
                 }
                 if let JsValue::Object(ref o) = callback
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && obj.borrow().callable.is_none()
                 {
                     return Completion::Throw(interp.create_type_error(
@@ -3067,7 +3067,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ref ctor_obj) = fr_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -845,7 +845,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("Map", BindingKind::Var);
-        let _ = self.realm().global_env.borrow_mut().set("Map", map_ctor);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "Map", map_ctor);
 
         self.realm_mut().map_prototype = Some(proto.borrow().id.unwrap());
     }
@@ -1966,7 +1967,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("Set", BindingKind::Var);
-        let _ = self.realm().global_env.borrow_mut().set("Set", set_ctor);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "Set", set_ctor);
 
         self.realm_mut().set_prototype = Some(proto.borrow().id.unwrap());
     }

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -596,7 +596,6 @@ impl Interpreter {
             );
 
         // constructor property
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // Map constructor
@@ -621,7 +620,6 @@ impl Interpreter {
                 interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
                 interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "Map".to_string();
                 interp.get_object_cell_expect(obj_id).borrow_mut().map_data = Some(Vec::new());
-                let obj_id = obj_id;
                 let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
 
                 let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
@@ -1883,7 +1881,6 @@ impl Interpreter {
                 ),
             );
 
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // Set constructor
@@ -1908,7 +1905,6 @@ impl Interpreter {
                 interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
                 interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "Set".to_string();
                 interp.get_object_cell_expect(obj_id).borrow_mut().set_data = Some(Vec::new());
-                let obj_id = obj_id;
                 let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
 
                 let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
@@ -2297,7 +2293,6 @@ impl Interpreter {
                 ),
             );
 
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // WeakMap constructor
@@ -2322,7 +2317,6 @@ impl Interpreter {
                 interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
                 interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "WeakMap".to_string();
                 interp.get_object_cell_expect(obj_id).borrow_mut().map_data = Some(Vec::new());
-                let obj_id = obj_id;
                 let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
 
                 let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
@@ -2583,7 +2577,6 @@ impl Interpreter {
                 ),
             );
 
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // WeakSet constructor
@@ -2608,7 +2601,6 @@ impl Interpreter {
                 interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
                 interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "WeakSet".to_string();
                 interp.get_object_cell_expect(obj_id).borrow_mut().set_data = Some(Vec::new());
-                let obj_id = obj_id;
                 let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
 
                 let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -62,15 +62,13 @@ fn date_to_locale_string(
         }
     };
 
-    let has_prop = |obj: &Rc<RefCell<JsObjectData>>, name: &str| -> bool {
-        obj.borrow().properties.contains_key(name)
-    };
+    let has_prop = |obj: &JsObjectData, name: &str| -> bool { obj.properties.contains_key(name) };
 
     let mut need_defaults = true;
 
     if required == "date" || required == "any" {
         for prop in &["weekday", "year", "month", "day"] {
-            if has_prop(&options_obj, prop) {
+            if has_prop(&options_obj.borrow(), prop) {
                 need_defaults = false;
                 break;
             }
@@ -84,13 +82,15 @@ fn date_to_locale_string(
             "second",
             "fractionalSecondDigits",
         ] {
-            if has_prop(&options_obj, prop) {
+            if has_prop(&options_obj.borrow(), prop) {
                 need_defaults = false;
                 break;
             }
         }
     }
-    if need_defaults && (has_prop(&options_obj, "dateStyle") || has_prop(&options_obj, "timeStyle"))
+    if need_defaults
+        && (has_prop(&options_obj.borrow(), "dateStyle")
+            || has_prop(&options_obj.borrow(), "timeStyle"))
     {
         need_defaults = false;
     }

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -44,12 +44,20 @@ fn date_to_locale_string(
             Completion::Normal(v) => {
                 if let JsValue::Object(o) = &v {
                     if let Some(src) = interp.get_object(o.id) {
-                        let new_obj = interp.create_object();
-                        let src_b = src.borrow();
-                        for (k, pd) in src_b.properties.iter() {
-                            new_obj.borrow_mut().insert_property(k.clone(), pd.clone());
+                        let pds: Vec<(String, PropertyDescriptor)> = src
+                            .borrow()
+                            .properties
+                            .iter()
+                            .map(|(k, pd)| (k.clone(), pd.clone()))
+                            .collect();
+                        let new_obj_id = interp.create_object_id();
+                        for (k, pd) in pds {
+                            interp
+                                .get_object_cell_expect(new_obj_id)
+                                .borrow_mut()
+                                .insert_property(k, pd);
                         }
-                        new_obj
+                        interp.get_object_expect(new_obj_id)
                     } else {
                         interp.create_object()
                     }
@@ -169,8 +177,10 @@ fn date_to_locale_string(
 
 impl Interpreter {
     pub(crate) fn setup_date_builtin(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Date".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Date".to_string();
         // Date.prototype does NOT have [[DateValue]] per spec
 
         fn this_time_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
@@ -1173,16 +1183,24 @@ impl Interpreter {
                     }
                     let ms = num_bigint::BigInt::from(t as i64);
                     let ns = ms * num_bigint::BigInt::from(1_000_000i64);
-                    let obj = interp.create_object();
-                    obj.borrow_mut().class_name = "Temporal.Instant".to_string();
+                    let obj_id = interp.create_object_id();
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .class_name = "Temporal.Instant".to_string();
                     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
-                        obj.borrow_mut().prototype_id = Some(proto_id);
+                        interp
+                            .get_object_cell_expect(obj_id)
+                            .borrow_mut()
+                            .prototype_id = Some(proto_id);
                     }
-                    obj.borrow_mut().temporal_data =
-                        Some(crate::interpreter::types::TemporalData::Instant {
-                            epoch_nanoseconds: ns,
-                        });
-                    let id = obj.borrow().id.unwrap();
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .temporal_data = Some(crate::interpreter::types::TemporalData::Instant {
+                        epoch_nanoseconds: ns,
+                    });
+                    let id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 }),
             ),
@@ -1191,7 +1209,9 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // Symbol.toPrimitive per spec:
@@ -1258,14 +1278,16 @@ impl Interpreter {
             && let JsValue::Object(sym_obj) = &sym_val
         {
             let tp_key = to_js_string(&self.get_property_on_id(sym_obj.id, "toPrimitive"));
-            proto.borrow_mut().insert_property(
-                tp_key,
-                PropertyDescriptor::data(to_prim_fn, false, false, true),
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    tp_key,
+                    PropertyDescriptor::data(to_prim_fn, false, false, true),
+                );
         }
 
         // Date constructor
-        let date_proto_clone_id = proto.borrow().id.unwrap();
+        let date_proto_clone_id = proto_id;
         let date_ctor = self.create_function(JsFunction::constructor(
             "Date".to_string(),
             7,
@@ -1489,16 +1511,14 @@ impl Interpreter {
             ));
             obj.borrow_mut().insert_builtin("UTC".to_string(), utc_fn);
 
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
         }
 
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("constructor".to_string(), date_ctor.clone());
 
@@ -1526,7 +1546,7 @@ impl Interpreter {
             }),
             false,
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getYear".to_string(), get_year_fn);
 
@@ -1564,18 +1584,18 @@ impl Interpreter {
             }),
             false,
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("setYear".to_string(), set_year_fn);
 
         // Annex B: toGMTString() -- alias for toUTCString()
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let to_gmt = self.get_property_on_id(proto_id, "toUTCString");
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toGMTString".to_string(), to_gmt);
 
-        self.realm_mut().date_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().date_prototype = Some(proto_id);
     }
 
     pub(crate) fn create_range_error(&mut self, msg: &str) -> JsValue {
@@ -1600,9 +1620,9 @@ impl Interpreter {
                 None
             }
         });
-        let obj = self.create_object();
+        let obj_id = self.create_object_id();
         {
-            let mut o = obj.borrow_mut();
+            let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
             o.class_name = name.to_string();
             if let Some(proto_id) = error_proto_id {
                 o.prototype_id = Some(proto_id);
@@ -1617,7 +1637,7 @@ impl Interpreter {
             );
             o.insert_builtin("stack".to_string(), JsValue::String(JsString::from_str("")));
         }
-        let id = obj.borrow().id.unwrap();
+        let id = obj_id;
         JsValue::Object(crate::types::JsObject { id })
     }
 }

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -1507,7 +1507,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("Date", BindingKind::Var);
-        let _ = self.realm().global_env.borrow_mut().set("Date", date_ctor);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "Date", date_ctor);
 
         // Annex B: getYear()
         let get_year_fn = self.create_function(JsFunction::Native(

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -1617,7 +1617,6 @@ impl Interpreter {
             .insert_builtin("setYear".to_string(), set_year_fn);
 
         // Annex B: toGMTString() -- alias for toUTCString()
-        let proto_id = proto_id;
         let to_gmt = self.get_property_on_id(proto_id, "toUTCString");
         self.get_object_cell_expect(proto_id)
             .borrow_mut()

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -1177,7 +1177,7 @@ impl Interpreter {
                     obj.borrow_mut().class_name = "Temporal.Instant".to_string();
                     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
                         obj.borrow_mut().prototype_id =
-                            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+                            Some(proto_id);
                     }
                     obj.borrow_mut().temporal_data =
                         Some(crate::interpreter::types::TemporalData::Instant {

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -37,8 +37,8 @@ fn date_to_locale_string(
     let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
 
     // ToDateTimeOptions(options, required, defaults)
-    let options_obj = if matches!(options_arg, JsValue::Undefined) {
-        interp.create_object()
+    let options_obj_id = if matches!(options_arg, JsValue::Undefined) {
+        interp.create_object_id()
     } else {
         match interp.to_object(&options_arg) {
             Completion::Normal(v) => {
@@ -57,16 +57,16 @@ fn date_to_locale_string(
                                 .borrow_mut()
                                 .insert_property(k, pd);
                         }
-                        interp.get_object_expect(new_obj_id)
+                        new_obj_id
                     } else {
-                        interp.create_object()
+                        interp.create_object_id()
                     }
                 } else {
-                    interp.create_object()
+                    interp.create_object_id()
                 }
             }
             Completion::Throw(e) => return Completion::Throw(e),
-            _ => interp.create_object(),
+            _ => interp.create_object_id(),
         }
     };
 
@@ -76,7 +76,10 @@ fn date_to_locale_string(
 
     if required == "date" || required == "any" {
         for prop in &["weekday", "year", "month", "day"] {
-            if has_prop(&options_obj.borrow(), prop) {
+            if has_prop(
+                &interp.get_object_cell_expect(options_obj_id).borrow(),
+                prop,
+            ) {
                 need_defaults = false;
                 break;
             }
@@ -90,15 +93,23 @@ fn date_to_locale_string(
             "second",
             "fractionalSecondDigits",
         ] {
-            if has_prop(&options_obj.borrow(), prop) {
+            if has_prop(
+                &interp.get_object_cell_expect(options_obj_id).borrow(),
+                prop,
+            ) {
                 need_defaults = false;
                 break;
             }
         }
     }
     if need_defaults
-        && (has_prop(&options_obj.borrow(), "dateStyle")
-            || has_prop(&options_obj.borrow(), "timeStyle"))
+        && (has_prop(
+            &interp.get_object_cell_expect(options_obj_id).borrow(),
+            "dateStyle",
+        ) || has_prop(
+            &interp.get_object_cell_expect(options_obj_id).borrow(),
+            "timeStyle",
+        ))
     {
         need_defaults = false;
     }
@@ -106,37 +117,54 @@ fn date_to_locale_string(
     if need_defaults {
         let numeric = JsValue::String(JsString::from_str("numeric"));
         if defaults == "date" || defaults == "all" {
-            options_obj.borrow_mut().insert_property(
-                "year".to_string(),
-                PropertyDescriptor::data(numeric.clone(), true, true, true),
-            );
-            options_obj.borrow_mut().insert_property(
-                "month".to_string(),
-                PropertyDescriptor::data(numeric.clone(), true, true, true),
-            );
-            options_obj.borrow_mut().insert_property(
-                "day".to_string(),
-                PropertyDescriptor::data(numeric.clone(), true, true, true),
-            );
+            interp
+                .get_object_cell_expect(options_obj_id)
+                .borrow_mut()
+                .insert_property(
+                    "year".to_string(),
+                    PropertyDescriptor::data(numeric.clone(), true, true, true),
+                );
+            interp
+                .get_object_cell_expect(options_obj_id)
+                .borrow_mut()
+                .insert_property(
+                    "month".to_string(),
+                    PropertyDescriptor::data(numeric.clone(), true, true, true),
+                );
+            interp
+                .get_object_cell_expect(options_obj_id)
+                .borrow_mut()
+                .insert_property(
+                    "day".to_string(),
+                    PropertyDescriptor::data(numeric.clone(), true, true, true),
+                );
         }
         if defaults == "time" || defaults == "all" {
-            options_obj.borrow_mut().insert_property(
-                "hour".to_string(),
-                PropertyDescriptor::data(numeric.clone(), true, true, true),
-            );
-            options_obj.borrow_mut().insert_property(
-                "minute".to_string(),
-                PropertyDescriptor::data(numeric.clone(), true, true, true),
-            );
-            options_obj.borrow_mut().insert_property(
-                "second".to_string(),
-                PropertyDescriptor::data(numeric, true, true, true),
-            );
+            interp
+                .get_object_cell_expect(options_obj_id)
+                .borrow_mut()
+                .insert_property(
+                    "hour".to_string(),
+                    PropertyDescriptor::data(numeric.clone(), true, true, true),
+                );
+            interp
+                .get_object_cell_expect(options_obj_id)
+                .borrow_mut()
+                .insert_property(
+                    "minute".to_string(),
+                    PropertyDescriptor::data(numeric.clone(), true, true, true),
+                );
+            interp
+                .get_object_cell_expect(options_obj_id)
+                .borrow_mut()
+                .insert_property(
+                    "second".to_string(),
+                    PropertyDescriptor::data(numeric, true, true, true),
+                );
         }
     }
 
-    let opt_id = options_obj.borrow().id.unwrap();
-    let opt_val = JsValue::Object(crate::types::JsObject { id: opt_id });
+    let opt_val = JsValue::Object(crate::types::JsObject { id: options_obj_id });
 
     // Use the built-in DateTimeFormat constructor directly (not through user-visible Intl property)
     let dtf_val = match interp.realm().intl_date_time_format_ctor.clone() {

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -1176,8 +1176,7 @@ impl Interpreter {
                     let obj = interp.create_object();
                     obj.borrow_mut().class_name = "Temporal.Instant".to_string();
                     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
-                        obj.borrow_mut().prototype_id =
-                            Some(proto_id);
+                        obj.borrow_mut().prototype_id = Some(proto_id);
                     }
                     obj.borrow_mut().temporal_data =
                         Some(crate::interpreter::types::TemporalData::Instant {

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -9,7 +9,7 @@ fn date_to_locale_string(
 ) -> Completion {
     fn this_time_value_locale(interp: &Interpreter, this: &JsValue) -> Option<f64> {
         if let JsValue::Object(o) = this
-            && let Some(obj) = interp.get_object(o.id)
+            && let Some(obj) = interp.get_object_cell(o.id)
         {
             let b = obj.borrow();
             if b.class_name == "Date"
@@ -43,7 +43,7 @@ fn date_to_locale_string(
         match interp.to_object(&options_arg) {
             Completion::Normal(v) => {
                 if let JsValue::Object(o) = &v {
-                    if let Some(src) = interp.get_object(o.id) {
+                    if let Some(src) = interp.get_object_cell(o.id) {
                         let pds: Vec<(String, PropertyDescriptor)> = src
                             .borrow()
                             .properties
@@ -213,7 +213,7 @@ impl Interpreter {
 
         fn this_time_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
             if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object(o.id)
+                && let Some(obj) = interp.get_object_cell(o.id)
             {
                 let b = obj.borrow();
                 if b.class_name == "Date"
@@ -227,7 +227,7 @@ impl Interpreter {
 
         fn set_date_value(interp: &Interpreter, this: &JsValue, v: f64) {
             if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object(o.id)
+                && let Some(obj) = interp.get_object_cell(o.id)
             {
                 obj.borrow_mut().primitive_value = Some(JsValue::Number(v));
             }
@@ -1153,7 +1153,7 @@ impl Interpreter {
                             Completion::Normal(func) => {
                                 if let JsValue::Object(fo) = &func
                                     && interp
-                                        .get_object(fo.id)
+                                        .get_object_cell(fo.id)
                                         .map(|obj| obj.borrow().callable.is_some())
                                         .unwrap_or(false)
                                 {
@@ -1284,7 +1284,7 @@ impl Interpreter {
                     };
                     if let JsValue::Object(fo) = &method_val
                         && interp
-                            .get_object(fo.id)
+                            .get_object_cell(fo.id)
                             .map(|o| o.borrow().callable.is_some())
                             .unwrap_or(false)
                     {
@@ -1332,7 +1332,7 @@ impl Interpreter {
                 } else if args.len() == 1 {
                     let v = &args[0];
                     if let JsValue::Object(o) = v
-                        && let Some(obj) = interp.get_object(o.id)
+                        && let Some(obj) = interp.get_object_cell(o.id)
                         && obj.borrow().class_name == "Date"
                         && obj.borrow().primitive_value.is_some()
                     {
@@ -1419,7 +1419,7 @@ impl Interpreter {
                 };
 
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
                     // OrdinaryCreateFromConstructor — realm-aware prototype
                     let proto = match interp
@@ -1428,7 +1428,7 @@ impl Interpreter {
                         Ok(p) => p.unwrap_or(date_proto_clone_id),
                         Err(e) => return Completion::Throw(e),
                     };
-                    let mut b = obj.borrow_mut();
+                    let mut b = interp.get_object_cell_expect(o.id).borrow_mut();
                     b.class_name = "Date".to_string();
                     b.primitive_value = Some(JsValue::Number(time_val));
                     b.prototype_id = Some(proto);
@@ -1438,19 +1438,24 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(o) = &date_ctor
-            && let Some(obj) = self.get_object(o.id)
+            && self.get_object_cell(o.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "length".to_string(),
-                PropertyDescriptor::data(JsValue::Number(7.0), false, false, true),
-            );
+            let date_ctor_id = o.id;
+            self.get_object_cell_expect(date_ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "length".to_string(),
+                    PropertyDescriptor::data(JsValue::Number(7.0), false, false, true),
+                );
 
             let now_fn = self.create_function(JsFunction::native(
                 "now".to_string(),
                 0,
                 |_interp, _this, _args| Completion::Normal(JsValue::Number(now_ms().floor())),
             ));
-            obj.borrow_mut().insert_builtin("now".to_string(), now_fn);
+            self.get_object_cell_expect(date_ctor_id)
+                .borrow_mut()
+                .insert_builtin("now".to_string(), now_fn);
 
             let parse_fn = self.create_function(JsFunction::native(
                 "parse".to_string(),
@@ -1466,7 +1471,8 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(parse_date_string(&s)))
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(date_ctor_id)
+                .borrow_mut()
                 .insert_builtin("parse".to_string(), parse_fn);
 
             let utc_fn = self.create_function(JsFunction::native(
@@ -1537,13 +1543,17 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(time_clip(make_date(d, time))))
                 },
             ));
-            obj.borrow_mut().insert_builtin("UTC".to_string(), utc_fn);
+            self.get_object_cell_expect(date_ctor_id)
+                .borrow_mut()
+                .insert_builtin("UTC".to_string(), utc_fn);
 
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val, false, false, false),
-            );
+            self.get_object_cell_expect(date_ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val, false, false, false),
+                );
         }
 
         self.get_object_cell_expect(proto_id)

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -305,8 +305,7 @@ impl Interpreter {
                     let new_obj = interp.create_object();
                     {
                         // Get DisposableStack prototype
-                        let env = interp.realm().global_env.borrow();
-                        if let Some(ctor_val) = env.get("DisposableStack")
+                        if let Some(ctor_val) = interp.get_global_var("DisposableStack")
                             && let JsValue::Object(ctor) = &ctor_val
                         {
                             let proto_val = interp.get_property_on_id(ctor.id, "prototype");
@@ -375,17 +374,13 @@ impl Interpreter {
         );
 
         // Wire up constructor and prototype
-        {
-            let env = self.realm().global_env.borrow();
-            if let Some(ctor_val) = env.get("DisposableStack") {
-                ds_proto
-                    .borrow_mut()
-                    .insert_builtin("constructor".to_string(), ctor_val);
-            }
+        if let Some(ctor_val) = self.get_global_var("DisposableStack") {
+            ds_proto
+                .borrow_mut()
+                .insert_builtin("constructor".to_string(), ctor_val);
         }
         {
-            let env = self.realm().global_env.borrow();
-            if let Some(ctor_val) = env.get("DisposableStack")
+            if let Some(ctor_val) = self.get_global_var("DisposableStack")
                 && let JsValue::Object(o) = &ctor_val
                 && let Some(ctor_obj) = self.get_object(o.id)
             {
@@ -842,17 +837,13 @@ impl Interpreter {
         );
 
         // Wire up
-        {
-            let env = self.realm().global_env.borrow();
-            if let Some(ctor_val) = env.get("AsyncDisposableStack") {
-                ads_proto
-                    .borrow_mut()
-                    .insert_builtin("constructor".to_string(), ctor_val);
-            }
+        if let Some(ctor_val) = self.get_global_var("AsyncDisposableStack") {
+            ads_proto
+                .borrow_mut()
+                .insert_builtin("constructor".to_string(), ctor_val);
         }
         {
-            let env = self.realm().global_env.borrow();
-            if let Some(ctor_val) = env.get("AsyncDisposableStack")
+            if let Some(ctor_val) = self.get_global_var("AsyncDisposableStack")
                 && let JsValue::Object(o) = &ctor_val
                 && let Some(ctor_obj) = self.get_object(o.id)
             {

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -46,19 +46,26 @@ impl Interpreter {
             "get disposed".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let b = obj.borrow();
-                    if b.class_name == "DisposableStack"
-                        && let Some(ref ds) = b.disposable_stack
-                    {
-                        return Completion::Normal(JsValue::Boolean(ds.disposed));
-                    }
+                let disposed = if let JsValue::Object(o) = this {
+                    interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
+                        if b.class_name == "DisposableStack"
+                            && let Some(ref ds) = b.disposable_stack
+                        {
+                            Some(ds.disposed)
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                };
+                match disposed {
+                    Some(d) => Completion::Normal(JsValue::Boolean(d)),
+                    None => Completion::Throw(interp.create_type_error(
+                        "DisposableStack.prototype.disposed called on non-DisposableStack",
+                    )),
                 }
-                Completion::Throw(interp.create_type_error(
-                    "DisposableStack.prototype.disposed called on non-DisposableStack",
-                ))
             },
         ));
         self.get_object_cell_expect(ds_proto_id)
@@ -75,29 +82,37 @@ impl Interpreter {
             |interp, this, args| {
                 let value = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
-                    {
-                        let b = obj.borrow();
+                    enum Probe {
+                        NotStack,
+                        AlreadyDisposed,
+                        Active,
+                    }
+                    let probe = {
+                        let b = interp.get_object_cell_expect(o.id).borrow();
                         if b.class_name != "DisposableStack" {
+                            Probe::NotStack
+                        } else {
+                            match &b.disposable_stack {
+                                Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                                Some(_) => Probe::Active,
+                                None => Probe::NotStack,
+                            }
+                        }
+                    };
+                    match probe {
+                        Probe::NotStack => {
                             return Completion::Throw(
                                 interp.create_type_error("Not a DisposableStack"),
                             );
                         }
-                        match &b.disposable_stack {
-                            Some(ds) => {
-                                if ds.disposed {
-                                    return Completion::Throw(interp.create_reference_error(
-                                        "DisposableStack has already been disposed",
-                                    ));
-                                }
-                            }
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("Not a DisposableStack"),
-                                );
-                            }
+                        Probe::AlreadyDisposed => {
+                            return Completion::Throw(interp.create_reference_error(
+                                "DisposableStack has already been disposed",
+                            ));
                         }
+                        Probe::Active => {}
                     }
                     if matches!(value, JsValue::Null | JsValue::Undefined) {
                         return Completion::Normal(value);
@@ -143,8 +158,8 @@ impl Interpreter {
                         hint: DisposeHint::Sync,
                         dispose_method: method,
                     };
-                    if let Some(obj) = interp.get_object(o.id) {
-                        let mut b = obj.borrow_mut();
+                    if let Some(cell) = interp.get_object_cell(o.id) {
+                        let mut b = cell.borrow_mut();
                         if let Some(ref mut ds) = b.disposable_stack {
                             ds.stack.push(resource);
                         }
@@ -166,23 +181,33 @@ impl Interpreter {
                 let value = args.first().cloned().unwrap_or(JsValue::Undefined);
                 let on_dispose = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
-                    {
-                        let b = obj.borrow();
+                    enum Probe {
+                        AlreadyDisposed,
+                        NotStack,
+                        Active,
+                    }
+                    let probe = {
+                        let b = interp.get_object_cell_expect(o.id).borrow();
                         match &b.disposable_stack {
-                            Some(ds) if ds.disposed => {
-                                return Completion::Throw(interp.create_reference_error(
-                                    "DisposableStack has already been disposed",
-                                ));
-                            }
-                            Some(_) => {}
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("Not a DisposableStack"),
-                                );
-                            }
+                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                            Some(_) => Probe::Active,
+                            None => Probe::NotStack,
                         }
+                    };
+                    match probe {
+                        Probe::AlreadyDisposed => {
+                            return Completion::Throw(interp.create_reference_error(
+                                "DisposableStack has already been disposed",
+                            ));
+                        }
+                        Probe::NotStack => {
+                            return Completion::Throw(
+                                interp.create_type_error("Not a DisposableStack"),
+                            );
+                        }
+                        Probe::Active => {}
                     }
                     if !interp.is_callable(&on_dispose) {
                         return Completion::Throw(
@@ -208,8 +233,8 @@ impl Interpreter {
                         hint: DisposeHint::Sync,
                         dispose_method: wrapper_fn,
                     };
-                    if let Some(obj2) = interp.get_object(o.id) {
-                        let mut b = obj2.borrow_mut();
+                    if let Some(cell) = interp.get_object_cell(o.id) {
+                        let mut b = cell.borrow_mut();
                         if let Some(ref mut ds) = b.disposable_stack {
                             ds.stack.push(resource);
                         }
@@ -230,23 +255,33 @@ impl Interpreter {
             |interp, this, args| {
                 let on_dispose = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
-                    {
-                        let b = obj.borrow();
+                    enum Probe {
+                        AlreadyDisposed,
+                        NotStack,
+                        Active,
+                    }
+                    let probe = {
+                        let b = interp.get_object_cell_expect(o.id).borrow();
                         match &b.disposable_stack {
-                            Some(ds) if ds.disposed => {
-                                return Completion::Throw(interp.create_reference_error(
-                                    "DisposableStack has already been disposed",
-                                ));
-                            }
-                            Some(_) => {}
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("Not a DisposableStack"),
-                                );
-                            }
+                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                            Some(_) => Probe::Active,
+                            None => Probe::NotStack,
                         }
+                    };
+                    match probe {
+                        Probe::AlreadyDisposed => {
+                            return Completion::Throw(interp.create_reference_error(
+                                "DisposableStack has already been disposed",
+                            ));
+                        }
+                        Probe::NotStack => {
+                            return Completion::Throw(
+                                interp.create_type_error("Not a DisposableStack"),
+                            );
+                        }
+                        Probe::Active => {}
                     }
                     if !interp.is_callable(&on_dispose) {
                         return Completion::Throw(
@@ -258,8 +293,8 @@ impl Interpreter {
                         hint: DisposeHint::Sync,
                         dispose_method: on_dispose,
                     };
-                    if let Some(obj2) = interp.get_object(o.id) {
-                        let mut b = obj2.borrow_mut();
+                    if let Some(cell) = interp.get_object_cell(o.id) {
+                        let mut b = cell.borrow_mut();
                         if let Some(ref mut ds) = b.disposable_stack {
                             ds.stack.push(resource);
                         }

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -4,8 +4,7 @@ impl Interpreter {
     pub(crate) fn setup_disposable_stack(&mut self) {
         let ds_proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            ds_proto.borrow_mut().prototype_id =
-                Some(op_id);
+            ds_proto.borrow_mut().prototype_id = Some(op_id);
         }
 
         // Symbol.toStringTag
@@ -453,8 +452,7 @@ impl Interpreter {
     pub(crate) fn setup_async_disposable_stack(&mut self) {
         let ads_proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            ads_proto.borrow_mut().prototype_id =
-                Some(op_id);
+            ads_proto.borrow_mut().prototype_id = Some(op_id);
         }
 
         // Symbol.toStringTag
@@ -771,8 +769,7 @@ impl Interpreter {
                     {
                         let default_proto_id = interp.realm().async_disposable_stack_prototype;
                         if let Some(pid) = default_proto_id {
-                            new_obj.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(pid).borrow().id.unwrap());
+                            new_obj.borrow_mut().prototype_id = Some(pid);
                         }
                     }
                     {

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -2,22 +2,26 @@ use super::*;
 
 impl Interpreter {
     pub(crate) fn setup_disposable_stack(&mut self) {
-        let ds_proto = self.create_object();
+        let ds_proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            ds_proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(ds_proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
 
         // Symbol.toStringTag
         if let Some(key) = self.get_symbol_key("toStringTag") {
-            ds_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("DisposableStack")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+            self.get_object_cell_expect(ds_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(
+                        JsValue::String(JsString::from_str("DisposableStack")),
+                        false,
+                        false,
+                        true,
+                    ),
+                );
         }
 
         // dispose()
@@ -26,13 +30,13 @@ impl Interpreter {
             0,
             |interp, this, _args| interp.disposable_stack_dispose(this, false),
         ));
-        ds_proto
+        self.get_object_cell_expect(ds_proto_id)
             .borrow_mut()
             .insert_builtin("dispose".to_string(), dispose_fn.clone());
 
         // Symbol.dispose = dispose
         if let Some(key) = self.get_symbol_key("dispose") {
-            ds_proto
+            self.get_object_cell_expect(ds_proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(dispose_fn, true, false, true));
         }
@@ -57,10 +61,12 @@ impl Interpreter {
                 ))
             },
         ));
-        ds_proto.borrow_mut().insert_property(
-            "disposed".to_string(),
-            PropertyDescriptor::accessor(Some(disposed_getter), None, false, true),
-        );
+        self.get_object_cell_expect(ds_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "disposed".to_string(),
+                PropertyDescriptor::accessor(Some(disposed_getter), None, false, true),
+            );
 
         // use(value)
         let use_fn = self.create_function(JsFunction::native(
@@ -148,7 +154,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("Not a DisposableStack"))
             },
         ));
-        ds_proto
+        self.get_object_cell_expect(ds_proto_id)
             .borrow_mut()
             .insert_builtin("use".to_string(), use_fn);
 
@@ -213,7 +219,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("Not a DisposableStack"))
             },
         ));
-        ds_proto
+        self.get_object_cell_expect(ds_proto_id)
             .borrow_mut()
             .insert_builtin("adopt".to_string(), adopt_fn);
 
@@ -263,7 +269,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("Not a DisposableStack"))
             },
         ));
-        ds_proto
+        self.get_object_cell_expect(ds_proto_id)
             .borrow_mut()
             .insert_builtin("defer".to_string(), defer_fn);
 
@@ -301,7 +307,7 @@ impl Interpreter {
                         }
                     };
                     // Create a new DisposableStack with the moved resources
-                    let new_obj = interp.create_object();
+                    let new_obj_id = interp.create_object_id();
                     {
                         // Get DisposableStack prototype
                         if let Some(ctor_val) = interp.get_global_var("DisposableStack")
@@ -309,30 +315,33 @@ impl Interpreter {
                         {
                             let proto_val = interp.get_property_on_id(ctor.id, "prototype");
                             if let JsValue::Object(p) = &proto_val {
-                                new_obj.borrow_mut().prototype_id = Some(p.id);
+                                interp
+                                    .get_object_cell_expect(new_obj_id)
+                                    .borrow_mut()
+                                    .prototype_id = Some(p.id);
                             }
                         }
                     }
                     {
-                        let mut b = new_obj.borrow_mut();
+                        let mut b = interp.get_object_cell_expect(new_obj_id).borrow_mut();
                         b.class_name = "DisposableStack".to_string();
                         b.disposable_stack = Some(DisposableStackData {
                             stack,
                             disposed: false,
                         });
                     }
-                    let id = new_obj.borrow().id.unwrap();
+                    let id = new_obj_id;
                     return Completion::Normal(JsValue::Object(crate::types::JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error("Not a DisposableStack"))
             },
         ));
-        ds_proto
+        self.get_object_cell_expect(ds_proto_id)
             .borrow_mut()
             .insert_builtin("move".to_string(), move_fn);
 
         // Store prototype in realm for OrdinaryCreateFromConstructor
-        self.realm_mut().disposable_stack_prototype = Some(ds_proto.borrow().id.unwrap());
+        self.realm_mut().disposable_stack_prototype = Some(ds_proto_id);
 
         // Constructor
         self.register_global_fn(
@@ -354,9 +363,9 @@ impl Interpreter {
                         Ok(p) => p,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let obj = interp.create_object();
+                    let obj_id = interp.create_object_id();
                     {
-                        let mut b = obj.borrow_mut();
+                        let mut b = interp.get_object_cell_expect(obj_id).borrow_mut();
                         b.class_name = "DisposableStack".to_string();
                         if let Some(p) = proto {
                             b.prototype_id = Some(p);
@@ -366,7 +375,7 @@ impl Interpreter {
                             disposed: false,
                         });
                     }
-                    let id = obj.borrow().id.unwrap();
+                    let id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 },
             ),
@@ -374,7 +383,7 @@ impl Interpreter {
 
         // Wire up constructor and prototype
         if let Some(ctor_val) = self.get_global_var("DisposableStack") {
-            ds_proto
+            self.get_object_cell_expect(ds_proto_id)
                 .borrow_mut()
                 .insert_builtin("constructor".to_string(), ctor_val);
         }
@@ -383,7 +392,7 @@ impl Interpreter {
                 && let JsValue::Object(o) = &ctor_val
                 && let Some(ctor_obj) = self.get_object(o.id)
             {
-                let proto_id = ds_proto.borrow().id.unwrap();
+                let proto_id = ds_proto_id;
                 // prototype property: { writable: false, enumerable: false, configurable: false }
                 ctor_obj.borrow_mut().insert_property(
                     "prototype".to_string(),
@@ -450,22 +459,26 @@ impl Interpreter {
     }
 
     pub(crate) fn setup_async_disposable_stack(&mut self) {
-        let ads_proto = self.create_object();
+        let ads_proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            ads_proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(ads_proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
 
         // Symbol.toStringTag
         if let Some(key) = self.get_symbol_key("toStringTag") {
-            ads_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("AsyncDisposableStack")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+            self.get_object_cell_expect(ads_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(
+                        JsValue::String(JsString::from_str("AsyncDisposableStack")),
+                        false,
+                        false,
+                        true,
+                    ),
+                );
         }
 
         // disposeAsync()
@@ -481,16 +494,18 @@ impl Interpreter {
                 }
             },
         ));
-        ads_proto
+        self.get_object_cell_expect(ads_proto_id)
             .borrow_mut()
             .insert_builtin("disposeAsync".to_string(), dispose_async_fn.clone());
 
         // Symbol.asyncDispose = disposeAsync
         if let Some(key) = self.get_symbol_key("asyncDispose") {
-            ads_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(dispose_async_fn, true, false, true),
-            );
+            self.get_object_cell_expect(ads_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(dispose_async_fn, true, false, true),
+                );
         }
 
         // get disposed
@@ -513,10 +528,12 @@ impl Interpreter {
                 ))
             },
         ));
-        ads_proto.borrow_mut().insert_property(
-            "disposed".to_string(),
-            PropertyDescriptor::accessor(Some(disposed_getter), None, false, true),
-        );
+        self.get_object_cell_expect(ads_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "disposed".to_string(),
+                PropertyDescriptor::accessor(Some(disposed_getter), None, false, true),
+            );
 
         // use(value)
         let use_fn = self.create_function(JsFunction::native(
@@ -614,7 +631,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
             },
         ));
-        ads_proto
+        self.get_object_cell_expect(ads_proto_id)
             .borrow_mut()
             .insert_builtin("use".to_string(), use_fn);
 
@@ -678,7 +695,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
             },
         ));
-        ads_proto
+        self.get_object_cell_expect(ads_proto_id)
             .borrow_mut()
             .insert_builtin("adopt".to_string(), adopt_fn);
 
@@ -728,7 +745,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
             },
         ));
-        ads_proto
+        self.get_object_cell_expect(ads_proto_id)
             .borrow_mut()
             .insert_builtin("defer".to_string(), defer_fn);
 
@@ -765,33 +782,36 @@ impl Interpreter {
                             }
                         }
                     };
-                    let new_obj = interp.create_object();
+                    let new_obj_id = interp.create_object_id();
                     {
                         let default_proto_id = interp.realm().async_disposable_stack_prototype;
                         if let Some(pid) = default_proto_id {
-                            new_obj.borrow_mut().prototype_id = Some(pid);
+                            interp
+                                .get_object_cell_expect(new_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(pid);
                         }
                     }
                     {
-                        let mut b = new_obj.borrow_mut();
+                        let mut b = interp.get_object_cell_expect(new_obj_id).borrow_mut();
                         b.class_name = "AsyncDisposableStack".to_string();
                         b.disposable_stack = Some(DisposableStackData {
                             stack,
                             disposed: false,
                         });
                     }
-                    let id = new_obj.borrow().id.unwrap();
+                    let id = new_obj_id;
                     return Completion::Normal(JsValue::Object(crate::types::JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
             },
         ));
-        ads_proto
+        self.get_object_cell_expect(ads_proto_id)
             .borrow_mut()
             .insert_builtin("move".to_string(), move_fn);
 
         // Store prototype in realm for OrdinaryCreateFromConstructor
-        self.realm_mut().async_disposable_stack_prototype = Some(ads_proto.borrow().id.unwrap());
+        self.realm_mut().async_disposable_stack_prototype = Some(ads_proto_id);
 
         // Constructor
         self.register_global_fn(
@@ -815,9 +835,9 @@ impl Interpreter {
                         Ok(p) => p,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let obj = interp.create_object();
+                    let obj_id = interp.create_object_id();
                     {
-                        let mut b = obj.borrow_mut();
+                        let mut b = interp.get_object_cell_expect(obj_id).borrow_mut();
                         b.class_name = "AsyncDisposableStack".to_string();
                         if let Some(p) = proto {
                             b.prototype_id = Some(p);
@@ -827,7 +847,7 @@ impl Interpreter {
                             disposed: false,
                         });
                     }
-                    let id = obj.borrow().id.unwrap();
+                    let id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 },
             ),
@@ -835,7 +855,7 @@ impl Interpreter {
 
         // Wire up
         if let Some(ctor_val) = self.get_global_var("AsyncDisposableStack") {
-            ads_proto
+            self.get_object_cell_expect(ads_proto_id)
                 .borrow_mut()
                 .insert_builtin("constructor".to_string(), ctor_val);
         }
@@ -844,7 +864,7 @@ impl Interpreter {
                 && let JsValue::Object(o) = &ctor_val
                 && let Some(ctor_obj) = self.get_object(o.id)
             {
-                let proto_id = ads_proto.borrow().id.unwrap();
+                let proto_id = ads_proto_id;
                 // prototype property: { writable: false, enumerable: false, configurable: false }
                 ctor_obj.borrow_mut().insert_property(
                     "prototype".to_string(),

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -5,7 +5,7 @@ impl Interpreter {
         let ds_proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             ds_proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
 
         // Symbol.toStringTag
@@ -454,7 +454,7 @@ impl Interpreter {
         let ads_proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             ads_proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
 
         // Symbol.toStringTag

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -314,32 +314,42 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
-                    let stack = {
-                        let mut b = obj.borrow_mut();
+                    enum Probe {
+                        NotStack,
+                        AlreadyDisposed,
+                        Moved(Vec<DisposableResource>),
+                    }
+                    let probe = {
+                        let cell = interp.get_object_cell_expect(o.id);
+                        let mut b = cell.borrow_mut();
                         if b.class_name != "DisposableStack" {
+                            Probe::NotStack
+                        } else {
+                            match &mut b.disposable_stack {
+                                Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                                Some(ds) => {
+                                    let s = std::mem::take(&mut ds.stack);
+                                    ds.disposed = true;
+                                    Probe::Moved(s)
+                                }
+                                None => Probe::NotStack,
+                            }
+                        }
+                    };
+                    let stack = match probe {
+                        Probe::NotStack => {
                             return Completion::Throw(
                                 interp.create_type_error("Not a DisposableStack"),
                             );
                         }
-                        match &mut b.disposable_stack {
-                            Some(ds) if ds.disposed => {
-                                return Completion::Throw(interp.create_reference_error(
-                                    "DisposableStack has already been disposed",
-                                ));
-                            }
-                            Some(ds) => {
-                                let s = std::mem::take(&mut ds.stack);
-                                ds.disposed = true;
-                                s
-                            }
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("Not a DisposableStack"),
-                                );
-                            }
+                        Probe::AlreadyDisposed => {
+                            return Completion::Throw(interp.create_reference_error(
+                                "DisposableStack has already been disposed",
+                            ));
                         }
+                        Probe::Moved(s) => s,
                     };
                     // Create a new DisposableStack with the moved resources
                     let new_obj_id = interp.create_object_id();
@@ -425,7 +435,7 @@ impl Interpreter {
         {
             if let Some(ctor_val) = self.get_global_var("DisposableStack")
                 && let JsValue::Object(o) = &ctor_val
-                && let Some(ctor_obj) = self.get_object(o.id)
+                && let Some(ctor_obj) = self.get_object_cell(o.id)
             {
                 let proto_id = ds_proto_id;
                 // prototype property: { writable: false, enumerable: false, configurable: false }
@@ -448,25 +458,38 @@ impl Interpreter {
         _is_async: bool,
     ) -> Completion {
         if let JsValue::Object(o) = this
-            && let Some(obj) = self.get_object(o.id)
+            && self.get_object_cell(o.id).is_some()
         {
-            let stack = {
-                let mut b = obj.borrow_mut();
+            enum Probe {
+                NotStack,
+                AlreadyDisposed,
+                Active(Vec<DisposableResource>),
+            }
+            let probe = {
+                let cell = self.get_object_cell_expect(o.id);
+                let mut b = cell.borrow_mut();
                 if b.class_name != "DisposableStack" {
+                    Probe::NotStack
+                } else {
+                    match &mut b.disposable_stack {
+                        Some(ds) => {
+                            if ds.disposed {
+                                Probe::AlreadyDisposed
+                            } else {
+                                ds.disposed = true;
+                                Probe::Active(std::mem::take(&mut ds.stack))
+                            }
+                        }
+                        None => Probe::NotStack,
+                    }
+                }
+            };
+            let stack = match probe {
+                Probe::NotStack => {
                     return Completion::Throw(self.create_type_error("Not a DisposableStack"));
                 }
-                match &mut b.disposable_stack {
-                    Some(ds) => {
-                        if ds.disposed {
-                            return Completion::Normal(JsValue::Undefined);
-                        }
-                        ds.disposed = true;
-                        std::mem::take(&mut ds.stack)
-                    }
-                    None => {
-                        return Completion::Throw(self.create_type_error("Not a DisposableStack"));
-                    }
-                }
+                Probe::AlreadyDisposed => return Completion::Normal(JsValue::Undefined),
+                Probe::Active(s) => s,
             };
 
             let mut current_error: Option<JsValue> = None;
@@ -548,19 +571,26 @@ impl Interpreter {
             "get disposed".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let b = obj.borrow();
-                    if b.class_name == "AsyncDisposableStack"
-                        && let Some(ref ds) = b.disposable_stack
-                    {
-                        return Completion::Normal(JsValue::Boolean(ds.disposed));
-                    }
+                let disposed = if let JsValue::Object(o) = this {
+                    interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
+                        if b.class_name == "AsyncDisposableStack"
+                            && let Some(ref ds) = b.disposable_stack
+                        {
+                            Some(ds.disposed)
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                };
+                match disposed {
+                    Some(d) => Completion::Normal(JsValue::Boolean(d)),
+                    None => Completion::Throw(interp.create_type_error(
+                        "AsyncDisposableStack.prototype.disposed called on non-AsyncDisposableStack",
+                    )),
                 }
-                Completion::Throw(interp.create_type_error(
-                    "AsyncDisposableStack.prototype.disposed called on non-AsyncDisposableStack",
-                ))
             },
         ));
         self.get_object_cell_expect(ads_proto_id)
@@ -577,28 +607,37 @@ impl Interpreter {
             |interp, this, args| {
                 let value = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
-                    {
-                        let b = obj.borrow();
+                    enum Probe {
+                        NotStack,
+                        AlreadyDisposed,
+                        Active,
+                    }
+                    let probe = {
+                        let b = interp.get_object_cell_expect(o.id).borrow();
                         if b.class_name != "AsyncDisposableStack" {
+                            Probe::NotStack
+                        } else {
+                            match &b.disposable_stack {
+                                Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                                Some(_) => Probe::Active,
+                                None => Probe::NotStack,
+                            }
+                        }
+                    };
+                    match probe {
+                        Probe::NotStack => {
                             return Completion::Throw(
                                 interp.create_type_error("Not an AsyncDisposableStack"),
                             );
                         }
-                        match &b.disposable_stack {
-                            Some(ds) if ds.disposed => {
-                                return Completion::Throw(interp.create_reference_error(
-                                    "AsyncDisposableStack has already been disposed",
-                                ));
-                            }
-                            Some(_) => {}
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("Not an AsyncDisposableStack"),
-                                );
-                            }
+                        Probe::AlreadyDisposed => {
+                            return Completion::Throw(interp.create_reference_error(
+                                "AsyncDisposableStack has already been disposed",
+                            ));
                         }
+                        Probe::Active => {}
                     }
                     if matches!(value, JsValue::Null | JsValue::Undefined) {
                         let resource = DisposableResource {
@@ -655,8 +694,8 @@ impl Interpreter {
                         hint,
                         dispose_method: method,
                     };
-                    if let Some(obj2) = interp.get_object(o.id) {
-                        let mut b = obj2.borrow_mut();
+                    if let Some(cell) = interp.get_object_cell(o.id) {
+                        let mut b = cell.borrow_mut();
                         if let Some(ref mut ds) = b.disposable_stack {
                             ds.stack.push(resource);
                         }
@@ -678,23 +717,33 @@ impl Interpreter {
                 let value = args.first().cloned().unwrap_or(JsValue::Undefined);
                 let on_dispose = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
-                    {
-                        let b = obj.borrow();
+                    enum Probe {
+                        AlreadyDisposed,
+                        NotStack,
+                        Active,
+                    }
+                    let probe = {
+                        let b = interp.get_object_cell_expect(o.id).borrow();
                         match &b.disposable_stack {
-                            Some(ds) if ds.disposed => {
-                                return Completion::Throw(interp.create_reference_error(
-                                    "AsyncDisposableStack has already been disposed",
-                                ));
-                            }
-                            Some(_) => {}
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("Not an AsyncDisposableStack"),
-                                );
-                            }
+                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                            Some(_) => Probe::Active,
+                            None => Probe::NotStack,
                         }
+                    };
+                    match probe {
+                        Probe::AlreadyDisposed => {
+                            return Completion::Throw(interp.create_reference_error(
+                                "AsyncDisposableStack has already been disposed",
+                            ));
+                        }
+                        Probe::NotStack => {
+                            return Completion::Throw(
+                                interp.create_type_error("Not an AsyncDisposableStack"),
+                            );
+                        }
+                        Probe::Active => {}
                     }
                     if !interp.is_callable(&on_dispose) {
                         return Completion::Throw(
@@ -719,8 +768,8 @@ impl Interpreter {
                         hint: DisposeHint::Async,
                         dispose_method: wrapper_fn,
                     };
-                    if let Some(obj2) = interp.get_object(o.id) {
-                        let mut b = obj2.borrow_mut();
+                    if let Some(cell) = interp.get_object_cell(o.id) {
+                        let mut b = cell.borrow_mut();
                         if let Some(ref mut ds) = b.disposable_stack {
                             ds.stack.push(resource);
                         }
@@ -741,23 +790,33 @@ impl Interpreter {
             |interp, this, args| {
                 let on_dispose = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
-                    {
-                        let b = obj.borrow();
+                    enum Probe {
+                        AlreadyDisposed,
+                        NotStack,
+                        Active,
+                    }
+                    let probe = {
+                        let b = interp.get_object_cell_expect(o.id).borrow();
                         match &b.disposable_stack {
-                            Some(ds) if ds.disposed => {
-                                return Completion::Throw(interp.create_reference_error(
-                                    "AsyncDisposableStack has already been disposed",
-                                ));
-                            }
-                            Some(_) => {}
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("Not an AsyncDisposableStack"),
-                                );
-                            }
+                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                            Some(_) => Probe::Active,
+                            None => Probe::NotStack,
                         }
+                    };
+                    match probe {
+                        Probe::AlreadyDisposed => {
+                            return Completion::Throw(interp.create_reference_error(
+                                "AsyncDisposableStack has already been disposed",
+                            ));
+                        }
+                        Probe::NotStack => {
+                            return Completion::Throw(
+                                interp.create_type_error("Not an AsyncDisposableStack"),
+                            );
+                        }
+                        Probe::Active => {}
                     }
                     if !interp.is_callable(&on_dispose) {
                         return Completion::Throw(
@@ -769,8 +828,8 @@ impl Interpreter {
                         hint: DisposeHint::Async,
                         dispose_method: on_dispose,
                     };
-                    if let Some(obj2) = interp.get_object(o.id) {
-                        let mut b = obj2.borrow_mut();
+                    if let Some(cell) = interp.get_object_cell(o.id) {
+                        let mut b = cell.borrow_mut();
                         if let Some(ref mut ds) = b.disposable_stack {
                             ds.stack.push(resource);
                         }
@@ -790,32 +849,42 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && interp.get_object_cell(o.id).is_some()
                 {
-                    let stack = {
-                        let mut b = obj.borrow_mut();
+                    enum Probe {
+                        NotStack,
+                        AlreadyDisposed,
+                        Moved(Vec<DisposableResource>),
+                    }
+                    let probe = {
+                        let cell = interp.get_object_cell_expect(o.id);
+                        let mut b = cell.borrow_mut();
                         if b.class_name != "AsyncDisposableStack" {
+                            Probe::NotStack
+                        } else {
+                            match &mut b.disposable_stack {
+                                Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                                Some(ds) => {
+                                    let s = std::mem::take(&mut ds.stack);
+                                    ds.disposed = true;
+                                    Probe::Moved(s)
+                                }
+                                None => Probe::NotStack,
+                            }
+                        }
+                    };
+                    let stack = match probe {
+                        Probe::NotStack => {
                             return Completion::Throw(
                                 interp.create_type_error("Not an AsyncDisposableStack"),
                             );
                         }
-                        match &mut b.disposable_stack {
-                            Some(ds) if ds.disposed => {
-                                return Completion::Throw(interp.create_reference_error(
-                                    "AsyncDisposableStack has already been disposed",
-                                ));
-                            }
-                            Some(ds) => {
-                                let s = std::mem::take(&mut ds.stack);
-                                ds.disposed = true;
-                                s
-                            }
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("Not an AsyncDisposableStack"),
-                                );
-                            }
+                        Probe::AlreadyDisposed => {
+                            return Completion::Throw(interp.create_reference_error(
+                                "AsyncDisposableStack has already been disposed",
+                            ));
                         }
+                        Probe::Moved(s) => s,
                     };
                     let new_obj_id = interp.create_object_id();
                     {
@@ -897,7 +966,7 @@ impl Interpreter {
         {
             if let Some(ctor_val) = self.get_global_var("AsyncDisposableStack")
                 && let JsValue::Object(o) = &ctor_val
-                && let Some(ctor_obj) = self.get_object(o.id)
+                && let Some(ctor_obj) = self.get_object_cell(o.id)
             {
                 let proto_id = ads_proto_id;
                 // prototype property: { writable: false, enumerable: false, configurable: false }
@@ -916,29 +985,40 @@ impl Interpreter {
 
     fn async_disposable_stack_dispose(&mut self, this: &JsValue) -> Completion {
         if let JsValue::Object(o) = this
-            && let Some(obj) = self.get_object(o.id)
+            && self.get_object_cell(o.id).is_some()
         {
-            let stack = {
-                let mut b = obj.borrow_mut();
+            enum Probe {
+                NotStack,
+                AlreadyDisposed,
+                Active(Vec<DisposableResource>),
+            }
+            let probe = {
+                let cell = self.get_object_cell_expect(o.id);
+                let mut b = cell.borrow_mut();
                 if b.class_name != "AsyncDisposableStack" {
+                    Probe::NotStack
+                } else {
+                    match &mut b.disposable_stack {
+                        Some(ds) => {
+                            if ds.disposed {
+                                Probe::AlreadyDisposed
+                            } else {
+                                ds.disposed = true;
+                                Probe::Active(std::mem::take(&mut ds.stack))
+                            }
+                        }
+                        None => Probe::NotStack,
+                    }
+                }
+            };
+            let stack = match probe {
+                Probe::NotStack => {
                     return Completion::Throw(
                         self.create_type_error("Not an AsyncDisposableStack"),
                     );
                 }
-                match &mut b.disposable_stack {
-                    Some(ds) => {
-                        if ds.disposed {
-                            return Completion::Normal(JsValue::Undefined);
-                        }
-                        ds.disposed = true;
-                        std::mem::take(&mut ds.stack)
-                    }
-                    None => {
-                        return Completion::Throw(
-                            self.create_type_error("Not an AsyncDisposableStack"),
-                        );
-                    }
-                }
+                Probe::AlreadyDisposed => return Completion::Normal(JsValue::Undefined),
+                Probe::Active(s) => s,
             };
 
             let mut current_error: Option<JsValue> = None;

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -571,7 +571,7 @@ impl Interpreter {
                             hint: DisposeHint::Async,
                             dispose_method: JsValue::Undefined,
                         };
-                        if let Some(obj2) = interp.get_object(o.id)
+                        if let Some(obj2) = interp.get_object_cell(o.id)
                             && let Some(ds) = &mut obj2.borrow_mut().disposable_stack
                         {
                             ds.stack.push(resource);

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -210,8 +210,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_collator(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.Collator".to_string();
 
@@ -368,8 +367,7 @@ impl Interpreter {
                     {
                         let result = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            result.borrow_mut().prototype_id =
-                                Some(op_id);
+                            result.borrow_mut().prototype_id = Some(op_id);
                         }
 
                         let props = vec![

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -207,7 +207,7 @@ fn is_thai_locale(locale_str: &str) -> bool {
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_collator(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_collator(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -699,10 +699,12 @@ impl Interpreter {
         );
 
         // Register Intl.Collator on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "Collator".to_string(),
-            PropertyDescriptor::data(collator_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "Collator".to_string(),
+                PropertyDescriptor::data(collator_ctor, true, false, true),
+            );
     }
 
     pub(crate) fn intl_locale_compare(

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -208,24 +208,30 @@ fn is_thai_locale(locale_str: &str) -> bool {
 
 impl Interpreter {
     pub(crate) fn setup_intl_collator(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.Collator".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.Collator".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.Collator"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.Collator"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // compare getter
         let compare_getter = self.create_function(JsFunction::native(
@@ -338,10 +344,12 @@ impl Interpreter {
                 ))
             },
         ));
-        proto.borrow_mut().insert_property(
-            "compare".to_string(),
-            PropertyDescriptor::accessor(Some(compare_getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "compare".to_string(),
+                PropertyDescriptor::accessor(Some(compare_getter), None, false, true),
+            );
 
         // resolvedOptions()
         let resolved_fn = self.create_function(JsFunction::native(
@@ -365,9 +373,12 @@ impl Interpreter {
                         case_first,
                     }) = data
                     {
-                        let result = interp.create_object();
+                        let result_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            result.borrow_mut().prototype_id = Some(op_id);
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .prototype_id = Some(op_id);
                         }
 
                         let props = vec![
@@ -386,13 +397,16 @@ impl Interpreter {
                             ),
                         ];
                         for (key, val) in props {
-                            result.borrow_mut().insert_property(
-                                key.to_string(),
-                                PropertyDescriptor::data(val, true, true, true),
-                            );
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .insert_property(
+                                    key.to_string(),
+                                    PropertyDescriptor::data(val, true, true, true),
+                                );
                         }
 
-                        let result_id = result.borrow().id.unwrap();
+                        let result_id = result_id;
                         return Completion::Normal(JsValue::Object(crate::types::JsObject {
                             id: result_id,
                         }));
@@ -403,16 +417,16 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_collator_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_collator_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let collator_ctor = self.create_function(JsFunction::constructor(
             "Collator".to_string(),
@@ -642,20 +656,27 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.Collator".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::Collator {
-                    locale,
-                    usage,
-                    sensitivity,
-                    ignore_punctuation,
-                    collation,
-                    numeric,
-                    case_first,
-                });
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Intl.Collator".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                    Some(IntlData::Collator {
+                        locale,
+                        usage,
+                        sensitivity,
+                        ignore_punctuation,
+                        collation,
+                        numeric,
+                        case_first,
+                    });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -691,10 +712,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(collator_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(collator_ctor.clone(), true, false, true),
+            );
 
         // Register Intl.Collator on the Intl namespace
         self.get_object_cell_expect(intl_obj_id)

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -211,7 +211,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.Collator".to_string();
 
@@ -369,7 +369,7 @@ impl Interpreter {
                         let result = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
                             result.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                Some(op_id);
                         }
 
                         let props = vec![
@@ -699,7 +699,7 @@ impl Interpreter {
         );
 
         // Register Intl.Collator on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "Collator".to_string(),

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -406,7 +406,6 @@ impl Interpreter {
                                 );
                         }
 
-                        let result_id = result_id;
                         return Completion::Normal(JsValue::Object(crate::types::JsObject {
                             id: result_id,
                         }));
@@ -424,7 +423,6 @@ impl Interpreter {
         self.realm_mut().intl_collator_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -676,7 +674,6 @@ impl Interpreter {
                         case_first,
                     });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -239,24 +239,63 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this {
-                    if let Some(obj) = interp.get_object(o.id) {
-                        let cached = {
-                            let b = obj.borrow();
+                    if let Some(cell) = interp.get_object_cell(o.id) {
+                        enum Probe {
+                            NotCollator,
+                            Cached(JsValue),
+                            Uncached,
+                        }
+                        let probe = {
+                            let b = cell.borrow();
                             if !matches!(b.intl_data, Some(IntlData::Collator { .. })) {
+                                Probe::NotCollator
+                            } else if let Some(func) = b
+                                .properties
+                                .get("[[BoundCompare]]")
+                                .and_then(|pd| pd.value.clone())
+                            {
+                                Probe::Cached(func)
+                            } else {
+                                Probe::Uncached
+                            }
+                        };
+                        match probe {
+                            Probe::NotCollator => {
                                 return Completion::Throw(interp.create_type_error(
                                     "Intl.Collator.prototype.compare called on non-Collator object",
                                 ));
                             }
-                            b.properties
-                                .get("[[BoundCompare]]")
-                                .and_then(|pd| pd.value.clone())
-                        };
-
-                        if let Some(func) = cached {
-                            return Completion::Normal(func);
+                            Probe::Cached(func) => return Completion::Normal(func),
+                            Probe::Uncached => {}
                         }
                     }
 
+                    let snapshot = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
+                        if let Some(IntlData::Collator {
+                            ref locale,
+                            ref usage,
+                            ref collation,
+                            ref sensitivity,
+                            ref ignore_punctuation,
+                            ref numeric,
+                            ref case_first,
+                            ..
+                        }) = b.intl_data
+                        {
+                            Some((
+                                locale.clone(),
+                                usage.clone(),
+                                collation.clone(),
+                                sensitivity.clone(),
+                                *numeric,
+                                case_first.clone(),
+                                *ignore_punctuation,
+                            ))
+                        } else {
+                            None
+                        }
+                    });
                     let (
                         locale,
                         usage,
@@ -265,35 +304,9 @@ impl Interpreter {
                         numeric,
                         case_first,
                         ignore_punctuation,
-                    ) = {
-                        if let Some(obj) = interp.get_object(o.id) {
-                            let b = obj.borrow();
-                            if let Some(IntlData::Collator {
-                                ref locale,
-                                ref usage,
-                                ref collation,
-                                ref sensitivity,
-                                ref ignore_punctuation,
-                                ref numeric,
-                                ref case_first,
-                                ..
-                            }) = b.intl_data
-                            {
-                                (
-                                    locale.clone(),
-                                    usage.clone(),
-                                    collation.clone(),
-                                    sensitivity.clone(),
-                                    *numeric,
-                                    case_first.clone(),
-                                    *ignore_punctuation,
-                                )
-                            } else {
-                                return Completion::Throw(interp.create_type_error(
-                                    "Intl.Collator.prototype.compare called on non-Collator object",
-                                ));
-                            }
-                        } else {
+                    ) = match snapshot {
+                        Some(t) => t,
+                        None => {
                             return Completion::Throw(interp.create_type_error(
                                 "Intl.Collator.prototype.compare called on non-Collator object",
                             ));
@@ -330,7 +343,7 @@ impl Interpreter {
                         },
                     ));
 
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         obj.borrow_mut().properties.insert(
                             "[[BoundCompare]]".to_string(),
                             PropertyDescriptor::data(compare_fn.clone(), false, false, false),
@@ -357,7 +370,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -680,12 +693,15 @@ impl Interpreter {
 
         // Set Collator.prototype on constructor
         if let JsValue::Object(ctor_ref) = &collator_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -704,7 +720,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -4710,7 +4710,7 @@ fn date_fields_to_epoch_ms(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_date_time_format(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_date_time_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -5752,9 +5752,11 @@ impl Interpreter {
         self.realm_mut().intl_date_time_format_ctor = Some(dtf_ctor.clone());
 
         // Register Intl.DateTimeFormat on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "DateTimeFormat".to_string(),
-            PropertyDescriptor::data(dtf_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "DateTimeFormat".to_string(),
+                PropertyDescriptor::data(dtf_ctor, true, false, true),
+            );
     }
 }

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -4714,7 +4714,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.DateTimeFormat".to_string();
 
@@ -4919,7 +4919,7 @@ impl Interpreter {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
                             part_obj.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -5159,7 +5159,7 @@ impl Interpreter {
                     .map(|(ptype, value, source)| {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id = Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                            part_obj.borrow_mut().prototype_id = Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -5213,7 +5213,7 @@ impl Interpreter {
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
                     result.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        Some(op_id);
                 }
 
                 // Properties in spec order
@@ -5752,7 +5752,7 @@ impl Interpreter {
         self.realm_mut().intl_date_time_format_ctor = Some(dtf_ctor.clone());
 
         // Register Intl.DateTimeFormat on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "DateTimeFormat".to_string(),

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -4711,24 +4711,30 @@ fn date_fields_to_epoch_ms(
 
 impl Interpreter {
     pub(crate) fn setup_intl_date_time_format(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.DateTimeFormat".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.DateTimeFormat".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.DateTimeFormat"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.DateTimeFormat"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // format getter (returns a bound function, like Collator.compare)
         let format_getter = self.create_function(JsFunction::native(
@@ -4866,10 +4872,12 @@ impl Interpreter {
                 ))
             },
         ));
-        proto.borrow_mut().insert_property(
-            "format".to_string(),
-            PropertyDescriptor::accessor(Some(format_getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "format".to_string(),
+                PropertyDescriptor::accessor(Some(format_getter), None, false, true),
+            );
 
         // formatToParts(date)
         let format_to_parts_fn = self.create_function(JsFunction::native(
@@ -4915,29 +4923,38 @@ impl Interpreter {
                 let js_parts: Vec<JsValue> = parts
                     .into_iter()
                     .map(|(ptype, value)| {
-                        let part_obj = interp.create_object();
+                        let part_obj_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id = Some(op_id);
+                            interp
+                                .get_object_cell_expect(part_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(op_id);
                         }
-                        part_obj.borrow_mut().insert_property(
-                            "type".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&ptype)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        part_obj.borrow_mut().insert_property(
-                            "value".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&value)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        let id = part_obj.borrow().id.unwrap();
+                        interp
+                            .get_object_cell_expect(part_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "type".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&ptype)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        interp
+                            .get_object_cell_expect(part_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "value".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&value)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        let id = part_obj_id;
                         JsValue::Object(crate::types::JsObject { id })
                     })
                     .collect();
@@ -4945,7 +4962,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(js_parts))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatToParts".to_string(), format_to_parts_fn);
 
@@ -5054,7 +5071,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatRange".to_string(), format_range_fn);
 
@@ -5155,11 +5172,11 @@ impl Interpreter {
                 let js_parts: Vec<JsValue> = all_parts
                     .into_iter()
                     .map(|(ptype, value, source)| {
-                        let part_obj = interp.create_object();
+                        let part_obj_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id = Some(op_id);
+                            interp.get_object_cell_expect(part_obj_id).borrow_mut().prototype_id = Some(op_id);
                         }
-                        part_obj.borrow_mut().insert_property(
+                        interp.get_object_cell_expect(part_obj_id).borrow_mut().insert_property(
                             "type".to_string(),
                             PropertyDescriptor::data(
                                 JsValue::String(JsString::from_str(&ptype)),
@@ -5168,7 +5185,7 @@ impl Interpreter {
                                 true,
                             ),
                         );
-                        part_obj.borrow_mut().insert_property(
+                        interp.get_object_cell_expect(part_obj_id).borrow_mut().insert_property(
                             "value".to_string(),
                             PropertyDescriptor::data(
                                 JsValue::String(JsString::from_str(&value)),
@@ -5177,7 +5194,7 @@ impl Interpreter {
                                 true,
                             ),
                         );
-                        part_obj.borrow_mut().insert_property(
+                        interp.get_object_cell_expect(part_obj_id).borrow_mut().insert_property(
                             "source".to_string(),
                             PropertyDescriptor::data(
                                 JsValue::String(JsString::from_str(&source)),
@@ -5186,7 +5203,7 @@ impl Interpreter {
                                 true,
                             ),
                         );
-                        let id = part_obj.borrow().id.unwrap();
+                        let id = part_obj_id;
                         JsValue::Object(crate::types::JsObject { id })
                     })
                     .collect();
@@ -5194,7 +5211,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(js_parts))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatRangeToParts".to_string(), format_range_to_parts_fn);
 
@@ -5208,9 +5225,12 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let result = interp.create_object();
+                let result_id = interp.create_object_id();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id = Some(op_id);
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .prototype_id = Some(op_id);
                 }
 
                 // Properties in spec order
@@ -5280,26 +5300,29 @@ impl Interpreter {
                 }
 
                 for (key, val) in props {
-                    result.borrow_mut().insert_property(
-                        key.to_string(),
-                        PropertyDescriptor::data(val, true, true, true),
-                    );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            key.to_string(),
+                            PropertyDescriptor::data(val, true, true, true),
+                        );
                 }
 
-                let result_id = result.borrow().id.unwrap();
+                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_date_time_format_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_date_time_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let dtf_ctor = self.create_function(JsFunction::constructor(
             "DateTimeFormat".to_string(),
@@ -5678,33 +5701,40 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.DateTimeFormat".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::DateTimeFormat {
-                    locale,
-                    calendar,
-                    numbering_system,
-                    time_zone,
-                    hour_cycle,
-                    hour12,
-                    weekday,
-                    era,
-                    year,
-                    month,
-                    day,
-                    day_period,
-                    hour: hour_opt,
-                    minute: minute_opt,
-                    second: second_opt,
-                    fractional_second_digits: fsd_opt,
-                    time_zone_name: tz_name,
-                    date_style,
-                    time_style,
-                    has_explicit_components: has_date_time_component || has_style,
-                });
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Intl.DateTimeFormat".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                    Some(IntlData::DateTimeFormat {
+                        locale,
+                        calendar,
+                        numbering_system,
+                        time_zone,
+                        hour_cycle,
+                        hour12,
+                        weekday,
+                        era,
+                        year,
+                        month,
+                        day,
+                        day_period,
+                        hour: hour_opt,
+                        minute: minute_opt,
+                        second: second_opt,
+                        fractional_second_digits: fsd_opt,
+                        time_zone_name: tz_name,
+                        date_style,
+                        time_style,
+                        has_explicit_components: has_date_time_component || has_style,
+                    });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -5740,10 +5770,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(dtf_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(dtf_ctor.clone(), true, false, true),
+            );
 
         // Save built-in constructor for internal use (e.g. Date.toLocaleString)
         self.realm_mut().intl_date_time_format_ctor = Some(dtf_ctor.clone());

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -4171,7 +4171,7 @@ fn format_to_parts_with_options_raw(ms: f64, opts: &DtfOptions) -> Vec<(String, 
 
 fn extract_dtf_data(interp: &mut Interpreter, this: &JsValue) -> Result<DtfOptions, JsValue> {
     if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let b = obj.borrow();
         if let Some(IntlData::DateTimeFormat {
@@ -4246,7 +4246,7 @@ fn resolve_date_value(interp: &mut Interpreter, date_arg: &JsValue) -> Result<f6
     }
     // Check if it's a Temporal object
     if let JsValue::Object(o) = date_arg
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let temporal = obj.borrow().temporal_data.clone();
         if let Some(td) = temporal {
@@ -4274,7 +4274,7 @@ enum TemporalType {
 
 fn detect_temporal_type(interp: &Interpreter, val: &JsValue) -> Option<TemporalType> {
     if let JsValue::Object(o) = val
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let td = obj.borrow().temporal_data.clone();
         return match td {
@@ -4293,7 +4293,7 @@ fn detect_temporal_type(interp: &Interpreter, val: &JsValue) -> Option<TemporalT
 
 fn detect_temporal_calendar(interp: &Interpreter, val: &JsValue) -> Option<String> {
     if let JsValue::Object(o) = val
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let td = obj.borrow().temporal_data.clone();
         return match td {
@@ -4742,79 +4742,93 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this {
-                    if let Some(obj) = interp.get_object(o.id) {
-                        let cached = {
-                            let b = obj.borrow();
+                    enum Probe {
+                        NotDtf,
+                        Cached(JsValue),
+                        Uncached,
+                    }
+                    let probe = interp
+                        .get_object_cell(o.id)
+                        .map(|cell| {
+                            let b = cell.borrow();
                             if !matches!(b.intl_data, Some(IntlData::DateTimeFormat { .. })) {
-                                return Completion::Throw(interp.create_type_error(
-                                    "Intl.DateTimeFormat.prototype.format called on incompatible receiver",
-                                ));
-                            }
-                            b.properties
+                                Probe::NotDtf
+                            } else if let Some(func) = b
+                                .properties
                                 .get("[[BoundFormat]]")
                                 .and_then(|pd| pd.value.clone())
-                        };
-
-                        if let Some(func) = cached {
-                            return Completion::Normal(func);
+                            {
+                                Probe::Cached(func)
+                            } else {
+                                Probe::Uncached
+                            }
+                        })
+                        .unwrap_or(Probe::Uncached);
+                    match probe {
+                        Probe::NotDtf => {
+                            return Completion::Throw(interp.create_type_error(
+                                "Intl.DateTimeFormat.prototype.format called on incompatible receiver",
+                            ));
                         }
+                        Probe::Cached(func) => return Completion::Normal(func),
+                        Probe::Uncached => {}
                     }
 
-                    let opts = {
-                        if let Some(obj) = interp.get_object(o.id) {
-                            let b = obj.borrow();
-                            if let Some(IntlData::DateTimeFormat {
-                                ref locale,
-                                ref calendar,
-                                ref numbering_system,
-                                ref time_zone,
-                                ref hour_cycle,
-                                ref hour12,
-                                ref weekday,
-                                ref era,
-                                ref year,
-                                ref month,
-                                ref day,
-                                ref day_period,
-                                ref hour,
-                                ref minute,
-                                ref second,
-                                ref fractional_second_digits,
-                                ref time_zone_name,
-                                ref date_style,
-                                ref time_style,
+                    let opts_snapshot = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
+                        if let Some(IntlData::DateTimeFormat {
+                            ref locale,
+                            ref calendar,
+                            ref numbering_system,
+                            ref time_zone,
+                            ref hour_cycle,
+                            ref hour12,
+                            ref weekday,
+                            ref era,
+                            ref year,
+                            ref month,
+                            ref day,
+                            ref day_period,
+                            ref hour,
+                            ref minute,
+                            ref second,
+                            ref fractional_second_digits,
+                            ref time_zone_name,
+                            ref date_style,
+                            ref time_style,
+                            has_explicit_components,
+                        }) = b.intl_data
+                        {
+                            Some(DtfOptions {
+                                locale: locale.clone(),
+                                calendar: calendar.clone(),
+                                numbering_system: numbering_system.clone(),
+                                time_zone: time_zone.clone(),
+                                hour_cycle: hour_cycle.clone(),
+                                hour12: *hour12,
+                                weekday: weekday.clone(),
+                                era: era.clone(),
+                                year: year.clone(),
+                                month: month.clone(),
+                                day: day.clone(),
+                                day_period: day_period.clone(),
+                                hour: hour.clone(),
+                                minute: minute.clone(),
+                                second: second.clone(),
+                                fractional_second_digits: *fractional_second_digits,
+                                time_zone_name: time_zone_name.clone(),
+                                date_style: date_style.clone(),
+                                time_style: time_style.clone(),
                                 has_explicit_components,
-                            }) = b.intl_data
-                            {
-                                DtfOptions {
-                                    locale: locale.clone(),
-                                    calendar: calendar.clone(),
-                                    numbering_system: numbering_system.clone(),
-                                    time_zone: time_zone.clone(),
-                                    hour_cycle: hour_cycle.clone(),
-                                    hour12: *hour12,
-                                    weekday: weekday.clone(),
-                                    era: era.clone(),
-                                    year: year.clone(),
-                                    month: month.clone(),
-                                    day: day.clone(),
-                                    day_period: day_period.clone(),
-                                    hour: hour.clone(),
-                                    minute: minute.clone(),
-                                    second: second.clone(),
-                                    fractional_second_digits: *fractional_second_digits,
-                                    time_zone_name: time_zone_name.clone(),
-                                    date_style: date_style.clone(),
-                                    time_style: time_style.clone(),
-                                    has_explicit_components,
-                                    temporal_type: None,
-                                }
-                            } else {
-                                return Completion::Throw(interp.create_type_error(
-                                    "Intl.DateTimeFormat.prototype.format called on incompatible receiver",
-                                ));
-                            }
+                                temporal_type: None,
+                            })
                         } else {
+                            None
+                        }
+                    });
+                    let opts = match opts_snapshot {
+                        Some(o) => o,
+                        None => {
                             return Completion::Throw(interp.create_type_error(
                                 "Intl.DateTimeFormat.prototype.format called on incompatible receiver",
                             ));
@@ -4858,7 +4872,7 @@ impl Interpreter {
                         },
                     ));
 
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         obj.borrow_mut().properties.insert(
                             "[[BoundFormat]]".to_string(),
                             PropertyDescriptor::data(format_fn.clone(), false, false, false),
@@ -5738,12 +5752,15 @@ impl Interpreter {
 
         // Set DateTimeFormat.prototype on constructor
         if let JsValue::Object(ctor_ref) = &dtf_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -5762,7 +5779,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -4713,8 +4713,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_date_time_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.DateTimeFormat".to_string();
 
@@ -4918,8 +4917,7 @@ impl Interpreter {
                     .map(|(ptype, value)| {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id =
-                                Some(op_id);
+                            part_obj.borrow_mut().prototype_id = Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -5212,8 +5210,7 @@ impl Interpreter {
 
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id =
-                        Some(op_id);
+                    result.borrow_mut().prototype_id = Some(op_id);
                 }
 
                 // Properties in spec order

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -5309,7 +5309,6 @@ impl Interpreter {
                         );
                 }
 
-                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
@@ -5320,7 +5319,6 @@ impl Interpreter {
         self.realm_mut().intl_date_time_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -5734,7 +5732,6 @@ impl Interpreter {
                         has_explicit_components: has_date_time_component || has_style,
                     });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));

--- a/src/interpreter/builtins/intl/displaynames.rs
+++ b/src/interpreter/builtins/intl/displaynames.rs
@@ -1070,8 +1070,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_display_names(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.DisplayNames".to_string();
 
@@ -1137,8 +1136,7 @@ impl Interpreter {
 
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id =
-                        Some(op_id);
+                    result.borrow_mut().prototype_id = Some(op_id);
                 }
 
                 // Properties in spec order: locale, style, type, fallback, languageDisplay

--- a/src/interpreter/builtins/intl/displaynames.rs
+++ b/src/interpreter/builtins/intl/displaynames.rs
@@ -887,9 +887,9 @@ fn extract_display_names_data(
     this: &JsValue,
 ) -> Result<DisplayNamesData, JsValue> {
     if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(cell) = interp.get_object_cell(o.id)
     {
-        let b = obj.borrow();
+        let b = cell.borrow();
         if let Some(IntlData::DisplayNames {
             ref locale,
             ref style,
@@ -1215,7 +1215,6 @@ impl Interpreter {
                         );
                 }
 
-                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
@@ -1226,7 +1225,6 @@ impl Interpreter {
         self.realm_mut().intl_display_names_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -1358,19 +1356,21 @@ impl Interpreter {
                         language_display,
                     });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
 
         // Set DisplayNames.prototype on constructor
         if let JsValue::Object(ctor_ref) = &display_names_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -1389,7 +1389,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/displaynames.rs
+++ b/src/interpreter/builtins/intl/displaynames.rs
@@ -1071,7 +1071,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.DisplayNames".to_string();
 
@@ -1138,7 +1138,7 @@ impl Interpreter {
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
                     result.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        Some(op_id);
                 }
 
                 // Properties in spec order: locale, style, type, fallback, languageDisplay
@@ -1369,7 +1369,7 @@ impl Interpreter {
         );
 
         // Register Intl.DisplayNames on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "DisplayNames".to_string(),

--- a/src/interpreter/builtins/intl/displaynames.rs
+++ b/src/interpreter/builtins/intl/displaynames.rs
@@ -1068,24 +1068,30 @@ fn get_display_name_for_code(
 
 impl Interpreter {
     pub(crate) fn setup_intl_display_names(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.DisplayNames".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.DisplayNames".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.DisplayNames"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.DisplayNames"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // of(code)
         let of_fn = self.create_function(JsFunction::native(
@@ -1122,7 +1128,9 @@ impl Interpreter {
                 }
             },
         ));
-        proto.borrow_mut().insert_builtin("of".to_string(), of_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("of".to_string(), of_fn);
 
         // resolvedOptions()
         let resolved_fn = self.create_function(JsFunction::native(
@@ -1134,75 +1142,93 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let result = interp.create_object();
+                let result_id = interp.create_object_id();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id = Some(op_id);
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .prototype_id = Some(op_id);
                 }
 
                 // Properties in spec order: locale, style, type, fallback, languageDisplay
-                result.borrow_mut().insert_property(
-                    "locale".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str(&data.locale)),
-                        true,
-                        true,
-                        true,
-                    ),
-                );
-                result.borrow_mut().insert_property(
-                    "style".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str(&data.style)),
-                        true,
-                        true,
-                        true,
-                    ),
-                );
-                result.borrow_mut().insert_property(
-                    "type".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str(&data.display_type)),
-                        true,
-                        true,
-                        true,
-                    ),
-                );
-                result.borrow_mut().insert_property(
-                    "fallback".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str(&data.fallback)),
-                        true,
-                        true,
-                        true,
-                    ),
-                );
-                if data.display_type == "language" {
-                    let ld = data.language_display.as_deref().unwrap_or("dialect");
-                    result.borrow_mut().insert_property(
-                        "languageDisplay".to_string(),
+                interp
+                    .get_object_cell_expect(result_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "locale".to_string(),
                         PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(ld)),
+                            JsValue::String(JsString::from_str(&data.locale)),
                             true,
                             true,
                             true,
                         ),
                     );
+                interp
+                    .get_object_cell_expect(result_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "style".to_string(),
+                        PropertyDescriptor::data(
+                            JsValue::String(JsString::from_str(&data.style)),
+                            true,
+                            true,
+                            true,
+                        ),
+                    );
+                interp
+                    .get_object_cell_expect(result_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "type".to_string(),
+                        PropertyDescriptor::data(
+                            JsValue::String(JsString::from_str(&data.display_type)),
+                            true,
+                            true,
+                            true,
+                        ),
+                    );
+                interp
+                    .get_object_cell_expect(result_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "fallback".to_string(),
+                        PropertyDescriptor::data(
+                            JsValue::String(JsString::from_str(&data.fallback)),
+                            true,
+                            true,
+                            true,
+                        ),
+                    );
+                if data.display_type == "language" {
+                    let ld = data.language_display.as_deref().unwrap_or("dialect");
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "languageDisplay".to_string(),
+                            PropertyDescriptor::data(
+                                JsValue::String(JsString::from_str(ld)),
+                                true,
+                                true,
+                                true,
+                            ),
+                        );
                 }
 
-                let result_id = result.borrow().id.unwrap();
+                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_display_names_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_display_names_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let display_names_ctor = self.create_function(JsFunction::constructor(
             "DisplayNames".to_string(),
@@ -1314,18 +1340,25 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.DisplayNames".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::DisplayNames {
-                    locale,
-                    style,
-                    display_type,
-                    fallback,
-                    language_display,
-                });
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Intl.DisplayNames".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                    Some(IntlData::DisplayNames {
+                        locale,
+                        style,
+                        display_type,
+                        fallback,
+                        language_display,
+                    });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -1361,10 +1394,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(display_names_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(display_names_ctor.clone(), true, false, true),
+            );
 
         // Register Intl.DisplayNames on the Intl namespace
         self.get_object_cell_expect(intl_obj_id)

--- a/src/interpreter/builtins/intl/displaynames.rs
+++ b/src/interpreter/builtins/intl/displaynames.rs
@@ -1067,7 +1067,7 @@ fn get_display_name_for_code(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_display_names(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_display_names(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -1369,9 +1369,11 @@ impl Interpreter {
         );
 
         // Register Intl.DisplayNames on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "DisplayNames".to_string(),
-            PropertyDescriptor::data(display_names_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "DisplayNames".to_string(),
+                PropertyDescriptor::data(display_names_ctor, true, false, true),
+            );
     }
 }

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -1139,8 +1139,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_duration_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.DurationFormat".to_string();
 
@@ -1204,8 +1203,7 @@ impl Interpreter {
                     .map(|(ptype, value, unit)| {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id =
-                                Some(op_id);
+                            part_obj.borrow_mut().prototype_id = Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -1260,8 +1258,7 @@ impl Interpreter {
 
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id =
-                        Some(op_id);
+                    result.borrow_mut().prototype_id = Some(op_id);
                 }
 
                 let mut props: Vec<(&str, JsValue)> = vec![

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -1136,7 +1136,7 @@ fn format_to_parts_duration(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_duration_format(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_duration_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -1762,9 +1762,11 @@ impl Interpreter {
         self.realm_mut().intl_duration_format_ctor = Some(duration_format_ctor.clone());
 
         // Register Intl.DurationFormat on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "DurationFormat".to_string(),
-            PropertyDescriptor::data(duration_format_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "DurationFormat".to_string(),
+                PropertyDescriptor::data(duration_format_ctor, true, false, true),
+            );
     }
 }

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -1137,24 +1137,30 @@ fn format_to_parts_duration(
 
 impl Interpreter {
     pub(crate) fn setup_intl_duration_format(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.DurationFormat".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.DurationFormat".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.DurationFormat"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.DurationFormat"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // format(duration)
         let format_fn = self.create_function(JsFunction::native(
@@ -1176,7 +1182,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("format".to_string(), format_fn);
 
@@ -1201,40 +1207,52 @@ impl Interpreter {
                 let js_parts: Vec<JsValue> = parts
                     .into_iter()
                     .map(|(ptype, value, unit)| {
-                        let part_obj = interp.create_object();
+                        let part_obj_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id = Some(op_id);
+                            interp
+                                .get_object_cell_expect(part_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(op_id);
                         }
-                        part_obj.borrow_mut().insert_property(
-                            "type".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&ptype)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        part_obj.borrow_mut().insert_property(
-                            "value".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&value)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        if !unit.is_empty() {
-                            part_obj.borrow_mut().insert_property(
-                                "unit".to_string(),
+                        interp
+                            .get_object_cell_expect(part_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "type".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&unit)),
+                                    JsValue::String(JsString::from_str(&ptype)),
                                     true,
                                     true,
                                     true,
                                 ),
                             );
+                        interp
+                            .get_object_cell_expect(part_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "value".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&value)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        if !unit.is_empty() {
+                            interp
+                                .get_object_cell_expect(part_obj_id)
+                                .borrow_mut()
+                                .insert_property(
+                                    "unit".to_string(),
+                                    PropertyDescriptor::data(
+                                        JsValue::String(JsString::from_str(&unit)),
+                                        true,
+                                        true,
+                                        true,
+                                    ),
+                                );
                         }
-                        let id = part_obj.borrow().id.unwrap();
+                        let id = part_obj_id;
                         JsValue::Object(crate::types::JsObject { id })
                     })
                     .collect();
@@ -1242,7 +1260,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(js_parts))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatToParts".to_string(), format_to_parts_fn);
 
@@ -1256,9 +1274,12 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let result = interp.create_object();
+                let result_id = interp.create_object_id();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id = Some(op_id);
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .prototype_id = Some(op_id);
                 }
 
                 let mut props: Vec<(&str, JsValue)> = vec![
@@ -1340,26 +1361,29 @@ impl Interpreter {
                 }
 
                 for (key, val) in props {
-                    result.borrow_mut().insert_property(
-                        key.to_string(),
-                        PropertyDescriptor::data(val, true, true, true),
-                    );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            key.to_string(),
+                            PropertyDescriptor::data(val, true, true, true),
+                        );
                 }
 
-                let result_id = result.borrow().id.unwrap();
+                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_duration_format_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_duration_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let duration_format_ctor = self.create_function(JsFunction::constructor(
             "DurationFormat".to_string(),
@@ -1684,37 +1708,44 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.DurationFormat".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::DurationFormat {
-                    locale,
-                    numbering_system,
-                    style,
-                    years: unit_styles[0].0.clone(),
-                    years_display: unit_styles[0].1.clone(),
-                    months: unit_styles[1].0.clone(),
-                    months_display: unit_styles[1].1.clone(),
-                    weeks: unit_styles[2].0.clone(),
-                    weeks_display: unit_styles[2].1.clone(),
-                    days: unit_styles[3].0.clone(),
-                    days_display: unit_styles[3].1.clone(),
-                    hours: unit_styles[4].0.clone(),
-                    hours_display: unit_styles[4].1.clone(),
-                    minutes: unit_styles[5].0.clone(),
-                    minutes_display: unit_styles[5].1.clone(),
-                    seconds: unit_styles[6].0.clone(),
-                    seconds_display: unit_styles[6].1.clone(),
-                    milliseconds: unit_styles[7].0.clone(),
-                    milliseconds_display: unit_styles[7].1.clone(),
-                    microseconds: unit_styles[8].0.clone(),
-                    microseconds_display: unit_styles[8].1.clone(),
-                    nanoseconds: unit_styles[9].0.clone(),
-                    nanoseconds_display: unit_styles[9].1.clone(),
-                    fractional_digits,
-                });
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Intl.DurationFormat".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                    Some(IntlData::DurationFormat {
+                        locale,
+                        numbering_system,
+                        style,
+                        years: unit_styles[0].0.clone(),
+                        years_display: unit_styles[0].1.clone(),
+                        months: unit_styles[1].0.clone(),
+                        months_display: unit_styles[1].1.clone(),
+                        weeks: unit_styles[2].0.clone(),
+                        weeks_display: unit_styles[2].1.clone(),
+                        days: unit_styles[3].0.clone(),
+                        days_display: unit_styles[3].1.clone(),
+                        hours: unit_styles[4].0.clone(),
+                        hours_display: unit_styles[4].1.clone(),
+                        minutes: unit_styles[5].0.clone(),
+                        minutes_display: unit_styles[5].1.clone(),
+                        seconds: unit_styles[6].0.clone(),
+                        seconds_display: unit_styles[6].1.clone(),
+                        milliseconds: unit_styles[7].0.clone(),
+                        milliseconds_display: unit_styles[7].1.clone(),
+                        microseconds: unit_styles[8].0.clone(),
+                        microseconds_display: unit_styles[8].1.clone(),
+                        nanoseconds: unit_styles[9].0.clone(),
+                        nanoseconds_display: unit_styles[9].1.clone(),
+                        fractional_digits,
+                    });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -1750,10 +1781,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(duration_format_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(duration_format_ctor.clone(), true, false, true),
+            );
 
         // Save built-in constructor for internal use (e.g. Duration.toLocaleString)
         self.realm_mut().intl_duration_format_ctor = Some(duration_format_ctor.clone());

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -595,7 +595,7 @@ fn to_duration_record(
     };
 
     // Check for Temporal.Duration
-    if let Some(obj_data) = interp.get_object(obj_id) {
+    if let Some(obj_data) = interp.get_object_cell(obj_id) {
         let b = obj_data.borrow();
         if let Some(TemporalData::Duration {
             years,
@@ -895,7 +895,7 @@ fn extract_duration_format_data(
     this: &JsValue,
 ) -> Result<DurationFormatData, JsValue> {
     if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let b = obj.borrow();
         if let Some(IntlData::DurationFormat {
@@ -1749,12 +1749,15 @@ impl Interpreter {
 
         // Set DurationFormat.prototype on constructor
         if let JsValue::Object(ctor_ref) = &duration_format_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -1773,7 +1776,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -1370,7 +1370,6 @@ impl Interpreter {
                         );
                 }
 
-                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
@@ -1381,7 +1380,6 @@ impl Interpreter {
         self.realm_mut().intl_duration_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -1745,7 +1743,6 @@ impl Interpreter {
                         fractional_digits,
                     });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -1140,7 +1140,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.DurationFormat".to_string();
 
@@ -1205,7 +1205,7 @@ impl Interpreter {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
                             part_obj.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -1261,7 +1261,7 @@ impl Interpreter {
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
                     result.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        Some(op_id);
                 }
 
                 let mut props: Vec<(&str, JsValue)> = vec![
@@ -1762,7 +1762,7 @@ impl Interpreter {
         self.realm_mut().intl_duration_format_ctor = Some(duration_format_ctor.clone());
 
         // Register Intl.DurationFormat on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "DurationFormat".to_string(),

--- a/src/interpreter/builtins/intl/listformat.rs
+++ b/src/interpreter/builtins/intl/listformat.rs
@@ -105,7 +105,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.ListFormat".to_string();
 
@@ -180,7 +180,7 @@ impl Interpreter {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
                             part_obj.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -225,7 +225,7 @@ impl Interpreter {
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
                     result.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        Some(op_id);
                 }
 
                 let props = vec![
@@ -369,7 +369,7 @@ impl Interpreter {
         );
 
         // Register Intl.ListFormat on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "ListFormat".to_string(),

--- a/src/interpreter/builtins/intl/listformat.rs
+++ b/src/interpreter/builtins/intl/listformat.rs
@@ -104,8 +104,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_list_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.ListFormat".to_string();
 
@@ -179,8 +178,7 @@ impl Interpreter {
                     .map(|(ptype, value)| {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id =
-                                Some(op_id);
+                            part_obj.borrow_mut().prototype_id = Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -224,8 +222,7 @@ impl Interpreter {
 
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id =
-                        Some(op_id);
+                    result.borrow_mut().prototype_id = Some(op_id);
                 }
 
                 let props = vec![

--- a/src/interpreter/builtins/intl/listformat.rs
+++ b/src/interpreter/builtins/intl/listformat.rs
@@ -101,7 +101,7 @@ fn format_list_to_parts(formatter: &ListFormatter, elements: &[String]) -> Vec<(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_list_format(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_list_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -369,10 +369,12 @@ impl Interpreter {
         );
 
         // Register Intl.ListFormat on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "ListFormat".to_string(),
-            PropertyDescriptor::data(list_format_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "ListFormat".to_string(),
+                PropertyDescriptor::data(list_format_ctor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/intl/listformat.rs
+++ b/src/interpreter/builtins/intl/listformat.rs
@@ -258,7 +258,6 @@ impl Interpreter {
                         );
                 }
 
-                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
@@ -269,7 +268,6 @@ impl Interpreter {
         self.realm_mut().intl_list_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -352,19 +350,21 @@ impl Interpreter {
                         style,
                     });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
 
         // Set ListFormat.prototype on constructor
         if let JsValue::Object(ctor_ref) = &list_format_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -383,7 +383,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 
@@ -410,9 +411,9 @@ fn extract_list_format_data(
     this: &JsValue,
 ) -> Result<(String, String, String), JsValue> {
     if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(cell) = interp.get_object_cell(o.id)
     {
-        let b = obj.borrow();
+        let b = cell.borrow();
         if let Some(IntlData::ListFormat {
             ref locale,
             ref list_type,

--- a/src/interpreter/builtins/intl/listformat.rs
+++ b/src/interpreter/builtins/intl/listformat.rs
@@ -102,24 +102,30 @@ fn format_list_to_parts(formatter: &ListFormatter, elements: &[String]) -> Vec<(
 
 impl Interpreter {
     pub(crate) fn setup_intl_list_format(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.ListFormat".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.ListFormat".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.ListFormat"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.ListFormat"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // format(list)
         let format_fn = self.create_function(JsFunction::native(
@@ -146,7 +152,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("format".to_string(), format_fn);
 
@@ -176,29 +182,38 @@ impl Interpreter {
                 let js_parts: Vec<JsValue> = parts
                     .into_iter()
                     .map(|(ptype, value)| {
-                        let part_obj = interp.create_object();
+                        let part_obj_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id = Some(op_id);
+                            interp
+                                .get_object_cell_expect(part_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(op_id);
                         }
-                        part_obj.borrow_mut().insert_property(
-                            "type".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&ptype)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        part_obj.borrow_mut().insert_property(
-                            "value".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&value)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        let id = part_obj.borrow().id.unwrap();
+                        interp
+                            .get_object_cell_expect(part_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "type".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&ptype)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        interp
+                            .get_object_cell_expect(part_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "value".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&value)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        let id = part_obj_id;
                         JsValue::Object(crate::types::JsObject { id })
                     })
                     .collect();
@@ -206,7 +221,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(js_parts))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatToParts".to_string(), format_to_parts_fn);
 
@@ -220,9 +235,12 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let result = interp.create_object();
+                let result_id = interp.create_object_id();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id = Some(op_id);
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .prototype_id = Some(op_id);
                 }
 
                 let props = vec![
@@ -231,26 +249,29 @@ impl Interpreter {
                     ("style", JsValue::String(JsString::from_str(&style))),
                 ];
                 for (key, val) in props {
-                    result.borrow_mut().insert_property(
-                        key.to_string(),
-                        PropertyDescriptor::data(val, true, true, true),
-                    );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            key.to_string(),
+                            PropertyDescriptor::data(val, true, true, true),
+                        );
                 }
 
-                let result_id = result.borrow().id.unwrap();
+                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_list_format_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_list_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let list_format_ctor = self.create_function(JsFunction::constructor(
             "ListFormat".to_string(),
@@ -315,16 +336,23 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.ListFormat".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::ListFormat {
-                    locale,
-                    list_type,
-                    style,
-                });
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Intl.ListFormat".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                    Some(IntlData::ListFormat {
+                        locale,
+                        list_type,
+                        style,
+                    });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -360,10 +388,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(list_format_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(list_format_ctor.clone(), true, false, true),
+            );
 
         // Register Intl.ListFormat on the Intl namespace
         self.get_object_cell_expect(intl_obj_id)

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -178,7 +178,7 @@ where
     F: FnOnce(&IntlData) -> Completion,
 {
     if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let b = obj.borrow();
         if let Some(ref data @ IntlData::Locale { .. }) = b.intl_data {
@@ -568,20 +568,23 @@ impl Interpreter {
             "maximize".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let tag = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let tag_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale { ref tag, .. }) = b.intl_data {
-                            tag.clone()
+                            Some(tag.clone())
                         } else {
+                            None
+                        }
+                    });
+                    let tag = match tag_opt {
+                        Some(t) => t,
+                        None => {
                             return Completion::Throw(interp.create_type_error(
                                 "Intl.Locale.prototype.maximize requires an Intl.Locale object",
                             ));
                         }
                     };
-
                     match tag.parse::<IcuLocale>() {
                         Ok(mut locale) => {
                             let expander = LocaleExpander::new_extended();
@@ -613,20 +616,23 @@ impl Interpreter {
             "minimize".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let tag = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let tag_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale { ref tag, .. }) = b.intl_data {
-                            tag.clone()
+                            Some(tag.clone())
                         } else {
+                            None
+                        }
+                    });
+                    let tag = match tag_opt {
+                        Some(t) => t,
+                        None => {
                             return Completion::Throw(interp.create_type_error(
                                 "Intl.Locale.prototype.minimize requires an Intl.Locale object",
                             ));
                         }
                     };
-
                     match tag.parse::<IcuLocale>() {
                         Ok(mut locale) => {
                             let expander = LocaleExpander::new_extended();
@@ -658,19 +664,22 @@ impl Interpreter {
             "getCalendars".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let cal = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let cal_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale { ref calendar, .. }) = b.intl_data {
-                            calendar.clone()
+                            Some(calendar.clone())
                         } else {
-                            return Completion::Throw(interp.create_type_error(
-                                "Intl.Locale.prototype.getCalendars requires an Intl.Locale object",
-                            ));
+                            None
                         }
-                    };
+                    });
+                    let cal =
+                        match cal_opt {
+                            Some(t) => t,
+                            None => return Completion::Throw(interp.create_type_error(
+                                "Intl.Locale.prototype.getCalendars requires an Intl.Locale object",
+                            )),
+                        };
                     let calendars = if let Some(ca) = cal {
                         vec![JsValue::String(JsString::from_str(&ca))]
                     } else {
@@ -692,18 +701,20 @@ impl Interpreter {
             "getCollations".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let col = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let col_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale { ref collation, .. }) = b.intl_data {
-                            collation.clone()
+                            Some(collation.clone())
                         } else {
-                            return Completion::Throw(interp.create_type_error(
-                                "Intl.Locale.prototype.getCollations requires an Intl.Locale object",
-                            ));
+                            None
                         }
+                    });
+                    let col = match col_opt {
+                        Some(t) => t,
+                        None => return Completion::Throw(interp.create_type_error(
+                            "Intl.Locale.prototype.getCollations requires an Intl.Locale object",
+                        )),
                     };
                     let collations = if let Some(co) = col {
                         if co == "standard" || co == "search" {
@@ -716,11 +727,9 @@ impl Interpreter {
                     };
                     return Completion::Normal(interp.create_array(collations));
                 }
-                Completion::Throw(
-                    interp.create_type_error(
-                        "Intl.Locale.prototype.getCollations requires an Intl.Locale object",
-                    ),
-                )
+                Completion::Throw(interp.create_type_error(
+                    "Intl.Locale.prototype.getCollations requires an Intl.Locale object",
+                ))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -732,19 +741,23 @@ impl Interpreter {
             "getHourCycles".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let (hc, region) = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let snapshot = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale {
                             ref hour_cycle,
                             ref region,
                             ..
                         }) = b.intl_data
                         {
-                            (hour_cycle.clone(), region.clone())
+                            Some((hour_cycle.clone(), region.clone()))
                         } else {
+                            None
+                        }
+                    });
+                    let (hc, region) = match snapshot {
+                        Some(t) => t,
+                        None => {
                             return Completion::Throw(interp.create_type_error(
                                 "Intl.Locale.prototype.getHourCycles requires an Intl.Locale object",
                             ));
@@ -779,18 +792,22 @@ impl Interpreter {
             "getNumberingSystems".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let nu = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let nu_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale {
                             ref numbering_system,
                             ..
                         }) = b.intl_data
                         {
-                            numbering_system.clone()
+                            Some(numbering_system.clone())
                         } else {
+                            None
+                        }
+                    });
+                    let nu = match nu_opt {
+                        Some(t) => t,
+                        None => {
                             return Completion::Throw(interp.create_type_error(
                                 "Intl.Locale.prototype.getNumberingSystems requires an Intl.Locale object",
                             ));
@@ -819,20 +836,22 @@ impl Interpreter {
             "getTextInfo".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let tag = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let tag_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale { ref tag, .. }) = b.intl_data {
-                            tag.clone()
+                            Some(tag.clone())
                         } else {
-                            return Completion::Throw(interp.create_type_error(
-                                "Intl.Locale.prototype.getTextInfo requires an Intl.Locale object",
-                            ));
+                            None
                         }
-                    };
-
+                    });
+                    let tag =
+                        match tag_opt {
+                            Some(t) => t,
+                            None => return Completion::Throw(interp.create_type_error(
+                                "Intl.Locale.prototype.getTextInfo requires an Intl.Locale object",
+                            )),
+                        };
                     let direction = if let Ok(locale) = tag.parse::<IcuLocale>() {
                         let ld = LocaleDirectionality::new_extended();
                         if ld.is_right_to_left(&locale.id) {
@@ -882,20 +901,22 @@ impl Interpreter {
             "getTimeZones".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let region = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let region_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale { ref region, .. }) = b.intl_data {
-                            region.clone()
+                            Some(region.clone())
                         } else {
-                            return Completion::Throw(interp.create_type_error(
-                                "Intl.Locale.prototype.getTimeZones requires an Intl.Locale object",
-                            ));
+                            None
                         }
-                    };
-
+                    });
+                    let region =
+                        match region_opt {
+                            Some(t) => t,
+                            None => return Completion::Throw(interp.create_type_error(
+                                "Intl.Locale.prototype.getTimeZones requires an Intl.Locale object",
+                            )),
+                        };
                     if region.is_none() {
                         return Completion::Normal(JsValue::Undefined);
                     }
@@ -922,19 +943,23 @@ impl Interpreter {
             "getWeekInfo".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let (tag, fw_value) = {
-                        let b = obj.borrow();
+                if let JsValue::Object(o) = this {
+                    let snapshot = interp.get_object_cell(o.id).and_then(|cell| {
+                        let b = cell.borrow();
                         if let Some(IntlData::Locale {
                             ref tag,
                             ref first_day_of_week,
                             ..
                         }) = b.intl_data
                         {
-                            (tag.clone(), first_day_of_week.clone())
+                            Some((tag.clone(), first_day_of_week.clone()))
                         } else {
+                            None
+                        }
+                    });
+                    let (tag, fw_value) = match snapshot {
+                        Some(t) => t,
+                        None => {
                             return Completion::Throw(interp.create_type_error(
                                 "Intl.Locale.prototype.getWeekInfo requires an Intl.Locale object",
                             ));
@@ -1060,7 +1085,7 @@ impl Interpreter {
 
                 // If tag_arg is an Intl.Locale, get its tag string
                 let tag_string = if let JsValue::Object(o) = &tag_arg {
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         let b = obj.borrow();
                         if let Some(IntlData::Locale { ref tag, .. }) = b.intl_data {
                             tag.clone()
@@ -1440,12 +1465,15 @@ impl Interpreter {
 
         // Set Locale.prototype on constructor
         if let JsValue::Object(ctor_ref) = &locale_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -1464,7 +1492,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -165,7 +165,6 @@ fn create_locale_object_from_icu(interp: &mut Interpreter, locale: &IcuLocale) -
         .class_name = "Intl.Locale".to_string();
     interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
         Some(build_intl_data_from_locale(locale));
-    let obj_id = obj_id;
     JsValue::Object(crate::types::JsObject { id: obj_id })
 }
 
@@ -1034,7 +1033,6 @@ impl Interpreter {
         self.realm_mut().intl_locale_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -1417,7 +1415,6 @@ impl Interpreter {
                             numbering_system: None,
                             first_day_of_week: None,
                         });
-                    let obj_id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
                 } else {
                     // Canonicalize again after applying options
@@ -1436,7 +1433,6 @@ impl Interpreter {
                         .class_name = "Intl.Locale".to_string();
                     interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
                         Some(build_intl_data_from_locale(&locale));
-                    let obj_id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
                 }
             },

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -152,13 +152,20 @@ fn build_intl_data_from_locale(locale: &IcuLocale) -> IntlData {
 }
 
 fn create_locale_object_from_icu(interp: &mut Interpreter, locale: &IcuLocale) -> JsValue {
-    let obj = interp.create_object();
+    let obj_id = interp.create_object_id();
     if let Some(proto_id) = interp.realm().intl_locale_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().class_name = "Intl.Locale".to_string();
-    obj.borrow_mut().intl_data = Some(build_intl_data_from_locale(locale));
-    let obj_id = obj.borrow().id.unwrap();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Intl.Locale".to_string();
+    interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+        Some(build_intl_data_from_locale(locale));
+    let obj_id = obj_id;
     JsValue::Object(crate::types::JsObject { id: obj_id })
 }
 
@@ -187,24 +194,30 @@ where
 
 impl Interpreter {
     pub(crate) fn setup_intl_locale(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.Locale".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.Locale".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.Locale"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.Locale"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // --- Getter accessors ---
 
@@ -242,10 +255,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "baseName".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "baseName".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // calendar
         let getter = self.create_function(JsFunction::native(
@@ -264,10 +279,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "calendar".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "calendar".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // caseFirst
         let getter = self.create_function(JsFunction::native(
@@ -286,10 +303,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "caseFirst".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "caseFirst".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // collation
         let getter = self.create_function(JsFunction::native(
@@ -308,10 +327,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "collation".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "collation".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // hourCycle
         let getter = self.create_function(JsFunction::native(
@@ -330,10 +351,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "hourCycle".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "hourCycle".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // language
         let getter = self.create_function(JsFunction::native(
@@ -349,10 +372,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "language".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "language".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // numberingSystem
         let getter = self.create_function(JsFunction::native(
@@ -374,10 +399,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "numberingSystem".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "numberingSystem".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // numeric
         let getter = self.create_function(JsFunction::native(
@@ -393,10 +420,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "numeric".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "numeric".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // region
         let getter = self.create_function(JsFunction::native(
@@ -415,10 +444,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "region".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "region".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // script
         let getter = self.create_function(JsFunction::native(
@@ -437,10 +468,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "script".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "script".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // variants
         let getter = self.create_function(JsFunction::native(
@@ -459,10 +492,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "variants".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "variants".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // firstDayOfWeek
         let getter = self.create_function(JsFunction::native(
@@ -484,10 +519,12 @@ impl Interpreter {
                 })
             },
         ));
-        proto.borrow_mut().insert_property(
-            "firstDayOfWeek".to_string(),
-            PropertyDescriptor::accessor(Some(getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "firstDayOfWeek".to_string(),
+                PropertyDescriptor::accessor(Some(getter), None, false, true),
+            );
 
         // --- Prototype methods ---
 
@@ -505,7 +542,7 @@ impl Interpreter {
                 })
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), to_string_fn);
 
@@ -523,7 +560,7 @@ impl Interpreter {
                 })
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toJSON".to_string(), to_json_fn);
 
@@ -568,7 +605,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("maximize".to_string(), maximize_fn);
 
@@ -611,7 +648,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("minimize".to_string(), minimize_fn);
 
@@ -647,7 +684,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getCalendars".to_string(), get_calendars_fn);
 
@@ -687,7 +724,7 @@ impl Interpreter {
                 )
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getCollations".to_string(), get_collations_fn);
 
@@ -734,7 +771,7 @@ impl Interpreter {
                 )
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getHourCycles".to_string(), get_hour_cycles_fn);
 
@@ -774,7 +811,7 @@ impl Interpreter {
                 )
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getNumberingSystems".to_string(), get_numbering_systems_fn);
 
@@ -808,20 +845,26 @@ impl Interpreter {
                         "ltr"
                     };
 
-                    let info_obj = interp.create_object();
+                    let info_obj_id = interp.create_object_id();
                     if let Some(op_id) = interp.realm().object_prototype {
-                        info_obj.borrow_mut().prototype_id = Some(op_id);
+                        interp
+                            .get_object_cell_expect(info_obj_id)
+                            .borrow_mut()
+                            .prototype_id = Some(op_id);
                     }
-                    info_obj.borrow_mut().insert_property(
-                        "direction".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(direction)),
-                            true,
-                            true,
-                            true,
-                        ),
-                    );
-                    let info_id = info_obj.borrow().id.unwrap();
+                    interp
+                        .get_object_cell_expect(info_obj_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "direction".to_string(),
+                            PropertyDescriptor::data(
+                                JsValue::String(JsString::from_str(direction)),
+                                true,
+                                true,
+                                true,
+                            ),
+                        );
+                    let info_id = info_obj_id;
                     return Completion::Normal(JsValue::Object(crate::types::JsObject {
                         id: info_id,
                     }));
@@ -831,7 +874,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getTextInfo".to_string(), get_text_info_fn);
 
@@ -871,7 +914,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getTimeZones".to_string(), get_time_zones_fn);
 
@@ -942,29 +985,38 @@ impl Interpreter {
                     }
                     weekend_days.sort();
 
-                    let info_obj = interp.create_object();
+                    let info_obj_id = interp.create_object_id();
                     if let Some(op_id) = interp.realm().object_prototype {
-                        info_obj.borrow_mut().prototype_id = Some(op_id);
+                        interp
+                            .get_object_cell_expect(info_obj_id)
+                            .borrow_mut()
+                            .prototype_id = Some(op_id);
                     }
-                    info_obj.borrow_mut().insert_property(
-                        "firstDay".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::Number(first_day as f64),
-                            true,
-                            true,
-                            true,
-                        ),
-                    );
+                    interp
+                        .get_object_cell_expect(info_obj_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "firstDay".to_string(),
+                            PropertyDescriptor::data(
+                                JsValue::Number(first_day as f64),
+                                true,
+                                true,
+                                true,
+                            ),
+                        );
                     let weekend_values: Vec<JsValue> = weekend_days
                         .iter()
                         .map(|&d| JsValue::Number(d as f64))
                         .collect();
                     let weekend_arr = interp.create_array(weekend_values);
-                    info_obj.borrow_mut().insert_property(
-                        "weekend".to_string(),
-                        PropertyDescriptor::data(weekend_arr, true, true, true),
-                    );
-                    let info_id = info_obj.borrow().id.unwrap();
+                    interp
+                        .get_object_cell_expect(info_obj_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "weekend".to_string(),
+                            PropertyDescriptor::data(weekend_arr, true, true, true),
+                        );
+                    let info_id = info_obj_id;
                     return Completion::Normal(JsValue::Object(crate::types::JsObject {
                         id: info_id,
                     }));
@@ -974,17 +1026,17 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("getWeekInfo".to_string(), get_week_info_fn);
 
         // Store the prototype
-        self.realm_mut().intl_locale_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_locale_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let locale_ctor = self.create_function(JsFunction::constructor(
             "Locale".to_string(),
@@ -1340,25 +1392,32 @@ impl Interpreter {
                 };
 
                 if is_fallback_tag {
-                    let obj = interp.create_object();
-                    obj.borrow_mut().prototype_id = Some(locale_proto);
-                    obj.borrow_mut().class_name = "Intl.Locale".to_string();
+                    let obj_id = interp.create_object_id();
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(locale_proto);
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .class_name = "Intl.Locale".to_string();
                     let lower_tag = tag_string.to_ascii_lowercase();
-                    obj.borrow_mut().intl_data = Some(IntlData::Locale {
-                        tag: lower_tag.clone(),
-                        language: lower_tag,
-                        script: None,
-                        region: None,
-                        variants: None,
-                        calendar: None,
-                        collation: None,
-                        hour_cycle: None,
-                        case_first: None,
-                        numeric: None,
-                        numbering_system: None,
-                        first_day_of_week: None,
-                    });
-                    let obj_id = obj.borrow().id.unwrap();
+                    interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                        Some(IntlData::Locale {
+                            tag: lower_tag.clone(),
+                            language: lower_tag,
+                            script: None,
+                            region: None,
+                            variants: None,
+                            calendar: None,
+                            collation: None,
+                            hour_cycle: None,
+                            case_first: None,
+                            numeric: None,
+                            numbering_system: None,
+                            first_day_of_week: None,
+                        });
+                    let obj_id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
                 } else {
                     // Canonicalize again after applying options
@@ -1366,11 +1425,18 @@ impl Interpreter {
                     canonicalizer.canonicalize(&mut locale);
                     canonicalize_unicode_keyword_values(&mut locale);
 
-                    let obj = interp.create_object();
-                    obj.borrow_mut().prototype_id = Some(locale_proto);
-                    obj.borrow_mut().class_name = "Intl.Locale".to_string();
-                    obj.borrow_mut().intl_data = Some(build_intl_data_from_locale(&locale));
-                    let obj_id = obj.borrow().id.unwrap();
+                    let obj_id = interp.create_object_id();
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(locale_proto);
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .class_name = "Intl.Locale".to_string();
+                    interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                        Some(build_intl_data_from_locale(&locale));
+                    let obj_id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
                 }
             },
@@ -1407,10 +1473,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(locale_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(locale_ctor.clone(), true, false, true),
+            );
 
         // Register Intl.Locale on the Intl namespace
         self.get_object_cell_expect(intl_obj_id)

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -154,8 +154,7 @@ fn build_intl_data_from_locale(locale: &IcuLocale) -> IntlData {
 fn create_locale_object_from_icu(interp: &mut Interpreter, locale: &IcuLocale) -> JsValue {
     let obj = interp.create_object();
     if let Some(proto_id) = interp.realm().intl_locale_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().class_name = "Intl.Locale".to_string();
     obj.borrow_mut().intl_data = Some(build_intl_data_from_locale(locale));
@@ -190,8 +189,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_locale(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.Locale".to_string();
 
@@ -812,8 +810,7 @@ impl Interpreter {
 
                     let info_obj = interp.create_object();
                     if let Some(op_id) = interp.realm().object_prototype {
-                        info_obj.borrow_mut().prototype_id =
-                            Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        info_obj.borrow_mut().prototype_id = Some(op_id);
                     }
                     info_obj.borrow_mut().insert_property(
                         "direction".to_string(),
@@ -947,8 +944,7 @@ impl Interpreter {
 
                     let info_obj = interp.create_object();
                     if let Some(op_id) = interp.realm().object_prototype {
-                        info_obj.borrow_mut().prototype_id =
-                            Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        info_obj.borrow_mut().prototype_id = Some(op_id);
                     }
                     info_obj.borrow_mut().insert_property(
                         "firstDay".to_string(),
@@ -1417,7 +1413,7 @@ impl Interpreter {
         );
 
         // Register Intl.Locale on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "Locale".to_string(),

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -187,7 +187,7 @@ where
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_locale(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_locale(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -1417,10 +1417,12 @@ impl Interpreter {
         );
 
         // Register Intl.Locale on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "Locale".to_string(),
-            PropertyDescriptor::data(locale_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "Locale".to_string(),
+                PropertyDescriptor::data(locale_ctor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -318,7 +318,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("Intl", BindingKind::Var);
-        let _ = self.realm().global_env.borrow_mut().set("Intl", intl_val);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "Intl", intl_val);
     }
 
     pub(crate) fn is_structurally_valid_language_tag(tag: &str) -> bool {

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -289,8 +289,6 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("supportedValuesOf".to_string(), svo_fn);
 
-        let intl_obj_id = intl_obj_id;
-
         // Intl.Locale
         self.setup_intl_locale(intl_obj_id);
 
@@ -469,9 +467,9 @@ impl Interpreter {
 
         // Check if locales is an Intl.Locale object itself (treat as single-element list)
         if let JsValue::Object(o) = locales
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(cell) = self.get_object_cell(o.id)
         {
-            let b = obj.borrow();
+            let b = cell.borrow();
             if let Some(IntlData::Locale { ref tag, .. }) = b.intl_data {
                 let tag_clone = tag.clone();
                 drop(b);
@@ -543,14 +541,15 @@ impl Interpreter {
 
             // Step 7c.iii-iv: If kValue has [[InitializedLocale]], use [[Locale]] directly
             let tag = if let JsValue::Object(o) = &k_value {
-                if let Some(obj_data) = self.get_object(o.id) {
-                    let b = obj_data.borrow();
-                    if let Some(IntlData::Locale { ref tag, .. }) = b.intl_data {
-                        tag.clone()
+                let cached = self.get_object_cell(o.id).and_then(|cell| {
+                    if let Some(IntlData::Locale { ref tag, .. }) = cell.borrow().intl_data {
+                        Some(tag.clone())
                     } else {
-                        drop(b);
-                        self.to_string_value(&k_value)?
+                        None
                     }
+                });
+                if let Some(tag) = cached {
+                    tag
                 } else {
                     self.to_string_value(&k_value)?
                 }

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -283,35 +283,37 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("supportedValuesOf".to_string(), svo_fn);
 
+        let intl_obj_id = intl_obj.borrow().id.unwrap();
+
         // Intl.Locale
-        self.setup_intl_locale(&intl_obj);
+        self.setup_intl_locale(intl_obj_id);
 
         // Intl.Collator
-        self.setup_intl_collator(&intl_obj);
+        self.setup_intl_collator(intl_obj_id);
 
         // Intl.NumberFormat
-        self.setup_intl_number_format(&intl_obj);
+        self.setup_intl_number_format(intl_obj_id);
 
         // Intl.PluralRules
-        self.setup_intl_plural_rules(&intl_obj);
+        self.setup_intl_plural_rules(intl_obj_id);
 
         // Intl.ListFormat
-        self.setup_intl_list_format(&intl_obj);
+        self.setup_intl_list_format(intl_obj_id);
 
         // Intl.RelativeTimeFormat
-        self.setup_intl_relative_time_format(&intl_obj);
+        self.setup_intl_relative_time_format(intl_obj_id);
 
         // Intl.Segmenter
-        self.setup_intl_segmenter(&intl_obj);
+        self.setup_intl_segmenter(intl_obj_id);
 
         // Intl.DisplayNames
-        self.setup_intl_display_names(&intl_obj);
+        self.setup_intl_display_names(intl_obj_id);
 
         // Intl.DateTimeFormat
-        self.setup_intl_date_time_format(&intl_obj);
+        self.setup_intl_date_time_format(intl_obj_id);
 
         // Intl.DurationFormat
-        self.setup_intl_duration_format(&intl_obj);
+        self.setup_intl_duration_format(intl_obj_id);
 
         let intl_val = JsValue::Object(crate::types::JsObject { id: intl_id });
         self.realm()

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -15,8 +15,8 @@ use icu::locale::LocaleCanonicalizer;
 
 impl Interpreter {
     pub(crate) fn setup_intl(&mut self) {
-        let intl_obj = self.create_object();
-        let intl_id = intl_obj.borrow().id.unwrap();
+        let intl_obj_id = self.create_object_id();
+        let intl_id = intl_obj_id;
 
         // @@toStringTag = "Intl" (per spec 8.1.1)
         {
@@ -29,8 +29,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            intl_obj.borrow_mut().property_order.push(key.clone());
-            intl_obj.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(intl_obj_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(intl_obj_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Intl.getCanonicalLocales(locales)
@@ -51,7 +57,7 @@ impl Interpreter {
                 }
             },
         ));
-        intl_obj
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_builtin("getCanonicalLocales".to_string(), gcl_fn);
 
@@ -279,11 +285,11 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(js_values))
             },
         ));
-        intl_obj
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_builtin("supportedValuesOf".to_string(), svo_fn);
 
-        let intl_obj_id = intl_obj.borrow().id.unwrap();
+        let intl_obj_id = intl_obj_id;
 
         // Intl.Locale
         self.setup_intl_locale(intl_obj_id);
@@ -585,17 +591,19 @@ impl Interpreter {
         options: &JsValue,
     ) -> Result<JsValue, JsValue> {
         if matches!(options, JsValue::Undefined) {
-            let obj = self.create_object();
-            obj.borrow_mut().prototype_id = None; // ObjectCreate(null)
-            let id = obj.borrow().id.unwrap();
+            let obj_id = self.create_object_id();
+            self.get_object_cell_expect(obj_id)
+                .borrow_mut()
+                .prototype_id = None; // ObjectCreate(null)
+            let id = obj_id;
             return Ok(JsValue::Object(crate::types::JsObject { id }));
         }
         match self.to_object(options) {
             Completion::Normal(v) => Ok(v),
             Completion::Throw(e) => Err(e),
             _ => {
-                let obj = self.create_object();
-                let id = obj.borrow().id.unwrap();
+                let obj_id = self.create_object_id();
+                let id = obj_id;
                 Ok(JsValue::Object(crate::types::JsObject { id }))
             }
         }
@@ -607,9 +615,11 @@ impl Interpreter {
         options: &JsValue,
     ) -> Result<JsValue, JsValue> {
         if matches!(options, JsValue::Undefined) {
-            let obj = self.create_object();
-            obj.borrow_mut().prototype_id = None;
-            let id = obj.borrow().id.unwrap();
+            let obj_id = self.create_object_id();
+            self.get_object_cell_expect(obj_id)
+                .borrow_mut()
+                .prototype_id = None;
+            let id = obj_id;
             return Ok(JsValue::Object(crate::types::JsObject { id }));
         }
         if matches!(options, JsValue::Object(_)) {

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -3639,7 +3639,6 @@ impl Interpreter {
                                 );
                         }
 
-                        let result_id = result_id;
                         return Completion::Normal(JsValue::Object(crate::types::JsObject {
                             id: result_id,
                         }));
@@ -3657,7 +3656,6 @@ impl Interpreter {
         self.realm_mut().intl_number_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -4384,7 +4382,6 @@ impl Interpreter {
                     trailing_zero_display,
                 });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -2935,26 +2935,40 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this {
-                    if let Some(obj) = interp.get_object(o.id) {
-                        let cached = {
-                            let b = obj.borrow();
+                    enum Probe {
+                        NotNf,
+                        Cached(JsValue),
+                        Uncached,
+                    }
+                    let probe = interp
+                        .get_object_cell(o.id)
+                        .map(|cell| {
+                            let b = cell.borrow();
                             if !matches!(b.intl_data, Some(IntlData::NumberFormat { .. })) {
-                                return Completion::Throw(interp.create_type_error(
-                                    "Intl.NumberFormat.prototype.format called on incompatible receiver",
-                                ));
-                            }
-                            b.properties
+                                Probe::NotNf
+                            } else if let Some(func) = b
+                                .properties
                                 .get("[[BoundFormat]]")
                                 .and_then(|pd| pd.value.clone())
-                        };
-
-                        if let Some(func) = cached {
-                            return Completion::Normal(func);
+                            {
+                                Probe::Cached(func)
+                            } else {
+                                Probe::Uncached
+                            }
+                        })
+                        .unwrap_or(Probe::Uncached);
+                    match probe {
+                        Probe::NotNf => {
+                            return Completion::Throw(interp.create_type_error(
+                                "Intl.NumberFormat.prototype.format called on incompatible receiver",
+                            ));
                         }
+                        Probe::Cached(func) => return Completion::Normal(func),
+                        Probe::Uncached => {}
                     }
 
                     let nf_data = {
-                        if let Some(obj) = interp.get_object(o.id) {
+                        if let Some(obj) = interp.get_object_cell(o.id) {
                             let b = obj.borrow();
                             b.intl_data.clone()
                         } else {
@@ -3033,7 +3047,7 @@ impl Interpreter {
                             },
                         ));
 
-                        if let Some(obj) = interp.get_object(o.id) {
+                        if let Some(obj) = interp.get_object_cell(o.id) {
                             obj.borrow_mut().properties.insert(
                                 "[[BoundFormat]]".to_string(),
                                 PropertyDescriptor::data(format_fn.clone(), false, false, false),
@@ -3062,7 +3076,7 @@ impl Interpreter {
             |interp, this, args| {
                 if let JsValue::Object(o) = this {
                     let nf_data = {
-                        if let Some(obj) = interp.get_object(o.id) {
+                        if let Some(obj) = interp.get_object_cell(o.id) {
                             let b = obj.borrow();
                             b.intl_data.clone()
                         } else {
@@ -3181,36 +3195,38 @@ impl Interpreter {
             "formatRange".to_string(),
             2,
             |interp, this, args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id) {
-                        let has_nf = {
-                            let b = obj.borrow();
-                            matches!(b.intl_data, Some(IntlData::NumberFormat { .. }))
-                        };
-                        if !has_nf {
-                            return Completion::Throw(interp.create_type_error(
-                                "Intl.NumberFormat.prototype.formatRange called on incompatible receiver",
-                            ));
-                        }
-
+                if let JsValue::Object(o) = this {
+                    let nf_present = interp.get_object_cell(o.id).is_some_and(|cell| {
+                        matches!(cell.borrow().intl_data, Some(IntlData::NumberFormat { .. }))
+                    });
+                    if nf_present {
                         let start = args.first().cloned().unwrap_or(JsValue::Undefined);
                         let end = args.get(1).cloned().unwrap_or(JsValue::Undefined);
 
-                        if matches!(start, JsValue::Undefined) || matches!(end, JsValue::Undefined) {
-                            return Completion::Throw(interp.create_type_error(
-                                "start and end must not be undefined",
-                            ));
+                        if matches!(start, JsValue::Undefined) || matches!(end, JsValue::Undefined)
+                        {
+                            return Completion::Throw(
+                                interp.create_type_error("start and end must not be undefined"),
+                            );
                         }
 
                         let start_str = if let JsValue::String(s) = &start {
                             let sv = s.to_string();
-                            if string_needs_decimal_precision(&sv) { Some(sv) } else { None }
+                            if string_needs_decimal_precision(&sv) {
+                                Some(sv)
+                            } else {
+                                None
+                            }
                         } else {
                             None
                         };
                         let end_str = if let JsValue::String(s) = &end {
                             let sv = s.to_string();
-                            if string_needs_decimal_precision(&sv) { Some(sv) } else { None }
+                            if string_needs_decimal_precision(&sv) {
+                                Some(sv)
+                            } else {
+                                None
+                            }
                         } else {
                             None
                         };
@@ -3230,10 +3246,9 @@ impl Interpreter {
                             );
                         }
 
-                        let nf_data = {
-                            let b = obj.borrow();
-                            b.intl_data.clone()
-                        };
+                        let nf_data = interp
+                            .get_object_cell(o.id)
+                            .and_then(|cell| cell.borrow().intl_data.clone());
 
                         if let Some(IntlData::NumberFormat {
                             locale,
@@ -3261,50 +3276,106 @@ impl Interpreter {
                         {
                             let fmt_start = if let Some(ref s) = start_str {
                                 format_number_from_string_decimal(
-                                    s, &locale, &style, &currency, &currency_display,
-                                    &currency_sign, &unit, &unit_display, &sign_display,
-                                    &use_grouping, minimum_integer_digits, minimum_fraction_digits,
-                                    maximum_fraction_digits, &numbering_system,
+                                    s,
+                                    &locale,
+                                    &style,
+                                    &currency,
+                                    &currency_display,
+                                    &currency_sign,
+                                    &unit,
+                                    &unit_display,
+                                    &sign_display,
+                                    &use_grouping,
+                                    minimum_integer_digits,
+                                    minimum_fraction_digits,
+                                    maximum_fraction_digits,
+                                    &numbering_system,
                                 )
                             } else {
                                 format_number_internal(
-                                    x, &locale, &style, &currency, &currency_display,
-                                    &currency_sign, &unit, &unit_display, &notation,
-                                    &compact_display, &sign_display, &use_grouping,
-                                    minimum_integer_digits, minimum_fraction_digits,
-                                    maximum_fraction_digits, &minimum_significant_digits,
-                                    &maximum_significant_digits, &rounding_mode, rounding_increment,
-                                    &rounding_priority, &trailing_zero_display, &numbering_system,
+                                    x,
+                                    &locale,
+                                    &style,
+                                    &currency,
+                                    &currency_display,
+                                    &currency_sign,
+                                    &unit,
+                                    &unit_display,
+                                    &notation,
+                                    &compact_display,
+                                    &sign_display,
+                                    &use_grouping,
+                                    minimum_integer_digits,
+                                    minimum_fraction_digits,
+                                    maximum_fraction_digits,
+                                    &minimum_significant_digits,
+                                    &maximum_significant_digits,
+                                    &rounding_mode,
+                                    rounding_increment,
+                                    &rounding_priority,
+                                    &trailing_zero_display,
+                                    &numbering_system,
                                 )
                             };
                             let fmt_end = if let Some(ref s) = end_str {
                                 format_number_from_string_decimal(
-                                    s, &locale, &style, &currency, &currency_display,
-                                    &currency_sign, &unit, &unit_display, &sign_display,
-                                    &use_grouping, minimum_integer_digits, minimum_fraction_digits,
-                                    maximum_fraction_digits, &numbering_system,
+                                    s,
+                                    &locale,
+                                    &style,
+                                    &currency,
+                                    &currency_display,
+                                    &currency_sign,
+                                    &unit,
+                                    &unit_display,
+                                    &sign_display,
+                                    &use_grouping,
+                                    minimum_integer_digits,
+                                    minimum_fraction_digits,
+                                    maximum_fraction_digits,
+                                    &numbering_system,
                                 )
                             } else {
                                 format_number_internal(
-                                    y, &locale, &style, &currency, &currency_display,
-                                    &currency_sign, &unit, &unit_display, &notation,
-                                    &compact_display, &sign_display, &use_grouping,
-                                    minimum_integer_digits, minimum_fraction_digits,
-                                    maximum_fraction_digits, &minimum_significant_digits,
-                                    &maximum_significant_digits, &rounding_mode, rounding_increment,
-                                    &rounding_priority, &trailing_zero_display, &numbering_system,
+                                    y,
+                                    &locale,
+                                    &style,
+                                    &currency,
+                                    &currency_display,
+                                    &currency_sign,
+                                    &unit,
+                                    &unit_display,
+                                    &notation,
+                                    &compact_display,
+                                    &sign_display,
+                                    &use_grouping,
+                                    minimum_integer_digits,
+                                    minimum_fraction_digits,
+                                    maximum_fraction_digits,
+                                    &minimum_significant_digits,
+                                    &maximum_significant_digits,
+                                    &rounding_mode,
+                                    rounding_increment,
+                                    &rounding_priority,
+                                    &trailing_zero_display,
+                                    &numbering_system,
                                 )
                             };
 
                             let result = format_range_string(
-                                &fmt_start, &fmt_end, &locale, &style,
-                                &currency, &currency_display, &sign_display,
+                                &fmt_start,
+                                &fmt_end,
+                                &locale,
+                                &style,
+                                &currency,
+                                &currency_display,
+                                &sign_display,
                             );
                             return Completion::Normal(JsValue::String(JsString::from_str(
                                 &result,
                             )));
                         }
                     }
+                }
                 Completion::Throw(interp.create_type_error(
                     "Intl.NumberFormat.prototype.formatRange called on incompatible receiver",
                 ))
@@ -3319,18 +3390,11 @@ impl Interpreter {
             "formatRangeToParts".to_string(),
             2,
             |interp, this, args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id) {
-                        let has_nf = {
-                            let b = obj.borrow();
-                            matches!(b.intl_data, Some(IntlData::NumberFormat { .. }))
-                        };
-                        if !has_nf {
-                            return Completion::Throw(interp.create_type_error(
-                                "Intl.NumberFormat.prototype.formatRangeToParts called on incompatible receiver",
-                            ));
-                        }
-
+                if let JsValue::Object(o) = this {
+                    let nf_present = interp
+                        .get_object_cell(o.id)
+                        .is_some_and(|cell| matches!(cell.borrow().intl_data, Some(IntlData::NumberFormat { .. })));
+                    if nf_present {
                         let start = args.first().cloned().unwrap_or(JsValue::Undefined);
                         let end = args.get(1).cloned().unwrap_or(JsValue::Undefined);
 
@@ -3355,10 +3419,9 @@ impl Interpreter {
                             );
                         }
 
-                        let nf_data = {
-                            let b = obj.borrow();
-                            b.intl_data.clone()
-                        };
+                        let nf_data = interp
+                            .get_object_cell(o.id)
+                            .and_then(|cell| cell.borrow().intl_data.clone());
 
                         if let Some(IntlData::NumberFormat {
                             locale,
@@ -3476,6 +3539,7 @@ impl Interpreter {
                             return Completion::Normal(interp.create_array(result_parts));
                         }
                     }
+                }
                 Completion::Throw(interp.create_type_error(
                     "Intl.NumberFormat.prototype.formatRangeToParts called on incompatible receiver",
                 ))
@@ -3491,7 +3555,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -4388,12 +4452,15 @@ impl Interpreter {
 
         // Set NumberFormat.prototype on constructor
         if let JsValue::Object(ctor_ref) = &nf_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -4412,7 +4479,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -2904,24 +2904,30 @@ pub(crate) fn format_to_parts_internal(
 
 impl Interpreter {
     pub(crate) fn setup_intl_number_format(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.NumberFormat".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.NumberFormat".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.NumberFormat"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.NumberFormat"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // format getter
         let format_getter = self.create_function(JsFunction::native(
@@ -3042,10 +3048,12 @@ impl Interpreter {
                 ))
             },
         ));
-        proto.borrow_mut().insert_property(
-            "format".to_string(),
-            PropertyDescriptor::accessor(Some(format_getter), None, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "format".to_string(),
+                PropertyDescriptor::accessor(Some(format_getter), None, false, true),
+            );
 
         // formatToParts(number)
         let format_to_parts_fn = self.create_function(JsFunction::native(
@@ -3120,29 +3128,38 @@ impl Interpreter {
                         let result_parts: Vec<JsValue> = parts
                             .into_iter()
                             .map(|(typ, val)| {
-                                let part_obj = interp.create_object();
+                                let part_obj_id = interp.create_object_id();
                                 if let Some(op_id) = interp.realm().object_prototype {
-                                    part_obj.borrow_mut().prototype_id = Some(op_id);
+                                    interp
+                                        .get_object_cell_expect(part_obj_id)
+                                        .borrow_mut()
+                                        .prototype_id = Some(op_id);
                                 }
-                                part_obj.borrow_mut().insert_property(
-                                    "type".to_string(),
-                                    PropertyDescriptor::data(
-                                        JsValue::String(JsString::from_str(&typ)),
-                                        true,
-                                        true,
-                                        true,
-                                    ),
-                                );
-                                part_obj.borrow_mut().insert_property(
-                                    "value".to_string(),
-                                    PropertyDescriptor::data(
-                                        JsValue::String(JsString::from_str(&val)),
-                                        true,
-                                        true,
-                                        true,
-                                    ),
-                                );
-                                let id = part_obj.borrow().id.unwrap();
+                                interp
+                                    .get_object_cell_expect(part_obj_id)
+                                    .borrow_mut()
+                                    .insert_property(
+                                        "type".to_string(),
+                                        PropertyDescriptor::data(
+                                            JsValue::String(JsString::from_str(&typ)),
+                                            true,
+                                            true,
+                                            true,
+                                        ),
+                                    );
+                                interp
+                                    .get_object_cell_expect(part_obj_id)
+                                    .borrow_mut()
+                                    .insert_property(
+                                        "value".to_string(),
+                                        PropertyDescriptor::data(
+                                            JsValue::String(JsString::from_str(&val)),
+                                            true,
+                                            true,
+                                            true,
+                                        ),
+                                    );
+                                let id = part_obj_id;
                                 JsValue::Object(crate::types::JsObject { id })
                             })
                             .collect();
@@ -3155,7 +3172,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatToParts".to_string(), format_to_parts_fn);
 
@@ -3293,7 +3310,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatRange".to_string(), format_range_fn);
 
@@ -3389,23 +3406,23 @@ impl Interpreter {
                             let approximately_equal = fmt_start == fmt_end;
 
                             let make_part = |interp: &mut Interpreter, typ: &str, val: &str, source: &str| -> JsValue {
-                                let part = interp.create_object();
+                                let part_id = interp.create_object_id();
                                 if let Some(op_id) = interp.realm().object_prototype {
-                                    part.borrow_mut().prototype_id = Some(op_id);
+                                    interp.get_object_cell_expect(part_id).borrow_mut().prototype_id = Some(op_id);
                                 }
-                                part.borrow_mut().insert_property(
+                                interp.get_object_cell_expect(part_id).borrow_mut().insert_property(
                                     "type".to_string(),
                                     PropertyDescriptor::data(JsValue::String(JsString::from_str(typ)), true, true, true),
                                 );
-                                part.borrow_mut().insert_property(
+                                interp.get_object_cell_expect(part_id).borrow_mut().insert_property(
                                     "value".to_string(),
                                     PropertyDescriptor::data(JsValue::String(JsString::from_str(val)), true, true, true),
                                 );
-                                part.borrow_mut().insert_property(
+                                interp.get_object_cell_expect(part_id).borrow_mut().insert_property(
                                     "source".to_string(),
                                     PropertyDescriptor::data(JsValue::String(JsString::from_str(source)), true, true, true),
                                 );
-                                let id = part.borrow().id.unwrap();
+                                let id = part_id;
                                 JsValue::Object(crate::types::JsObject { id })
                             };
 
@@ -3464,7 +3481,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatRangeToParts".to_string(), format_range_to_parts_fn);
 
@@ -3504,9 +3521,12 @@ impl Interpreter {
                         trailing_zero_display,
                     }) = data
                     {
-                        let result = interp.create_object();
+                        let result_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            result.borrow_mut().prototype_id = Some(op_id);
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .prototype_id = Some(op_id);
                         }
 
                         let mut props: Vec<(&str, JsValue)> = vec![
@@ -3610,13 +3630,16 @@ impl Interpreter {
                         ));
 
                         for (key, val) in props {
-                            result.borrow_mut().insert_property(
-                                key.to_string(),
-                                PropertyDescriptor::data(val, true, true, true),
-                            );
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .insert_property(
+                                    key.to_string(),
+                                    PropertyDescriptor::data(val, true, true, true),
+                                );
                         }
 
-                        let result_id = result.borrow().id.unwrap();
+                        let result_id = result_id;
                         return Completion::Normal(JsValue::Object(crate::types::JsObject {
                             id: result_id,
                         }));
@@ -3627,16 +3650,16 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_number_format_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_number_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let nf_ctor = self.create_function(JsFunction::constructor(
             "NumberFormat".to_string(),
@@ -4334,10 +4357,10 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.NumberFormat".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::NumberFormat {
+                let obj_id = interp.create_object_id();
+                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
+                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "Intl.NumberFormat".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data = Some(IntlData::NumberFormat {
                     locale,
                     numbering_system,
                     style,
@@ -4361,7 +4384,7 @@ impl Interpreter {
                     trailing_zero_display,
                 });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -4397,10 +4420,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(nf_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(nf_ctor.clone(), true, false, true),
+            );
 
         // Save built-in constructor for internal use (e.g. toLocaleString)
         self.realm_mut().intl_number_format_ctor = Some(nf_ctor.clone());

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -2907,7 +2907,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.NumberFormat".to_string();
 
@@ -3392,7 +3392,7 @@ impl Interpreter {
                             let make_part = |interp: &mut Interpreter, typ: &str, val: &str, source: &str| -> JsValue {
                                 let part = interp.create_object();
                                 if let Some(op_id) = interp.realm().object_prototype {
-                                    part.borrow_mut().prototype_id = Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                    part.borrow_mut().prototype_id = Some(op_id);
                                 }
                                 part.borrow_mut().insert_property(
                                     "type".to_string(),
@@ -3508,7 +3508,7 @@ impl Interpreter {
                         let result = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
                             result.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                Some(op_id);
                         }
 
                         let mut props: Vec<(&str, JsValue)> = vec![
@@ -4408,7 +4408,7 @@ impl Interpreter {
         self.realm_mut().intl_number_format_ctor = Some(nf_ctor.clone());
 
         // Register Intl.NumberFormat on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "NumberFormat".to_string(),

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -2903,7 +2903,7 @@ pub(crate) fn format_to_parts_internal(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_number_format(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_number_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -4408,9 +4408,11 @@ impl Interpreter {
         self.realm_mut().intl_number_format_ctor = Some(nf_ctor.clone());
 
         // Register Intl.NumberFormat on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "NumberFormat".to_string(),
-            PropertyDescriptor::data(nf_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "NumberFormat".to_string(),
+                PropertyDescriptor::data(nf_ctor, true, false, true),
+            );
     }
 }

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -2906,8 +2906,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_number_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.NumberFormat".to_string();
 
@@ -3507,8 +3506,7 @@ impl Interpreter {
                     {
                         let result = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            result.borrow_mut().prototype_id =
-                                Some(op_id);
+                            result.borrow_mut().prototype_id = Some(op_id);
                         }
 
                         let mut props: Vec<(&str, JsValue)> = vec![

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -150,7 +150,7 @@ fn get_plural_categories_sorted(locale_str: &str, plural_type: &str) -> Vec<&'st
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_plural_rules(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_plural_rules(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -1011,9 +1011,11 @@ impl Interpreter {
         );
 
         // Register Intl.PluralRules on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "PluralRules".to_string(),
-            PropertyDescriptor::data(ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "PluralRules".to_string(),
+                PropertyDescriptor::data(ctor, true, false, true),
+            );
     }
 }

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -182,7 +182,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -249,7 +249,7 @@ impl Interpreter {
             2,
             |interp, this, args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -331,7 +331,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -1025,12 +1025,15 @@ impl Interpreter {
 
         // Set PluralRules.prototype on constructor
         if let JsValue::Object(ctor_ref) = &ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -1049,7 +1052,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -153,8 +153,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_plural_rules(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.PluralRules".to_string();
 
@@ -349,8 +348,7 @@ impl Interpreter {
                     {
                         let result = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            result.borrow_mut().prototype_id =
-                                Some(op_id);
+                            result.borrow_mut().prototype_id = Some(op_id);
                         }
 
                         // Spec order: locale, type, notation, minimumIntegerDigits,

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -563,7 +563,6 @@ impl Interpreter {
                                 ),
                             );
 
-                        let result_id = result_id;
                         return Completion::Normal(JsValue::Object(crate::types::JsObject {
                             id: result_id,
                         }));
@@ -581,7 +580,6 @@ impl Interpreter {
         self.realm_mut().intl_plural_rules_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -1021,7 +1019,6 @@ impl Interpreter {
                     trailing_zero_display,
                 });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -154,7 +154,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.PluralRules".to_string();
 
@@ -350,7 +350,7 @@ impl Interpreter {
                         let result = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
                             result.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                Some(op_id);
                         }
 
                         // Spec order: locale, type, notation, minimumIntegerDigits,
@@ -1011,7 +1011,7 @@ impl Interpreter {
         );
 
         // Register Intl.PluralRules on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "PluralRules".to_string(),

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -151,24 +151,30 @@ fn get_plural_categories_sorted(locale_str: &str, plural_type: &str) -> Vec<&'st
 
 impl Interpreter {
     pub(crate) fn setup_intl_plural_rules(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.PluralRules".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.PluralRules".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.PluralRules"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.PluralRules"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // select(value)
         let select_fn = self.create_function(JsFunction::native(
@@ -233,7 +239,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("select".to_string(), select_fn);
 
@@ -315,7 +321,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("selectRange".to_string(), select_range_fn);
 
@@ -346,9 +352,12 @@ impl Interpreter {
                         trailing_zero_display,
                     }) = data
                     {
-                        let result = interp.create_object();
+                        let result_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            result.borrow_mut().prototype_id = Some(op_id);
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .prototype_id = Some(op_id);
                         }
 
                         // Spec order: locale, type, notation, minimumIntegerDigits,
@@ -356,67 +365,61 @@ impl Interpreter {
                         // pluralCategories, roundingIncrement, roundingMode,
                         // roundingPriority, trailingZeroDisplay
 
-                        result.borrow_mut().insert_property(
-                            "locale".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&locale)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        result.borrow_mut().insert_property(
-                            "type".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&plural_type)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        result.borrow_mut().insert_property(
-                            "notation".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&notation)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        result.borrow_mut().insert_property(
-                            "minimumIntegerDigits".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::Number(minimum_integer_digits as f64),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "locale".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&locale)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "type".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&plural_type)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "notation".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&notation)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "minimumIntegerDigits".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::Number(minimum_integer_digits as f64),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
 
                         if minimum_significant_digits.is_none() {
                             // Only show fraction digits when no significant digits
-                            result.borrow_mut().insert_property(
-                                "minimumFractionDigits".to_string(),
-                                PropertyDescriptor::data(
-                                    JsValue::Number(minimum_fraction_digits as f64),
-                                    true,
-                                    true,
-                                    true,
-                                ),
-                            );
-                            result.borrow_mut().insert_property(
-                                "maximumFractionDigits".to_string(),
-                                PropertyDescriptor::data(
-                                    JsValue::Number(maximum_fraction_digits as f64),
-                                    true,
-                                    true,
-                                    true,
-                                ),
-                            );
-                        } else {
-                            // Both specified (morePrecision/lessPrecision) - show both
-                            if rounding_priority != "auto" {
-                                result.borrow_mut().insert_property(
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .insert_property(
                                     "minimumFractionDigits".to_string(),
                                     PropertyDescriptor::data(
                                         JsValue::Number(minimum_fraction_digits as f64),
@@ -425,7 +428,10 @@ impl Interpreter {
                                         true,
                                     ),
                                 );
-                                result.borrow_mut().insert_property(
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .insert_property(
                                     "maximumFractionDigits".to_string(),
                                     PropertyDescriptor::data(
                                         JsValue::Number(maximum_fraction_digits as f64),
@@ -434,30 +440,63 @@ impl Interpreter {
                                         true,
                                     ),
                                 );
+                        } else {
+                            // Both specified (morePrecision/lessPrecision) - show both
+                            if rounding_priority != "auto" {
+                                interp
+                                    .get_object_cell_expect(result_id)
+                                    .borrow_mut()
+                                    .insert_property(
+                                        "minimumFractionDigits".to_string(),
+                                        PropertyDescriptor::data(
+                                            JsValue::Number(minimum_fraction_digits as f64),
+                                            true,
+                                            true,
+                                            true,
+                                        ),
+                                    );
+                                interp
+                                    .get_object_cell_expect(result_id)
+                                    .borrow_mut()
+                                    .insert_property(
+                                        "maximumFractionDigits".to_string(),
+                                        PropertyDescriptor::data(
+                                            JsValue::Number(maximum_fraction_digits as f64),
+                                            true,
+                                            true,
+                                            true,
+                                        ),
+                                    );
                             }
                         }
 
                         if let Some(min_sd) = minimum_significant_digits {
-                            result.borrow_mut().insert_property(
-                                "minimumSignificantDigits".to_string(),
-                                PropertyDescriptor::data(
-                                    JsValue::Number(min_sd as f64),
-                                    true,
-                                    true,
-                                    true,
-                                ),
-                            );
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .insert_property(
+                                    "minimumSignificantDigits".to_string(),
+                                    PropertyDescriptor::data(
+                                        JsValue::Number(min_sd as f64),
+                                        true,
+                                        true,
+                                        true,
+                                    ),
+                                );
                         }
                         if let Some(max_sd) = maximum_significant_digits {
-                            result.borrow_mut().insert_property(
-                                "maximumSignificantDigits".to_string(),
-                                PropertyDescriptor::data(
-                                    JsValue::Number(max_sd as f64),
-                                    true,
-                                    true,
-                                    true,
-                                ),
-                            );
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .insert_property(
+                                    "maximumSignificantDigits".to_string(),
+                                    PropertyDescriptor::data(
+                                        JsValue::Number(max_sd as f64),
+                                        true,
+                                        true,
+                                        true,
+                                    ),
+                                );
                         }
 
                         // pluralCategories
@@ -467,49 +506,64 @@ impl Interpreter {
                             .map(|c| JsValue::String(JsString::from_str(c)))
                             .collect();
                         let cat_array = interp.create_array(cat_values);
-                        result.borrow_mut().insert_property(
-                            "pluralCategories".to_string(),
-                            PropertyDescriptor::data(cat_array, true, true, true),
-                        );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "pluralCategories".to_string(),
+                                PropertyDescriptor::data(cat_array, true, true, true),
+                            );
 
-                        result.borrow_mut().insert_property(
-                            "roundingIncrement".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::Number(rounding_increment as f64),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        result.borrow_mut().insert_property(
-                            "roundingMode".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&rounding_mode)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        result.borrow_mut().insert_property(
-                            "roundingPriority".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&rounding_priority)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        result.borrow_mut().insert_property(
-                            "trailingZeroDisplay".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&trailing_zero_display)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "roundingIncrement".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::Number(rounding_increment as f64),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "roundingMode".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&rounding_mode)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "roundingPriority".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&rounding_priority)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        interp
+                            .get_object_cell_expect(result_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "trailingZeroDisplay".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&trailing_zero_display)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
 
-                        let result_id = result.borrow().id.unwrap();
+                        let result_id = result_id;
                         return Completion::Normal(JsValue::Object(crate::types::JsObject {
                             id: result_id,
                         }));
@@ -520,16 +574,16 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_plural_rules_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_plural_rules_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let ctor = self.create_function(JsFunction::constructor(
             "PluralRules".to_string(),
@@ -949,10 +1003,10 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.PluralRules".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::PluralRules {
+                let obj_id = interp.create_object_id();
+                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
+                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "Intl.PluralRules".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data = Some(IntlData::PluralRules {
                     locale,
                     plural_type,
                     notation,
@@ -967,7 +1021,7 @@ impl Interpreter {
                     trailing_zero_display,
                 });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -1003,10 +1057,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(ctor.clone(), true, false, true),
+            );
 
         // Register Intl.PluralRules on the Intl namespace
         self.get_object_cell_expect(intl_obj_id)

--- a/src/interpreter/builtins/intl/relativetimeformat.rs
+++ b/src/interpreter/builtins/intl/relativetimeformat.rs
@@ -440,9 +440,9 @@ fn extract_rtf_data(
     this: &JsValue,
 ) -> Result<(String, String, String, String), JsValue> {
     if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(cell) = interp.get_object_cell(o.id)
     {
-        let b = obj.borrow();
+        let b = cell.borrow();
         if let Some(IntlData::RelativeTimeFormat {
             ref locale,
             ref style,
@@ -680,7 +680,6 @@ impl Interpreter {
                         );
                 }
 
-                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
@@ -691,7 +690,6 @@ impl Interpreter {
         self.realm_mut().intl_relative_time_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -869,19 +867,21 @@ impl Interpreter {
                         numbering_system,
                     });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
 
         // Set RelativeTimeFormat.prototype on constructor
         if let JsValue::Object(ctor_ref) = &rtf_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -900,7 +900,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/relativetimeformat.rs
+++ b/src/interpreter/builtins/intl/relativetimeformat.rs
@@ -466,7 +466,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.RelativeTimeFormat".to_string();
 
@@ -583,7 +583,7 @@ impl Interpreter {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
                             part_obj.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -640,7 +640,7 @@ impl Interpreter {
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
                     result.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        Some(op_id);
                 }
 
                 let props = vec![
@@ -883,7 +883,7 @@ impl Interpreter {
         );
 
         // Register Intl.RelativeTimeFormat on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "RelativeTimeFormat".to_string(),

--- a/src/interpreter/builtins/intl/relativetimeformat.rs
+++ b/src/interpreter/builtins/intl/relativetimeformat.rs
@@ -462,7 +462,7 @@ fn extract_rtf_data(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_relative_time_format(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_relative_time_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -883,9 +883,11 @@ impl Interpreter {
         );
 
         // Register Intl.RelativeTimeFormat on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "RelativeTimeFormat".to_string(),
-            PropertyDescriptor::data(rtf_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "RelativeTimeFormat".to_string(),
+                PropertyDescriptor::data(rtf_ctor, true, false, true),
+            );
     }
 }

--- a/src/interpreter/builtins/intl/relativetimeformat.rs
+++ b/src/interpreter/builtins/intl/relativetimeformat.rs
@@ -465,8 +465,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_relative_time_format(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.RelativeTimeFormat".to_string();
 
@@ -582,8 +581,7 @@ impl Interpreter {
                     .map(|(ptype, pvalue, punit)| {
                         let part_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id =
-                                Some(op_id);
+                            part_obj.borrow_mut().prototype_id = Some(op_id);
                         }
                         part_obj.borrow_mut().insert_property(
                             "type".to_string(),
@@ -639,8 +637,7 @@ impl Interpreter {
 
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id =
-                        Some(op_id);
+                    result.borrow_mut().prototype_id = Some(op_id);
                 }
 
                 let props = vec![

--- a/src/interpreter/builtins/intl/relativetimeformat.rs
+++ b/src/interpreter/builtins/intl/relativetimeformat.rs
@@ -463,26 +463,32 @@ fn extract_rtf_data(
 
 impl Interpreter {
     pub(crate) fn setup_intl_relative_time_format(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.RelativeTimeFormat".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.RelativeTimeFormat".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str(
-                    "Intl.RelativeTimeFormat",
-                ))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str(
+                        "Intl.RelativeTimeFormat",
+                    ))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // format(value, unit)
         let format_fn =
@@ -528,7 +534,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&result)))
                 },
             ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("format".to_string(), format_fn);
 
@@ -579,40 +585,52 @@ impl Interpreter {
                 let js_parts: Vec<JsValue> = parts_data
                     .into_iter()
                     .map(|(ptype, pvalue, punit)| {
-                        let part_obj = interp.create_object();
+                        let part_obj_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            part_obj.borrow_mut().prototype_id = Some(op_id);
+                            interp
+                                .get_object_cell_expect(part_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(op_id);
                         }
-                        part_obj.borrow_mut().insert_property(
-                            "type".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&ptype)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        part_obj.borrow_mut().insert_property(
-                            "value".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&pvalue)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
-                        if let Some(u) = punit {
-                            part_obj.borrow_mut().insert_property(
-                                "unit".to_string(),
+                        interp
+                            .get_object_cell_expect(part_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "type".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&u)),
+                                    JsValue::String(JsString::from_str(&ptype)),
                                     true,
                                     true,
                                     true,
                                 ),
                             );
+                        interp
+                            .get_object_cell_expect(part_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "value".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&pvalue)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
+                        if let Some(u) = punit {
+                            interp
+                                .get_object_cell_expect(part_obj_id)
+                                .borrow_mut()
+                                .insert_property(
+                                    "unit".to_string(),
+                                    PropertyDescriptor::data(
+                                        JsValue::String(JsString::from_str(&u)),
+                                        true,
+                                        true,
+                                        true,
+                                    ),
+                                );
                         }
-                        let id = part_obj.borrow().id.unwrap();
+                        let id = part_obj_id;
                         JsValue::Object(crate::types::JsObject { id })
                     })
                     .collect();
@@ -620,7 +638,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(js_parts))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("formatToParts".to_string(), format_to_parts_fn);
 
@@ -635,9 +653,12 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
 
-                let result = interp.create_object();
+                let result_id = interp.create_object_id();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id = Some(op_id);
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .prototype_id = Some(op_id);
                 }
 
                 let props = vec![
@@ -650,26 +671,29 @@ impl Interpreter {
                     ),
                 ];
                 for (key, val) in props {
-                    result.borrow_mut().insert_property(
-                        key.to_string(),
-                        PropertyDescriptor::data(val, true, true, true),
-                    );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            key.to_string(),
+                            PropertyDescriptor::data(val, true, true, true),
+                        );
                 }
 
-                let result_id = result.borrow().id.unwrap();
+                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_relative_time_format_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_relative_time_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let rtf_ctor = self.create_function(JsFunction::constructor(
             "RelativeTimeFormat".to_string(),
@@ -828,17 +852,24 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.RelativeTimeFormat".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::RelativeTimeFormat {
-                    locale,
-                    style,
-                    numeric,
-                    numbering_system,
-                });
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Intl.RelativeTimeFormat".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                    Some(IntlData::RelativeTimeFormat {
+                        locale,
+                        style,
+                        numeric,
+                        numbering_system,
+                    });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -874,10 +905,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(rtf_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(rtf_ctor.clone(), true, false, true),
+            );
 
         // Register Intl.RelativeTimeFormat on the Intl namespace
         self.get_object_cell_expect(intl_obj_id)

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -147,7 +147,7 @@ fn extract_segmenter_data(
     this: &JsValue,
 ) -> Result<(String, String), JsValue> {
     if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let b = obj.borrow();
         if let Some(IntlData::Segmenter {
@@ -269,7 +269,7 @@ impl Interpreter {
                     |interp, this, args| {
                         // RequireInternalSlot(segments, [[SegmentsSegmenter]])
                         let is_segments = if let JsValue::Object(o) = this {
-                            if let Some(obj) = interp.get_object(o.id) {
+                            if let Some(obj) = interp.get_object_cell(o.id) {
                                 let b = obj.borrow();
                                 b.class_name == "Segmenter Segments"
                                     && b.properties.contains_key("[[SegmenterInput]]")
@@ -304,7 +304,7 @@ impl Interpreter {
                         let idx = idx as usize;
 
                         let (input_u16, granularity, breaks) = if let JsValue::Object(o) = this {
-                            if let Some(obj) = interp.get_object(o.id) {
+                            if let Some(obj) = interp.get_object_cell(o.id) {
                                 let b = obj.borrow();
                                 let input_u16 = b
                                     .properties
@@ -336,7 +336,7 @@ impl Interpreter {
 
                                 let mut break_points = Vec::new();
                                 if let Some(JsValue::Object(arr_obj)) = breaks_val
-                                    && let Some(arr) = interp.get_object(arr_obj.id)
+                                    && let Some(arr) = interp.get_object_cell(arr_obj.id)
                                 {
                                     let ab = arr.borrow();
                                     if let Some(elems) = &ab.array_elements {
@@ -453,26 +453,57 @@ impl Interpreter {
                             0,
                             |interp, this, _args| {
                                 if let JsValue::Object(o) = this
-                                    && let Some(obj) = interp.get_object(o.id)
+                                    && interp.get_object_cell(o.id).is_some()
                                 {
-                                    let has_word_like = {
-                                        let b = obj.borrow();
-                                        b.properties
+                                    let iter_id = o.id;
+                                    enum Step {
+                                        Done,
+                                        Yield {
+                                            seg: Vec<u16>,
+                                            idx: usize,
+                                            input: std::rc::Rc<Vec<u16>>,
+                                            wl: bool,
+                                            has_word_like: bool,
+                                        },
+                                        NotIter,
+                                    }
+                                    let step = {
+                                        let cell = interp.get_object_cell_expect(iter_id);
+                                        let has_word_like = cell
+                                            .borrow()
+                                            .properties
                                             .get("[[HasWordLike]]")
                                             .and_then(|pd| pd.value.as_ref())
                                             .map(|v| matches!(v, JsValue::Boolean(true)))
-                                            .unwrap_or(false)
+                                            .unwrap_or(false);
+                                        let mut b = cell.borrow_mut();
+                                        if let Some(IteratorState::SegmentIterator {
+                                            ref mut segments,
+                                            ref input,
+                                            ref mut position,
+                                            ref mut done,
+                                        }) = b.iterator_state
+                                        {
+                                            if *done || *position >= segments.len() {
+                                                *done = true;
+                                                Step::Done
+                                            } else {
+                                                let (seg, idx, wl) = segments[*position].clone();
+                                                *position += 1;
+                                                Step::Yield {
+                                                    seg,
+                                                    idx,
+                                                    input: input.clone(),
+                                                    wl,
+                                                    has_word_like,
+                                                }
+                                            }
+                                        } else {
+                                            Step::NotIter
+                                        }
                                     };
-
-                                    if let Some(IteratorState::SegmentIterator {
-                                        ref mut segments,
-                                        ref input,
-                                        ref mut position,
-                                        ref mut done,
-                                    }) = obj.borrow_mut().iterator_state
-                                    {
-                                        if *done || *position >= segments.len() {
-                                            *done = true;
+                                    match step {
+                                        Step::Done => {
                                             return Completion::Normal(
                                                 interp.create_iter_result_object(
                                                     JsValue::Undefined,
@@ -480,23 +511,27 @@ impl Interpreter {
                                                 ),
                                             );
                                         }
-
-                                        let (seg, idx, wl) = segments[*position].clone();
-                                        *position += 1;
-
-                                        let is_word_like =
-                                            if has_word_like { Some(wl) } else { None };
-                                        let seg_obj = create_segment_object(
-                                            interp,
-                                            &seg,
+                                        Step::Yield {
+                                            seg,
                                             idx,
                                             input,
-                                            is_word_like,
-                                        );
-
-                                        return Completion::Normal(
-                                            interp.create_iter_result_object(seg_obj, false),
-                                        );
+                                            wl,
+                                            has_word_like,
+                                        } => {
+                                            let is_word_like =
+                                                if has_word_like { Some(wl) } else { None };
+                                            let seg_obj = create_segment_object(
+                                                interp,
+                                                &seg,
+                                                idx,
+                                                &input,
+                                                is_word_like,
+                                            );
+                                            return Completion::Normal(
+                                                interp.create_iter_result_object(seg_obj, false),
+                                            );
+                                        }
+                                        Step::NotIter => {}
                                     }
                                 }
                                 Completion::Normal(
@@ -651,12 +686,15 @@ impl Interpreter {
 
         // Set Segmenter.prototype on constructor
         if let JsValue::Object(ctor_ref) = &segmenter_ctor
-            && let Some(obj) = self.get_object(ctor_ref.id)
+            && self.get_object_cell(ctor_ref.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(proto_val.clone(), false, false, false),
-            );
+            let ctor_id = ctor_ref.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(proto_val.clone(), false, false, false),
+                );
 
             // supportedLocalesOf static method
             let slof = self.create_function(JsFunction::native(
@@ -675,7 +713,8 @@ impl Interpreter {
                     }
                 },
             ));
-            obj.borrow_mut()
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
                 .insert_builtin("supportedLocalesOf".to_string(), slof);
         }
 

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -91,39 +91,54 @@ fn create_segment_object(
     input: &[u16],
     is_word_like: Option<bool>,
 ) -> JsValue {
-    let obj = interp.create_object();
+    let obj_id = interp.create_object_id();
     if let Some(op_id) = interp.realm().object_prototype {
-        obj.borrow_mut().prototype_id = Some(op_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(op_id);
     }
-    obj.borrow_mut().insert_property(
-        "segment".to_string(),
-        PropertyDescriptor::data(
-            JsValue::String(JsString::from_vec(segment.to_vec())),
-            true,
-            true,
-            true,
-        ),
-    );
-    obj.borrow_mut().insert_property(
-        "index".to_string(),
-        PropertyDescriptor::data(JsValue::Number(index as f64), true, true, true),
-    );
-    obj.borrow_mut().insert_property(
-        "input".to_string(),
-        PropertyDescriptor::data(
-            JsValue::String(JsString::from_vec(input.to_vec())),
-            true,
-            true,
-            true,
-        ),
-    );
-    if let Some(wl) = is_word_like {
-        obj.borrow_mut().insert_property(
-            "isWordLike".to_string(),
-            PropertyDescriptor::data(JsValue::Boolean(wl), true, true, true),
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .insert_property(
+            "segment".to_string(),
+            PropertyDescriptor::data(
+                JsValue::String(JsString::from_vec(segment.to_vec())),
+                true,
+                true,
+                true,
+            ),
         );
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .insert_property(
+            "index".to_string(),
+            PropertyDescriptor::data(JsValue::Number(index as f64), true, true, true),
+        );
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .insert_property(
+            "input".to_string(),
+            PropertyDescriptor::data(
+                JsValue::String(JsString::from_vec(input.to_vec())),
+                true,
+                true,
+                true,
+            ),
+        );
+    if let Some(wl) = is_word_like {
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .insert_property(
+                "isWordLike".to_string(),
+                PropertyDescriptor::data(JsValue::Boolean(wl), true, true, true),
+            );
     }
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     JsValue::Object(crate::types::JsObject { id })
 }
 
@@ -148,24 +163,30 @@ fn extract_segmenter_data(
 
 impl Interpreter {
     pub(crate) fn setup_intl_segmenter(&mut self, intl_obj_id: u64) {
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id = Some(op_id);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .prototype_id = Some(op_id);
         }
-        proto.borrow_mut().class_name = "Intl.Segmenter".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Intl.Segmenter".to_string();
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl.Segmenter"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: Some(JsValue::String(JsString::from_str("Intl.Segmenter"))),
+                    writable: Some(false),
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                    get: None,
+                    set: None,
+                },
+            );
 
         // segment(string)
         let segment_fn = self.create_function(JsFunction::native(
@@ -186,42 +207,60 @@ impl Interpreter {
 
                 let breaks = compute_break_points_utf16(&input_u16, &granularity);
 
-                let segments_obj = interp.create_object();
+                let segments_obj_id = interp.create_object_id();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    segments_obj.borrow_mut().prototype_id = Some(op_id);
+                    interp
+                        .get_object_cell_expect(segments_obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(op_id);
                 }
-                segments_obj.borrow_mut().class_name = "Segmenter Segments".to_string();
+                interp
+                    .get_object_cell_expect(segments_obj_id)
+                    .borrow_mut()
+                    .class_name = "Segmenter Segments".to_string();
 
-                segments_obj.borrow_mut().insert_property(
-                    "[[SegmenterInput]]".to_string(),
-                    PropertyDescriptor::data(JsValue::String(input_js), false, false, false),
-                );
-                segments_obj.borrow_mut().insert_property(
-                    "[[SegmenterGranularity]]".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str(&granularity)),
-                        false,
-                        false,
-                        false,
-                    ),
-                );
-                segments_obj.borrow_mut().insert_property(
-                    "[[SegmenterLocale]]".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str(&locale)),
-                        false,
-                        false,
-                        false,
-                    ),
-                );
+                interp
+                    .get_object_cell_expect(segments_obj_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "[[SegmenterInput]]".to_string(),
+                        PropertyDescriptor::data(JsValue::String(input_js), false, false, false),
+                    );
+                interp
+                    .get_object_cell_expect(segments_obj_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "[[SegmenterGranularity]]".to_string(),
+                        PropertyDescriptor::data(
+                            JsValue::String(JsString::from_str(&granularity)),
+                            false,
+                            false,
+                            false,
+                        ),
+                    );
+                interp
+                    .get_object_cell_expect(segments_obj_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "[[SegmenterLocale]]".to_string(),
+                        PropertyDescriptor::data(
+                            JsValue::String(JsString::from_str(&locale)),
+                            false,
+                            false,
+                            false,
+                        ),
+                    );
 
                 let breaks_vals: Vec<JsValue> =
                     breaks.iter().map(|&b| JsValue::Number(b as f64)).collect();
                 let breaks_arr = interp.create_array(breaks_vals);
-                segments_obj.borrow_mut().insert_property(
-                    "[[SegmenterBreaks]]".to_string(),
-                    PropertyDescriptor::data(breaks_arr, false, false, false),
-                );
+                interp
+                    .get_object_cell_expect(segments_obj_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "[[SegmenterBreaks]]".to_string(),
+                        PropertyDescriptor::data(breaks_arr, false, false, false),
+                    );
 
                 // containing(index) method
                 let containing_fn = interp.create_function(JsFunction::native(
@@ -354,7 +393,8 @@ impl Interpreter {
                         ))
                     },
                 ));
-                segments_obj
+                interp
+                    .get_object_cell_expect(segments_obj_id)
                     .borrow_mut()
                     .insert_builtin("containing".to_string(), containing_fn);
 
@@ -371,31 +411,42 @@ impl Interpreter {
                             .map(|s| (s.segment, s.index, s.is_word_like.unwrap_or(false)))
                             .collect();
 
-                        let iter_obj = interp.create_object();
+                        let iter_obj_id = interp.create_object_id();
                         if let Some(ip_id) = interp.realm().iterator_prototype {
-                            iter_obj.borrow_mut().prototype_id = Some(ip_id);
+                            interp
+                                .get_object_cell_expect(iter_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(ip_id);
                         }
-                        iter_obj.borrow_mut().class_name = "Segmenter String Iterator".to_string();
+                        interp
+                            .get_object_cell_expect(iter_obj_id)
+                            .borrow_mut()
+                            .class_name = "Segmenter String Iterator".to_string();
 
                         let has_word_like = granularity_clone == "word";
 
-                        iter_obj.borrow_mut().iterator_state =
-                            Some(IteratorState::SegmentIterator {
-                                segments: seg_data,
-                                input: std::rc::Rc::new(input_clone.as_ref().clone()),
-                                position: 0,
-                                done: false,
-                            });
+                        interp
+                            .get_object_cell_expect(iter_obj_id)
+                            .borrow_mut()
+                            .iterator_state = Some(IteratorState::SegmentIterator {
+                            segments: seg_data,
+                            input: std::rc::Rc::new(input_clone.as_ref().clone()),
+                            position: 0,
+                            done: false,
+                        });
 
-                        iter_obj.borrow_mut().insert_property(
-                            "[[HasWordLike]]".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::Boolean(has_word_like),
-                                false,
-                                false,
-                                false,
-                            ),
-                        );
+                        interp
+                            .get_object_cell_expect(iter_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "[[HasWordLike]]".to_string(),
+                                PropertyDescriptor::data(
+                                    JsValue::Boolean(has_word_like),
+                                    false,
+                                    false,
+                                    false,
+                                ),
+                            );
 
                         let next_fn = interp.create_function(JsFunction::native(
                             "next".to_string(),
@@ -453,25 +504,29 @@ impl Interpreter {
                                 )
                             },
                         ));
-                        iter_obj
+                        interp
+                            .get_object_cell_expect(iter_obj_id)
                             .borrow_mut()
                             .insert_builtin("next".to_string(), next_fn);
 
-                        let iter_id = iter_obj.borrow().id.unwrap();
+                        let iter_id = iter_obj_id;
                         Completion::Normal(JsValue::Object(crate::types::JsObject { id: iter_id }))
                     },
                 ));
 
-                segments_obj.borrow_mut().insert_property(
-                    "Symbol(Symbol.iterator)".to_string(),
-                    PropertyDescriptor::data(iter_fn, true, false, true),
-                );
+                interp
+                    .get_object_cell_expect(segments_obj_id)
+                    .borrow_mut()
+                    .insert_property(
+                        "Symbol(Symbol.iterator)".to_string(),
+                        PropertyDescriptor::data(iter_fn, true, false, true),
+                    );
 
-                let segments_id = segments_obj.borrow().id.unwrap();
+                let segments_id = segments_obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: segments_id }))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("segment".to_string(), segment_fn);
 
@@ -485,9 +540,12 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let result = interp.create_object();
+                let result_id = interp.create_object_id();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id = Some(op_id);
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .prototype_id = Some(op_id);
                 }
 
                 let props = vec![
@@ -498,26 +556,29 @@ impl Interpreter {
                     ),
                 ];
                 for (key, val) in props {
-                    result.borrow_mut().insert_property(
-                        key.to_string(),
-                        PropertyDescriptor::data(val, true, true, true),
-                    );
+                    interp
+                        .get_object_cell_expect(result_id)
+                        .borrow_mut()
+                        .insert_property(
+                            key.to_string(),
+                            PropertyDescriptor::data(val, true, true, true),
+                        );
                 }
 
-                let result_id = result.borrow().id.unwrap();
+                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("resolvedOptions".to_string(), resolved_fn);
 
-        self.realm_mut().intl_segmenter_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().intl_segmenter_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-        let proto_clone_id = proto.borrow().id.unwrap();
+        let proto_clone_id = proto_id;
 
         let segmenter_ctor = self.create_function(JsFunction::constructor(
             "Segmenter".to_string(),
@@ -571,15 +632,22 @@ impl Interpreter {
                     Ok(p) => p.unwrap_or(proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = Some(proto);
-                obj.borrow_mut().class_name = "Intl.Segmenter".to_string();
-                obj.borrow_mut().intl_data = Some(IntlData::Segmenter {
-                    locale,
-                    granularity,
-                });
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Intl.Segmenter".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().intl_data =
+                    Some(IntlData::Segmenter {
+                        locale,
+                        granularity,
+                    });
 
-                let obj_id = obj.borrow().id.unwrap();
+                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
@@ -615,10 +683,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(segmenter_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(segmenter_ctor.clone(), true, false, true),
+            );
 
         // Register Intl.Segmenter on the Intl namespace
         self.get_object_cell_expect(intl_obj_id)

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -565,7 +565,6 @@ impl Interpreter {
                         );
                 }
 
-                let result_id = result_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
             },
         ));
@@ -576,7 +575,6 @@ impl Interpreter {
         self.realm_mut().intl_segmenter_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
         let proto_clone_id = proto_id;
 
@@ -647,7 +645,6 @@ impl Interpreter {
                         granularity,
                     });
 
-                let obj_id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -147,7 +147,7 @@ fn extract_segmenter_data(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_intl_segmenter(&mut self, intl_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_intl_segmenter(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
@@ -625,9 +625,11 @@ impl Interpreter {
         );
 
         // Register Intl.Segmenter on the Intl namespace
-        intl_obj.borrow_mut().insert_property(
-            "Segmenter".to_string(),
-            PropertyDescriptor::data(segmenter_ctor, true, false, true),
-        );
+        self.get_object_expect(intl_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "Segmenter".to_string(),
+                PropertyDescriptor::data(segmenter_ctor, true, false, true),
+            );
     }
 }

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -93,7 +93,7 @@ fn create_segment_object(
 ) -> JsValue {
     let obj = interp.create_object();
     if let Some(op_id) = interp.realm().object_prototype {
-        obj.borrow_mut().prototype_id = Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+        obj.borrow_mut().prototype_id = Some(op_id);
     }
     obj.borrow_mut().insert_property(
         "segment".to_string(),
@@ -151,7 +151,7 @@ impl Interpreter {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
             proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(op_id).borrow().id.unwrap());
+                Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.Segmenter".to_string();
 
@@ -190,7 +190,7 @@ impl Interpreter {
                 let segments_obj = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
                     segments_obj.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        Some(op_id);
                 }
                 segments_obj.borrow_mut().class_name = "Segmenter Segments".to_string();
 
@@ -491,7 +491,7 @@ impl Interpreter {
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
                     result.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                        Some(op_id);
                 }
 
                 let props = vec![
@@ -625,7 +625,7 @@ impl Interpreter {
         );
 
         // Register Intl.Segmenter on the Intl namespace
-        self.get_object_expect(intl_obj_id)
+        self.get_object_cell_expect(intl_obj_id)
             .borrow_mut()
             .insert_property(
                 "Segmenter".to_string(),

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -150,8 +150,7 @@ impl Interpreter {
     pub(crate) fn setup_intl_segmenter(&mut self, intl_obj_id: u64) {
         let proto = self.create_object();
         if let Some(op_id) = self.realm().object_prototype {
-            proto.borrow_mut().prototype_id =
-                Some(op_id);
+            proto.borrow_mut().prototype_id = Some(op_id);
         }
         proto.borrow_mut().class_name = "Intl.Segmenter".to_string();
 
@@ -189,8 +188,7 @@ impl Interpreter {
 
                 let segments_obj = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    segments_obj.borrow_mut().prototype_id =
-                        Some(op_id);
+                    segments_obj.borrow_mut().prototype_id = Some(op_id);
                 }
                 segments_obj.borrow_mut().class_name = "Segmenter Segments".to_string();
 
@@ -375,8 +373,7 @@ impl Interpreter {
 
                         let iter_obj = interp.create_object();
                         if let Some(ip_id) = interp.realm().iterator_prototype {
-                            iter_obj.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(ip_id).borrow().id.unwrap());
+                            iter_obj.borrow_mut().prototype_id = Some(ip_id);
                         }
                         iter_obj.borrow_mut().class_name = "Segmenter String Iterator".to_string();
 
@@ -490,8 +487,7 @@ impl Interpreter {
 
                 let result = interp.create_object();
                 if let Some(op_id) = interp.realm().object_prototype {
-                    result.borrow_mut().prototype_id =
-                        Some(op_id);
+                    result.borrow_mut().prototype_id = Some(op_id);
                 }
 
                 let props = vec![

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -414,7 +414,7 @@ fn get_iterator_flattenable(
         // Has @@iterator - check it's callable and call it
         if let JsValue::Object(mo) = &method {
             if !interp
-                .get_object(mo.id)
+                .get_object_cell(mo.id)
                 .map(|od| od.borrow().callable.is_some())
                 .unwrap_or(false)
             {
@@ -632,13 +632,13 @@ impl Interpreter {
                     let prop_key = tst_key_for_setter
                         .clone()
                         .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
-                    let has_own = if let Some(od) = interp.get_object(this_id) {
+                    let has_own = if let Some(od) = interp.get_object_cell(this_id) {
                         od.borrow().properties.contains_key(&prop_key)
                     } else {
                         false
                     };
                     if !has_own {
-                        if let Some(od) = interp.get_object(this_id) {
+                        if let Some(od) = interp.get_object_cell(this_id) {
                             let frozen = !od.borrow().extensible;
                             if frozen {
                                 let err = interp.create_type_error(
@@ -651,7 +651,7 @@ impl Interpreter {
                                 PropertyDescriptor::data(v, true, true, true),
                             );
                         }
-                    } else if let Some(od) = interp.get_object(this_id)
+                    } else if let Some(od) = interp.get_object_cell(this_id)
                         && !od.borrow_mut().set_property_value(&prop_key, v)
                     {
                         let err = interp.create_type_error("Cannot set property");
@@ -682,7 +682,7 @@ impl Interpreter {
             |interp, this, _args| {
                 if let JsValue::Object(o) = this {
                     let return_method = interp.get_property_on_id(o.id, "return");
-                    if matches!(&return_method, JsValue::Object(ro) if interp.get_object(ro.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                    if matches!(&return_method, JsValue::Object(ro) if interp.get_object_cell(ro.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                     {
                         return interp.call_function(&return_method, this, &[]);
                     }
@@ -749,7 +749,7 @@ impl Interpreter {
 
         // Set Iterator.prototype_id
         if let JsValue::Object(ctor_obj) = &iterator_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -792,14 +792,14 @@ impl Interpreter {
                         return Completion::Throw(err);
                     }
                     // Step 3: Check if this has own "constructor" property
-                    let has_own = if let Some(od) = interp.get_object(this_id) {
+                    let has_own = if let Some(od) = interp.get_object_cell(this_id) {
                         od.borrow().properties.contains_key("constructor")
                     } else {
                         false
                     };
                     if !has_own {
                         // CreateDataPropertyOrThrow(this, "constructor", v)
-                        if let Some(od) = interp.get_object(this_id) {
+                        if let Some(od) = interp.get_object_cell(this_id) {
                             let frozen = !od.borrow().extensible;
                             if frozen {
                                 let err = interp.create_type_error(
@@ -814,7 +814,7 @@ impl Interpreter {
                         }
                     } else {
                         // Set(this, "constructor", v, true)
-                        if let Some(od) = interp.get_object(this_id)
+                        if let Some(od) = interp.get_object_cell(this_id)
                             && !od.borrow_mut().set_property_value("constructor", v)
                         {
                             let err = interp.create_type_error("Cannot set property constructor");
@@ -882,7 +882,7 @@ impl Interpreter {
                                 );
                             }
                             let is_proxy = interp
-                                .get_object(array_id)
+                                .get_object_cell(array_id)
                                 .is_some_and(|o| o.borrow().is_proxy());
                             if is_proxy {
                                 let arr_val =
@@ -895,7 +895,7 @@ impl Interpreter {
                                     c => return c,
                                 };
                                 if index >= len {
-                                    if let Some(obj) = interp.get_object(o.id) {
+                                    if let Some(obj) = interp.get_object_cell(o.id) {
                                         obj.borrow_mut().iterator_state =
                                             Some(IteratorState::ArrayIterator {
                                                 array_id,
@@ -1216,7 +1216,7 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 if let JsValue::Object(o) = this {
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         let state = obj.borrow().iterator_state.clone();
                         if let Some(IteratorState::StringIterator {
                             ref string,
@@ -1487,7 +1487,7 @@ impl Interpreter {
 
     fn set_helper_gc_roots(&mut self, helper: &JsValue, roots: Vec<JsValue>) {
         if let JsValue::Object(ho) = helper
-            && let Some(obj) = self.get_object(ho.id)
+            && let Some(obj) = self.get_object_cell(ho.id)
         {
             obj.borrow_mut().gc_native_roots = Some(roots);
         }
@@ -1534,7 +1534,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&callback, JsValue::Object(o) if interp.get_object(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                if !matches!(&callback, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                 {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("callback is not a function");
@@ -1579,7 +1579,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 let predicate = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&predicate, JsValue::Object(o) if interp.get_object(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                if !matches!(&predicate, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                 {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("predicate is not a function");
@@ -1634,7 +1634,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 let predicate = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&predicate, JsValue::Object(o) if interp.get_object(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                if !matches!(&predicate, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                 {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("predicate is not a function");
@@ -1688,7 +1688,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 let predicate = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&predicate, JsValue::Object(o) if interp.get_object(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                if !matches!(&predicate, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                 {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("predicate is not a function");
@@ -1742,7 +1742,7 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 let reducer = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&reducer, JsValue::Object(o) if interp.get_object(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                if !matches!(&reducer, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                 {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("reducer is not a function");
@@ -1821,7 +1821,7 @@ impl Interpreter {
                     return Completion::Throw(err);
                 }
                 let mapper = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&mapper, JsValue::Object(o) if interp.get_object(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                if !matches!(&mapper, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                 {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("mapper is not a function");
@@ -1950,7 +1950,7 @@ impl Interpreter {
                     return Completion::Throw(err);
                 }
                 let predicate = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&predicate, JsValue::Object(o) if interp.get_object(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                if !matches!(&predicate, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                 {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("predicate is not a function");
@@ -2407,7 +2407,7 @@ impl Interpreter {
                     return Completion::Throw(err);
                 }
                 let mapper = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&mapper, JsValue::Object(o) if interp.get_object(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
+                if !matches!(&mapper, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
                 {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("mapper is not a function");
@@ -2650,7 +2650,7 @@ impl Interpreter {
                     }
                 };
                 let record = interp
-                    .get_object(this_id)
+                    .get_object_cell(this_id)
                     .and_then(|o| o.borrow().wrap_iter_record.clone());
                 let (iter, next_method) = match record {
                     Some(r) => r,
@@ -2678,7 +2678,7 @@ impl Interpreter {
                     }
                 };
                 let record = interp
-                    .get_object(this_id)
+                    .get_object_cell(this_id)
                     .and_then(|o| o.borrow().wrap_iter_record.clone());
                 let (iter, _next_method) = match record {
                     Some(r) => r,
@@ -2756,7 +2756,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ctor_obj) = iterator_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -2792,7 +2792,7 @@ impl Interpreter {
                         // Verify it's callable
                         let is_callable = if let JsValue::Object(fo) = &iter_fn {
                             interp
-                                .get_object(fo.id)
+                                .get_object_cell(fo.id)
                                 .map(|od| od.borrow().callable.is_some())
                                 .unwrap_or(false)
                         } else {
@@ -2972,7 +2972,7 @@ impl Interpreter {
 
         // Fix concat.length to 0 (spec says rest parameter = length 0)
         if let JsValue::Object(concat_obj) = &concat_fn
-            && let Some(obj) = self.get_object(concat_obj.id)
+            && let Some(obj) = self.get_object_cell(concat_obj.id)
         {
             obj.borrow_mut().insert_property(
                 "length".to_string(),
@@ -2981,7 +2981,7 @@ impl Interpreter {
         }
 
         if let JsValue::Object(ctor_obj) = iterator_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut()
                 .insert_builtin("concat".to_string(), concat_fn);
@@ -3280,7 +3280,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ctor_obj) = iterator_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut().insert_builtin("zip".to_string(), zip_fn);
         }
@@ -3602,7 +3602,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ctor_obj) = iterator_ctor
-            && let Some(obj) = self.get_object(ctor_obj.id)
+            && let Some(obj) = self.get_object_cell(ctor_obj.id)
         {
             obj.borrow_mut()
                 .insert_builtin("zipKeyed".to_string(), zip_keyed_fn);
@@ -3683,7 +3683,7 @@ impl Interpreter {
                 let value = args.first().cloned().unwrap_or(JsValue::Undefined);
                 // Check which variant we have
                 if let JsValue::Object(o) = this
-                    && let Some(obj_rc) = interp.get_object(o.id)
+                    && let Some(obj_rc) = interp.get_object_cell(o.id)
                 {
                     let is_state_machine = matches!(
                         obj_rc.borrow().iterator_state,
@@ -3711,7 +3711,7 @@ impl Interpreter {
                 let value = args.first().cloned().unwrap_or(JsValue::Undefined);
                 // Check which variant we have
                 if let JsValue::Object(o) = this
-                    && let Some(obj_rc) = interp.get_object(o.id)
+                    && let Some(obj_rc) = interp.get_object_cell(o.id)
                 {
                     let is_state_machine = matches!(
                         obj_rc.borrow().iterator_state,
@@ -3739,7 +3739,7 @@ impl Interpreter {
                 let exception = args.first().cloned().unwrap_or(JsValue::Undefined);
                 // Check which variant we have
                 if let JsValue::Object(o) = this
-                    && let Some(obj_rc) = interp.get_object(o.id)
+                    && let Some(obj_rc) = interp.get_object_cell(o.id)
                 {
                     let is_state_machine = matches!(
                         obj_rc.borrow().iterator_state,
@@ -3788,7 +3788,7 @@ impl Interpreter {
             && let JsValue::Object(func_obj) = func_val
             && let JsValue::Object(func_proto_obj) =
                 self.get_property_on_id(func_obj.id, "prototype")
-            && let Some(func_proto) = self.get_object(func_proto_obj.id)
+            && let Some(func_proto) = self.get_object_cell(func_proto_obj.id)
         {
             self.get_object_cell_expect(gf_proto_id)
                 .borrow_mut()
@@ -3965,7 +3965,7 @@ impl Interpreter {
 
                 let fulfill_reaction2 = fulfill_reaction.clone();
                 let reject_reaction2 = reject_reaction.clone();
-                let state = if let Some(obj) = interp.get_object(wrapper_id) {
+                let state = if let Some(obj) = interp.get_object_cell(wrapper_id) {
                     let mut o = obj.borrow_mut();
                     if let Some(ref mut pd) = o.promise_data {
                         pd.is_handled = true;

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -834,11 +834,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("Iterator", BindingKind::Var);
-        let _ = self
-            .realm()
-            .global_env
-            .borrow_mut()
-            .set("Iterator", iterator_ctor.clone());
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "Iterator", iterator_ctor.clone());
 
         // Setup consuming and lazy helper methods on %IteratorPrototype%
         self.setup_iterator_helper_methods(&iter_proto);
@@ -3795,10 +3792,7 @@ impl Interpreter {
                 // 1. Let O be the this value.
                 // 2. Let promiseCapability be ! NewPromiseCapability(%Promise%).
                 let promise_ctor = interp
-                    .realm()
-                    .global_env
-                    .borrow()
-                    .get("Promise")
+                    .get_global_var("Promise")
                     .unwrap_or(JsValue::Undefined);
                 let cap = match interp.new_promise_capability(&promise_ctor) {
                     Ok(c) => c,

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -279,15 +279,21 @@ fn zip_keyed_next_inner(interp: &mut Interpreter, state: &ZipKeyedState) -> Comp
     }
 
     // Create null-prototype result object with key-value pairs
-    let result_obj = interp.create_object();
-    result_obj.borrow_mut().prototype_id = None;
+    let result_obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(result_obj_id)
+        .borrow_mut()
+        .prototype_id = None;
     for (key, val) in &values {
-        result_obj.borrow_mut().insert_property(
-            key.clone(),
-            PropertyDescriptor::data(val.clone(), true, true, true),
-        );
+        interp
+            .get_object_cell_expect(result_obj_id)
+            .borrow_mut()
+            .insert_property(
+                key.clone(),
+                PropertyDescriptor::data(val.clone(), true, true, true),
+            );
     }
-    let result_id = result_obj.borrow().id.unwrap();
+    let result_id = result_obj_id;
     let result_val = JsValue::Object(crate::types::JsObject { id: result_id });
     Completion::Normal(interp.create_iter_result_object(result_val, false))
 }
@@ -575,8 +581,10 @@ fn iterator_close_all(
 impl Interpreter {
     pub(crate) fn setup_iterator_prototypes(&mut self) {
         // %IteratorPrototype% (§27.1.2)
-        let iter_proto = self.create_object();
-        iter_proto.borrow_mut().class_name = "Iterator".to_string();
+        let iter_proto_id = self.create_object_id();
+        self.get_object_cell_expect(iter_proto_id)
+            .borrow_mut()
+            .class_name = "Iterator".to_string();
 
         // %IteratorPrototype%[@@iterator]() returns this
         let iter_self_fn = self.create_function(JsFunction::native(
@@ -585,14 +593,16 @@ impl Interpreter {
             |_interp, this, _args| Completion::Normal(this.clone()),
         ));
         if let Some(key) = self.get_symbol_iterator_key() {
-            iter_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(iter_self_fn, true, false, true),
-            );
+            self.get_object_cell_expect(iter_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(iter_self_fn, true, false, true),
+                );
         }
         // @@toStringTag on %IteratorPrototype% — accessor property per spec
         {
-            let iter_proto_id = iter_proto.borrow().id.unwrap();
+            let iter_proto_id = iter_proto_id;
             let tst_getter = self.create_function(JsFunction::native(
                 "get [Symbol.toStringTag]".to_string(),
                 0,
@@ -651,17 +661,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Undefined)
                 },
             ));
-            iter_proto.borrow_mut().insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(tst_getter),
-                    set: Some(tst_setter),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            self.get_object_cell_expect(iter_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "Symbol(Symbol.toStringTag)".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        get: Some(tst_getter),
+                        set: Some(tst_setter),
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                    },
+                );
         }
 
         // [Symbol.dispose]() — calls this.return() if it exists
@@ -680,12 +692,12 @@ impl Interpreter {
             },
         ));
         if let Some(key) = self.get_symbol_key("dispose") {
-            iter_proto
+            self.get_object_cell_expect(iter_proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(dispose_fn, true, false, true));
         }
 
-        self.realm_mut().iterator_prototype = Some(iter_proto.borrow().id.unwrap());
+        self.realm_mut().iterator_prototype = Some(iter_proto_id);
 
         // Iterator constructor (abstract — throws TypeError when called directly)
         let iterator_ctor = self.create_function(JsFunction::constructor(
@@ -743,9 +755,7 @@ impl Interpreter {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject {
-                        id: iter_proto.borrow().id.unwrap(),
-                    }),
+                    JsValue::Object(crate::types::JsObject { id: iter_proto_id }),
                     false,
                     false,
                     false,
@@ -756,7 +766,7 @@ impl Interpreter {
         // Set %IteratorPrototype%.constructor as accessor property per spec
         // Getter returns Iterator, setter implements SetterThatIgnoresPrototypeProperties
         {
-            let iter_proto_id = iter_proto.borrow().id.unwrap();
+            let iter_proto_id = iter_proto_id;
             let ctor_val = iterator_ctor.clone();
             let getter = self.create_function(JsFunction::native(
                 "get constructor".to_string(),
@@ -816,17 +826,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Undefined)
                 },
             ));
-            iter_proto.borrow_mut().insert_property(
-                "constructor".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(getter),
-                    set: Some(setter),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            self.get_object_cell_expect(iter_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "constructor".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        get: Some(getter),
+                        set: Some(setter),
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                    },
+                );
         }
 
         // Register Iterator as global
@@ -838,16 +850,20 @@ impl Interpreter {
         let _ = self.env_set(&env, "Iterator", iterator_ctor.clone());
 
         // Setup consuming and lazy helper methods on %IteratorPrototype%
-        let iter_proto_id = iter_proto.borrow().id.unwrap();
+        let iter_proto_id = iter_proto_id;
         self.setup_iterator_helper_methods(iter_proto_id);
 
         // Setup static methods on Iterator constructor
         self.setup_iterator_static_methods(&iterator_ctor);
 
         // %ArrayIteratorPrototype% (§23.1.5.1)
-        let arr_iter_proto = self.create_object();
-        arr_iter_proto.borrow_mut().prototype_id = Some(iter_proto.borrow().id.unwrap());
-        arr_iter_proto.borrow_mut().class_name = "Array Iterator".to_string();
+        let arr_iter_proto_id = self.create_object_id();
+        self.get_object_cell_expect(arr_iter_proto_id)
+            .borrow_mut()
+            .prototype_id = Some(iter_proto_id);
+        self.get_object_cell_expect(arr_iter_proto_id)
+            .borrow_mut()
+            .class_name = "Array Iterator".to_string();
 
         let arr_iter_next = self.create_function(JsFunction::native(
             "next".to_string(),
@@ -1170,27 +1186,33 @@ impl Interpreter {
                 }
             },
         ));
-        arr_iter_proto
+        self.get_object_cell_expect(arr_iter_proto_id)
             .borrow_mut()
             .insert_builtin("next".to_string(), arr_iter_next);
 
         // Set @@toStringTag
-        arr_iter_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Array Iterator")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(arr_iter_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Array Iterator")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        self.realm_mut().array_iterator_prototype = Some(arr_iter_proto.borrow().id.unwrap());
+        self.realm_mut().array_iterator_prototype = Some(arr_iter_proto_id);
 
         // %StringIteratorPrototype% (§22.1.5.1)
-        let str_iter_proto = self.create_object();
-        str_iter_proto.borrow_mut().prototype_id = Some(iter_proto.borrow().id.unwrap());
-        str_iter_proto.borrow_mut().class_name = "String Iterator".to_string();
+        let str_iter_proto_id = self.create_object_id();
+        self.get_object_cell_expect(str_iter_proto_id)
+            .borrow_mut()
+            .prototype_id = Some(iter_proto_id);
+        self.get_object_cell_expect(str_iter_proto_id)
+            .borrow_mut()
+            .class_name = "String Iterator".to_string();
 
         let str_iter_next = self.create_function(JsFunction::native(
             "next".to_string(),
@@ -1255,30 +1277,36 @@ impl Interpreter {
                 }
             },
         ));
-        str_iter_proto
+        self.get_object_cell_expect(str_iter_proto_id)
             .borrow_mut()
             .insert_builtin("next".to_string(), str_iter_next);
 
-        str_iter_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("String Iterator")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(str_iter_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("String Iterator")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        self.realm_mut().string_iterator_prototype = Some(str_iter_proto.borrow().id.unwrap());
+        self.realm_mut().string_iterator_prototype = Some(str_iter_proto_id);
     }
 
     fn ensure_iterator_helper_prototype(&mut self) {
         if self.realm().iterator_helper_prototype.is_some() {
             return;
         }
-        let proto = self.create_object();
-        proto.borrow_mut().prototype_id = self.realm().iterator_prototype;
-        proto.borrow_mut().class_name = "Iterator Helper".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .prototype_id = self.realm().iterator_prototype;
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Iterator Helper".to_string();
 
         // next() — reads helper_next_closure and helper_gen_state from this
         let next_fn = self.create_function(JsFunction::native(
@@ -1342,7 +1370,7 @@ impl Interpreter {
                 result
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("next".to_string(), next_fn);
 
@@ -1400,7 +1428,7 @@ impl Interpreter {
                 result
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("return".to_string(), return_fn);
 
@@ -1411,38 +1439,52 @@ impl Interpreter {
             |_interp, this, _args| Completion::Normal(this.clone()),
         ));
         if let Some(key) = self.get_symbol_iterator_key() {
-            proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(iter_self_fn, true, false, true),
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(iter_self_fn, true, false, true),
+                );
         }
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Iterator Helper")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Iterator Helper")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        self.realm_mut().iterator_helper_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().iterator_helper_prototype = Some(proto_id);
     }
 
     fn create_iterator_helper_object(&mut self, next_fn: JsValue, return_fn: JsValue) -> JsValue {
         self.ensure_iterator_helper_prototype();
         let state = Rc::new(std::cell::Cell::new(0u8));
 
-        let obj = self.create_object();
-        obj.borrow_mut().prototype_id = self.realm().iterator_helper_prototype;
-        obj.borrow_mut().class_name = "Iterator Helper".to_string();
-        obj.borrow_mut().helper_next_closure = Some(next_fn.clone());
-        obj.borrow_mut().helper_return_closure = Some(return_fn.clone());
-        obj.borrow_mut().helper_gen_state = Some(state);
-        obj.borrow_mut().gc_native_roots = Some(vec![next_fn, return_fn]);
+        let obj_id = self.create_object_id();
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = self.realm().iterator_helper_prototype;
+        self.get_object_cell_expect(obj_id).borrow_mut().class_name = "Iterator Helper".to_string();
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .helper_next_closure = Some(next_fn.clone());
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .helper_return_closure = Some(return_fn.clone());
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .helper_gen_state = Some(state);
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .gc_native_roots = Some(vec![next_fn, return_fn]);
 
-        let id = obj.borrow().id.unwrap();
+        let id = obj_id;
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -2594,8 +2636,10 @@ impl Interpreter {
     fn setup_iterator_static_methods(&mut self, iterator_ctor: &JsValue) {
         // Iterator.from(obj) — per spec §27.1.4.2
         // Create shared WrapForValidIteratorPrototype
-        let wrap_valid_proto = self.create_object();
-        wrap_valid_proto.borrow_mut().prototype_id = self.realm().iterator_prototype;
+        let wrap_valid_proto_id = self.create_object_id();
+        self.get_object_cell_expect(wrap_valid_proto_id)
+            .borrow_mut()
+            .prototype_id = self.realm().iterator_prototype;
 
         let wrap_next_fn = self.create_function(JsFunction::native(
             "next".to_string(),
@@ -2621,7 +2665,7 @@ impl Interpreter {
                 interp.call_function(&next_method, &iter, &[])
             },
         ));
-        wrap_valid_proto
+        self.get_object_cell_expect(wrap_valid_proto_id)
             .borrow_mut()
             .insert_builtin("next".to_string(), wrap_next_fn);
 
@@ -2663,11 +2707,11 @@ impl Interpreter {
                 }
             },
         ));
-        wrap_valid_proto
+        self.get_object_cell_expect(wrap_valid_proto_id)
             .borrow_mut()
             .insert_builtin("return".to_string(), wrap_return_fn);
 
-        let wrap_valid_proto_id = wrap_valid_proto.borrow().id.unwrap();
+        let wrap_valid_proto_id = wrap_valid_proto_id;
 
         let wvp_for_from: Option<u64> = Some(wrap_valid_proto_id);
         let iterator_ctor_for_from = iterator_ctor.clone();
@@ -2694,14 +2738,25 @@ impl Interpreter {
                 }
 
                 // Create wrapper with shared WrapForValidIteratorPrototype
-                let wrapper = interp.create_object();
-                wrapper.borrow_mut().prototype_id = wvp_for_from;
-                wrapper.borrow_mut().class_name = "Iterator".to_string();
-                wrapper.borrow_mut().wrap_iter_record =
-                    Some((iter_val.clone(), next_method.clone()));
-                wrapper.borrow_mut().gc_native_roots = Some(vec![iter_val, next_method]);
+                let wrapper_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(wrapper_id)
+                    .borrow_mut()
+                    .prototype_id = wvp_for_from;
+                interp
+                    .get_object_cell_expect(wrapper_id)
+                    .borrow_mut()
+                    .class_name = "Iterator".to_string();
+                interp
+                    .get_object_cell_expect(wrapper_id)
+                    .borrow_mut()
+                    .wrap_iter_record = Some((iter_val.clone(), next_method.clone()));
+                interp
+                    .get_object_cell_expect(wrapper_id)
+                    .borrow_mut()
+                    .gc_native_roots = Some(vec![iter_val, next_method]);
 
-                let wrapper_id = wrapper.borrow().id.unwrap();
+                let wrapper_id = wrapper_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: wrapper_id }))
             },
         ));
@@ -3618,9 +3673,13 @@ impl Interpreter {
     }
 
     pub(crate) fn setup_generator_prototype(&mut self) {
-        let gen_proto = self.create_object();
-        gen_proto.borrow_mut().class_name = "Generator".to_string();
-        gen_proto.borrow_mut().prototype_id = self.realm().iterator_prototype;
+        let gen_proto_id = self.create_object_id();
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .class_name = "Generator".to_string();
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .prototype_id = self.realm().iterator_prototype;
 
         // next(value)
         let next_fn = self.create_function(JsFunction::native(
@@ -3643,10 +3702,12 @@ impl Interpreter {
                 interp.generator_next(this, value)
             },
         ));
-        gen_proto.borrow_mut().insert_property(
-            "next".to_string(),
-            PropertyDescriptor::data(next_fn, true, false, true),
-        );
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "next".to_string(),
+                PropertyDescriptor::data(next_fn, true, false, true),
+            );
 
         // return(value)
         let return_fn = self.create_function(JsFunction::native(
@@ -3669,10 +3730,12 @@ impl Interpreter {
                 interp.generator_return(this, value)
             },
         ));
-        gen_proto.borrow_mut().insert_property(
-            "return".to_string(),
-            PropertyDescriptor::data(return_fn, true, false, true),
-        );
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "return".to_string(),
+                PropertyDescriptor::data(return_fn, true, false, true),
+            );
 
         // throw(exception)
         let throw_fn = self.create_function(JsFunction::native(
@@ -3695,29 +3758,35 @@ impl Interpreter {
                 interp.generator_throw(this, exception)
             },
         ));
-        gen_proto.borrow_mut().insert_property(
-            "throw".to_string(),
-            PropertyDescriptor::data(throw_fn, true, false, true),
-        );
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "throw".to_string(),
+                PropertyDescriptor::data(throw_fn, true, false, true),
+            );
 
         // @@iterator is inherited from %IteratorPrototype%
 
         // Symbol.toStringTag
-        gen_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Generator")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Generator")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        self.realm_mut().generator_prototype = Some(gen_proto.borrow().id.unwrap());
+        self.realm_mut().generator_prototype = Some(gen_proto_id);
 
         // %GeneratorFunction.prototype% - the prototype of generator function objects
-        let gf_proto = self.create_object();
-        gf_proto.borrow_mut().class_name = "GeneratorFunction".to_string();
+        let gf_proto_id = self.create_object_id();
+        self.get_object_cell_expect(gf_proto_id)
+            .borrow_mut()
+            .class_name = "GeneratorFunction".to_string();
 
         // [[Prototype]] = Function.prototype_id
         // Get Function.prototype from global Function
@@ -3727,51 +3796,61 @@ impl Interpreter {
                 self.get_property_on_id(func_obj.id, "prototype")
             && let Some(func_proto) = self.get_object(func_proto_obj.id)
         {
-            gf_proto.borrow_mut().prototype_id = Some(func_proto.borrow().id.unwrap());
+            self.get_object_cell_expect(gf_proto_id)
+                .borrow_mut()
+                .prototype_id = Some(func_proto.borrow().id.unwrap());
         }
 
         // GeneratorFunction.prototype.prototype_id = Generator.prototype_id
-        let gen_proto_id = gen_proto.borrow().id.unwrap();
-        gf_proto.borrow_mut().insert_property(
-            "prototype".to_string(),
-            PropertyDescriptor::data(
-                JsValue::Object(crate::types::JsObject { id: gen_proto_id }),
-                false,
-                false,
-                true,
-            ),
-        );
+        let gen_proto_id = gen_proto_id;
+        self.get_object_cell_expect(gf_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "prototype".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::Object(crate::types::JsObject { id: gen_proto_id }),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
         // Symbol.toStringTag = "GeneratorFunction"
-        gf_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("GeneratorFunction")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(gf_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("GeneratorFunction")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
         // Set constructor on Generator.prototype pointing back to GeneratorFunction.prototype_id
-        let gf_proto_id = gf_proto.borrow().id.unwrap();
-        gen_proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(
-                JsValue::Object(crate::types::JsObject { id: gf_proto_id }),
-                false,
-                false,
-                true,
-            ),
-        );
+        let gf_proto_id = gf_proto_id;
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::Object(crate::types::JsObject { id: gf_proto_id }),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        self.realm_mut().generator_function_prototype = Some(gf_proto.borrow().id.unwrap());
+        self.realm_mut().generator_function_prototype = Some(gf_proto_id);
     }
 
     pub(crate) fn setup_async_generator_prototype(&mut self) {
         // %AsyncIteratorPrototype% — has [Symbol.asyncIterator]() returning this
-        let async_iter_proto = self.create_object();
-        async_iter_proto.borrow_mut().class_name = "AsyncIterator".to_string();
+        let async_iter_proto_id = self.create_object_id();
+        self.get_object_cell_expect(async_iter_proto_id)
+            .borrow_mut()
+            .class_name = "AsyncIterator".to_string();
 
         let async_iter_self_fn = self.create_function(JsFunction::native(
             "[Symbol.asyncIterator]".to_string(),
@@ -3779,10 +3858,12 @@ impl Interpreter {
             |_interp, this, _args| Completion::Normal(this.clone()),
         ));
         if let Some(key) = self.get_symbol_key("asyncIterator") {
-            async_iter_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(async_iter_self_fn, true, false, true),
-            );
+            self.get_object_cell_expect(async_iter_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(async_iter_self_fn, true, false, true),
+                );
         }
 
         // [Symbol.asyncDispose]() — §27.1.3.2
@@ -3929,18 +4010,24 @@ impl Interpreter {
             },
         ));
         if let Some(key) = self.get_symbol_key("asyncDispose") {
-            async_iter_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(async_dispose_fn, true, false, true),
-            );
+            self.get_object_cell_expect(async_iter_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(async_dispose_fn, true, false, true),
+                );
         }
 
-        self.realm_mut().async_iterator_prototype = Some(async_iter_proto.borrow().id.unwrap());
+        self.realm_mut().async_iterator_prototype = Some(async_iter_proto_id);
 
         // %AsyncGeneratorPrototype%
-        let gen_proto = self.create_object();
-        gen_proto.borrow_mut().prototype_id = Some(async_iter_proto.borrow().id.unwrap());
-        gen_proto.borrow_mut().class_name = "AsyncGenerator".to_string();
+        let gen_proto_id = self.create_object_id();
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .prototype_id = Some(async_iter_proto_id);
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .class_name = "AsyncGenerator".to_string();
 
         // next(value)
         let next_fn = self.create_function(JsFunction::native(
@@ -3951,10 +4038,12 @@ impl Interpreter {
                 interp.async_generator_next(this, value)
             },
         ));
-        gen_proto.borrow_mut().insert_property(
-            "next".to_string(),
-            PropertyDescriptor::data(next_fn, true, false, true),
-        );
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "next".to_string(),
+                PropertyDescriptor::data(next_fn, true, false, true),
+            );
 
         // return(value)
         let return_fn = self.create_function(JsFunction::native(
@@ -3965,10 +4054,12 @@ impl Interpreter {
                 interp.async_generator_return(this, value)
             },
         ));
-        gen_proto.borrow_mut().insert_property(
-            "return".to_string(),
-            PropertyDescriptor::data(return_fn, true, false, true),
-        );
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "return".to_string(),
+                PropertyDescriptor::data(return_fn, true, false, true),
+            );
 
         // throw(exception)
         let throw_fn = self.create_function(JsFunction::native(
@@ -3979,59 +4070,71 @@ impl Interpreter {
                 interp.async_generator_throw(this, exception)
             },
         ));
-        gen_proto.borrow_mut().insert_property(
-            "throw".to_string(),
-            PropertyDescriptor::data(throw_fn, true, false, true),
-        );
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "throw".to_string(),
+                PropertyDescriptor::data(throw_fn, true, false, true),
+            );
 
         // Symbol.toStringTag
-        gen_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("AsyncGenerator")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("AsyncGenerator")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
-        self.realm_mut().async_generator_prototype = Some(gen_proto.borrow().id.unwrap());
+        self.realm_mut().async_generator_prototype = Some(gen_proto_id);
 
         // %AsyncGeneratorFunction.prototype%
-        let agf_proto = self.create_object();
-        agf_proto.borrow_mut().class_name = "AsyncGeneratorFunction".to_string();
+        let agf_proto_id = self.create_object_id();
+        self.get_object_cell_expect(agf_proto_id)
+            .borrow_mut()
+            .class_name = "AsyncGeneratorFunction".to_string();
         // prototype property points to AsyncGenerator.prototype_id
-        let gen_proto_id = gen_proto.borrow().id.unwrap();
-        agf_proto.borrow_mut().insert_property(
-            "prototype".to_string(),
-            PropertyDescriptor::data(
-                JsValue::Object(crate::types::JsObject { id: gen_proto_id }),
-                false,
-                false,
-                true,
-            ),
-        );
+        let gen_proto_id = gen_proto_id;
+        self.get_object_cell_expect(agf_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "prototype".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::Object(crate::types::JsObject { id: gen_proto_id }),
+                    false,
+                    false,
+                    true,
+                ),
+            );
         // Symbol.toStringTag
-        agf_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("AsyncGeneratorFunction")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(agf_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("AsyncGeneratorFunction")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
         // Set constructor on AsyncGenerator.prototype pointing back to AsyncGeneratorFunction.prototype_id
-        let agf_proto_id = agf_proto.borrow().id.unwrap();
-        gen_proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(
-                JsValue::Object(crate::types::JsObject { id: agf_proto_id }),
-                false,
-                false,
-                true,
-            ),
-        );
-        self.realm_mut().async_generator_function_prototype = Some(agf_proto.borrow().id.unwrap());
+        let agf_proto_id = agf_proto_id;
+        self.get_object_cell_expect(gen_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::Object(crate::types::JsObject { id: agf_proto_id }),
+                    false,
+                    false,
+                    true,
+                ),
+            );
+        self.realm_mut().async_generator_function_prototype = Some(agf_proto_id);
     }
 }

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -1485,7 +1485,7 @@ impl Interpreter {
                 Completion::Normal(arr)
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("toArray".to_string(), to_array_fn);
 
@@ -1530,7 +1530,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("forEach".to_string(), for_each_fn);
 
@@ -1585,7 +1585,7 @@ impl Interpreter {
                 }
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("some".to_string(), some_fn);
 
@@ -1639,7 +1639,7 @@ impl Interpreter {
                 }
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("every".to_string(), every_fn);
 
@@ -1693,7 +1693,7 @@ impl Interpreter {
                 }
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("find".to_string(), find_fn);
 
@@ -1762,7 +1762,7 @@ impl Interpreter {
                 }
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("reduce".to_string(), reduce_fn);
 
@@ -1897,7 +1897,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("map".to_string(), map_fn);
 
@@ -2035,7 +2035,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("filter".to_string(), filter_fn);
 
@@ -2189,7 +2189,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("take".to_string(), take_fn);
 
@@ -2354,7 +2354,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("drop".to_string(), drop_fn);
 
@@ -2586,7 +2586,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        self.get_object_expect(iter_proto_id)
+        self.get_object_cell_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("flatMap".to_string(), flat_map_fn);
     }

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -602,7 +602,6 @@ impl Interpreter {
         }
         // @@toStringTag on %IteratorPrototype% — accessor property per spec
         {
-            let iter_proto_id = iter_proto_id;
             let tst_getter = self.create_function(JsFunction::native(
                 "get [Symbol.toStringTag]".to_string(),
                 0,
@@ -766,7 +765,6 @@ impl Interpreter {
         // Set %IteratorPrototype%.constructor as accessor property per spec
         // Getter returns Iterator, setter implements SetterThatIgnoresPrototypeProperties
         {
-            let iter_proto_id = iter_proto_id;
             let ctor_val = iterator_ctor.clone();
             let getter = self.create_function(JsFunction::native(
                 "get constructor".to_string(),
@@ -850,7 +848,6 @@ impl Interpreter {
         let _ = self.env_set(&env, "Iterator", iterator_ctor.clone());
 
         // Setup consuming and lazy helper methods on %IteratorPrototype%
-        let iter_proto_id = iter_proto_id;
         self.setup_iterator_helper_methods(iter_proto_id);
 
         // Setup static methods on Iterator constructor
@@ -2711,8 +2708,6 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("return".to_string(), wrap_return_fn);
 
-        let wrap_valid_proto_id = wrap_valid_proto_id;
-
         let wvp_for_from: Option<u64> = Some(wrap_valid_proto_id);
         let iterator_ctor_for_from = iterator_ctor.clone();
         let from_fn = self.create_function(JsFunction::native(
@@ -2756,7 +2751,6 @@ impl Interpreter {
                     .borrow_mut()
                     .gc_native_roots = Some(vec![iter_val, next_method]);
 
-                let wrapper_id = wrapper_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: wrapper_id }))
             },
         ));
@@ -3802,7 +3796,6 @@ impl Interpreter {
         }
 
         // GeneratorFunction.prototype.prototype_id = Generator.prototype_id
-        let gen_proto_id = gen_proto_id;
         self.get_object_cell_expect(gf_proto_id)
             .borrow_mut()
             .insert_property(
@@ -3829,7 +3822,6 @@ impl Interpreter {
             );
 
         // Set constructor on Generator.prototype pointing back to GeneratorFunction.prototype_id
-        let gf_proto_id = gf_proto_id;
         self.get_object_cell_expect(gen_proto_id)
             .borrow_mut()
             .insert_property(
@@ -4098,7 +4090,6 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "AsyncGeneratorFunction".to_string();
         // prototype property points to AsyncGenerator.prototype_id
-        let gen_proto_id = gen_proto_id;
         self.get_object_cell_expect(agf_proto_id)
             .borrow_mut()
             .insert_property(
@@ -4123,7 +4114,6 @@ impl Interpreter {
                 ),
             );
         // Set constructor on AsyncGenerator.prototype pointing back to AsyncGeneratorFunction.prototype_id
-        let agf_proto_id = agf_proto_id;
         self.get_object_cell_expect(gen_proto_id)
             .borrow_mut()
             .insert_property(

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -838,7 +838,8 @@ impl Interpreter {
         let _ = self.env_set(&env, "Iterator", iterator_ctor.clone());
 
         // Setup consuming and lazy helper methods on %IteratorPrototype%
-        self.setup_iterator_helper_methods(&iter_proto);
+        let iter_proto_id = iter_proto.borrow().id.unwrap();
+        self.setup_iterator_helper_methods(iter_proto_id);
 
         // Setup static methods on Iterator constructor
         self.setup_iterator_static_methods(&iterator_ctor);
@@ -1453,7 +1454,7 @@ impl Interpreter {
         }
     }
 
-    fn setup_iterator_helper_methods(&mut self, iter_proto: &Rc<RefCell<JsObjectData>>) {
+    fn setup_iterator_helper_methods(&mut self, iter_proto_id: u64) {
         // toArray()
         let to_array_fn = self.create_function(JsFunction::native(
             "toArray".to_string(),
@@ -1484,7 +1485,7 @@ impl Interpreter {
                 Completion::Normal(arr)
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("toArray".to_string(), to_array_fn);
 
@@ -1529,7 +1530,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("forEach".to_string(), for_each_fn);
 
@@ -1584,7 +1585,7 @@ impl Interpreter {
                 }
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("some".to_string(), some_fn);
 
@@ -1638,7 +1639,7 @@ impl Interpreter {
                 }
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("every".to_string(), every_fn);
 
@@ -1692,7 +1693,7 @@ impl Interpreter {
                 }
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("find".to_string(), find_fn);
 
@@ -1761,15 +1762,15 @@ impl Interpreter {
                 }
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("reduce".to_string(), reduce_fn);
 
         // Lazy helpers: map, filter, take, drop, flatMap
-        self.setup_iterator_lazy_helpers(iter_proto);
+        self.setup_iterator_lazy_helpers(iter_proto_id);
     }
 
-    fn setup_iterator_lazy_helpers(&mut self, iter_proto: &Rc<RefCell<JsObjectData>>) {
+    fn setup_iterator_lazy_helpers(&mut self, iter_proto_id: u64) {
         // map(mapper)
         let map_fn = self.create_function(JsFunction::native(
             "map".to_string(),
@@ -1896,7 +1897,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("map".to_string(), map_fn);
 
@@ -2034,7 +2035,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("filter".to_string(), filter_fn);
 
@@ -2188,7 +2189,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("take".to_string(), take_fn);
 
@@ -2353,7 +2354,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("drop".to_string(), drop_fn);
 
@@ -2585,7 +2586,7 @@ impl Interpreter {
                 Completion::Normal(helper)
             },
         ));
-        iter_proto
+        self.get_object_expect(iter_proto_id)
             .borrow_mut()
             .insert_builtin("flatMap".to_string(), flat_map_fn);
     }

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -445,7 +445,8 @@ impl Interpreter {
                 .global_env
                 .borrow_mut()
                 .declare("print", BindingKind::Var);
-            let _ = self.realm().global_env.borrow_mut().set("print", print_fn);
+            let env = self.realm().global_env.clone();
+            let _ = self.env_set(&env, "print", print_fn);
         }
 
         // Error constructor
@@ -527,24 +528,20 @@ impl Interpreter {
             // Mark Error constructor as deferred_construct so construct_with_new_target
             // doesn't do an early prototype lookup (the constructor body handles it via
             // get_prototype_from_new_target_realm, per spec §20.5.1.1 step 2).
-            let env = self.realm().global_env.borrow();
-            if let Some(error_val) = env.get("Error")
+            if let Some(error_val) = self.get_global_var("Error")
                 && let JsValue::Object(o) = &error_val
                 && let Some(func_obj) = self.get_object(o.id)
             {
                 func_obj.borrow_mut().deferred_construct = true;
             }
-            drop(env);
         }
 
         // Get Error.prototype for inheritance
         let error_prototype_id: Option<u64> = {
-            let env = self.realm().global_env.borrow();
-            if let Some(error_val) = env.get("Error")
+            if let Some(error_val) = self.get_global_var("Error")
                 && let JsValue::Object(o) = &error_val
             {
                 let ctor_id = o.id;
-                drop(env);
                 let proto_val = self.get_property_on_id(ctor_id, "prototype");
                 if let JsValue::Object(p) = &proto_val {
                     Some(p.id)
@@ -610,12 +607,9 @@ impl Interpreter {
                 JsValue::String(JsString::from_str("")),
             );
             // Set constructor on Error.prototype_id
-            {
-                let env = self.realm().global_env.borrow();
-                if let Some(error_ctor) = env.get("Error") {
-                    ep.borrow_mut()
-                        .insert_builtin("constructor".to_string(), error_ctor);
-                }
+            if let Some(error_ctor) = self.get_global_var("Error") {
+                ep.borrow_mut()
+                    .insert_builtin("constructor".to_string(), error_ctor);
             }
         }
 
@@ -637,8 +631,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::Boolean(false))
                 },
             ));
-            let env = self.realm().global_env.borrow();
-            if let Some(error_ctor) = env.get("Error")
+            if let Some(error_ctor) = self.get_global_var("Error")
                 && let JsValue::Object(o) = &error_ctor
                 && let Some(obj) = self.get_object(o.id)
             {
@@ -820,21 +813,14 @@ impl Interpreter {
             );
 
             // Set constructor on the per-type prototype
-            {
-                let ctor_val = {
-                    let env = self.realm().global_env.borrow();
-                    env.get(name)
-                };
-                if let Some(ctor_val) = ctor_val {
-                    native_proto
-                        .borrow_mut()
-                        .insert_builtin("constructor".to_string(), ctor_val.clone());
-                }
+            if let Some(ctor_val) = self.get_global_var(name) {
+                native_proto
+                    .borrow_mut()
+                    .insert_builtin("constructor".to_string(), ctor_val.clone());
             }
             // Set constructor's .prototype to the per-type prototype
             {
-                let env = self.realm().global_env.borrow();
-                if let Some(ctor_val) = env.get(name)
+                if let Some(ctor_val) = self.get_global_var(name)
                     && let JsValue::Object(o) = &ctor_val
                     && let Some(ctor_obj) = self.get_object(o.id)
                 {
@@ -936,9 +922,7 @@ impl Interpreter {
             global_env
                 .borrow_mut()
                 .declare("SuppressedError", BindingKind::Var);
-            let _ = global_env
-                .borrow_mut()
-                .set("SuppressedError", suppressed_ctor);
+            let _ = self.env_set(&global_env, "SuppressedError", suppressed_ctor);
         }
 
         // AggregateError constructor
@@ -1044,16 +1028,14 @@ impl Interpreter {
                 ),
             );
             {
-                let env = self.realm().global_env.borrow();
-                if let Some(ctor_val) = env.get("AggregateError") {
+                if let Some(ctor_val) = self.get_global_var("AggregateError") {
                     agg_proto
                         .borrow_mut()
                         .insert_builtin("constructor".to_string(), ctor_val);
                 }
             }
             {
-                let env = self.realm().global_env.borrow();
-                if let Some(ctor_val) = env.get("AggregateError")
+                if let Some(ctor_val) = self.get_global_var("AggregateError")
                     && let JsValue::Object(o) = &ctor_val
                     && let Some(ctor_obj) = self.get_object(o.id)
                 {
@@ -1265,11 +1247,8 @@ impl Interpreter {
                 .global_env
                 .borrow_mut()
                 .declare("Symbol", BindingKind::Var);
-            let _ = self
-                .realm()
-                .global_env
-                .borrow_mut()
-                .set("Symbol", symbol_fn);
+            let env = self.realm().global_env.clone();
+            let _ = self.env_set(&env, "Symbol", symbol_fn);
         }
 
         self.setup_iterator_prototypes();
@@ -1403,8 +1382,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&result)))
                 },
             ));
-            let env = self.realm().global_env.borrow();
-            if let Some(string_ctor) = env.get("String")
+            if let Some(string_ctor) = self.get_global_var("String")
                 && let JsValue::Object(o) = &string_ctor
                 && let Some(obj) = self.get_object(o.id)
             {
@@ -2408,7 +2386,7 @@ impl Interpreter {
             }
             let global_env = self.realm().global_env.clone();
             global_env.borrow_mut().declare("eval", BindingKind::Var);
-            let _ = global_env.borrow_mut().set("eval", eval_fn);
+            let _ = self.env_set(&global_env, "eval", eval_fn);
         }
 
         self.register_global_fn(
@@ -2563,7 +2541,7 @@ impl Interpreter {
             global_env
                 .borrow_mut()
                 .declare("Function", BindingKind::Var);
-            let _ = global_env.borrow_mut().set("Function", fn_ctor_fn);
+            let _ = self.env_set(&global_env, "Function", fn_ctor_fn);
         }
 
         // Per spec §20.2.3, Function.prototype is itself a function object.
@@ -2950,16 +2928,13 @@ impl Interpreter {
         // Set NativeError constructors' [[Prototype]] to %Error% (spec §20.5.6.1)
         // Must happen after the Function.prototype retroactive fix above
         {
-            let error_ctor_obj = {
-                let env = self.realm().global_env.borrow();
-                env.get("Error").and_then(|v| {
-                    if let JsValue::Object(o) = &v {
-                        self.get_object(o.id)
-                    } else {
-                        None
-                    }
-                })
-            };
+            let error_ctor_obj = self.get_global_var("Error").and_then(|v| {
+                if let JsValue::Object(o) = &v {
+                    self.get_object(o.id)
+                } else {
+                    None
+                }
+            });
             if let Some(err_data) = error_ctor_obj {
                 for name in [
                     "SyntaxError",
@@ -3144,10 +3119,7 @@ impl Interpreter {
                 af.borrow_mut().deferred_construct = true;
                 // §27.7.1 %AsyncFunction% inherits from %Function%
                 let function_ctor = self
-                    .realm()
-                    .global_env
-                    .borrow()
-                    .get("Function")
+                    .get_global_var("Function")
                     .unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(fc) = &function_ctor
                     && let Some(fc_obj) = self.get_object(fc.id)
@@ -3304,10 +3276,7 @@ impl Interpreter {
                 gf.borrow_mut().deferred_construct = true;
                 // §27.3.1 %GeneratorFunction% inherits from %Function%
                 let function_ctor = self
-                    .realm()
-                    .global_env
-                    .borrow()
-                    .get("Function")
+                    .get_global_var("Function")
                     .unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(fc) = &function_ctor
                     && let Some(fc_obj) = self.get_object(fc.id)
@@ -3466,10 +3435,7 @@ impl Interpreter {
                 agf.borrow_mut().deferred_construct = true;
                 // §27.4.1 %AsyncGeneratorFunction% inherits from %Function%
                 let function_ctor = self
-                    .realm()
-                    .global_env
-                    .borrow()
-                    .get("Function")
+                    .get_global_var("Function")
                     .unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(fc) = &function_ctor
                     && let Some(fc_obj) = self.get_object(fc.id)
@@ -3709,7 +3675,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("JSON", BindingKind::Var);
-        let _ = self.realm().global_env.borrow_mut().set("JSON", json_val);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "JSON", json_val);
 
         // String.fromCharCode
         {
@@ -3825,11 +3792,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("globalThis", BindingKind::Var);
-        let _ = self
-            .realm()
-            .global_env
-            .borrow_mut()
-            .set("globalThis", global_val.clone());
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "globalThis", global_val.clone());
         self.realm().global_env.borrow_mut().bindings.insert(
             "this".to_string(),
             Binding {
@@ -3910,13 +3874,10 @@ impl Interpreter {
             "ShadowRealm",
             "Iterator",
         ];
-        let vals: Vec<(String, JsValue)> = {
-            let env = self.realm().global_env.borrow();
-            global_names
-                .iter()
-                .filter_map(|name| env.get(name).map(|v| (name.to_string(), v)))
-                .collect()
-        };
+        let vals: Vec<(String, JsValue)> = global_names
+            .iter()
+            .filter_map(|name| self.get_global_var(name).map(|v| (name.to_string(), v)))
+            .collect();
         for (name, val) in vals {
             let (writable, configurable) = match name.as_str() {
                 "NaN" | "Infinity" | "undefined" => (false, false),
@@ -3959,13 +3920,10 @@ impl Interpreter {
             "FinalizationRegistry",
             "ShadowRealm",
         ];
-        let ctor_vals: Vec<JsValue> = {
-            let env = self.realm().global_env.borrow();
-            builtin_ctors
-                .iter()
-                .filter_map(|name| env.get(name))
-                .collect()
-        };
+        let ctor_vals: Vec<JsValue> = builtin_ctors
+            .iter()
+            .filter_map(|name| self.get_global_var(name))
+            .collect();
         for ctor_val in &ctor_vals {
             if let JsValue::Object(o) = ctor_val
                 && let Some(ctor_obj) = self.get_object(o.id)
@@ -3985,11 +3943,7 @@ impl Interpreter {
         // Record whose binding object is the global object. Variable lookups in global
         // scope should check global object properties.
         let gid = global_obj.borrow().id.unwrap();
-        {
-            let mut env = self.realm().global_env.borrow_mut();
-            env.global_object_id = Some(gid);
-            env.global_object_rc = Some(global_obj.clone());
-        }
+        self.realm().global_env.borrow_mut().global_object_id = Some(gid);
         self.realm_mut().global_object = Some(gid);
 
         // Per §9.1.1.4, built-in global names live on the global object (Object
@@ -4015,7 +3969,7 @@ impl Interpreter {
             let dollar_262_val = self.create_dollar_262(realm_id);
             let global_env = self.realm().global_env.clone();
             global_env.borrow_mut().declare("$262", BindingKind::Var);
-            let _ = global_env.borrow_mut().set("$262", dollar_262_val);
+            let _ = self.env_set(&global_env, "$262", dollar_262_val);
         }
     }
 
@@ -4040,28 +3994,25 @@ impl Interpreter {
                 proto_obj.borrow_mut().is_immutable_prototype = true;
 
                 // Fix Error.prototype chain - created before object_prototype was available
-                {
-                    let env = self.realm().global_env.borrow();
-                    for name in [
-                        "Error",
-                        "SyntaxError",
-                        "TypeError",
-                        "ReferenceError",
-                        "RangeError",
-                        "URIError",
-                        "EvalError",
-                        "Test262Error",
-                    ] {
-                        if let Some(error_val) = env.get(name)
-                            && let JsValue::Object(o) = &error_val
+                for name in [
+                    "Error",
+                    "SyntaxError",
+                    "TypeError",
+                    "ReferenceError",
+                    "RangeError",
+                    "URIError",
+                    "EvalError",
+                    "Test262Error",
+                ] {
+                    if let Some(error_val) = self.get_global_var(name)
+                        && let JsValue::Object(o) = &error_val
+                    {
+                        let pv = self.get_property_on_id(o.id, "prototype");
+                        if let JsValue::Object(p) = &pv
+                            && let Some(ep) = self.get_object(p.id)
+                            && ep.borrow().prototype_id.is_none()
                         {
-                            let pv = self.get_property_on_id(o.id, "prototype");
-                            if let JsValue::Object(p) = &pv
-                                && let Some(ep) = self.get_object(p.id)
-                                && ep.borrow().prototype_id.is_none()
-                            {
-                                ep.borrow_mut().prototype_id = Some(proto_obj.borrow().id.unwrap());
-                            }
+                            ep.borrow_mut().prototype_id = Some(proto_obj.borrow().id.unwrap());
                         }
                     }
                 }
@@ -8561,7 +8512,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("Proxy", BindingKind::Var);
-        let _ = self.realm().global_env.borrow_mut().set("Proxy", proxy_fn);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "Proxy", proxy_fn);
     }
 
     fn setup_function_prototype(&mut self, obj_proto: &Rc<RefCell<JsObjectData>>) {

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -370,13 +370,15 @@ impl Interpreter {
         // Create a placeholder Function.prototype early so all functions created during
         // setup get the correct [[Prototype]]. It will be adopted by Function.prototype later.
         if self.realm().function_prototype.is_none() {
-            let fp = self.create_object();
-            fp.borrow_mut().prototype_id = self.realm().object_prototype;
-            fp.borrow_mut().callable = Some(JsFunction::native(String::new(), 0, |_, _, _| {
-                Completion::Normal(JsValue::Undefined)
-            }));
-            fp.borrow_mut().class_name = "Function".to_string();
-            self.realm_mut().function_prototype = Some(fp.borrow().id.unwrap());
+            let fp_id = self.create_object_id();
+            self.get_object_cell_expect(fp_id).borrow_mut().prototype_id =
+                self.realm().object_prototype;
+            self.get_object_cell_expect(fp_id).borrow_mut().callable =
+                Some(JsFunction::native(String::new(), 0, |_, _, _| {
+                    Completion::Normal(JsValue::Undefined)
+                }));
+            self.get_object_cell_expect(fp_id).borrow_mut().class_name = "Function".to_string();
+            self.realm_mut().function_prototype = Some(fp_id);
         }
 
         // Create %ThrowTypeError% intrinsic (§10.2.4) — must exist before anything uses it
@@ -404,8 +406,8 @@ impl Interpreter {
             self.realm_mut().throw_type_error = Some(thrower);
         }
 
-        let console = self.create_object();
-        let console_id = console.borrow().id.unwrap();
+        let console_id = self.create_object_id();
+        let console_id = console_id;
         {
             let log_fn = self.create_function(JsFunction::native(
                 "log".to_string(),
@@ -416,7 +418,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::Undefined)
                 },
             ));
-            console
+            self.get_object_cell_expect(console_id)
                 .borrow_mut()
                 .insert_builtin("log".to_string(), log_fn);
         }
@@ -516,12 +518,12 @@ impl Interpreter {
                         }
                         return Completion::Normal(this.clone());
                     }
-                    let obj = interp.create_object();
+                    let obj_id = interp.create_object_id();
                     {
-                        let mut o = obj.borrow_mut();
+                        let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         init_error!(o);
                     }
-                    let id = obj.borrow().id.unwrap();
+                    let id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 }),
             );
@@ -668,9 +670,9 @@ impl Interpreter {
                             }
                             return Completion::Normal(this.clone());
                         }
-                        let obj = interp.create_object();
+                        let obj_id = interp.create_object_id();
                         {
-                            let mut o = obj.borrow_mut();
+                            let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                             o.class_name = "Test262Error".to_string();
                             if let Some(ref ep) = error_proto_clone {
                                 o.prototype_id = Some(ep.borrow().id.unwrap());
@@ -683,7 +685,7 @@ impl Interpreter {
                                 JsValue::String(JsString::from_str("Test262Error")),
                             );
                         }
-                        let id = obj.borrow().id.unwrap();
+                        let id = obj_id;
                         Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                     },
                 ),
@@ -702,21 +704,27 @@ impl Interpreter {
             let error_name = name.to_string();
 
             // Create per-type prototype inheriting from Error.prototype_id
-            let native_proto = self.create_object();
+            let native_proto_id = self.create_object_id();
             if let Some(ref ep) = error_prototype {
-                native_proto.borrow_mut().prototype_id = Some(ep.borrow().id.unwrap());
+                self.get_object_cell_expect(native_proto_id)
+                    .borrow_mut()
+                    .prototype_id = Some(ep.borrow().id.unwrap());
             }
-            native_proto.borrow_mut().insert_builtin(
-                "name".to_string(),
-                JsValue::String(JsString::from_str(name)),
-            );
-            native_proto.borrow_mut().insert_builtin(
-                "message".to_string(),
-                JsValue::String(JsString::from_str("")),
-            );
+            self.get_object_cell_expect(native_proto_id)
+                .borrow_mut()
+                .insert_builtin(
+                    "name".to_string(),
+                    JsValue::String(JsString::from_str(name)),
+                );
+            self.get_object_cell_expect(native_proto_id)
+                .borrow_mut()
+                .insert_builtin(
+                    "message".to_string(),
+                    JsValue::String(JsString::from_str("")),
+                );
 
             // Store native error prototype on realm
-            let native_proto_id = native_proto.borrow().id.unwrap();
+            let native_proto_id = native_proto_id;
             match name {
                 "SyntaxError" => self.realm_mut().syntax_error_prototype = Some(native_proto_id),
                 "TypeError" => self.realm_mut().type_error_prototype = Some(native_proto_id),
@@ -729,7 +737,7 @@ impl Interpreter {
                 _ => {}
             }
 
-            let native_proto_clone_id = native_proto.borrow().id.unwrap();
+            let native_proto_clone_id = native_proto_id;
             let error_name_clone = error_name.clone();
             self.register_global_fn(
                 name,
@@ -802,19 +810,19 @@ impl Interpreter {
                         }
                         return Completion::Normal(this.clone());
                     }
-                    let obj = interp.create_object();
+                    let obj_id = interp.create_object_id();
                     {
-                        let mut o = obj.borrow_mut();
+                        let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         init_native_error!(o);
                     }
-                    let id = obj.borrow().id.unwrap();
+                    let id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 }),
             );
 
             // Set constructor on the per-type prototype
             if let Some(ctor_val) = self.get_global_var(name) {
-                native_proto
+                self.get_object_cell_expect(native_proto_id)
                     .borrow_mut()
                     .insert_builtin("constructor".to_string(), ctor_val.clone());
             }
@@ -824,7 +832,7 @@ impl Interpreter {
                     && let JsValue::Object(o) = &ctor_val
                     && let Some(ctor_obj) = self.get_object(o.id)
                 {
-                    let proto_id = native_proto.borrow().id.unwrap();
+                    let proto_id = native_proto_id;
                     ctor_obj.borrow_mut().insert_property(
                         "prototype".to_string(),
                         PropertyDescriptor::data(
@@ -841,21 +849,26 @@ impl Interpreter {
 
         // SuppressedError constructor
         {
-            let suppressed_proto = self.create_object();
+            let suppressed_proto_id = self.create_object_id();
             if let Some(ref ep) = error_prototype {
-                suppressed_proto.borrow_mut().prototype_id = Some(ep.borrow().id.unwrap());
+                self.get_object_cell_expect(suppressed_proto_id)
+                    .borrow_mut()
+                    .prototype_id = Some(ep.borrow().id.unwrap());
             }
-            suppressed_proto.borrow_mut().insert_builtin(
-                "name".to_string(),
-                JsValue::String(JsString::from_str("SuppressedError")),
-            );
-            suppressed_proto.borrow_mut().insert_builtin(
-                "message".to_string(),
-                JsValue::String(JsString::from_str("")),
-            );
+            self.get_object_cell_expect(suppressed_proto_id)
+                .borrow_mut()
+                .insert_builtin(
+                    "name".to_string(),
+                    JsValue::String(JsString::from_str("SuppressedError")),
+                );
+            self.get_object_cell_expect(suppressed_proto_id)
+                .borrow_mut()
+                .insert_builtin(
+                    "message".to_string(),
+                    JsValue::String(JsString::from_str("")),
+                );
 
-            self.realm_mut().suppressed_error_prototype =
-                Some(suppressed_proto.borrow().id.unwrap());
+            self.realm_mut().suppressed_error_prototype = Some(suppressed_proto_id);
 
             let suppressed_ctor = self.create_function(JsFunction::constructor(
                 "SuppressedError".to_string(),
@@ -872,19 +885,25 @@ impl Interpreter {
                         Ok(p) => p,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let obj = interp.create_object();
+                    // Extract msg_str BEFORE the mut borrow on obj's RefCell
+                    // (lifetime is tied to &interp; can't hold across &mut interp).
+                    let msg_str = if !matches!(msg_raw, JsValue::Undefined) {
+                        match interp.to_string_value(&msg_raw) {
+                            Ok(s) => Some(JsValue::String(JsString::from_str(&s))),
+                            Err(e) => return Completion::Throw(e),
+                        }
+                    } else {
+                        None
+                    };
+                    let obj_id = interp.create_object_id();
                     {
-                        let mut o = obj.borrow_mut();
+                        let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         o.class_name = "SuppressedError".to_string();
                         if let Some(p) = proto {
                             o.prototype_id = Some(p);
                         }
                         // Per spec: message first, then error, then suppressed
-                        if !matches!(msg_raw, JsValue::Undefined) {
-                            let msg_str = match interp.to_string_value(&msg_raw) {
-                                Ok(s) => JsValue::String(JsString::from_str(&s)),
-                                Err(e) => return Completion::Throw(e),
-                            };
+                        if let Some(msg_str) = msg_str {
                             o.insert_builtin("message".to_string(), msg_str);
                         }
                         o.insert_builtin("error".to_string(), error_val.clone());
@@ -894,19 +913,19 @@ impl Interpreter {
                             JsValue::String(JsString::from_str("")),
                         );
                     }
-                    let id = obj.borrow().id.unwrap();
+                    let id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 },
             ));
 
-            suppressed_proto
+            self.get_object_cell_expect(suppressed_proto_id)
                 .borrow_mut()
                 .insert_builtin("constructor".to_string(), suppressed_ctor.clone());
 
             if let JsValue::Object(ref ctor_ref) = suppressed_ctor
                 && let Some(ctor_obj) = self.get_object(ctor_ref.id)
             {
-                let proto_id = suppressed_proto.borrow().id.unwrap();
+                let proto_id = suppressed_proto_id;
                 ctor_obj.borrow_mut().insert_property(
                     "prototype".to_string(),
                     PropertyDescriptor::data(
@@ -927,20 +946,26 @@ impl Interpreter {
 
         // AggregateError constructor
         {
-            let agg_proto = self.create_object();
+            let agg_proto_id = self.create_object_id();
             if let Some(ref ep) = error_prototype {
-                agg_proto.borrow_mut().prototype_id = Some(ep.borrow().id.unwrap());
+                self.get_object_cell_expect(agg_proto_id)
+                    .borrow_mut()
+                    .prototype_id = Some(ep.borrow().id.unwrap());
             }
-            agg_proto.borrow_mut().insert_builtin(
-                "name".to_string(),
-                JsValue::String(JsString::from_str("AggregateError")),
-            );
-            agg_proto.borrow_mut().insert_builtin(
-                "message".to_string(),
-                JsValue::String(JsString::from_str("")),
-            );
-            let agg_proto_clone_id = agg_proto.borrow().id.unwrap();
-            self.realm_mut().aggregate_error_prototype = Some(agg_proto.borrow().id.unwrap());
+            self.get_object_cell_expect(agg_proto_id)
+                .borrow_mut()
+                .insert_builtin(
+                    "name".to_string(),
+                    JsValue::String(JsString::from_str("AggregateError")),
+                );
+            self.get_object_cell_expect(agg_proto_id)
+                .borrow_mut()
+                .insert_builtin(
+                    "message".to_string(),
+                    JsValue::String(JsString::from_str("")),
+                );
+            let agg_proto_clone_id = agg_proto_id;
+            self.realm_mut().aggregate_error_prototype = Some(agg_proto_id);
             self.register_global_fn(
                 "AggregateError",
                 BindingKind::Var,
@@ -1017,19 +1042,19 @@ impl Interpreter {
                             }
                             return Completion::Normal(this.clone());
                         }
-                        let obj = interp.create_object();
+                        let obj_id = interp.create_object_id();
                         {
-                            let mut o = obj.borrow_mut();
+                            let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                             init_agg_error!(o);
                         }
-                        let id = obj.borrow().id.unwrap();
+                        let id = obj_id;
                         Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                     },
                 ),
             );
             {
                 if let Some(ctor_val) = self.get_global_var("AggregateError") {
-                    agg_proto
+                    self.get_object_cell_expect(agg_proto_id)
                         .borrow_mut()
                         .insert_builtin("constructor".to_string(), ctor_val);
                 }
@@ -1039,7 +1064,7 @@ impl Interpreter {
                     && let JsValue::Object(o) = &ctor_val
                     && let Some(ctor_obj) = self.get_object(o.id)
                 {
-                    let proto_id = agg_proto.borrow().id.unwrap();
+                    let proto_id = agg_proto_id;
                     ctor_obj.borrow_mut().insert_property(
                         "prototype".to_string(),
                         PropertyDescriptor::data(
@@ -1067,8 +1092,8 @@ impl Interpreter {
                     if !nt_is_object {
                         // OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%")
                         let default_proto = interp.realm().object_prototype;
-                        let new_obj_rc = interp.create_object();
-                        let no_id = new_obj_rc.borrow().id.unwrap();
+                        let new_obj_rc_id = interp.create_object_id();
+                        let no_id = new_obj_rc_id;
                         interp.apply_new_target_prototype(no_id, default_proto, |realm| realm.object_prototype);
                         let new_obj_val = JsValue::Object(crate::types::JsObject { id: no_id });
                         return Completion::Normal(new_obj_val);
@@ -1082,8 +1107,8 @@ impl Interpreter {
                         interp.to_object(val)
                     }
                     _ => {
-                        let obj = interp.create_object();
-                        let id = obj.borrow().id.unwrap();
+                        let obj_id = interp.create_object_id();
+                        let id = obj_id;
                         Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                     }
                 }
@@ -1918,10 +1943,10 @@ impl Interpreter {
         );
 
         // Math object
-        let math_obj = self.create_object();
-        let math_id = math_obj.borrow().id.unwrap();
+        let math_obj_id = self.create_object_id();
+        let math_id = math_obj_id;
         {
-            let mut m = math_obj.borrow_mut();
+            let mut m = self.get_object_cell_expect(math_obj_id).borrow_mut();
             m.class_name = "Math".to_string();
             let math_consts: &[(&str, f64)] = &[
                 ("PI", std::f64::consts::PI),
@@ -1979,7 +2004,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(op(x)))
                 },
             ));
-            math_obj
+            self.get_object_cell_expect(math_obj_id)
                 .borrow_mut()
                 .insert_builtin(name.to_string(), fn_val);
         }
@@ -2003,7 +2028,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(result))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("round".to_string(), round_fn);
         // Math.max, Math.min, Math.pow, Math.random, Math.atan2
@@ -2040,7 +2065,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(result))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("max".to_string(), max_fn);
         let min_fn = self.create_function(JsFunction::native(
@@ -2076,7 +2101,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(result))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("min".to_string(), min_fn);
         let pow_fn = self.create_function(JsFunction::native(
@@ -2088,7 +2113,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(number_ops::exponentiate(base, exp)))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("pow".to_string(), pow_fn);
         let random_fn = self.create_function(JsFunction::native(
@@ -2098,7 +2123,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(0.5)) // deterministic for testing
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("random".to_string(), random_fn);
 
@@ -2112,7 +2137,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(y.atan2(x)))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("atan2".to_string(), atan2_fn);
 
@@ -2151,7 +2176,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(sum.sqrt()))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("hypot".to_string(), hypot_fn);
 
@@ -2164,7 +2189,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(x.log2()))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("log2".to_string(), log2_fn);
         let log10_fn = self.create_function(JsFunction::native(
@@ -2175,7 +2200,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(x.log10()))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("log10".to_string(), log10_fn);
 
@@ -2188,7 +2213,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number((x as f32) as f64))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("fround".to_string(), fround_fn);
 
@@ -2202,7 +2227,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(n.leading_zeros() as f64))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("clz32".to_string(), clz32_fn);
 
@@ -2218,7 +2243,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(ia.wrapping_mul(ib) as f64))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("imul".to_string(), imul_fn);
 
@@ -2243,7 +2268,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(op(x)))
                 },
             ));
-            math_obj
+            self.get_object_cell_expect(math_obj_id)
                 .borrow_mut()
                 .insert_builtin(name.to_string(), fn_val);
         }
@@ -2261,7 +2286,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(f64_to_f16_to_f64(n)))
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("f16round".to_string(), f16round_fn);
 
@@ -2336,7 +2361,7 @@ impl Interpreter {
                 }
             },
         ));
-        math_obj
+        self.get_object_cell_expect(math_obj_id)
             .borrow_mut()
             .insert_builtin("sumPrecise".to_string(), sum_precise_fn);
 
@@ -2351,8 +2376,14 @@ impl Interpreter {
                 set: None,
             };
             let key = "Symbol(Symbol.toStringTag)".to_string();
-            math_obj.borrow_mut().property_order.push(key.clone());
-            math_obj.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(math_obj_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(math_obj_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         let math_val = JsValue::Object(crate::types::JsObject { id: math_id });
@@ -2958,8 +2989,10 @@ impl Interpreter {
         // %AsyncFunction.prototype%
         // Per spec, this should inherit from Function.prototype_id
         {
-            let af_proto = self.create_object();
-            af_proto.borrow_mut().class_name = "AsyncFunction".to_string();
+            let af_proto_id = self.create_object_id();
+            self.get_object_cell_expect(af_proto_id)
+                .borrow_mut()
+                .class_name = "AsyncFunction".to_string();
 
             // [[Prototype]] = Function.prototype_id
             if let Some(func_val) = self.get_global_var("Function")
@@ -2968,21 +3001,25 @@ impl Interpreter {
                     self.get_property_on_id(func_obj.id, "prototype")
                 && let Some(func_proto) = self.get_object(func_proto_obj.id)
             {
-                af_proto.borrow_mut().prototype_id = Some(func_proto.borrow().id.unwrap());
+                self.get_object_cell_expect(af_proto_id)
+                    .borrow_mut()
+                    .prototype_id = Some(func_proto.borrow().id.unwrap());
             }
 
             // Symbol.toStringTag = "AsyncFunction"
-            af_proto.borrow_mut().insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("AsyncFunction")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+            self.get_object_cell_expect(af_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "Symbol(Symbol.toStringTag)".to_string(),
+                    PropertyDescriptor::data(
+                        JsValue::String(JsString::from_str("AsyncFunction")),
+                        false,
+                        false,
+                        true,
+                    ),
+                );
 
-            self.realm_mut().async_function_prototype = Some(af_proto.borrow().id.unwrap());
+            self.realm_mut().async_function_prototype = Some(af_proto_id);
         }
 
         // AsyncFunction constructor (not a global per spec)
@@ -3541,9 +3578,10 @@ impl Interpreter {
                     let (result, smap) = json_parse_value_with_source(interp, &s);
                     match result {
                         Completion::Normal(parsed) => {
-                            let wrapper = interp.create_object();
-                            let wrapper_id = wrapper.borrow().id.unwrap();
-                            wrapper
+                            let wrapper_id = interp.create_object_id();
+                            let wrapper_id = wrapper_id;
+                            interp
+                                .get_object_cell_expect(wrapper_id)
                                 .borrow_mut()
                                 .insert_value("".to_string(), parsed.clone());
                             // Store source text for top-level primitive
@@ -3609,10 +3647,13 @@ impl Interpreter {
                 if let Completion::Throw(e) = json_parse_value(interp, &text) {
                     return Completion::Throw(e);
                 }
-                let obj = interp.create_object();
-                obj.borrow_mut().prototype_id = None;
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = None;
                 {
-                    let mut o = obj.borrow_mut();
+                    let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                     let desc = PropertyDescriptor::data(
                         JsValue::String(JsString::from_str(&text)),
                         false,
@@ -3622,9 +3663,15 @@ impl Interpreter {
                     o.property_order.push("rawJSON".to_string());
                     o.properties.insert("rawJSON".to_string(), desc);
                 }
-                obj.borrow_mut().extensible = false;
-                obj.borrow_mut().is_raw_json = true;
-                let id = obj.borrow().id.unwrap();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .extensible = false;
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .is_raw_json = true;
+                let id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
             },
         ));
@@ -5159,17 +5206,23 @@ impl Interpreter {
                             ),
                         );
                     }
-                    let new_obj = interp.create_object();
+                    let new_obj_id = interp.create_object_id();
                     match &proto_arg {
                         JsValue::Object(o) => {
-                            new_obj.borrow_mut().prototype_id = Some(o.id);
+                            interp
+                                .get_object_cell_expect(new_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(o.id);
                         }
                         JsValue::Null => {
-                            new_obj.borrow_mut().prototype_id = None;
+                            interp
+                                .get_object_cell_expect(new_obj_id)
+                                .borrow_mut()
+                                .prototype_id = None;
                         }
                         _ => unreachable!(),
                     }
-                    let id = new_obj.borrow().id.unwrap();
+                    let id = new_obj_id;
                     let target = JsValue::Object(crate::types::JsObject { id });
 
                     let props_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
@@ -5617,9 +5670,9 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let result_obj = interp.create_object();
-                    result_obj.borrow_mut().prototype_id = None;
-                    let result_id = result_obj.borrow().id.unwrap();
+                    let result_obj_id = interp.create_object_id();
+                    interp.get_object_cell_expect(result_obj_id).borrow_mut().prototype_id = None;
+                    let result_id = result_obj_id;
                     let result_val = JsValue::Object(crate::types::JsObject { id: result_id });
                     let mut k: u64 = 0;
                     loop {
@@ -6513,7 +6566,7 @@ impl Interpreter {
                         for k in sym_keys {
                             keys.push(k);
                         }
-                        let result = interp.create_object();
+                        let result_id = interp.create_object_id();
                         for key in keys {
                             // Use proxy_get_own_property_descriptor to invoke trap
                             let desc_val =
@@ -6528,15 +6581,18 @@ impl Interpreter {
                                 } else {
                                     key.clone()
                                 };
-                                result.borrow_mut().insert_value(key_str, desc_val);
+                                interp
+                                    .get_object_cell_expect(result_id)
+                                    .borrow_mut()
+                                    .insert_value(key_str, desc_val);
                             }
                         }
-                        let id = result.borrow().id.unwrap();
+                        let id = result_id;
                         return Completion::Normal(JsValue::Object(crate::types::JsObject { id }));
                     }
                     // Primitive wrapped to object with no own properties
-                    let result = interp.create_object();
-                    let id = result.borrow().id.unwrap();
+                    let result_id = interp.create_object_id();
+                    let id = result_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 },
             ));
@@ -6550,8 +6606,8 @@ impl Interpreter {
                 1,
                 |interp, _this, args| {
                     let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let obj = interp.create_object();
-                    let obj_id = obj.borrow().id.unwrap();
+                    let obj_id = interp.create_object_id();
+                    let obj_id = obj_id;
                     let obj_val = JsValue::Object(crate::types::JsObject { id: obj_id });
                     let iterator = match interp.get_iterator(&iterable) {
                         Ok(v) => v,
@@ -6638,11 +6694,14 @@ impl Interpreter {
     }
 
     pub(crate) fn create_iter_result_object(&mut self, value: JsValue, done: bool) -> JsValue {
-        let obj = self.create_object();
-        obj.borrow_mut().insert_value("value".to_string(), value);
-        obj.borrow_mut()
+        let obj_id = self.create_object_id();
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .insert_value("value".to_string(), value);
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
             .insert_value("done".to_string(), JsValue::Boolean(done));
-        let id = obj.borrow().id.unwrap();
+        let id = obj_id;
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -6778,7 +6837,7 @@ impl Interpreter {
     }
 
     fn create_async_from_sync_iterator(&mut self, sync_iter: JsValue) -> JsValue {
-        let wrapper = self.create_object();
+        let wrapper_id = self.create_object_id();
         let cached_next = if let JsValue::Object(io) = &sync_iter {
             if let Some(cached) = self.iterator_next_cache.get(&io.id).cloned() {
                 cached
@@ -6819,7 +6878,7 @@ impl Interpreter {
                 interp.async_from_sync_continuation(result, sync_for_next.clone(), true)
             },
         ));
-        wrapper
+        self.get_object_cell_expect(wrapper_id)
             .borrow_mut()
             .insert_builtin("next".to_string(), next_fn);
 
@@ -6883,7 +6942,7 @@ impl Interpreter {
                 }
             },
         ));
-        wrapper
+        self.get_object_cell_expect(wrapper_id)
             .borrow_mut()
             .insert_builtin("return".to_string(), return_fn);
 
@@ -6936,11 +6995,11 @@ impl Interpreter {
                 }
             },
         ));
-        wrapper
+        self.get_object_cell_expect(wrapper_id)
             .borrow_mut()
             .insert_builtin("throw".to_string(), throw_fn);
 
-        let id = wrapper.borrow().id.unwrap();
+        let id = wrapper_id;
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -7289,8 +7348,8 @@ impl Interpreter {
     }
 
     fn setup_reflect(&mut self) {
-        let reflect_obj = self.create_object();
-        let reflect_id = reflect_obj.borrow().id.unwrap();
+        let reflect_obj_id = self.create_object_id();
+        let reflect_id = reflect_obj_id;
 
         // Reflect.apply(target, thisArg, argsList)
         let apply_fn = self.create_function(JsFunction::native(
@@ -7318,7 +7377,7 @@ impl Interpreter {
                 interp.call_function(&target, &this_arg, &call_args)
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("apply".to_string(), apply_fn);
 
@@ -7353,7 +7412,7 @@ impl Interpreter {
                 interp.construct_with_new_target(&target, &call_args, new_target)
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("construct".to_string(), construct_fn);
 
@@ -7449,7 +7508,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("defineProperty".to_string(), def_prop_fn);
 
@@ -7521,7 +7580,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("deleteProperty".to_string(), del_prop_fn);
 
@@ -7549,7 +7608,7 @@ impl Interpreter {
                 }
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("get".to_string(), get_fn);
 
@@ -7642,7 +7701,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::Undefined)
                 },
             ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("getOwnPropertyDescriptor".to_string(), gopd_fn);
 
@@ -7677,7 +7736,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Null)
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("getPrototypeOf".to_string(), gpo_fn);
 
@@ -7706,7 +7765,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("has".to_string(), has_fn);
 
@@ -7739,7 +7798,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("isExtensible".to_string(), is_ext_fn);
 
@@ -7882,7 +7941,7 @@ impl Interpreter {
                 Completion::Normal(interp.create_array(Vec::new()))
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("ownKeys".to_string(), own_keys_fn);
 
@@ -7932,7 +7991,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(true))
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("preventExtensions".to_string(), pe_fn);
 
@@ -8255,7 +8314,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("set".to_string(), set_fn);
 
@@ -8351,7 +8410,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        reflect_obj
+        self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("setPrototypeOf".to_string(), spo_fn);
 
@@ -8366,8 +8425,14 @@ impl Interpreter {
                 set: None,
             };
             let key = "Symbol(Symbol.toStringTag)".to_string();
-            reflect_obj.borrow_mut().property_order.push(key.clone());
-            reflect_obj.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(reflect_obj_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(reflect_obj_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Register Reflect as global
@@ -8407,22 +8472,34 @@ impl Interpreter {
                             .create_type_error("Cannot create proxy with a non-object as handler"),
                     );
                 }
-                let proxy_obj = interp.create_object();
-                proxy_obj.borrow_mut().class_name = "Proxy".to_string();
+                let proxy_obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(proxy_obj_id)
+                    .borrow_mut()
+                    .class_name = "Proxy".to_string();
                 if let JsValue::Object(ref t) = target
                     && let Some(target_rc) = interp.get_object(t.id)
                 {
                     // Copy callable if target is callable
                     let callable = target_rc.borrow().callable.clone();
                     if callable.is_some() {
-                        proxy_obj.borrow_mut().callable = callable;
+                        interp
+                            .get_object_cell_expect(proxy_obj_id)
+                            .borrow_mut()
+                            .callable = callable;
                     }
-                    proxy_obj.borrow_mut().proxy_target_id = Some(t.id);
+                    interp
+                        .get_object_cell_expect(proxy_obj_id)
+                        .borrow_mut()
+                        .proxy_target_id = Some(t.id);
                 }
                 if let JsValue::Object(ref h) = handler {
-                    proxy_obj.borrow_mut().proxy_handler_id = Some(h.id);
+                    interp
+                        .get_object_cell_expect(proxy_obj_id)
+                        .borrow_mut()
+                        .proxy_handler_id = Some(h.id);
                 }
-                let proxy_id = proxy_obj.borrow().id.unwrap();
+                let proxy_id = proxy_obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: proxy_id }))
             },
         ));
@@ -8459,21 +8536,33 @@ impl Interpreter {
                             "Cannot create proxy with a non-object as handler",
                         ));
                     }
-                    let proxy_obj = interp.create_object();
-                    proxy_obj.borrow_mut().class_name = "Proxy".to_string();
+                    let proxy_obj_id = interp.create_object_id();
+                    interp
+                        .get_object_cell_expect(proxy_obj_id)
+                        .borrow_mut()
+                        .class_name = "Proxy".to_string();
                     if let JsValue::Object(ref t) = target
                         && let Some(target_rc) = interp.get_object(t.id)
                     {
                         let callable = target_rc.borrow().callable.clone();
                         if callable.is_some() {
-                            proxy_obj.borrow_mut().callable = callable;
+                            interp
+                                .get_object_cell_expect(proxy_obj_id)
+                                .borrow_mut()
+                                .callable = callable;
                         }
-                        proxy_obj.borrow_mut().proxy_target_id = Some(t.id);
+                        interp
+                            .get_object_cell_expect(proxy_obj_id)
+                            .borrow_mut()
+                            .proxy_target_id = Some(t.id);
                     }
                     if let JsValue::Object(ref h) = handler {
-                        proxy_obj.borrow_mut().proxy_handler_id = Some(h.id);
+                        interp
+                            .get_object_cell_expect(proxy_obj_id)
+                            .borrow_mut()
+                            .proxy_handler_id = Some(h.id);
                     }
-                    let proxy_id = proxy_obj.borrow().id.unwrap();
+                    let proxy_id = proxy_obj_id;
                     let proxy_val = JsValue::Object(crate::types::JsObject { id: proxy_id });
 
                     // Create revoke function that captures proxy_id
@@ -8491,14 +8580,16 @@ impl Interpreter {
                         },
                     ));
 
-                    let result = interp.create_object();
-                    result
+                    let result_id = interp.create_object_id();
+                    interp
+                        .get_object_cell_expect(result_id)
                         .borrow_mut()
                         .insert_builtin("proxy".to_string(), proxy_val);
-                    result
+                    interp
+                        .get_object_cell_expect(result_id)
                         .borrow_mut()
                         .insert_builtin("revoke".to_string(), revoke_fn);
-                    let result_id = result.borrow().id.unwrap();
+                    let result_id = result_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
                 },
             ));
@@ -8831,10 +8922,10 @@ impl Interpreter {
 
     pub(crate) fn setup_shadow_realm(&mut self) {
         let my_realm_id = self.current_realm_id;
-        let proto = self.create_object();
+        let proto_id = self.create_object_id();
         let op = self.realm().object_prototype;
         {
-            let mut p = proto.borrow_mut();
+            let mut p = self.get_object_cell_expect(proto_id).borrow_mut();
             p.class_name = "ShadowRealm".to_string();
             p.prototype_id = op;
         }
@@ -8843,15 +8934,17 @@ impl Interpreter {
         let to_string_tag_key = self
             .get_symbol_key("toStringTag")
             .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
-        proto.borrow_mut().insert_property(
-            to_string_tag_key,
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("ShadowRealm")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                to_string_tag_key,
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("ShadowRealm")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
         // ShadowRealm.prototype.evaluate
         let evaluate_fn = self.create_function(JsFunction::native(
@@ -8886,7 +8979,7 @@ impl Interpreter {
                 interp.perform_realm_eval(&source_text, my_realm_id, eval_realm_id)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("evaluate".to_string(), evaluate_fn);
 
@@ -9012,11 +9105,11 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("importValue".to_string(), import_value_fn);
 
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // ShadowRealm constructor
@@ -9033,18 +9126,16 @@ impl Interpreter {
 
                 let new_realm_id = interp.create_new_realm();
 
-                let obj = interp.create_object();
+                let obj_id = interp.create_object_id();
                 {
-                    let mut o = obj.borrow_mut();
+                    let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                     o.class_name = "ShadowRealm".to_string();
                     o.shadow_realm_id = Some(new_realm_id);
                     if let JsValue::Object(ref p) = proto_val_for_ctor {
                         o.prototype_id = Some(p.id);
                     }
                 }
-                Completion::Normal(JsValue::Object(crate::types::JsObject {
-                    id: obj.borrow().id.unwrap(),
-                }))
+                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },
         ));
 

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2551,8 +2551,7 @@ impl Interpreter {
             let fp = self.realm().function_prototype;
             if let Some(fp_id) = fp {
                 // Already has callable from early init, but ensure length/name
-                let fp_obj = self.get_object_expect(fp_id);
-                let mut b = fp_obj.borrow_mut();
+                let mut b = self.get_object_cell_expect(fp_id).borrow_mut();
                 if !b.properties.contains_key("length") {
                     b.insert_property(
                         "length".to_string(),
@@ -4614,7 +4613,7 @@ impl Interpreter {
                                                     ),
                                                 );
                                             }
-                                            check = interp.get_object_expect(c_id).borrow().prototype_id;
+                                            check = interp.get_object_cell_expect(c_id).borrow().prototype_id;
                                         }
                                         obj.borrow_mut().prototype_id = Some(p.id);
                                     }
@@ -8528,7 +8527,7 @@ impl Interpreter {
                 interp.call_function(_this, &this_arg, call_args)
             },
         ));
-        self.get_object_expect(obj_proto_id)
+        self.get_object_cell_expect(obj_proto_id)
             .borrow_mut()
             .insert_builtin("call".to_string(), call_fn);
 
@@ -8584,7 +8583,7 @@ impl Interpreter {
                 interp.call_function(_this, &this_arg, &call_args)
             },
         ));
-        self.get_object_expect(obj_proto_id)
+        self.get_object_cell_expect(obj_proto_id)
             .borrow_mut()
             .insert_builtin("apply".to_string(), apply_fn);
 
@@ -8752,7 +8751,7 @@ impl Interpreter {
                 Completion::Normal(result)
             },
         ));
-        self.get_object_expect(obj_proto_id)
+        self.get_object_cell_expect(obj_proto_id)
             .borrow_mut()
             .insert_builtin("bind".to_string(), bind_fn);
 
@@ -8825,7 +8824,7 @@ impl Interpreter {
                 ))
             },
         ));
-        self.get_object_expect(obj_proto_id)
+        self.get_object_cell_expect(obj_proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), fn_tostring);
     }

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -385,7 +385,7 @@ impl Interpreter {
         {
             let thrower = self.create_thrower_function();
             if let JsValue::Object(ref o) = thrower
-                && let Some(obj) = self.get_object(o.id)
+                && let Some(obj) = self.get_object_cell(o.id)
             {
                 let mut b = obj.borrow_mut();
                 b.extensible = false;
@@ -511,7 +511,7 @@ impl Interpreter {
                     }
 
                     if let JsValue::Object(o) = this {
-                        if let Some(obj) = interp.get_object(o.id) {
+                        if let Some(obj) = interp.get_object_cell(o.id) {
                             let mut o = obj.borrow_mut();
                             init_error!(o);
                         }
@@ -1737,7 +1737,7 @@ impl Interpreter {
             let parse_float = self.get_global_var("parseFloat");
             if let Some(num_val) = self.get_global_var("Number")
                 && let JsValue::Object(o) = &num_val
-                && let Some(num_obj) = self.get_object(o.id)
+                && let Some(num_obj) = self.get_object_cell(o.id)
             {
                 let mut n = num_obj.borrow_mut();
                 if let Some(pi) = parse_int {
@@ -2548,7 +2548,7 @@ impl Interpreter {
                         };
                         if let Some(p) = proto
                             && let JsValue::Object(fo) = &result
-                            && let Some(fobj) = interp.get_object(fo.id)
+                            && let Some(fobj) = interp.get_object_cell(fo.id)
                         {
                             fobj.borrow_mut().prototype_id = Some(p);
                         }
@@ -2562,7 +2562,7 @@ impl Interpreter {
             ));
             // Parse-before-getprototype: body is parsed before prototype lookup
             if let JsValue::Object(ref fo) = fn_ctor_fn
-                && let Some(func_obj) = self.get_object(fo.id)
+                && let Some(func_obj) = self.get_object_cell(fo.id)
             {
                 func_obj.borrow_mut().deferred_construct = true;
             }
@@ -2603,7 +2603,7 @@ impl Interpreter {
                 if let Some(JsValue::Object(fo)) = func_val {
                     let pv = self.get_property_on_id(fo.id, "prototype");
                     if let JsValue::Object(pr) = pv
-                        && let Some(proto_obj) = self.get_object(pr.id)
+                        && let Some(proto_obj) = self.get_object_cell(pr.id)
                     {
                         proto_obj.borrow_mut().callable = Some(JsFunction::native(
                             "".to_string(),
@@ -2840,9 +2840,9 @@ impl Interpreter {
                         .collect();
                     for val in &bindings {
                         if let JsValue::Object(o) = val
-                            && let Some(obj) = self.get_object(o.id)
+                            && let Some(obj) = self.get_object_cell(o.id)
                         {
-                            fix_callable(&obj, &fp);
+                            fix_callable(obj, &fp);
                             // Level 2: properties of global bindings (static methods, .prototype)
                             let level2_vals: Vec<JsValue> = obj
                                 .borrow()
@@ -2852,11 +2852,11 @@ impl Interpreter {
                                 .collect();
                             for pv in &level2_vals {
                                 if let JsValue::Object(po) = pv
-                                    && let Some(pobj) = self.get_object(po.id)
+                                    && let Some(pobj) = self.get_object_cell(po.id)
                                 {
                                     // Don't set fp's own [[Prototype]] to itself
                                     if Some(po.id) != fp_id {
-                                        fix_callable(&pobj, &fp);
+                                        fix_callable(pobj, &fp);
                                     }
                                     // Level 3: always walk into properties (including fp's own)
                                     let level3_vals: Vec<JsValue> = pobj
@@ -2870,8 +2870,8 @@ impl Interpreter {
                                             if Some(po3.id) == fp_id {
                                                 continue;
                                             }
-                                            if let Some(pobj3) = self.get_object(po3.id) {
-                                                fix_callable(&pobj3, &fp);
+                                            if let Some(pobj3) = self.get_object_cell(po3.id) {
+                                                fix_callable(pobj3, &fp);
                                             }
                                         }
                                     }
@@ -2892,7 +2892,7 @@ impl Interpreter {
                     .flatten()
                     .collect();
                     for sp_id in special_proto_ids {
-                        if let Some(special_proto) = self.get_object(sp_id) {
+                        if let Some(special_proto) = self.get_object_cell(sp_id) {
                             special_proto.borrow_mut().prototype_id = Some(fp.borrow().id.unwrap());
                         }
                     }
@@ -2920,9 +2920,9 @@ impl Interpreter {
                     .into_iter()
                     .flatten()
                     .collect();
-                    let internal_protos: Vec<Rc<RefCell<JsObjectData>>> = internal_proto_ids
+                    let internal_protos: Vec<&RefCell<JsObjectData>> = internal_proto_ids
                         .into_iter()
-                        .filter_map(|id| self.get_object(id))
+                        .filter_map(|id| self.get_object_cell(id))
                         .collect();
                     for proto in &internal_protos {
                         let prop_vals: Vec<JsValue> = proto
@@ -2936,8 +2936,8 @@ impl Interpreter {
                                 if Some(po.id) == fp_id {
                                     continue;
                                 }
-                                if let Some(pobj) = self.get_object(po.id) {
-                                    fix_callable(&pobj, &fp);
+                                if let Some(pobj) = self.get_object_cell(po.id) {
+                                    fix_callable(pobj, &fp);
                                 }
                             }
                         }
@@ -2945,7 +2945,7 @@ impl Interpreter {
 
                     // Fix %ThrowTypeError% prototype (§10.2.4 step 11)
                     if let Some(JsValue::Object(ref te)) = self.realm().throw_type_error
-                        && let Some(te_obj) = self.get_object(te.id)
+                        && let Some(te_obj) = self.get_object_cell(te.id)
                     {
                         te_obj.borrow_mut().prototype_id = Some(fp.borrow().id.unwrap());
                     }
@@ -2976,7 +2976,7 @@ impl Interpreter {
                 ] {
                     let ctor_val = self.get_global_var(name);
                     if let Some(JsValue::Object(o)) = ctor_val
-                        && let Some(ctor_obj) = self.get_object(o.id)
+                        && let Some(ctor_obj) = self.get_object_cell(o.id)
                     {
                         ctor_obj.borrow_mut().prototype_id = Some(err_data.borrow().id.unwrap());
                     }
@@ -2997,7 +2997,7 @@ impl Interpreter {
                 && let JsValue::Object(func_obj) = func_val
                 && let JsValue::Object(func_proto_obj) =
                     self.get_property_on_id(func_obj.id, "prototype")
-                && let Some(func_proto) = self.get_object(func_proto_obj.id)
+                && let Some(func_proto) = self.get_object_cell(func_proto_obj.id)
             {
                 self.get_object_cell_expect(af_proto_id)
                     .borrow_mut()
@@ -3129,7 +3129,7 @@ impl Interpreter {
                             });
                             match proto {
                                 Ok(Some(proto_rc)) => {
-                                    if let Some(fo_obj) = interp.get_object(fo.id) {
+                                    if let Some(fo_obj) = interp.get_object_cell(fo.id) {
                                         fo_obj.borrow_mut().prototype_id = Some(proto_rc);
                                     }
                                 }
@@ -3156,7 +3156,7 @@ impl Interpreter {
                     .get_global_var("Function")
                     .unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(fc) = &function_ctor
-                    && let Some(fc_obj) = self.get_object(fc.id)
+                    && let Some(fc_obj) = self.get_object_cell(fc.id)
                 {
                     af.borrow_mut().prototype_id = Some(fc_obj.borrow().id.unwrap());
                 }
@@ -3286,7 +3286,7 @@ impl Interpreter {
                             });
                             match proto {
                                 Ok(Some(proto_rc)) => {
-                                    if let Some(fo_obj) = interp.get_object(fo.id) {
+                                    if let Some(fo_obj) = interp.get_object_cell(fo.id) {
                                         fo_obj.borrow_mut().prototype_id = Some(proto_rc);
                                     }
                                 }
@@ -3313,7 +3313,7 @@ impl Interpreter {
                     .get_global_var("Function")
                     .unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(fc) = &function_ctor
-                    && let Some(fc_obj) = self.get_object(fc.id)
+                    && let Some(fc_obj) = self.get_object_cell(fc.id)
                 {
                     gf.borrow_mut().prototype_id = Some(fc_obj.borrow().id.unwrap());
                 }
@@ -3445,7 +3445,7 @@ impl Interpreter {
                             });
                             match proto {
                                 Ok(Some(proto_rc)) => {
-                                    if let Some(fo_obj) = interp.get_object(fo.id) {
+                                    if let Some(fo_obj) = interp.get_object_cell(fo.id) {
                                         fo_obj.borrow_mut().prototype_id = Some(proto_rc);
                                     }
                                 }
@@ -3472,7 +3472,7 @@ impl Interpreter {
                     .get_global_var("Function")
                     .unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(fc) = &function_ctor
-                    && let Some(fc_obj) = self.get_object(fc.id)
+                    && let Some(fc_obj) = self.get_object_cell(fc.id)
                 {
                     agf.borrow_mut().prototype_id = Some(fc_obj.borrow().id.unwrap());
                 }
@@ -3508,7 +3508,7 @@ impl Interpreter {
                 // Process space argument per spec (ToNumber for Number objects, ToString for String objects)
                 let mut space_val = space_arg;
                 if let JsValue::Object(o) = &space_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let cn = obj.borrow().class_name.clone();
                     if cn == "Number" {
@@ -3565,7 +3565,7 @@ impl Interpreter {
 
                 let has_reviver = if let Some(JsValue::Object(rev_obj)) = &reviver {
                     interp
-                        .get_object(rev_obj.id)
+                        .get_object_cell(rev_obj.id)
                         .map(|o| o.borrow().callable.is_some())
                         .unwrap_or(false)
                 } else {
@@ -3678,7 +3678,7 @@ impl Interpreter {
             |interp, _this, args: &[JsValue]| {
                 let val = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = &val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     return Completion::Normal(JsValue::Boolean(obj.borrow().is_raw_json));
                 }
@@ -3796,7 +3796,7 @@ impl Interpreter {
                         Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
                     },
                 ));
-                if let Some(obj) = self.get_object(o.id) {
+                if let Some(obj) = self.get_object_cell(o.id) {
                     obj.borrow_mut()
                         .insert_builtin("fromCharCode".to_string(), from_char_code);
                     obj.borrow_mut()
@@ -3973,7 +3973,7 @@ impl Interpreter {
             .collect();
         for ctor_val in &ctor_vals {
             if let JsValue::Object(o) = ctor_val
-                && let Some(ctor_obj) = self.get_object(o.id)
+                && let Some(ctor_obj) = self.get_object_cell(o.id)
             {
                 let proto_val = ctor_obj.borrow().get_property_value("prototype");
                 if let Some(val) = proto_val {
@@ -4330,7 +4330,7 @@ impl Interpreter {
                             other => return other,
                         };
                         let getter = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                        if !matches!(&getter, JsValue::Object(o) if interp.get_object(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
+                        if !matches!(&getter, JsValue::Object(o) if interp.get_object_cell(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
                         {
                             return Completion::Throw(
                                 interp.create_type_error("Getter must be a function"),
@@ -4352,7 +4352,7 @@ impl Interpreter {
                             configurable: Some(true),
                         };
                         if let JsValue::Object(ref obj_ref) = o {
-                            let is_proxy = interp.get_object(obj_ref.id)
+                            let is_proxy = interp.get_object_cell(obj_ref.id)
                                 .map(|obj| { let b = obj.borrow(); b.is_proxy() || b.proxy_revoked })
                                 .unwrap_or(false);
                             if is_proxy {
@@ -4385,7 +4385,7 @@ impl Interpreter {
                             other => return other,
                         };
                         let setter = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                        if !matches!(&setter, JsValue::Object(o) if interp.get_object(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
+                        if !matches!(&setter, JsValue::Object(o) if interp.get_object_cell(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
                         {
                             return Completion::Throw(
                                 interp.create_type_error("Setter must be a function"),
@@ -4405,7 +4405,7 @@ impl Interpreter {
                             configurable: Some(true),
                         };
                         if let JsValue::Object(ref obj_ref) = o {
-                            let is_proxy = interp.get_object(obj_ref.id)
+                            let is_proxy = interp.get_object_cell(obj_ref.id)
                                 .map(|obj| { let b = obj.borrow(); b.is_proxy() || b.proxy_revoked })
                                 .unwrap_or(false);
                             if is_proxy {
@@ -4460,7 +4460,7 @@ impl Interpreter {
                             }
                             // Step 4c: O.[[GetPrototypeOf]]() (proxy-aware)
                             let is_proxy = interp
-                                .get_object(obj_id)
+                                .get_object_cell(obj_id)
                                 .map(|o| {
                                     let b = o.borrow();
                                     b.is_proxy() || b.proxy_revoked
@@ -4525,7 +4525,7 @@ impl Interpreter {
                                 return Completion::Normal(JsValue::Undefined);
                             }
                             let is_proxy = interp
-                                .get_object(obj_id)
+                                .get_object_cell(obj_id)
                                 .map(|o| {
                                     let b = o.borrow();
                                     b.is_proxy() || b.proxy_revoked
@@ -4814,7 +4814,7 @@ impl Interpreter {
                     if let JsValue::Object(ref o) = target {
                         // Deferred namespace: trigger evaluation on [[GetOwnProperty]] with non-symbol-like key
                         {
-                            let deferred_ns = interp.get_object(o.id).and_then(|obj| {
+                            let deferred_ns = interp.get_object_cell(o.id).and_then(|obj| {
                                 let b = obj.borrow();
                                 b.module_namespace.as_ref().map(|ns| ns.deferred)
                             });
@@ -4826,7 +4826,7 @@ impl Interpreter {
                             }
                         }
                         // Proxy getOwnPropertyDescriptor trap
-                        if let Some(obj) = interp.get_object(o.id)
+                        if let Some(obj) = interp.get_object_cell(o.id)
                             && {
                                 let _b = obj.borrow();
                                 _b.is_proxy() || _b.proxy_revoked
@@ -4839,7 +4839,7 @@ impl Interpreter {
                         }
                         // Module namespace [[GetOwnProperty]] (§10.4.6.4): live binding
                         let is_ns = interp
-                            .get_object(o.id)
+                            .get_object_cell(o.id)
                             .map(|obj| obj.borrow().module_namespace.is_some())
                             .unwrap_or(false);
                         if is_ns {
@@ -4909,10 +4909,10 @@ impl Interpreter {
                         // For non-proxy, also include string wrapper char indices
                         let mut extra_str_keys: Vec<String> = Vec::new();
                         if interp
-                            .get_object(obj_id)
+                            .get_object_cell(obj_id)
                             .map(|ob| !ob.borrow().is_proxy())
                             .unwrap_or(false)
-                            && let Some(obj) = interp.get_object(obj_id)
+                            && let Some(obj) = interp.get_object_cell(obj_id)
                         {
                             let b = obj.borrow();
                             if let Some(JsValue::String(ref s)) = b.primitive_value {
@@ -5014,7 +5014,7 @@ impl Interpreter {
                     if let JsValue::Object(ref o) = target {
                         let obj_id = o.id;
                         let is_proxy = interp
-                            .get_object(obj_id)
+                            .get_object_cell(obj_id)
                             .map(|obj| {
                                 let b = obj.borrow();
                                 b.is_proxy() || b.proxy_revoked
@@ -5317,10 +5317,10 @@ impl Interpreter {
                             // String exotic: prepend char indices as enumerable
                             let mut extra_str_keys: Vec<String> = Vec::new();
                             if interp
-                                .get_object(obj_id)
+                                .get_object_cell(obj_id)
                                 .map(|ob| !ob.borrow().is_proxy())
                                 .unwrap_or(false)
-                                && let Some(obj) = interp.get_object(obj_id)
+                                && let Some(obj) = interp.get_object_cell(obj_id)
                             {
                                 let b = obj.borrow();
                                 if let Some(JsValue::String(ref s)) = b.primitive_value {
@@ -5422,7 +5422,7 @@ impl Interpreter {
                         // String exotic: prepend char indices as enumerable
                         let mut extra_str_keys: Vec<String> = Vec::new();
                         if interp
-                            .get_object(obj_id)
+                            .get_object_cell(obj_id)
                             .map(|ob| !ob.borrow().is_proxy())
                             .unwrap_or(false)
                             && let Some(obj) = interp.get_object(obj_id)
@@ -5535,7 +5535,7 @@ impl Interpreter {
                         // for non-proxy, build OrdinaryOwnPropertyKeys manually
                         // (integer indices, then string keys, then symbol keys).
                         let is_proxy_src = interp
-                            .get_object(s_id)
+                            .get_object_cell(s_id)
                             .map(|o| o.borrow().is_proxy())
                             .unwrap_or(false);
                         let raw_keys: Vec<JsValue> = if is_proxy_src {
@@ -5661,7 +5661,7 @@ impl Interpreter {
                 |interp, _this, args| {
                     let items = args.first().cloned().unwrap_or(JsValue::Undefined);
                     let callback = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    if !matches!(&callback, JsValue::Object(o) if interp.get_object(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
+                    if !matches!(&callback, JsValue::Object(o) if interp.get_object_cell(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
                     {
                         return Completion::Throw(
                             interp.create_type_error("callbackfn is not a function"),
@@ -5766,7 +5766,7 @@ impl Interpreter {
                     } else {
                         return Completion::Normal(interp.create_array(Vec::new()));
                     };
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
                         {
                             let is_deferred_ns = obj
@@ -5780,7 +5780,7 @@ impl Interpreter {
                                 return Completion::Throw(e);
                             }
                         }
-                        let obj = interp.get_object(o.id).unwrap();
+                        let obj = interp.get_object_cell(o.id).unwrap();
                         // Proxy ownKeys trap (getOwnPropertyNames returns all string keys)
                         let res = {
                             let _b = obj.borrow();
@@ -5908,7 +5908,7 @@ impl Interpreter {
                     if let JsValue::Object(ref o) = target {
                         let obj_id = o.id;
                         // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
-                        if let Some(obj) = interp.get_object(obj_id) {
+                        if let Some(obj) = interp.get_object_cell(obj_id) {
                             let is_deferred_ns = obj
                                 .borrow()
                                 .module_namespace
@@ -6056,7 +6056,7 @@ impl Interpreter {
                         let obj_id = o.id;
                         // TestIntegrityLevel: check extensible first, then each key
                         let is_proxy = interp
-                            .get_object(obj_id)
+                            .get_object_cell(obj_id)
                             .map(|ob| {
                                 let b = ob.borrow();
                                 b.is_proxy() || b.proxy_revoked
@@ -6117,7 +6117,7 @@ impl Interpreter {
                     if let JsValue::Object(o) = &target {
                         let obj_id = o.id;
                         let is_proxy = interp
-                            .get_object(obj_id)
+                            .get_object_cell(obj_id)
                             .map(|ob| {
                                 let b = ob.borrow();
                                 b.is_proxy() || b.proxy_revoked
@@ -6173,7 +6173,7 @@ impl Interpreter {
                     if let JsValue::Object(ref o) = target {
                         let obj_id = o.id;
                         let is_proxy = interp
-                            .get_object(obj_id)
+                            .get_object_cell(obj_id)
                             .map(|obj| {
                                 let b = obj.borrow();
                                 b.is_proxy() || b.proxy_revoked
@@ -6331,7 +6331,7 @@ impl Interpreter {
                         ));
                     }
                     if let JsValue::Object(ref o) = target
-                        && let Some(obj) = interp.get_object(o.id)
+                        && let Some(obj) = interp.get_object_cell(o.id)
                     {
                         // Proxy setPrototypeOf trap
                         let res = {
@@ -6515,12 +6515,12 @@ impl Interpreter {
                         // String exotic: prepend character indices
                         let mut keys: Vec<String> = Vec::new();
                         let is_string_wrapper = interp
-                            .get_object(obj_id)
+                            .get_object_cell(obj_id)
                             .map(|ob| {
                                 matches!(ob.borrow().primitive_value, Some(JsValue::String(_)))
                             })
                             .unwrap_or(false);
-                        if is_string_wrapper && let Some(obj) = interp.get_object(obj_id) {
+                        if is_string_wrapper && let Some(obj) = interp.get_object_cell(obj_id) {
                             let b = obj.borrow();
                             if let Some(JsValue::String(ref s)) = b.primitive_value {
                                 for i in 0..s.code_units.len() {
@@ -6669,7 +6669,7 @@ impl Interpreter {
                                 return Completion::Throw(e);
                             }
                         };
-                        if let Some(obj_data) = interp.get_object(obj_id) {
+                        if let Some(obj_data) = interp.get_object_cell(obj_id) {
                             obj_data.borrow_mut().insert_value(key, value);
                         }
                     }
@@ -7529,7 +7529,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let res = {
                         let _b = obj.borrow();
@@ -7632,7 +7632,7 @@ impl Interpreter {
                     if let JsValue::Object(ref o) = target {
                         // Deferred namespace: trigger evaluation
                         {
-                            let deferred_ns = interp.get_object(o.id).and_then(|obj| {
+                            let deferred_ns = interp.get_object_cell(o.id).and_then(|obj| {
                                 let b = obj.borrow();
                                 b.module_namespace.as_ref().map(|ns| ns.deferred)
                             });
@@ -7643,7 +7643,7 @@ impl Interpreter {
                                 return Completion::Throw(e);
                             }
                         }
-                        if let Some(obj) = interp.get_object(o.id)
+                        if let Some(obj) = interp.get_object_cell(o.id)
                             && {
                                 let _b = obj.borrow();
                                 _b.is_proxy() || _b.proxy_revoked
@@ -7656,12 +7656,12 @@ impl Interpreter {
                         }
                         // Module namespace [[GetOwnProperty]] (§10.4.6.4): live binding
                         let is_ns = interp
-                            .get_object(o.id)
+                            .get_object_cell(o.id)
                             .map(|obj| obj.borrow().module_namespace.is_some())
                             .unwrap_or(false);
                         if is_ns {
                             let is_export = interp
-                                .get_object(o.id)
+                                .get_object_cell(o.id)
                                 .and_then(|obj| {
                                     let b = obj.borrow();
                                     let ns = b.module_namespace.as_ref()?;
@@ -7717,7 +7717,7 @@ impl Interpreter {
                     );
                 }
                 if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let res = {
                         let _b = obj.borrow();
@@ -7781,7 +7781,7 @@ impl Interpreter {
                     );
                 }
                 if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let res = {
                         let _b = obj.borrow();
@@ -7814,7 +7814,7 @@ impl Interpreter {
                     );
                 }
                 if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
                     {
@@ -7829,7 +7829,7 @@ impl Interpreter {
                             return Completion::Throw(e);
                         }
                     }
-                    let obj = interp.get_object(o.id).unwrap();
+                    let obj = interp.get_object_cell(o.id).unwrap();
                     let res = {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.proxy_revoked
@@ -7957,7 +7957,7 @@ impl Interpreter {
                     );
                 }
                 if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let res = {
                         let _b = obj.borrow();
@@ -7975,7 +7975,7 @@ impl Interpreter {
                         if let Some(ref ta) = b.typed_array_info {
                             let is_fixed = b
                                 .view_buffer_object_id
-                                .and_then(|buf_id| interp.get_object(buf_id))
+                                .and_then(|buf_id| interp.get_object_cell(buf_id))
                                 .map(|buf| {
                                     use crate::interpreter::types::is_typed_array_fixed_length;
                                     is_typed_array_fixed_length(ta, &buf.borrow())
@@ -8015,7 +8015,7 @@ impl Interpreter {
                 let receiver = args.get(3).cloned().unwrap_or(target.clone());
                 // Check if target is a proxy
                 if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.proxy_revoked
@@ -8028,7 +8028,7 @@ impl Interpreter {
                 }
                 // Module namespace exotic: [[Set]] always returns false
                 if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && obj.borrow().module_namespace.is_some()
                 {
                     return Completion::Normal(JsValue::Boolean(false));
@@ -8036,7 +8036,7 @@ impl Interpreter {
                 // TypedArray [[Set]] exotic — §10.4.5.5
                 if let JsValue::Object(ref o) = target {
                     let ta_info_opt = interp
-                        .get_object(o.id)
+                        .get_object_cell(o.id)
                         .and_then(|obj| obj.borrow().typed_array_info.clone());
                     if let Some(ta_info) = ta_info_opt
                         && let Some(index) = canonical_numeric_index_string(&key)
@@ -8071,7 +8071,7 @@ impl Interpreter {
                         // Index is in bounds in target: OrdinarySet to receiver
                         if let JsValue::Object(ref r) = receiver {
                             let recv_ta_opt = interp
-                                .get_object(r.id)
+                                .get_object_cell(r.id)
                                 .and_then(|obj| obj.borrow().typed_array_info.clone());
                             if let Some(recv_ta) = recv_ta_opt {
                                 // Receiver is TypedArray: IntegerIndexedElementSet
@@ -8092,7 +8092,7 @@ impl Interpreter {
                                 };
                                 typed_array_set_index(&recv_ta, index as usize, &num_val);
                                 return Completion::Normal(JsValue::Boolean(true));
-                            } else if let Some(recv_obj) = interp.get_object(r.id) {
+                            } else if let Some(recv_obj) = interp.get_object_cell(r.id) {
                                 // Non-TypedArray receiver: create plain property, no coercion
                                 let existing = recv_obj.borrow().get_own_property(&key);
                                 if let Some(ref ed) = existing {
@@ -8136,7 +8136,7 @@ impl Interpreter {
                                 Err(e) => return Completion::Throw(e),
                             }
                         }
-                        if let Some(cur_obj) = interp.get_object(cid) {
+                        if let Some(cur_obj) = interp.get_object_cell(cid) {
                             // TypedArray [[Set]] §10.4.5.5 via prototype chain
                             {
                                 let borrow = cur_obj.borrow();
@@ -8273,7 +8273,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    if let Some(recv_obj) = interp.get_object(r.id) {
+                    if let Some(recv_obj) = interp.get_object_cell(r.id) {
                         let existing = recv_obj.borrow().get_own_property(&key);
                         if let Some(ref ed) = existing {
                             if ed.get.is_some() || ed.set.is_some() {
@@ -8337,7 +8337,7 @@ impl Interpreter {
                     ));
                 }
                 if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let res = {
                         let _b = obj.borrow();
@@ -8381,7 +8381,7 @@ impl Interpreter {
                             if pid == target_id {
                                 return Completion::Normal(JsValue::Boolean(false));
                             }
-                            if let Some(p_obj) = interp.get_object(pid) {
+                            if let Some(p_obj) = interp.get_object_cell(pid) {
                                 // If p is a Proxy, stop the loop (done = true per spec step 8.c.i)
                                 if p_obj.borrow().is_proxy() {
                                     break;
@@ -8398,7 +8398,7 @@ impl Interpreter {
                             obj.borrow_mut().prototype_id = None;
                         }
                         JsValue::Object(p) => {
-                            if let Some(proto_obj) = interp.get_object(p.id) {
+                            if let Some(proto_obj) = interp.get_object_cell(p.id) {
                                 obj.borrow_mut().prototype_id =
                                     Some(proto_obj.borrow().id.unwrap());
                             }
@@ -8478,7 +8478,7 @@ impl Interpreter {
                     .borrow_mut()
                     .class_name = "Proxy".to_string();
                 if let JsValue::Object(ref t) = target
-                    && let Some(target_rc) = interp.get_object(t.id)
+                    && let Some(target_rc) = interp.get_object_cell(t.id)
                 {
                     // Copy callable if target is callable
                     let callable = target_rc.borrow().callable.clone();
@@ -8509,7 +8509,7 @@ impl Interpreter {
 
         // Per spec §26.2.2: Proxy constructor has no prototype property
         if let JsValue::Object(ref pf) = proxy_fn
-            && let Some(proxy_func_obj) = self.get_object(pf.id)
+            && let Some(proxy_func_obj) = self.get_object_cell(pf.id)
         {
             proxy_func_obj.borrow_mut().properties.remove("prototype");
         }
@@ -8542,7 +8542,7 @@ impl Interpreter {
                         .borrow_mut()
                         .class_name = "Proxy".to_string();
                     if let JsValue::Object(ref t) = target
-                        && let Some(target_rc) = interp.get_object(t.id)
+                        && let Some(target_rc) = interp.get_object_cell(t.id)
                     {
                         let callable = target_rc.borrow().callable.clone();
                         if callable.is_some() {
@@ -8570,7 +8570,7 @@ impl Interpreter {
                         "".to_string(),
                         0,
                         move |interp2, _this2, _args2| {
-                            if let Some(p) = interp2.get_object(proxy_id) {
+                            if let Some(p) = interp2.get_object_cell(proxy_id) {
                                 let mut pm = p.borrow_mut();
                                 pm.proxy_revoked = true;
                                 pm.proxy_target_id = None;
@@ -8689,7 +8689,7 @@ impl Interpreter {
                 }
                 // Check if target is callable
                 let is_callable = if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     obj.borrow().callable.is_some()
                 } else {
@@ -8708,7 +8708,7 @@ impl Interpreter {
                 // For proxy targets, use invoke_proxy_trap to trigger getOwnPropertyDescriptor
                 let target_length_f64: f64 = if let JsValue::Object(o) = this_val {
                     let is_proxy = interp
-                        .get_object(o.id)
+                        .get_object_cell(o.id)
                         .is_some_and(|obj| obj.borrow().is_proxy());
                     let has_own_length = if is_proxy {
                         match interp.invoke_proxy_trap(
@@ -8723,7 +8723,7 @@ impl Interpreter {
                             Ok(None) => {
                                 let target_val = interp.get_proxy_target_val(o.id);
                                 if let JsValue::Object(t) = &target_val
-                                    && let Some(target_obj) = interp.get_object(t.id)
+                                    && let Some(target_obj) = interp.get_object_cell(t.id)
                                 {
                                     target_obj.borrow().get_own_property("length").is_some()
                                 } else {
@@ -8732,7 +8732,7 @@ impl Interpreter {
                             }
                             Err(e) => return Completion::Throw(e),
                         }
-                    } else if let Some(obj) = interp.get_object(o.id) {
+                    } else if let Some(obj) = interp.get_object_cell(o.id) {
                         obj.borrow().get_own_property("length").is_some()
                     } else {
                         false
@@ -8787,7 +8787,7 @@ impl Interpreter {
                         move |interp2: &mut Interpreter, this: &JsValue, call_args: &[JsValue]| {
                             let obj_id = id_cell.get();
                             let (target, bt, ba) = {
-                                let obj = interp2.get_object(obj_id).unwrap();
+                                let obj = interp2.get_object_cell(obj_id).unwrap();
                                 let b = obj.borrow();
                                 (
                                     b.bound_target_function
@@ -8810,12 +8810,12 @@ impl Interpreter {
                 );
                 let result = interp.create_function(bound);
                 if let JsValue::Object(ref o) = result
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     bound_id_cell.set(o.id);
                     // §20.2.3.2 step 4-5: Set bound function's [[Prototype]] to target's [[Prototype]]
                     if let JsValue::Object(target_o) = this_val
-                        && let Some(target_obj) = interp.get_object(target_o.id)
+                        && let Some(target_obj) = interp.get_object_cell(target_o.id)
                     {
                         obj.borrow_mut().prototype_id = target_obj.borrow().prototype_id;
                     }
@@ -8851,7 +8851,7 @@ impl Interpreter {
             0,
             |interp, this_val, _args: &[JsValue]| {
                 if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let b = obj.borrow();
                     if b.is_proxy() || b.proxy_revoked {
@@ -8951,7 +8951,7 @@ impl Interpreter {
             1,
             move |interp, this, args| {
                 let eval_realm_id = if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && let Some(realm_id) = obj.borrow().shadow_realm_id
                 {
                     realm_id
@@ -8988,7 +8988,7 @@ impl Interpreter {
             2,
             move |interp, this, args| {
                 let eval_realm_id = if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                     && let Some(realm_id) = obj.borrow().shadow_realm_id
                 {
                     realm_id
@@ -9139,7 +9139,7 @@ impl Interpreter {
 
         // Set ShadowRealm.prototype on constructor
         if let JsValue::Object(ref ctor_o) = shadow_realm_ctor
-            && let Some(ctor_obj) = self.get_object(ctor_o.id)
+            && let Some(ctor_obj) = self.get_object_cell(ctor_o.id)
         {
             ctor_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -9149,7 +9149,7 @@ impl Interpreter {
 
         // Set ShadowRealm.prototype.constructor = ShadowRealm
         if let JsValue::Object(ref p) = proto_val
-            && let Some(proto_obj) = self.get_object(p.id)
+            && let Some(proto_obj) = self.get_object_cell(p.id)
         {
             proto_obj
                 .borrow_mut()

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -407,7 +407,6 @@ impl Interpreter {
         }
 
         let console_id = self.create_object_id();
-        let console_id = console_id;
         {
             let log_fn = self.create_function(JsFunction::native(
                 "log".to_string(),
@@ -724,7 +723,6 @@ impl Interpreter {
                 );
 
             // Store native error prototype on realm
-            let native_proto_id = native_proto_id;
             match name {
                 "SyntaxError" => self.realm_mut().syntax_error_prototype = Some(native_proto_id),
                 "TypeError" => self.realm_mut().type_error_prototype = Some(native_proto_id),
@@ -3579,7 +3577,6 @@ impl Interpreter {
                     match result {
                         Completion::Normal(parsed) => {
                             let wrapper_id = interp.create_object_id();
-                            let wrapper_id = wrapper_id;
                             interp
                                 .get_object_cell_expect(wrapper_id)
                                 .borrow_mut()
@@ -6611,7 +6608,6 @@ impl Interpreter {
                 |interp, _this, args| {
                     let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
                     let obj_id = interp.create_object_id();
-                    let obj_id = obj_id;
                     let obj_val = JsValue::Object(crate::types::JsObject { id: obj_id });
                     let iterator = match interp.get_iterator(&iterable) {
                         Ok(v) => v,
@@ -8593,7 +8589,6 @@ impl Interpreter {
                         .get_object_cell_expect(result_id)
                         .borrow_mut()
                         .insert_builtin("revoke".to_string(), revoke_fn);
-                    let result_id = result_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
                 },
             ));
@@ -9113,7 +9108,6 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("importValue".to_string(), import_value_fn);
 
-        let proto_id = proto_id;
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
         // ShadowRealm constructor

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2781,12 +2781,11 @@ impl Interpreter {
                     let fp_id = fp.borrow().id;
 
                     // Helper: fix a single object's prototype if it's callable
-                    let fix_callable =
-                        |obj: &Rc<RefCell<JsObjectData>>, fp: &Rc<RefCell<JsObjectData>>| {
-                            if obj.borrow().callable.is_some() {
-                                obj.borrow_mut().prototype_id = Some(fp.borrow().id.unwrap());
-                            }
-                        };
+                    let fix_callable = |obj: &RefCell<JsObjectData>, fp: &RefCell<JsObjectData>| {
+                        if obj.borrow().callable.is_some() {
+                            obj.borrow_mut().prototype_id = Some(fp.borrow().id.unwrap());
+                        }
+                    };
 
                     // Collect all JsValue objects from a property descriptor (value + accessors)
                     fn collect_pd_objects(pd: &PropertyDescriptor) -> Vec<JsValue> {

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -3498,7 +3498,7 @@ impl Interpreter {
         }
 
         // JSON object
-        let json_obj = self.create_object();
+        let json_obj_id = self.create_object_id();
         let json_stringify = self.create_function(JsFunction::native(
             "stringify".to_string(),
             3,
@@ -3688,16 +3688,16 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        json_obj
+        self.get_object_cell_expect(json_obj_id)
             .borrow_mut()
             .insert_builtin("stringify".to_string(), json_stringify);
-        json_obj
+        self.get_object_cell_expect(json_obj_id)
             .borrow_mut()
             .insert_builtin("parse".to_string(), json_parse);
-        json_obj
+        self.get_object_cell_expect(json_obj_id)
             .borrow_mut()
             .insert_builtin("rawJSON".to_string(), json_raw_json);
-        json_obj
+        self.get_object_cell_expect(json_obj_id)
             .borrow_mut()
             .insert_builtin("isRawJSON".to_string(), json_is_raw_json);
         // @@toStringTag
@@ -3711,12 +3711,16 @@ impl Interpreter {
                 set: None,
             };
             let key = "Symbol(Symbol.toStringTag)".to_string();
-            json_obj.borrow_mut().property_order.push(key.clone());
-            json_obj.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(json_obj_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(json_obj_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
-        let json_val = JsValue::Object(crate::types::JsObject {
-            id: json_obj.borrow().id.unwrap(),
-        });
+        let json_val = JsValue::Object(crate::types::JsObject { id: json_obj_id });
         self.realm()
             .global_env
             .borrow_mut()
@@ -3830,10 +3834,8 @@ impl Interpreter {
         self.setup_shadow_realm();
 
         // globalThis - create a global object
-        let global_obj = self.create_object();
-        let global_val = JsValue::Object(crate::types::JsObject {
-            id: global_obj.borrow().id.unwrap(),
-        });
+        let global_obj_id = self.create_object_id();
+        let global_val = JsValue::Object(crate::types::JsObject { id: global_obj_id });
         self.realm()
             .global_env
             .borrow_mut()
@@ -3929,19 +3931,21 @@ impl Interpreter {
                 "NaN" | "Infinity" | "undefined" => (false, false),
                 _ => (true, true),
             };
-            global_obj.borrow_mut().insert_property(
-                name,
-                PropertyDescriptor::data(val, writable, false, configurable),
-            );
+            self.get_object_cell_expect(global_obj_id)
+                .borrow_mut()
+                .insert_property(
+                    name,
+                    PropertyDescriptor::data(val, writable, false, configurable),
+                );
         }
         // Also set globalThis on itself
-        let gt_val = JsValue::Object(crate::types::JsObject {
-            id: global_obj.borrow().id.unwrap(),
-        });
-        global_obj.borrow_mut().insert_property(
-            "globalThis".to_string(),
-            PropertyDescriptor::data(gt_val, true, false, true),
-        );
+        let gt_val = JsValue::Object(crate::types::JsObject { id: global_obj_id });
+        self.get_object_cell_expect(global_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "globalThis".to_string(),
+                PropertyDescriptor::data(gt_val, true, false, true),
+            );
 
         // Fix .prototype descriptors on built-in constructors.
         // create_function sets writable=true (correct for user-defined constructors per §10.2.5),
@@ -3988,7 +3992,7 @@ impl Interpreter {
         // Per spec §9.1.1.4, the Global Environment Record has an Object Environment
         // Record whose binding object is the global object. Variable lookups in global
         // scope should check global object properties.
-        let gid = global_obj.borrow().id.unwrap();
+        let gid = global_obj_id;
         self.realm().global_env.borrow_mut().global_object_id = Some(gid);
         self.realm_mut().global_object = Some(gid);
 

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2641,7 +2641,8 @@ impl Interpreter {
                     self.realm_mut().function_prototype = Some(fp.borrow().id.unwrap());
 
                     // Install call/apply/bind/toString on Function.prototype_id
-                    self.setup_function_prototype(&fp);
+                    let fp_id = fp.borrow().id.unwrap();
+                    self.setup_function_prototype(fp_id);
 
                     // Add Function.prototype[@@hasInstance]
                     if let Some(sym_key) = self.get_symbol_key("hasInstance") {
@@ -8516,7 +8517,7 @@ impl Interpreter {
         let _ = self.env_set(&env, "Proxy", proxy_fn);
     }
 
-    fn setup_function_prototype(&mut self, obj_proto: &Rc<RefCell<JsObjectData>>) {
+    fn setup_function_prototype(&mut self, obj_proto_id: u64) {
         let fn_proto_realm_id = self.current_realm_id;
         // Add call to Object.prototype (simplified - applies to all functions via prototype chain)
         let call_fn = self.create_function(JsFunction::native(
@@ -8528,7 +8529,7 @@ impl Interpreter {
                 interp.call_function(_this, &this_arg, call_args)
             },
         ));
-        obj_proto
+        self.get_object_expect(obj_proto_id)
             .borrow_mut()
             .insert_builtin("call".to_string(), call_fn);
 
@@ -8584,7 +8585,7 @@ impl Interpreter {
                 interp.call_function(_this, &this_arg, &call_args)
             },
         ));
-        obj_proto
+        self.get_object_expect(obj_proto_id)
             .borrow_mut()
             .insert_builtin("apply".to_string(), apply_fn);
 
@@ -8752,7 +8753,7 @@ impl Interpreter {
                 Completion::Normal(result)
             },
         ));
-        obj_proto
+        self.get_object_expect(obj_proto_id)
             .borrow_mut()
             .insert_builtin("bind".to_string(), bind_fn);
 
@@ -8825,7 +8826,7 @@ impl Interpreter {
                 ))
             },
         ));
-        obj_proto
+        self.get_object_expect(obj_proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), fn_tostring);
     }

--- a/src/interpreter/builtins/number.rs
+++ b/src/interpreter/builtins/number.rs
@@ -261,7 +261,7 @@ impl Interpreter {
         ) -> Option<crate::types::JsSymbol> {
             match this {
                 JsValue::Symbol(s) => Some(s.clone()),
-                JsValue::Object(o) => interp.get_object(o.id).and_then(|obj| {
+                JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|obj| {
                     let b = obj.borrow();
                     if b.class_name == "Symbol"
                         && let Some(JsValue::Symbol(s)) = &b.primitive_value
@@ -418,7 +418,7 @@ impl Interpreter {
         // Set Symbol.prototype on the Symbol constructor
         if let Some(sym_val) = self.get_global_var("Symbol")
             && let JsValue::Object(o) = &sym_val
-            && let Some(sym_obj) = self.get_object(o.id)
+            && let Some(sym_obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             sym_obj.borrow_mut().insert_property(
@@ -447,7 +447,7 @@ impl Interpreter {
         fn this_number_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
             match this {
                 JsValue::Number(n) => Some(*n),
-                JsValue::Object(o) => interp.get_object(o.id).and_then(|obj| {
+                JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|obj| {
                     let b = obj.borrow();
                     if b.class_name == "Number"
                         && let Some(JsValue::Number(n)) = &b.primitive_value
@@ -685,7 +685,7 @@ impl Interpreter {
         // Set Number.prototype on the Number constructor
         if let Some(num_val) = self.get_global_var("Number")
             && let JsValue::Object(o) = &num_val
-            && let Some(num_obj) = self.get_object(o.id)
+            && let Some(num_obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             num_obj.borrow_mut().insert_property(
@@ -712,7 +712,7 @@ impl Interpreter {
         fn this_boolean_value(interp: &Interpreter, this: &JsValue) -> Option<bool> {
             match this {
                 JsValue::Boolean(b) => Some(*b),
-                JsValue::Object(o) => interp.get_object(o.id).and_then(|obj| {
+                JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|obj| {
                     let b = obj.borrow();
                     if b.class_name == "Boolean"
                         && let Some(JsValue::Boolean(v)) = &b.primitive_value
@@ -772,7 +772,7 @@ impl Interpreter {
         // Set Boolean.prototype on the Boolean constructor
         if let Some(bool_val) = self.get_global_var("Boolean")
             && let JsValue::Object(o) = &bool_val
-            && let Some(bool_obj) = self.get_object(o.id)
+            && let Some(bool_obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             bool_obj.borrow_mut().insert_property(

--- a/src/interpreter/builtins/number.rs
+++ b/src/interpreter/builtins/number.rs
@@ -250,8 +250,8 @@ fn format_precision(n: f64, precision: usize) -> String {
 
 impl Interpreter {
     pub(crate) fn setup_symbol_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Symbol".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id).borrow_mut().class_name = "Symbol".to_string();
 
         fn this_symbol_value(
             interp: &Interpreter,
@@ -314,7 +314,7 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id).borrow_mut().insert_builtin(name.to_string(), fn_val);
         }
 
         // description getter
@@ -334,7 +334,7 @@ impl Interpreter {
             }),
             false,
         ));
-        proto.borrow_mut().insert_property(
+        self.get_object_cell_expect(proto_id).borrow_mut().insert_property(
             "description".to_string(),
             PropertyDescriptor {
                 value: None,
@@ -373,7 +373,7 @@ impl Interpreter {
                         .map(|d| d.to_rust_string())
                         .unwrap_or_default()
                 );
-                proto.borrow_mut().insert_property(
+                self.get_object_cell_expect(proto_id).borrow_mut().insert_property(
                     key,
                     PropertyDescriptor::data(to_prim_fn, false, false, true),
                 );
@@ -393,7 +393,7 @@ impl Interpreter {
                         .map(|d| d.to_rust_string())
                         .unwrap_or_default()
                 );
-                proto.borrow_mut().insert_property(
+                self.get_object_cell_expect(proto_id).borrow_mut().insert_property(
                     key,
                     PropertyDescriptor::data(
                         JsValue::String(JsString::from_str("Symbol")),
@@ -411,7 +411,7 @@ impl Interpreter {
             && let Some(sym_obj) = self.get_object(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
+                id: proto_id,
             });
             sym_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -419,18 +419,17 @@ impl Interpreter {
             );
             // Set constructor on prototype
             let ctor_val = sym_val.clone();
-            proto
-                .borrow_mut()
+            self.get_object_cell_expect(proto_id).borrow_mut()
                 .insert_builtin("constructor".to_string(), ctor_val);
         }
 
-        self.realm_mut().symbol_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().symbol_prototype = Some(proto_id);
     }
 
     pub(crate) fn setup_number_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Number".to_string();
-        proto.borrow_mut().primitive_value = Some(JsValue::Number(0.0));
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id).borrow_mut().class_name = "Number".to_string();
+        self.get_object_cell_expect(proto_id).borrow_mut().primitive_value = Some(JsValue::Number(0.0));
 
         fn this_number_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
             match this {
@@ -665,7 +664,7 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id).borrow_mut().insert_builtin(name.to_string(), fn_val);
         }
 
         // Set Number.prototype on the Number constructor
@@ -674,24 +673,23 @@ impl Interpreter {
             && let Some(num_obj) = self.get_object(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
+                id: proto_id,
             });
             num_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
-            proto
-                .borrow_mut()
+            self.get_object_cell_expect(proto_id).borrow_mut()
                 .insert_builtin("constructor".to_string(), num_val);
         }
 
-        self.realm_mut().number_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().number_prototype = Some(proto_id);
     }
 
     pub(crate) fn setup_boolean_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Boolean".to_string();
-        proto.borrow_mut().primitive_value = Some(JsValue::Boolean(false));
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id).borrow_mut().class_name = "Boolean".to_string();
+        self.get_object_cell_expect(proto_id).borrow_mut().primitive_value = Some(JsValue::Boolean(false));
 
         fn this_boolean_value(interp: &Interpreter, this: &JsValue) -> Option<bool> {
             match this {
@@ -748,7 +746,7 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id).borrow_mut().insert_builtin(name.to_string(), fn_val);
         }
 
         // Set Boolean.prototype on the Boolean constructor
@@ -757,17 +755,16 @@ impl Interpreter {
             && let Some(bool_obj) = self.get_object(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
+                id: proto_id,
             });
             bool_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
-            proto
-                .borrow_mut()
+            self.get_object_cell_expect(proto_id).borrow_mut()
                 .insert_builtin("constructor".to_string(), bool_val);
         }
 
-        self.realm_mut().boolean_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().boolean_prototype = Some(proto_id);
     }
 }

--- a/src/interpreter/builtins/number.rs
+++ b/src/interpreter/builtins/number.rs
@@ -251,7 +251,9 @@ fn format_precision(n: f64, precision: usize) -> String {
 impl Interpreter {
     pub(crate) fn setup_symbol_prototype(&mut self) {
         let proto_id = self.create_object_id();
-        self.get_object_cell_expect(proto_id).borrow_mut().class_name = "Symbol".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Symbol".to_string();
 
         fn this_symbol_value(
             interp: &Interpreter,
@@ -314,7 +316,9 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            self.get_object_cell_expect(proto_id).borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // description getter
@@ -334,17 +338,19 @@ impl Interpreter {
             }),
             false,
         ));
-        self.get_object_cell_expect(proto_id).borrow_mut().insert_property(
-            "description".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(desc_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "description".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(desc_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // [Symbol.toPrimitive]
         let to_prim_fn = self.create_function(JsFunction::Native(
@@ -373,10 +379,12 @@ impl Interpreter {
                         .map(|d| d.to_rust_string())
                         .unwrap_or_default()
                 );
-                self.get_object_cell_expect(proto_id).borrow_mut().insert_property(
-                    key,
-                    PropertyDescriptor::data(to_prim_fn, false, false, true),
-                );
+                self.get_object_cell_expect(proto_id)
+                    .borrow_mut()
+                    .insert_property(
+                        key,
+                        PropertyDescriptor::data(to_prim_fn, false, false, true),
+                    );
             }
         }
 
@@ -393,15 +401,17 @@ impl Interpreter {
                         .map(|d| d.to_rust_string())
                         .unwrap_or_default()
                 );
-                self.get_object_cell_expect(proto_id).borrow_mut().insert_property(
-                    key,
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str("Symbol")),
-                        false,
-                        false,
-                        true,
-                    ),
-                );
+                self.get_object_cell_expect(proto_id)
+                    .borrow_mut()
+                    .insert_property(
+                        key,
+                        PropertyDescriptor::data(
+                            JsValue::String(JsString::from_str("Symbol")),
+                            false,
+                            false,
+                            true,
+                        ),
+                    );
             }
         }
 
@@ -410,16 +420,15 @@ impl Interpreter {
             && let JsValue::Object(o) = &sym_val
             && let Some(sym_obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto_id,
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             sym_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
             // Set constructor on prototype
             let ctor_val = sym_val.clone();
-            self.get_object_cell_expect(proto_id).borrow_mut()
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
                 .insert_builtin("constructor".to_string(), ctor_val);
         }
 
@@ -428,8 +437,12 @@ impl Interpreter {
 
     pub(crate) fn setup_number_prototype(&mut self) {
         let proto_id = self.create_object_id();
-        self.get_object_cell_expect(proto_id).borrow_mut().class_name = "Number".to_string();
-        self.get_object_cell_expect(proto_id).borrow_mut().primitive_value = Some(JsValue::Number(0.0));
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Number".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .primitive_value = Some(JsValue::Number(0.0));
 
         fn this_number_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
             match this {
@@ -664,7 +677,9 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            self.get_object_cell_expect(proto_id).borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // Set Number.prototype on the Number constructor
@@ -672,14 +687,13 @@ impl Interpreter {
             && let JsValue::Object(o) = &num_val
             && let Some(num_obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto_id,
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             num_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
-            self.get_object_cell_expect(proto_id).borrow_mut()
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
                 .insert_builtin("constructor".to_string(), num_val);
         }
 
@@ -688,8 +702,12 @@ impl Interpreter {
 
     pub(crate) fn setup_boolean_prototype(&mut self) {
         let proto_id = self.create_object_id();
-        self.get_object_cell_expect(proto_id).borrow_mut().class_name = "Boolean".to_string();
-        self.get_object_cell_expect(proto_id).borrow_mut().primitive_value = Some(JsValue::Boolean(false));
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Boolean".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .primitive_value = Some(JsValue::Boolean(false));
 
         fn this_boolean_value(interp: &Interpreter, this: &JsValue) -> Option<bool> {
             match this {
@@ -746,7 +764,9 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            self.get_object_cell_expect(proto_id).borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // Set Boolean.prototype on the Boolean constructor
@@ -754,14 +774,13 @@ impl Interpreter {
             && let JsValue::Object(o) = &bool_val
             && let Some(bool_obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto_id,
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             bool_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
-            self.get_object_cell_expect(proto_id).borrow_mut()
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
                 .insert_builtin("constructor".to_string(), bool_val);
         }
 

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -741,7 +741,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("Promise", BindingKind::Var);
-        let _ = self.realm().global_env.borrow_mut().set("Promise", ctor);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "Promise", ctor);
     }
 
     pub(crate) fn create_promise_object(&mut self) -> JsValue {

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -162,7 +162,7 @@ impl Interpreter {
     ) -> Result<JsValue, JsValue> {
         // If value is a promise and its constructor matches C, return it
         if let JsValue::Object(o) = value
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
             && obj.borrow().promise_data.is_some()
         {
             let ctor_val = match self.get_object_property(o.id, "constructor", value) {
@@ -421,7 +421,7 @@ impl Interpreter {
                 let promise = interp.create_promise_object();
                 if let Some(p) = proto
                     && let JsValue::Object(po) = &promise
-                    && let Some(pobj) = interp.get_object(po.id)
+                    && let Some(pobj) = interp.get_object_cell(po.id)
                 {
                     pobj.borrow_mut().prototype_id = Some(p);
                 }
@@ -449,24 +449,27 @@ impl Interpreter {
         // Mark Promise constructor as deferred_construct so construct_with_new_target
         // skips early prototype access (Promise checks callable before OrdinaryCreateFromConstructor).
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj.borrow_mut().deferred_construct = true;
         }
 
         // Set Promise.prototype on constructor
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && self.get_object_cell(o.id).is_some()
         {
-            func_obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject { id: proto_id }),
-                    false,
-                    false,
-                    false,
-                ),
-            );
+            let ctor_id = o.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(
+                        JsValue::Object(crate::types::JsObject { id: proto_id }),
+                        false,
+                        false,
+                        false,
+                    ),
+                );
 
             // Promise[Symbol.species] getter
             let species_getter = self.create_function(JsFunction::native(
@@ -474,17 +477,19 @@ impl Interpreter {
                 0,
                 |_interp, this_val, _args| Completion::Normal(this_val.clone()),
             ));
-            func_obj.borrow_mut().insert_property(
-                "Symbol(Symbol.species)".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(species_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "Symbol(Symbol.species)".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        get: Some(species_getter),
+                        set: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                    },
+                );
         }
 
         // Set constructor on prototype
@@ -513,7 +518,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -545,7 +550,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -562,7 +567,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -579,7 +584,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -596,7 +601,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -613,7 +618,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -646,7 +651,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -699,7 +704,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -717,7 +722,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -735,7 +740,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj
                 .borrow_mut()
@@ -854,7 +859,7 @@ impl Interpreter {
             let pin = JsValue::Object(crate::types::JsObject { id: promise_id });
             for fn_val in [&resolve_fn, &reject_fn] {
                 if let JsValue::Object(o) = fn_val
-                    && let Some(fn_obj) = self.get_object(o.id)
+                    && let Some(fn_obj) = self.get_object_cell(o.id)
                 {
                     let mut borrowed = fn_obj.borrow_mut();
                     borrowed
@@ -869,7 +874,7 @@ impl Interpreter {
     }
 
     pub(crate) fn fulfill_promise(&mut self, promise_id: u64, value: JsValue) {
-        let reactions = if let Some(obj) = self.get_object(promise_id) {
+        let reactions = if let Some(obj) = self.get_object_cell(promise_id) {
             let mut o = obj.borrow_mut();
             if let Some(ref mut pd) = o.promise_data {
                 if !matches!(pd.state, PromiseState::Pending) {
@@ -889,7 +894,7 @@ impl Interpreter {
     }
 
     pub(crate) fn reject_promise(&mut self, promise_id: u64, reason: JsValue) {
-        let reactions = if let Some(obj) = self.get_object(promise_id) {
+        let reactions = if let Some(obj) = self.get_object_cell(promise_id) {
             let mut o = obj.borrow_mut();
             if let Some(ref mut pd) = o.promise_data {
                 if !matches!(pd.state, PromiseState::Pending) {
@@ -1066,7 +1071,7 @@ impl Interpreter {
 
         let fulfill_reaction2 = fulfill_reaction.clone();
         let reject_reaction2 = reject_reaction.clone();
-        let state = if let Some(obj) = self.get_object(promise_id) {
+        let state = if let Some(obj) = self.get_object_cell(promise_id) {
             let mut o = obj.borrow_mut();
             if let Some(ref mut pd) = o.promise_data {
                 pd.is_handled = true;
@@ -1104,7 +1109,7 @@ impl Interpreter {
         on_rejected: &JsValue,
     ) -> Completion {
         let promise_id = if let JsValue::Object(o) = promise_val {
-            if let Some(obj) = self.get_object(o.id) {
+            if let Some(obj) = self.get_object_cell(o.id) {
                 if obj.borrow().promise_data.is_some() {
                     o.id
                 } else {
@@ -1169,7 +1174,7 @@ impl Interpreter {
 
         let fulfill_reaction2 = fulfill_reaction.clone();
         let reject_reaction2 = reject_reaction.clone();
-        let state = if let Some(obj) = self.get_object(promise_id) {
+        let state = if let Some(obj) = self.get_object_cell(promise_id) {
             let mut o = obj.borrow_mut();
             if let Some(ref mut pd) = o.promise_data {
                 pd.is_handled = true;
@@ -1203,7 +1208,7 @@ impl Interpreter {
     pub(crate) fn promise_resolve_value(&mut self, value: &JsValue) -> JsValue {
         // §27.2.4.7.1 PromiseResolve(C, x): if IsPromise(x), check x.constructor === C
         if let JsValue::Object(o) = value
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
             && obj.borrow().promise_data.is_some()
         {
             match self.get_object_property(o.id, "constructor", value) {
@@ -1790,7 +1795,7 @@ impl Interpreter {
 
     pub(crate) fn is_callable(&self, val: &JsValue) -> bool {
         if let JsValue::Object(o) = val
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             if obj.borrow().callable.is_some() {
                 return true;
@@ -1806,7 +1811,7 @@ impl Interpreter {
 
     pub(crate) fn is_constructor(&self, val: &JsValue) -> bool {
         if let JsValue::Object(o) = val
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             if let Some(ref func) = obj.borrow().callable {
                 return match func {
@@ -1831,7 +1836,7 @@ impl Interpreter {
 
     pub(crate) fn is_promise(&self, val: &JsValue) -> bool {
         if let JsValue::Object(o) = val
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             return obj.borrow().promise_data.is_some();
         }
@@ -1839,7 +1844,7 @@ impl Interpreter {
     }
 
     pub(crate) fn get_promise_state(&self, promise_id: u64) -> Option<PromiseState> {
-        if let Some(obj) = self.get_object(promise_id)
+        if let Some(obj) = self.get_object_cell(promise_id)
             && let Some(ref pd) = obj.borrow().promise_data
         {
             return Some(pd.state.clone());

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -458,7 +458,6 @@ impl Interpreter {
         if let JsValue::Object(ref o) = ctor
             && let Some(func_obj) = self.get_object(o.id)
         {
-            let proto_id = proto_id;
             func_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -187,8 +187,8 @@ impl Interpreter {
     }
 
     pub(crate) fn setup_promise(&mut self) {
-        let proto = self.create_object();
-        self.realm_mut().promise_prototype = Some(proto.borrow().id.unwrap());
+        let proto_id = self.create_object_id();
+        self.realm_mut().promise_prototype = Some(proto_id);
 
         // Promise.prototype.then
         let then_fn = self.create_function(JsFunction::native(
@@ -200,7 +200,7 @@ impl Interpreter {
                 interp.promise_then(this, &on_fulfilled, &on_rejected)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("then".to_string(), then_fn);
 
@@ -230,7 +230,7 @@ impl Interpreter {
                 interp.call_function(&then_method, this, &[JsValue::Undefined, on_rejected])
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("catch".to_string(), catch_fn);
 
@@ -376,20 +376,22 @@ impl Interpreter {
                 interp.call_function(&then_method, this, &[then_finally, catch_finally])
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("finally".to_string(), finally_fn);
 
         // @@toStringTag
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Promise")),
-                false,
-                false,
-                true,
-            ),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Promise")),
+                    false,
+                    false,
+                    true,
+                ),
+            );
 
         // Promise constructor
         let _promise_proto = self.realm().promise_prototype;
@@ -456,7 +458,7 @@ impl Interpreter {
         if let JsValue::Object(ref o) = ctor
             && let Some(func_obj) = self.get_object(o.id)
         {
-            let proto_id = proto.borrow().id.unwrap();
+            let proto_id = proto_id;
             func_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(
@@ -487,10 +489,12 @@ impl Interpreter {
         }
 
         // Set constructor on prototype
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(ctor.clone(), true, false, true),
+            );
 
         // Promise.resolve
         let resolve_fn = self.create_function(JsFunction::native(
@@ -623,17 +627,20 @@ impl Interpreter {
             0,
             |interp, this, _args| match interp.new_promise_capability(this) {
                 Ok(cap) => {
-                    let result = interp.create_object();
-                    result
+                    let result_id = interp.create_object_id();
+                    interp
+                        .get_object_cell_expect(result_id)
                         .borrow_mut()
                         .insert_value("promise".to_string(), cap.promise);
-                    result
+                    interp
+                        .get_object_cell_expect(result_id)
                         .borrow_mut()
                         .insert_value("resolve".to_string(), cap.resolve);
-                    result
+                    interp
+                        .get_object_cell_expect(result_id)
                         .borrow_mut()
                         .insert_value("reject".to_string(), cap.reject);
-                    let id = result.borrow().id.unwrap();
+                    let id = result_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 }
                 Err(e) => Completion::Throw(e),
@@ -1476,16 +1483,16 @@ impl Interpreter {
                     }
                     ac_f.set(true);
                     let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let obj = interp.create_object();
+                    let obj_id = interp.create_object_id();
                     {
-                        let mut o = obj.borrow_mut();
+                        let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         o.insert_value(
                             "status".to_string(),
                             JsValue::String(JsString::from_str("fulfilled")),
                         );
                         o.insert_value("value".to_string(), val);
                     }
-                    let oid = obj.borrow().id.unwrap();
+                    let oid = obj_id;
                     results_f.borrow_mut()[i] = JsValue::Object(crate::types::JsObject { id: oid });
                     let r = remaining_f.get() - 1;
                     remaining_f.set(r);
@@ -1511,16 +1518,16 @@ impl Interpreter {
                     }
                     ac_r.set(true);
                     let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let obj = interp.create_object();
+                    let obj_id = interp.create_object_id();
                     {
-                        let mut o = obj.borrow_mut();
+                        let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         o.insert_value(
                             "status".to_string(),
                             JsValue::String(JsString::from_str("rejected")),
                         );
                         o.insert_value("reason".to_string(), val);
                     }
-                    let oid = obj.borrow().id.unwrap();
+                    let oid = obj_id;
                     results_r.borrow_mut()[i] = JsValue::Object(crate::types::JsObject { id: oid });
                     let r = remaining_r.get() - 1;
                     remaining_r.set(r);
@@ -1762,9 +1769,9 @@ impl Interpreter {
     }
 
     fn create_aggregate_error(&mut self, errors: Vec<JsValue>, message: &str) -> JsValue {
-        let obj = self.create_object();
+        let obj_id = self.create_object_id();
         {
-            let mut o = obj.borrow_mut();
+            let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
             o.class_name = "AggregateError".to_string();
             if let Some(proto_id) = self.realm().aggregate_error_prototype {
                 o.prototype_id = Some(proto_id);
@@ -1775,9 +1782,10 @@ impl Interpreter {
             );
         }
         let errors_arr = self.create_array(errors);
-        obj.borrow_mut()
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
             .insert_builtin("errors".to_string(), errors_arr);
-        let id = obj.borrow().id.unwrap();
+        let id = obj_id;
         JsValue::Object(crate::types::JsObject { id })
     }
 

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -1767,7 +1767,7 @@ impl Interpreter {
             let mut o = obj.borrow_mut();
             o.class_name = "AggregateError".to_string();
             if let Some(proto_id) = self.realm().aggregate_error_prototype {
-                o.prototype_id = Some(self.get_object_expect(proto_id).borrow().id.unwrap());
+                o.prototype_id = Some(proto_id);
             }
             o.insert_builtin(
                 "message".to_string(),

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -8424,8 +8424,7 @@ impl Interpreter {
                 let iter_obj = interp.create_object();
                 iter_obj.borrow_mut().class_name = "RegExp String Iterator".to_string();
                 if let Some(rsi_proto_id) = interp.realm().regexp_string_iterator_prototype {
-                    iter_obj.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(rsi_proto_id).borrow().id.unwrap());
+                    iter_obj.borrow_mut().prototype_id = Some(rsi_proto_id);
                 }
 
                 // Store matcher ID for spec-compliant RegExpExec
@@ -8462,8 +8461,7 @@ impl Interpreter {
         let rsi_proto = self.create_object();
         rsi_proto.borrow_mut().class_name = "RegExp String Iterator".to_string();
         if let Some(ip_id) = self.realm().iterator_prototype {
-            rsi_proto.borrow_mut().prototype_id =
-                Some(self.get_object_expect(ip_id).borrow().id.unwrap());
+            rsi_proto.borrow_mut().prototype_id = Some(ip_id);
         }
 
         // %RegExpStringIteratorPrototype%.next

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -6217,7 +6217,7 @@ fn bytes_regex_captures_at(
 
 fn extract_source_flags(interp: &Interpreter, this_val: &JsValue) -> Option<(String, String, u64)> {
     if let JsValue::Object(o) = this_val
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let b = obj.borrow();
         let source = if let Some(ref s) = b.regexp_original_source {
@@ -6240,7 +6240,7 @@ fn extract_source_flags(interp: &Interpreter, this_val: &JsValue) -> Option<(Str
 /// Fast path: read flags directly from internal slots for pristine RegExp objects.
 /// Returns None if the object isn't a RegExp with internal flags set.
 fn get_flags_fast(interp: &Interpreter, rx_id: u64) -> Option<String> {
-    if let Some(obj) = interp.get_object(rx_id) {
+    if let Some(obj) = interp.get_object_cell(rx_id) {
         let b = obj.borrow();
         if b.class_name == "RegExp"
             && let Some(ref flags) = b.regexp_original_flags
@@ -6254,7 +6254,7 @@ fn get_flags_fast(interp: &Interpreter, rx_id: u64) -> Option<String> {
 /// Check if a RegExp object is "pristine": standard prototype, exec not overridden.
 /// Used to enable fast paths in Symbol.match/replace that bypass JS-level dispatch.
 fn is_pristine_regexp(interp: &Interpreter, rx_id: u64) -> bool {
-    let Some(obj) = interp.get_object(rx_id) else {
+    let Some(obj) = interp.get_object_cell(rx_id) else {
         return false;
     };
     let b = obj.borrow();
@@ -6277,7 +6277,7 @@ fn is_pristine_regexp(interp: &Interpreter, rx_id: u64) -> bool {
     let Some(builtin_exec_id) = interp.realm().builtin_regexp_exec_id else {
         return false;
     };
-    let Some(realm_proto) = interp.get_object(realm_proto_id) else {
+    let Some(realm_proto) = interp.get_object_cell(realm_proto_id) else {
         return false;
     };
     let bp = realm_proto.borrow();
@@ -6298,7 +6298,7 @@ fn spec_set(
     throw: bool,
 ) -> Result<(), JsValue> {
     let obj_val = JsValue::Object(crate::types::JsObject { id: obj_id });
-    if let Some(obj) = interp.get_object(obj_id) {
+    if let Some(obj) = interp.get_object_cell(obj_id) {
         // Proxy set trap
         if obj.borrow().is_proxy() || obj.borrow().proxy_revoked {
             let receiver = obj_val.clone();
@@ -6384,7 +6384,7 @@ fn regexp_exec_abstract(
         }
     } else {
         // If R does not have a [[RegExpMatcher]] internal slot, throw TypeError
-        let is_regexp = if let Some(obj) = interp.get_object(rx_id) {
+        let is_regexp = if let Some(obj) = interp.get_object_cell(rx_id) {
             obj.borrow().class_name == "RegExp"
         } else {
             false
@@ -6394,7 +6394,7 @@ fn regexp_exec_abstract(
                 "RegExp.prototype.exec requires that 'this' be a RegExp object",
             ));
         }
-        let (source, flags) = if let Some(obj) = interp.get_object(rx_id) {
+        let (source, flags) = if let Some(obj) = interp.get_object_cell(rx_id) {
             let b = obj.borrow();
             let src = if let Some(ref s) = b.regexp_original_source {
                 js_string_to_regex_input(&s.code_units)
@@ -6644,7 +6644,7 @@ fn regexp_exec_raw(
 
     // Re-read source/flags from internal slots (may have changed via compile() side effect)
     let (source_owned, flags_owned) = {
-        if let Some(obj) = interp.get_object(this_id) {
+        if let Some(obj) = interp.get_object_cell(this_id) {
             let b = obj.borrow();
             let src = b
                 .regexp_original_source
@@ -6898,7 +6898,7 @@ fn regexp_exec_raw(
                         .insert_value(name.clone(), val);
                 }
                 if let JsValue::Object(ref io) = indices_arr
-                    && let Some(iobj) = interp.get_object(io.id)
+                    && let Some(iobj) = interp.get_object_cell(io.id)
                 {
                     iobj.borrow_mut().insert_value(
                         "groups".to_string(),
@@ -6906,7 +6906,7 @@ fn regexp_exec_raw(
                     );
                 }
             } else if let JsValue::Object(ref io) = indices_arr
-                && let Some(iobj) = interp.get_object(io.id)
+                && let Some(iobj) = interp.get_object_cell(io.id)
             {
                 iobj.borrow_mut()
                     .insert_value("groups".to_string(), JsValue::Undefined);
@@ -6945,7 +6945,7 @@ impl Interpreter {
                         ));
                     }
                 };
-                if let Some(obj) = interp.get_object(obj_id)
+                if let Some(obj) = interp.get_object_cell(obj_id)
                     && obj.borrow().class_name != "RegExp"
                 {
                     return Completion::Throw(interp.create_type_error(
@@ -7058,7 +7058,7 @@ impl Interpreter {
                     }
                 };
                 // 2. Perform ? RequireInternalSlot(O, [[RegExpMatcher]]).
-                if let Some(obj) = interp.get_object(obj_id) {
+                if let Some(obj) = interp.get_object_cell(obj_id) {
                     if obj.borrow().class_name != "RegExp" {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype.compile requires that 'this' be a RegExp object",
@@ -7086,7 +7086,7 @@ impl Interpreter {
                 // 3. If pattern is a RegExp object
                 let pattern_is_regexp = if let JsValue::Object(po) = &pattern_arg {
                     interp
-                        .get_object(po.id)
+                        .get_object_cell(po.id)
                         .map(|o| o.borrow().class_name == "RegExp")
                         .unwrap_or(false)
                 } else {
@@ -7107,7 +7107,7 @@ impl Interpreter {
                     } else {
                         unreachable!()
                     };
-                    if let Some(pobj) = interp.get_object(po_id) {
+                    if let Some(pobj) = interp.get_object_cell(po_id) {
                         let b = pobj.borrow();
                         pattern_str = if let Some(ref s) = b.regexp_original_source {
                             js_string_to_regex_input(&s.code_units)
@@ -7182,7 +7182,7 @@ impl Interpreter {
                 };
 
                 // 5. Return ? RegExpInitialize(O, P, F).
-                if let Some(obj) = interp.get_object(obj_id) {
+                if let Some(obj) = interp.get_object_cell(obj_id) {
                     let mut b = obj.borrow_mut();
                     b.regexp_original_source = Some(source_js);
                     b.regexp_original_flags = Some(JsString::from_str(&flags_str));
@@ -7250,7 +7250,7 @@ impl Interpreter {
                 // Fast path: for pristine RegExp, bypass JS dispatch and use regex directly
                 if is_pristine_regexp(interp, rx_id) {
                     let (source, flags_owned) = {
-                        let obj = interp.get_object(rx_id).unwrap();
+                        let obj = interp.get_object_cell(rx_id).unwrap();
                         let b = obj.borrow();
                         let src = js_string_to_regex_input(
                             &b.regexp_original_source.as_ref().unwrap().code_units,
@@ -7571,7 +7571,7 @@ impl Interpreter {
                 // bypass JS dispatch and build replacement directly from regex matches
                 if global && !functional_replace && is_pristine_regexp(interp, rx_id) {
                     let (source, flags_owned) = {
-                        let obj = interp.get_object(rx_id).unwrap();
+                        let obj = interp.get_object_cell(rx_id).unwrap();
                         let b = obj.borrow();
                         let src = js_string_to_regex_input(
                             &b.regexp_original_source.as_ref().unwrap().code_units,
@@ -8516,7 +8516,7 @@ impl Interpreter {
                         ));
                     }
                 };
-                let obj = match interp.get_object(o.id) {
+                let obj = match interp.get_object_cell(o.id) {
                     Some(obj) => obj,
                     None => {
                         return Completion::Throw(interp.create_type_error(
@@ -8570,7 +8570,7 @@ impl Interpreter {
                     };
 
                     if matches!(result_val, JsValue::Null) {
-                        if let Some(obj2) = interp.get_object(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o.id) {
                             obj2.borrow_mut().iterator_state =
                                 Some(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
@@ -8583,7 +8583,7 @@ impl Interpreter {
                     }
 
                     if !global {
-                        if let Some(obj2) = interp.get_object(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o.id) {
                             obj2.borrow_mut().iterator_state =
                                 Some(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
@@ -8599,7 +8599,7 @@ impl Interpreter {
                     let result_id = if let JsValue::Object(ro) = &result_val {
                         ro.id
                     } else {
-                        if let Some(obj2) = interp.get_object(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o.id) {
                             obj2.borrow_mut().iterator_state =
                                 Some(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
@@ -8648,7 +8648,7 @@ impl Interpreter {
                         }
                     }
 
-                    if let Some(obj2) = interp.get_object(o.id) {
+                    if let Some(obj2) = interp.get_object_cell(o.id) {
                         obj2.borrow_mut().iterator_state =
                             Some(IteratorState::RegExpStringIterator {
                                 source, flags, string, global,
@@ -8664,7 +8664,7 @@ impl Interpreter {
                 let re = match build_regex(&source, &flags) {
                     Ok(r) => r,
                     Err(_) => {
-                        if let Some(obj2) = interp.get_object(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o.id) {
                             obj2.borrow_mut().iterator_state =
                                 Some(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
@@ -8678,7 +8678,7 @@ impl Interpreter {
                 };
 
                 if last_index > string.len() {
-                    if let Some(obj2) = interp.get_object(o.id) {
+                    if let Some(obj2) = interp.get_object_cell(o.id) {
                         obj2.borrow_mut().iterator_state =
                             Some(IteratorState::RegExpStringIterator {
                                 source, flags, string, global,
@@ -8692,7 +8692,7 @@ impl Interpreter {
 
                 match regex_captures(&re, &string[last_index..]) {
                     None => {
-                        if let Some(obj2) = interp.get_object(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o.id) {
                             obj2.borrow_mut().iterator_state =
                                 Some(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
@@ -8721,7 +8721,7 @@ impl Interpreter {
 
                         let result_arr = interp.create_array(elements);
                         if let JsValue::Object(ref ro) = result_arr
-                            && let Some(robj) = interp.get_object(ro.id)
+                            && let Some(robj) = interp.get_object_cell(ro.id)
                         {
                             robj.borrow_mut().insert_value(
                                 "index".to_string(),
@@ -8744,7 +8744,7 @@ impl Interpreter {
                         };
                         let new_done = !global;
 
-                        if let Some(obj2) = interp.get_object(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o.id) {
                             obj2.borrow_mut().iterator_state =
                                 Some(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
@@ -8798,7 +8798,7 @@ impl Interpreter {
                         return Completion::Throw(err);
                     }
                 };
-                if interp.get_object(obj_id).is_none() {
+                if interp.get_object_cell(obj_id).is_none() {
                     let err = interp.create_type_error(
                         "RegExp.prototype.flags requires that 'this' be an Object",
                     );
@@ -8872,7 +8872,7 @@ impl Interpreter {
                             ));
                         }
                     };
-                    let obj = match interp.get_object(obj_ref.id) {
+                    let obj = match interp.get_object_cell(obj_ref.id) {
                         Some(o) => o,
                         None => return Completion::Normal(JsValue::Undefined),
                     };
@@ -8927,7 +8927,7 @@ impl Interpreter {
                         ));
                     }
                 };
-                let obj = match interp.get_object(obj_ref.id) {
+                let obj = match interp.get_object_cell(obj_ref.id) {
                     Some(o) => o,
                     None => return Completion::Normal(JsValue::Undefined),
                 };
@@ -8987,13 +8987,13 @@ impl Interpreter {
                             interp.to_boolean_val(&matcher)
                         } else {
                             // Symbol.match is undefined, check [[RegExpMatcher]]
-                            if let Some(obj) = interp.get_object(o.id) {
+                            if let Some(obj) = interp.get_object_cell(o.id) {
                                 obj.borrow().class_name == "RegExp"
                             } else {
                                 false
                             }
                         }
-                    } else if let Some(obj) = interp.get_object(o.id) {
+                    } else if let Some(obj) = interp.get_object_cell(o.id) {
                         obj.borrow().class_name == "RegExp"
                     } else {
                         false
@@ -9028,7 +9028,7 @@ impl Interpreter {
                 // but flags ToString is deferred until after RegExpAlloc (step 5).
                 let has_regexp_matcher = if let JsValue::Object(ref o) = pattern_arg {
                     interp
-                        .get_object(o.id)
+                        .get_object_cell(o.id)
                         .is_some_and(|obj| obj.borrow().class_name == "RegExp")
                 } else {
                     false
@@ -9042,14 +9042,14 @@ impl Interpreter {
                 let (pattern_js, pattern_str, raw_flags) =
                     if has_regexp_matcher && let JsValue::Object(ref o) = pattern_arg {
                         let src_js = interp
-                            .get_object(o.id)
+                            .get_object_cell(o.id)
                             .and_then(|obj| obj.borrow().regexp_original_source.clone())
                             .unwrap_or_else(|| JsString::from_str(""));
                         let src = js_string_to_regex_input(&src_js.code_units);
                         let flg = if matches!(flags_arg, JsValue::Undefined) {
                             RawFlags::Resolved(
                                 interp
-                                    .get_object(o.id)
+                                    .get_object_cell(o.id)
                                     .and_then(|obj| {
                                         obj.borrow()
                                             .regexp_original_flags

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -8101,10 +8101,7 @@ impl Interpreter {
                 // 3. Let C be ? SpeciesConstructor(rx, %RegExp%).
                 let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
                 let regexp_ctor = interp
-                    .realm()
-                    .global_env
-                    .borrow()
-                    .get("RegExp")
+                    .get_global_var("RegExp")
                     .unwrap_or(JsValue::Undefined);
                 let c = match interp.species_constructor(&rx_val, &regexp_ctor) {
                     Ok(v) => v,
@@ -8344,10 +8341,7 @@ impl Interpreter {
                 // 3. Let C be ? SpeciesConstructor(R, %RegExp%).
                 let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
                 let regexp_ctor = interp
-                    .realm()
-                    .global_env
-                    .borrow()
-                    .get("RegExp")
+                    .get_global_var("RegExp")
                     .unwrap_or(JsValue::Undefined);
                 let c = match interp.species_constructor(&rx_val, &regexp_ctor) {
                     Ok(v) => v,
@@ -8976,10 +8970,7 @@ impl Interpreter {
                     };
                     // Get the active function object (RegExp constructor)
                     let regexp_fn = interp
-                        .realm()
-                        .global_env
-                        .borrow()
-                        .get("RegExp")
+                        .get_global_var("RegExp")
                         .unwrap_or(JsValue::Undefined);
                     if same_value(&regexp_fn, &ctor) {
                         return Completion::Normal(pattern_arg.clone());
@@ -9450,11 +9441,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("RegExp", BindingKind::Var);
-        let _ = self
-            .realm()
-            .global_env
-            .borrow_mut()
-            .set("RegExp", regexp_ctor);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "RegExp", regexp_ctor);
 
         self.realm_mut().regexp_prototype = Some(regexp_proto.borrow().id.unwrap());
     }

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -6897,7 +6897,6 @@ fn regexp_exec_raw(
                         .borrow_mut()
                         .insert_value(name.clone(), val);
                 }
-                let idx_groups_id = idx_groups_id;
                 if let JsValue::Object(ref io) = indices_arr
                     && let Some(iobj) = interp.get_object(io.id)
                 {
@@ -8853,7 +8852,6 @@ impl Interpreter {
             ("sticky", 'y'),
             ("hasIndices", 'd'),
         ];
-        let regexp_proto_id = regexp_proto_id;
         let my_realm_id = self.current_realm_id;
         for &(prop_name, flag_char) in flag_props {
             let name = prop_name.to_string();

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -6814,16 +6814,22 @@ fn regexp_exec_raw(
         None
     };
     let groups_val = if let Some(ref resolved) = resolved_named {
-        let groups_obj = interp.create_object();
-        groups_obj.borrow_mut().prototype_id = None;
+        let groups_obj_id = interp.create_object_id();
+        interp
+            .get_object_cell_expect(groups_obj_id)
+            .borrow_mut()
+            .prototype_id = None;
         for (name, m) in resolved {
             let val = match m {
                 Some(m) => JsValue::String(regex_output_to_js_string(&m.text)),
                 None => JsValue::Undefined,
             };
-            groups_obj.borrow_mut().insert_value(name.clone(), val);
+            interp
+                .get_object_cell_expect(groups_obj_id)
+                .borrow_mut()
+                .insert_value(name.clone(), val);
         }
-        let id = groups_obj.borrow().id.unwrap();
+        let id = groups_obj_id;
         JsValue::Object(crate::types::JsObject { id })
     } else {
         JsValue::Undefined
@@ -6869,8 +6875,11 @@ fn regexp_exec_raw(
             }
             let indices_arr = interp.create_array(index_pairs);
             if let Some(ref resolved) = resolved_named {
-                let idx_groups = interp.create_object();
-                idx_groups.borrow_mut().prototype_id = None;
+                let idx_groups_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(idx_groups_id)
+                    .borrow_mut()
+                    .prototype_id = None;
                 for (name, m) in resolved {
                     let val = match m {
                         Some(m) => {
@@ -6883,9 +6892,12 @@ fn regexp_exec_raw(
                         }
                         None => JsValue::Undefined,
                     };
-                    idx_groups.borrow_mut().insert_value(name.clone(), val);
+                    interp
+                        .get_object_cell_expect(idx_groups_id)
+                        .borrow_mut()
+                        .insert_value(name.clone(), val);
                 }
-                let idx_groups_id = idx_groups.borrow().id.unwrap();
+                let idx_groups_id = idx_groups_id;
                 if let JsValue::Object(ref io) = indices_arr
                     && let Some(iobj) = interp.get_object(io.id)
                 {
@@ -6919,7 +6931,7 @@ fn get_symbol_key(interp: &Interpreter, name: &str) -> Option<String> {
 
 impl Interpreter {
     pub(crate) fn setup_regexp(&mut self) {
-        let regexp_proto = self.create_object();
+        let regexp_proto_id = self.create_object_id();
 
         // RegExp.prototype.exec
         let exec_fn = self.create_function(JsFunction::native(
@@ -6955,7 +6967,7 @@ impl Interpreter {
         if let JsValue::Object(ref o) = exec_fn {
             self.realm_mut().builtin_regexp_exec_id = Some(o.id);
         }
-        regexp_proto
+        self.get_object_cell_expect(regexp_proto_id)
             .borrow_mut()
             .insert_builtin("exec".to_string(), exec_fn);
 
@@ -6986,7 +6998,7 @@ impl Interpreter {
                 }
             },
         ));
-        regexp_proto
+        self.get_object_cell_expect(regexp_proto_id)
             .borrow_mut()
             .insert_builtin("test".to_string(), test_fn);
 
@@ -7027,12 +7039,12 @@ impl Interpreter {
                 ))))
             },
         ));
-        regexp_proto
+        self.get_object_cell_expect(regexp_proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), tostring_fn);
 
         // RegExp.prototype.compile (Annex B §B.2.5.1)
-        let compile_proto_id = regexp_proto.borrow().id.unwrap();
+        let compile_proto_id = regexp_proto_id;
         let compile_fn = self.create_function(JsFunction::native(
             "compile".to_string(),
             2,
@@ -7184,7 +7196,7 @@ impl Interpreter {
                 Completion::Normal(this_val.clone())
             },
         ));
-        regexp_proto
+        self.get_object_cell_expect(regexp_proto_id)
             .borrow_mut()
             .insert_builtin("compile".to_string(), compile_fn);
 
@@ -7396,7 +7408,7 @@ impl Interpreter {
             },
         ));
         if let Some(key) = get_symbol_key(self, "match") {
-            regexp_proto
+            self.get_object_cell_expect(regexp_proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(match_fn, true, false, true));
         }
@@ -7475,7 +7487,7 @@ impl Interpreter {
             },
         ));
         if let Some(key) = get_symbol_key(self, "search") {
-            regexp_proto
+            self.get_object_cell_expect(regexp_proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(search_fn, true, false, true));
         }
@@ -7669,8 +7681,11 @@ impl Interpreter {
                         // Named captures
                         let has_named = caps.names.iter().any(|n| n.is_some());
                         let named_captures_obj = if has_named {
-                            let groups_obj = interp.create_object();
-                            groups_obj.borrow_mut().prototype_id = None;
+                            let groups_obj_id = interp.create_object_id();
+                            interp
+                                .get_object_cell_expect(groups_obj_id)
+                                .borrow_mut()
+                                .prototype_id = None;
                             for orig_name in &cached.name_order {
                                 if let Some(variants) = cached.dup_map.get(orig_name as &str) {
                                     let mut matched_val = JsValue::Undefined;
@@ -7691,7 +7706,8 @@ impl Interpreter {
                                             break;
                                         }
                                     }
-                                    groups_obj
+                                    interp
+                                        .get_object_cell_expect(groups_obj_id)
                                         .borrow_mut()
                                         .insert_value(orig_name.clone(), matched_val);
                                 } else {
@@ -7710,10 +7726,13 @@ impl Interpreter {
                                             break;
                                         }
                                     }
-                                    groups_obj.borrow_mut().insert_value(orig_name.clone(), val);
+                                    interp
+                                        .get_object_cell_expect(groups_obj_id)
+                                        .borrow_mut()
+                                        .insert_value(orig_name.clone(), val);
                                 }
                             }
-                            let groups_id = groups_obj.borrow().id.unwrap();
+                            let groups_id = groups_obj_id;
                             JsValue::Object(crate::types::JsObject { id: groups_id })
                         } else {
                             JsValue::Undefined
@@ -8072,7 +8091,7 @@ impl Interpreter {
             },
         ));
         if let Some(key) = get_symbol_key(self, "replace") {
-            regexp_proto
+            self.get_object_cell_expect(regexp_proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(replace_fn, true, false, true));
         }
@@ -8312,7 +8331,7 @@ impl Interpreter {
             },
         ));
         if let Some(key) = get_symbol_key(self, "split") {
-            regexp_proto
+            self.get_object_cell_expect(regexp_proto_id)
                 .borrow_mut()
                 .insert_property(key, PropertyDescriptor::data(split_fn, true, false, true));
         }
@@ -8421,23 +8440,38 @@ impl Interpreter {
                 };
 
                 // Create iterator with %RegExpStringIteratorPrototype%
-                let iter_obj = interp.create_object();
-                iter_obj.borrow_mut().class_name = "RegExp String Iterator".to_string();
+                let iter_obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(iter_obj_id)
+                    .borrow_mut()
+                    .class_name = "RegExp String Iterator".to_string();
                 if let Some(rsi_proto_id) = interp.realm().regexp_string_iterator_prototype {
-                    iter_obj.borrow_mut().prototype_id = Some(rsi_proto_id);
+                    interp
+                        .get_object_cell_expect(iter_obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(rsi_proto_id);
                 }
 
                 // Store matcher ID for spec-compliant RegExpExec
-                iter_obj.borrow_mut().insert_value(
-                    "__matcher__".to_string(),
-                    JsValue::Number(matcher_id as f64),
-                );
-                iter_obj.borrow_mut().insert_value(
-                    "__full_unicode__".to_string(),
-                    JsValue::Boolean(full_unicode),
-                );
+                interp
+                    .get_object_cell_expect(iter_obj_id)
+                    .borrow_mut()
+                    .insert_value(
+                        "__matcher__".to_string(),
+                        JsValue::Number(matcher_id as f64),
+                    );
+                interp
+                    .get_object_cell_expect(iter_obj_id)
+                    .borrow_mut()
+                    .insert_value(
+                        "__full_unicode__".to_string(),
+                        JsValue::Boolean(full_unicode),
+                    );
 
-                iter_obj.borrow_mut().iterator_state = Some(IteratorState::RegExpStringIterator {
+                interp
+                    .get_object_cell_expect(iter_obj_id)
+                    .borrow_mut()
+                    .iterator_state = Some(IteratorState::RegExpStringIterator {
                     source: m_source,
                     flags: m_flags,
                     string: s,
@@ -8446,22 +8480,28 @@ impl Interpreter {
                     done: false,
                 });
 
-                let id = iter_obj.borrow().id.unwrap();
+                let id = iter_obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
             },
         ));
         if let Some(key) = get_symbol_key(self, "matchAll") {
-            regexp_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(match_all_fn, true, false, true),
-            );
+            self.get_object_cell_expect(regexp_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(match_all_fn, true, false, true),
+                );
         }
 
         // Setup %RegExpStringIteratorPrototype% (§22.2.9.2)
-        let rsi_proto = self.create_object();
-        rsi_proto.borrow_mut().class_name = "RegExp String Iterator".to_string();
+        let rsi_proto_id = self.create_object_id();
+        self.get_object_cell_expect(rsi_proto_id)
+            .borrow_mut()
+            .class_name = "RegExp String Iterator".to_string();
         if let Some(ip_id) = self.realm().iterator_prototype {
-            rsi_proto.borrow_mut().prototype_id = Some(ip_id);
+            self.get_object_cell_expect(rsi_proto_id)
+                .borrow_mut()
+                .prototype_id = Some(ip_id);
         }
 
         // %RegExpStringIteratorPrototype%.next
@@ -8721,25 +8761,29 @@ impl Interpreter {
                 }
             },
         ));
-        rsi_proto.borrow_mut().insert_property(
-            "next".to_string(),
-            PropertyDescriptor::data(rsi_next_fn, true, false, true),
-        );
+        self.get_object_cell_expect(rsi_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "next".to_string(),
+                PropertyDescriptor::data(rsi_next_fn, true, false, true),
+            );
 
         // %RegExpStringIteratorPrototype%[@@toStringTag]
         if let Some(key) = get_symbol_key(self, "toStringTag") {
-            rsi_proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("RegExp String Iterator")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+            self.get_object_cell_expect(rsi_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(
+                        JsValue::String(JsString::from_str("RegExp String Iterator")),
+                        false,
+                        false,
+                        true,
+                    ),
+                );
         }
 
-        self.realm_mut().regexp_string_iterator_prototype = Some(rsi_proto.borrow().id.unwrap());
+        self.realm_mut().regexp_string_iterator_prototype = Some(rsi_proto_id);
 
         // RegExp.prototype.flags getter (§22.2.5.3)
         let flags_getter = self.create_function(JsFunction::native(
@@ -8784,17 +8828,19 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        regexp_proto.borrow_mut().insert_property(
-            "flags".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(flags_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(regexp_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "flags".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(flags_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // Flag property getters on prototype (§22.2.5.x)
         let flag_props: &[(&str, char)] = &[
@@ -8807,7 +8853,7 @@ impl Interpreter {
             ("sticky", 'y'),
             ("hasIndices", 'd'),
         ];
-        let regexp_proto_id = regexp_proto.borrow().id.unwrap();
+        let regexp_proto_id = regexp_proto_id;
         let my_realm_id = self.current_realm_id;
         for &(prop_name, flag_char) in flag_props {
             let name = prop_name.to_string();
@@ -8853,17 +8899,19 @@ impl Interpreter {
                     }
                 },
             ));
-            regexp_proto.borrow_mut().insert_property(
-                prop_name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            self.get_object_cell_expect(regexp_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    prop_name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        get: Some(getter),
+                        set: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                    },
+                );
         }
 
         // source getter (§22.2.5.10)
@@ -8904,19 +8952,21 @@ impl Interpreter {
                 }
             },
         ));
-        regexp_proto.borrow_mut().insert_property(
-            "source".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(source_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(regexp_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "source".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(source_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
-        let regexp_proto_rc_id = regexp_proto.borrow().id.unwrap();
+        let regexp_proto_rc_id = regexp_proto_id;
 
         // RegExp constructor
         let regexp_ctor = self.create_function(JsFunction::constructor(
@@ -9191,7 +9241,7 @@ impl Interpreter {
             obj.borrow_mut().insert_builtin(
                 "prototype".to_string(),
                 JsValue::Object(crate::types::JsObject {
-                    id: regexp_proto.borrow().id.unwrap(),
+                    id: regexp_proto_id,
                 }),
             );
             obj.borrow_mut()
@@ -9431,7 +9481,7 @@ impl Interpreter {
                 );
             }
 
-            regexp_proto
+            self.get_object_cell_expect(regexp_proto_id)
                 .borrow_mut()
                 .insert_builtin("constructor".to_string(), regexp_ctor.clone());
         }
@@ -9442,7 +9492,7 @@ impl Interpreter {
         let env = self.realm().global_env.clone();
         let _ = self.env_set(&env, "RegExp", regexp_ctor);
 
-        self.realm_mut().regexp_prototype = Some(regexp_proto.borrow().id.unwrap());
+        self.realm_mut().regexp_prototype = Some(regexp_proto_id);
     }
 
     pub(crate) fn get_symbol_key(&self, name: &str) -> Option<String> {

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -133,9 +133,13 @@ fn utf16_substring(units: &[u16], from: usize, to: usize) -> String {
 
 impl Interpreter {
     pub(crate) fn setup_string_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "String".to_string();
-        proto.borrow_mut().primitive_value = Some(JsValue::String(JsString::from_str("")));
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "String".to_string();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .primitive_value = Some(JsValue::String(JsString::from_str("")));
 
         #[allow(clippy::type_complexity)]
         let methods: Vec<(
@@ -1477,7 +1481,9 @@ impl Interpreter {
         for (name, arity, func) in methods {
             let fn_val =
                 self.create_function(JsFunction::Native(name.to_string(), arity, func, false));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // toString and valueOf: realm-aware so cross-realm calls throw the right realm's TypeError
@@ -1508,7 +1514,7 @@ impl Interpreter {
                     )),
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toString".to_string(), tostring_fn);
 
@@ -1537,7 +1543,7 @@ impl Interpreter {
                     )),
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("valueOf".to_string(), valueof_fn);
         }
@@ -1571,7 +1577,9 @@ impl Interpreter {
                 }),
                 false,
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         let html_one_arg: Vec<(&str, &str, &str, &str)> = vec![
@@ -1604,7 +1612,9 @@ impl Interpreter {
                 }),
                 false,
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // Annex B: substr(start, length)
@@ -1650,19 +1660,19 @@ impl Interpreter {
                 }),
                 false,
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("substr".to_string(), fn_val);
         }
 
         // Aliases
-        let proto_id = proto.borrow().id.unwrap();
+        let proto_id = proto_id;
         let trim_start_fn = self.get_property_on_id(proto_id, "trimStart");
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("trimLeft".to_string(), trim_start_fn);
         let trim_end_fn = self.get_property_on_id(proto_id, "trimEnd");
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("trimRight".to_string(), trim_end_fn);
 
@@ -1687,10 +1697,12 @@ impl Interpreter {
             },
         ));
         if let Some(key) = self.get_symbol_iterator_key() {
-            proto.borrow_mut().insert_property(
-                key,
-                PropertyDescriptor::data(str_iter_fn, true, false, true),
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(str_iter_fn, true, false, true),
+                );
         }
 
         // Set String.prototype on the String constructor and wire constructor back
@@ -1698,19 +1710,17 @@ impl Interpreter {
             && let JsValue::Object(o) = &str_val
             && let Some(str_obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             str_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val.clone(), false, false, false),
             );
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("constructor".to_string(), str_val.clone());
         }
 
-        self.realm_mut().string_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().string_prototype = Some(proto_id);
     }
 }
 

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -1666,7 +1666,6 @@ impl Interpreter {
         }
 
         // Aliases
-        let proto_id = proto_id;
         let trim_start_fn = self.get_property_on_id(proto_id, "trimStart");
         self.get_object_cell_expect(proto_id)
             .borrow_mut()

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -26,7 +26,7 @@ fn this_string_value(interp: &mut Interpreter, this: &JsValue) -> Result<String,
         )),
         JsValue::String(s) => Ok(s.to_rust_string()),
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id)
+            if let Some(obj) = interp.get_object_cell(o.id)
                 && obj.borrow().class_name == "String"
                 && let Some(JsValue::String(s)) = &obj.borrow().primitive_value
             {
@@ -52,7 +52,7 @@ fn this_js_string(interp: &mut Interpreter, this: &JsValue) -> Result<JsString, 
         )),
         JsValue::String(s) => Ok(s.clone()),
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id)
+            if let Some(obj) = interp.get_object_cell(o.id)
                 && obj.borrow().class_name == "String"
                 && let Some(JsValue::String(s)) = &obj.borrow().primitive_value
             {
@@ -117,7 +117,7 @@ fn is_regexp(interp: &mut Interpreter, obj_id: u64, obj_val: &JsValue) -> Result
         }
     }
     Ok(interp
-        .get_object(obj_id)
+        .get_object_cell(obj_id)
         .map(|obj| obj.borrow().class_name == "RegExp")
         .unwrap_or(false))
 }
@@ -883,7 +883,7 @@ impl Interpreter {
                     let replace_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                     let is_fn = if let JsValue::Object(ref o) = replace_arg {
                         interp
-                            .get_object(o.id)
+                            .get_object_cell(o.id)
                             .map(|obj| obj.borrow().callable.is_some())
                             .unwrap_or(false)
                     } else {
@@ -983,7 +983,7 @@ impl Interpreter {
                                     interp.to_boolean_val(&v)
                                 }
                                 Completion::Normal(_) => interp
-                                    .get_object(o.id)
+                                    .get_object_cell(o.id)
                                     .map(|obj| obj.borrow().class_name == "RegExp")
                                     .unwrap_or(false),
                                 Completion::Throw(e) => return Completion::Throw(e),
@@ -991,7 +991,7 @@ impl Interpreter {
                             }
                         } else {
                             interp
-                                .get_object(o.id)
+                                .get_object_cell(o.id)
                                 .map(|obj| obj.borrow().class_name == "RegExp")
                                 .unwrap_or(false)
                         };
@@ -1043,7 +1043,7 @@ impl Interpreter {
                     let replace_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                     let is_fn = if let JsValue::Object(ref o) = replace_arg {
                         interp
-                            .get_object(o.id)
+                            .get_object_cell(o.id)
                             .map(|obj| obj.borrow().callable.is_some())
                             .unwrap_or(false)
                     } else {
@@ -1254,7 +1254,7 @@ impl Interpreter {
                             let matched = JsValue::String(JsString::from_str(m.as_str()));
                             let result = interp.create_array(vec![matched]);
                             if let JsValue::Object(ro) = &result
-                                && let Some(robj) = interp.get_object(ro.id)
+                                && let Some(robj) = interp.get_object_cell(ro.id)
                             {
                                 robj.borrow_mut().insert_value(
                                     "index".to_string(),
@@ -1292,7 +1292,7 @@ impl Interpreter {
                                     interp.to_boolean_val(&v)
                                 }
                                 Completion::Normal(_) => interp
-                                    .get_object(o.id)
+                                    .get_object_cell(o.id)
                                     .map(|obj| obj.borrow().class_name == "RegExp")
                                     .unwrap_or(false),
                                 Completion::Throw(e) => return Completion::Throw(e),
@@ -1300,7 +1300,7 @@ impl Interpreter {
                             }
                         } else {
                             interp
-                                .get_object(o.id)
+                                .get_object_cell(o.id)
                                 .map(|obj| obj.borrow().class_name == "RegExp")
                                 .unwrap_or(false)
                         };
@@ -1495,7 +1495,7 @@ impl Interpreter {
                 move |interp, this_val, _args| match this_val {
                     JsValue::String(s) => Completion::Normal(JsValue::String(s.clone())),
                     JsValue::Object(o) => {
-                        if let Some(obj) = interp.get_object(o.id)
+                        if let Some(obj) = interp.get_object_cell(o.id)
                             && obj.borrow().class_name == "String"
                             && let Some(ref pv) = obj.borrow().primitive_value
                         {
@@ -1524,7 +1524,7 @@ impl Interpreter {
                 move |interp, this_val, _args| match this_val {
                     JsValue::String(s) => Completion::Normal(JsValue::String(s.clone())),
                     JsValue::Object(o) => {
-                        if let Some(obj) = interp.get_object(o.id)
+                        if let Some(obj) = interp.get_object_cell(o.id)
                             && obj.borrow().class_name == "String"
                             && let Some(ref pv) = obj.borrow().primitive_value
                         {
@@ -1707,7 +1707,7 @@ impl Interpreter {
         // Set String.prototype on the String constructor and wire constructor back
         if let Some(str_val) = self.get_global_var("String")
             && let JsValue::Object(o) = &str_val
-            && let Some(str_obj) = self.get_object(o.id)
+            && let Some(str_obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             str_obj.borrow_mut().insert_property(

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -218,7 +218,7 @@ fn to_relative_to_date(
     }
     // If the value is a Temporal object, handle directly (no property bag reading)
     if let JsValue::Object(obj_ref) = val
-        && let Some(obj) = interp.get_object(obj_ref.id)
+        && let Some(obj) = interp.get_object_cell(obj_ref.id)
     {
         let td = obj.borrow().temporal_data.clone();
         if let Some(super::TemporalData::ZonedDateTime {
@@ -1679,22 +1679,14 @@ impl Interpreter {
                 format!("get {name}"),
                 0,
                 move |interp, this, _args| {
-                    let obj = match &this {
-                        JsValue::Object(o) => match interp.get_object(o.id) {
-                            Some(obj) => obj,
-                            None => {
-                                return Completion::Throw(
-                                    interp.create_type_error("invalid object"),
-                                );
-                            }
-                        },
-                        _ => return Completion::Throw(interp.create_type_error(&format!(
-                            "get Temporal.Duration.prototype.{name} requires a Temporal.Duration"
-                        ))),
+                    let snapshot = match &this {
+                        JsValue::Object(o) => interp
+                            .get_object_cell(o.id)
+                            .map(|cell| cell.borrow().temporal_data.clone()),
+                        _ => None,
                     };
-                    let data = obj.borrow();
-                    match &data.temporal_data {
-                        Some(TemporalData::Duration {
+                    match snapshot {
+                        Some(Some(TemporalData::Duration {
                             years,
                             months,
                             weeks,
@@ -1705,42 +1697,42 @@ impl Interpreter {
                             milliseconds,
                             microseconds,
                             nanoseconds,
-                        }) => {
+                        })) => {
                             let val = match name {
-                                "years" => JsValue::Number(*years),
-                                "months" => JsValue::Number(*months),
-                                "weeks" => JsValue::Number(*weeks),
-                                "days" => JsValue::Number(*days),
-                                "hours" => JsValue::Number(*hours),
-                                "minutes" => JsValue::Number(*minutes),
-                                "seconds" => JsValue::Number(*seconds),
-                                "milliseconds" => JsValue::Number(*milliseconds),
-                                "microseconds" => JsValue::Number(*microseconds),
-                                "nanoseconds" => JsValue::Number(*nanoseconds),
+                                "years" => JsValue::Number(years),
+                                "months" => JsValue::Number(months),
+                                "weeks" => JsValue::Number(weeks),
+                                "days" => JsValue::Number(days),
+                                "hours" => JsValue::Number(hours),
+                                "minutes" => JsValue::Number(minutes),
+                                "seconds" => JsValue::Number(seconds),
+                                "milliseconds" => JsValue::Number(milliseconds),
+                                "microseconds" => JsValue::Number(microseconds),
+                                "nanoseconds" => JsValue::Number(nanoseconds),
                                 "sign" => JsValue::Number(duration_sign(
-                                    *years,
-                                    *months,
-                                    *weeks,
-                                    *days,
-                                    *hours,
-                                    *minutes,
-                                    *seconds,
-                                    *milliseconds,
-                                    *microseconds,
-                                    *nanoseconds,
+                                    years,
+                                    months,
+                                    weeks,
+                                    days,
+                                    hours,
+                                    minutes,
+                                    seconds,
+                                    milliseconds,
+                                    microseconds,
+                                    nanoseconds,
                                 ) as f64),
                                 "blank" => JsValue::Boolean(
                                     duration_sign(
-                                        *years,
-                                        *months,
-                                        *weeks,
-                                        *days,
-                                        *hours,
-                                        *minutes,
-                                        *seconds,
-                                        *milliseconds,
-                                        *microseconds,
-                                        *nanoseconds,
+                                        years,
+                                        months,
+                                        weeks,
+                                        days,
+                                        hours,
+                                        minutes,
+                                        seconds,
+                                        milliseconds,
+                                        microseconds,
+                                        nanoseconds,
                                     ) == 0,
                                 ),
                                 _ => JsValue::Undefined,
@@ -2632,7 +2624,7 @@ impl Interpreter {
 
         // Constructor.prototype_id
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
@@ -2664,7 +2656,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -2818,7 +2810,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -2838,24 +2830,14 @@ fn get_duration_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(f64, f64, f64, f64, f64, f64, f64, f64, f64, f64), Completion> {
-    let obj = match this {
-        JsValue::Object(o) => match interp.get_object(o.id) {
-            Some(obj) => obj,
-            None => {
-                return Err(Completion::Throw(
-                    interp.create_type_error("invalid object"),
-                ));
-            }
-        },
-        _ => {
-            return Err(Completion::Throw(
-                interp.create_type_error("not a Temporal.Duration"),
-            ));
-        }
+    let snapshot = match this {
+        JsValue::Object(o) => interp
+            .get_object_cell(o.id)
+            .map(|cell| cell.borrow().temporal_data.clone()),
+        _ => None,
     };
-    let data = obj.borrow();
-    match &data.temporal_data {
-        Some(TemporalData::Duration {
+    match snapshot {
+        Some(Some(TemporalData::Duration {
             years,
             months,
             weeks,
@@ -2866,17 +2848,17 @@ fn get_duration_fields(
             milliseconds,
             microseconds,
             nanoseconds,
-        }) => Ok((
-            *years,
-            *months,
-            *weeks,
-            *days,
-            *hours,
-            *minutes,
-            *seconds,
-            *milliseconds,
-            *microseconds,
-            *nanoseconds,
+        })) => Ok((
+            years,
+            months,
+            weeks,
+            days,
+            hours,
+            minutes,
+            seconds,
+            milliseconds,
+            microseconds,
+            nanoseconds,
         )),
         _ => Err(Completion::Throw(
             interp.create_type_error("not a Temporal.Duration"),
@@ -2991,7 +2973,7 @@ pub(crate) fn to_temporal_duration_record(
     }
     // Check for existing Duration instance
     if let JsValue::Object(o) = &item
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         let data = obj.borrow();
         if let Some(TemporalData::Duration {

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -1633,8 +1633,10 @@ fn round_relative_duration(
 
 impl Interpreter {
     pub(crate) fn setup_temporal_duration(&mut self, temporal_obj_id: u64) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Temporal.Duration".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Temporal.Duration".to_string();
 
         // @@toStringTag
         {
@@ -1647,8 +1649,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Accessor properties for the 10 components + sign + blank
@@ -1753,7 +1761,9 @@ impl Interpreter {
                 get: Some(getter),
                 set: None,
             };
-            proto.borrow_mut().insert_property(name.to_string(), desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(name.to_string(), desc);
         }
 
         // negated()
@@ -1769,7 +1779,7 @@ impl Interpreter {
                 create_duration_result(interp, -y, -mo, -w, -d, -h, -mi, -s, -ms, -us, -ns)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("negated".to_string(), negated_fn);
 
@@ -1798,7 +1808,9 @@ impl Interpreter {
                 )
             },
         ));
-        proto.borrow_mut().insert_builtin("abs".to_string(), abs_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("abs".to_string(), abs_fn);
 
         // with(durationLike)
         let with_fn = self.create_function(JsFunction::native(
@@ -1854,7 +1866,7 @@ impl Interpreter {
                 create_duration_result(interp, ny, nmo, nw, nd, nh, nmi, ns_val, nms, nus, nns)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("with".to_string(), with_fn);
 
@@ -1899,7 +1911,9 @@ impl Interpreter {
                 create_duration_result(interp, ry, rmo, rw, rd, rh, rmi, rs, rms, rus, rns)
             },
         ));
-        proto.borrow_mut().insert_builtin("add".to_string(), add_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("add".to_string(), add_fn);
 
         // subtract(other)
         let subtract_fn = self.create_function(JsFunction::native(
@@ -1942,7 +1956,7 @@ impl Interpreter {
                 create_duration_result(interp, ry, rmo, rw, rd, rh, rmi, rs, rms, rus, rns)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("subtract".to_string(), subtract_fn);
 
@@ -2241,7 +2255,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("round".to_string(), round_fn);
 
@@ -2368,7 +2382,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("total".to_string(), total_fn);
 
@@ -2409,7 +2423,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), to_string_fn);
 
@@ -2431,7 +2445,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toJSON".to_string(), to_json_fn);
 
@@ -2492,7 +2506,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_string_fn);
 
@@ -2507,11 +2521,11 @@ impl Interpreter {
                     ))
                 },
             ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("valueOf".to_string(), value_of_fn);
 
-        self.realm_mut().temporal_duration_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().temporal_duration_prototype = Some(proto_id);
 
         // Constructor
         let constructor = self.create_function(JsFunction::constructor(
@@ -2620,9 +2634,7 @@ impl Interpreter {
         if let JsValue::Object(ref o) = constructor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -2630,10 +2642,12 @@ impl Interpreter {
         }
 
         // prototype.constructor
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(constructor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(constructor.clone(), true, false, true),
+            );
 
         // Duration.from(item)
         let from_fn = self.create_function(JsFunction::native(
@@ -2910,12 +2924,21 @@ pub(crate) fn create_duration_result(
             interp.create_range_error("Invalid duration: mixed signs or non-finite"),
         );
     }
-    let obj = interp.create_object();
-    obj.borrow_mut().class_name = "Temporal.Duration".to_string();
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Temporal.Duration".to_string();
     if let Some(proto_id) = interp.realm().temporal_duration_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().temporal_data = Some(TemporalData::Duration {
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .temporal_data = Some(TemporalData::Duration {
         years,
         months,
         weeks,
@@ -2927,7 +2950,7 @@ pub(crate) fn create_duration_result(
         microseconds,
         nanoseconds,
     });
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
 }
 

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -1632,7 +1632,7 @@ fn round_relative_duration(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_duration(&mut self, temporal_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_temporal_duration(&mut self, temporal_obj_id: u64) {
         let proto = self.create_object();
         proto.borrow_mut().class_name = "Temporal.Duration".to_string();
 
@@ -2811,10 +2811,12 @@ impl Interpreter {
         }
 
         // Register Duration on Temporal namespace
-        temporal_obj.borrow_mut().insert_property(
-            "Duration".to_string(),
-            PropertyDescriptor::data(constructor, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "Duration".to_string(),
+                PropertyDescriptor::data(constructor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -2811,7 +2811,7 @@ impl Interpreter {
         }
 
         // Register Duration on Temporal namespace
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "Duration".to_string(),
@@ -2914,7 +2914,7 @@ pub(crate) fn create_duration_result(
     obj.borrow_mut().class_name = "Temporal.Duration".to_string();
     if let Some(proto_id) = interp.realm().temporal_duration_prototype {
         obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+            Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::Duration {
         years,

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -2913,8 +2913,7 @@ pub(crate) fn create_duration_result(
     let obj = interp.create_object();
     obj.borrow_mut().class_name = "Temporal.Duration".to_string();
     if let Some(proto_id) = interp.realm().temporal_duration_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(proto_id);
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::Duration {
         years,

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -607,7 +607,7 @@ impl Interpreter {
 
         // Constructor.prototype_id
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
@@ -636,7 +636,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -664,7 +664,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("fromEpochMilliseconds".to_string(), from_ms_fn);
@@ -687,7 +687,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("fromEpochNanoseconds".to_string(), from_ns_fn);
@@ -723,7 +723,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -815,24 +815,14 @@ fn is_valid_instant_round_unit(unit: &str) -> bool {
 }
 
 fn get_instant_ns(interp: &mut Interpreter, this: &JsValue) -> Result<BigInt, Completion> {
-    let obj = match this {
-        JsValue::Object(o) => match interp.get_object(o.id) {
-            Some(obj) => obj,
-            None => {
-                return Err(Completion::Throw(
-                    interp.create_type_error("invalid object"),
-                ));
-            }
-        },
-        _ => {
-            return Err(Completion::Throw(
-                interp.create_type_error("not a Temporal.Instant"),
-            ));
-        }
+    let snapshot = match this {
+        JsValue::Object(o) => interp
+            .get_object_cell(o.id)
+            .map(|cell| cell.borrow().temporal_data.clone()),
+        _ => None,
     };
-    let data = obj.borrow();
-    match &data.temporal_data {
-        Some(TemporalData::Instant { epoch_nanoseconds }) => Ok(epoch_nanoseconds.clone()),
+    match snapshot {
+        Some(Some(TemporalData::Instant { epoch_nanoseconds })) => Ok(epoch_nanoseconds),
         _ => Err(Completion::Throw(
             interp.create_type_error("not a Temporal.Instant"),
         )),
@@ -867,7 +857,7 @@ pub(super) fn to_temporal_instant(
 ) -> Result<BigInt, Completion> {
     match &item {
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 let data = obj.borrow();
                 if let Some(TemporalData::Instant { epoch_nanoseconds }) = &data.temporal_data {
                     return Ok(epoch_nanoseconds.clone());

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -14,7 +14,7 @@ pub(super) fn is_valid_epoch_ns(ns: &BigInt) -> bool {
 }
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_instant(&mut self, temporal_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_temporal_instant(&mut self, temporal_obj_id: u64) {
         let proto = self.create_object();
         proto.borrow_mut().class_name = "Temporal.Instant".to_string();
 
@@ -713,10 +713,12 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        temporal_obj.borrow_mut().insert_property(
-            "Instant".to_string(),
-            PropertyDescriptor::data(constructor, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "Instant".to_string(),
+                PropertyDescriptor::data(constructor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -827,8 +827,7 @@ fn create_instant_result(interp: &mut Interpreter, epoch_ns: BigInt) -> Completi
     let obj = interp.create_object();
     obj.borrow_mut().class_name = "Temporal.Instant".to_string();
     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(proto_id);
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
         epoch_nanoseconds: epoch_ns,

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -15,8 +15,10 @@ pub(super) fn is_valid_epoch_ns(ns: &BigInt) -> bool {
 
 impl Interpreter {
     pub(crate) fn setup_temporal_instant(&mut self, temporal_obj_id: u64) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Temporal.Instant".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Temporal.Instant".to_string();
 
         // @@toStringTag
         {
@@ -29,8 +31,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Getter: epochMilliseconds
@@ -47,17 +55,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(bigint_to_f64(&ms)))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "epochMilliseconds".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "epochMilliseconds".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: epochNanoseconds
@@ -73,17 +83,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::BigInt(crate::types::JsBigInt { value: ns }))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "epochNanoseconds".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "epochNanoseconds".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // equals(other)
@@ -105,7 +117,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(ns == other))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("equals".to_string(), equals_fn);
 
@@ -143,7 +155,9 @@ impl Interpreter {
                 create_instant_result(interp, result)
             },
         ));
-        proto.borrow_mut().insert_builtin("add".to_string(), add_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("add".to_string(), add_fn);
 
         // subtract(temporalDuration)
         let subtract_fn = self.create_function(JsFunction::native(
@@ -179,7 +193,7 @@ impl Interpreter {
                 create_instant_result(interp, result)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("subtract".to_string(), subtract_fn);
 
@@ -274,7 +288,9 @@ impl Interpreter {
                     )
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // round(roundTo)
@@ -409,7 +425,7 @@ impl Interpreter {
                 create_instant_result(interp, result)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("round".to_string(), round_fn);
 
@@ -468,7 +484,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), to_string_fn);
 
@@ -485,7 +501,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toJSON".to_string(), to_json_fn);
 
@@ -515,7 +531,7 @@ impl Interpreter {
                 super::temporal_format_with_dtf(interp, &dtf_instance, this)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_fn);
 
@@ -530,7 +546,7 @@ impl Interpreter {
                 )
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("valueOf".to_string(), value_of_fn);
 
@@ -556,11 +572,11 @@ impl Interpreter {
                 super::zoned_date_time::create_zdt_pub(interp, ns, tz, "iso8601".to_string())
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toZonedDateTimeISO".to_string(), to_zdt_fn);
 
-        self.realm_mut().temporal_instant_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().temporal_instant_prototype = Some(proto_id);
 
         // Constructor
         let constructor = self.create_function(JsFunction::constructor(
@@ -593,18 +609,18 @@ impl Interpreter {
         if let JsValue::Object(ref o) = constructor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(constructor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(constructor.clone(), true, false, true),
+            );
 
         // Instant.from(item)
         let from_fn = self.create_function(JsFunction::native(
@@ -824,15 +840,24 @@ fn get_instant_ns(interp: &mut Interpreter, this: &JsValue) -> Result<BigInt, Co
 }
 
 fn create_instant_result(interp: &mut Interpreter, epoch_ns: BigInt) -> Completion {
-    let obj = interp.create_object();
-    obj.borrow_mut().class_name = "Temporal.Instant".to_string();
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Temporal.Instant".to_string();
     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .temporal_data = Some(TemporalData::Instant {
         epoch_nanoseconds: epoch_ns,
     });
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
 }
 

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -713,7 +713,7 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "Instant".to_string(),
@@ -828,7 +828,7 @@ fn create_instant_result(interp: &mut Interpreter, epoch_ns: BigInt) -> Completi
     obj.borrow_mut().class_name = "Temporal.Instant".to_string();
     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
         obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+            Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
         epoch_nanoseconds: epoch_ns,

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -1647,11 +1647,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("Temporal", BindingKind::Var);
-        let _ = self
-            .realm()
-            .global_env
-            .borrow_mut()
-            .set("Temporal", temporal_val);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "Temporal", temporal_val);
     }
 }
 

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -1631,15 +1631,16 @@ impl Interpreter {
             temporal_obj.borrow_mut().properties.insert(key, desc);
         }
 
-        self.setup_temporal_duration(&temporal_obj);
-        self.setup_temporal_instant(&temporal_obj);
-        self.setup_temporal_plain_time(&temporal_obj);
-        self.setup_temporal_plain_date(&temporal_obj);
-        self.setup_temporal_plain_date_time(&temporal_obj);
-        self.setup_temporal_plain_year_month(&temporal_obj);
-        self.setup_temporal_plain_month_day(&temporal_obj);
-        self.setup_temporal_zoned_date_time(&temporal_obj);
-        self.setup_temporal_now(&temporal_obj);
+        let temporal_obj_id = temporal_obj.borrow().id.unwrap();
+        self.setup_temporal_duration(temporal_obj_id);
+        self.setup_temporal_instant(temporal_obj_id);
+        self.setup_temporal_plain_time(temporal_obj_id);
+        self.setup_temporal_plain_date(temporal_obj_id);
+        self.setup_temporal_plain_date_time(temporal_obj_id);
+        self.setup_temporal_plain_year_month(temporal_obj_id);
+        self.setup_temporal_plain_month_day(temporal_obj_id);
+        self.setup_temporal_zoned_date_time(temporal_obj_id);
+        self.setup_temporal_now(temporal_obj_id);
 
         // Register Temporal as global (writable, not enumerable, configurable)
         let temporal_val = JsValue::Object(crate::types::JsObject { id: temporal_id });

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -1637,7 +1637,6 @@ impl Interpreter {
                 .insert(key, desc);
         }
 
-        let temporal_obj_id = temporal_obj_id;
         self.setup_temporal_duration(temporal_obj_id);
         self.setup_temporal_instant(temporal_obj_id);
         self.setup_temporal_plain_time(temporal_obj_id);

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -1293,7 +1293,7 @@ pub(crate) fn to_temporal_calendar_slot_value(
     match val {
         JsValue::Undefined => Ok("iso8601".to_string()),
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 let data = obj.borrow();
                 match &data.temporal_data {
                     Some(TemporalData::PlainDate { calendar, .. })
@@ -1372,7 +1372,7 @@ pub(crate) fn is_partial_temporal_object(
         }
     };
 
-    if let Some(obj) = interp.get_object(obj_ref.id) {
+    if let Some(obj) = interp.get_object_cell(obj_ref.id) {
         let td = obj.borrow().temporal_data.clone();
         if let Some(
             TemporalData::PlainDate { .. }
@@ -2857,7 +2857,7 @@ pub(super) fn to_temporal_time_zone_identifier(
         }
         JsValue::Object(o) => {
             // If it's a Temporal.ZonedDateTime, extract timeZoneId
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 let td = obj.borrow().temporal_data.clone();
                 if let Some(TemporalData::ZonedDateTime { time_zone, .. }) = td {
                     return Ok(time_zone);

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -1613,8 +1613,8 @@ pub(crate) fn parse_overflow_option(
 
 impl Interpreter {
     pub(crate) fn setup_temporal(&mut self) {
-        let temporal_obj = self.create_object();
-        let temporal_id = temporal_obj.borrow().id.unwrap();
+        let temporal_obj_id = self.create_object_id();
+        let temporal_id = temporal_obj_id;
 
         // @@toStringTag = "Temporal"
         {
@@ -1627,11 +1627,17 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            temporal_obj.borrow_mut().property_order.push(key.clone());
-            temporal_obj.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(temporal_obj_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(temporal_obj_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
-        let temporal_obj_id = temporal_obj.borrow().id.unwrap();
+        let temporal_obj_id = temporal_obj_id;
         self.setup_temporal_duration(temporal_obj_id);
         self.setup_temporal_instant(temporal_obj_id);
         self.setup_temporal_plain_time(temporal_obj_id);

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -45,7 +45,7 @@ impl Interpreter {
                 obj.borrow_mut().class_name = "Temporal.Instant".to_string();
                 if let Some(proto_id) = interp.realm().temporal_instant_prototype {
                     obj.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+                        Some(proto_id);
                 }
                 obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
                     epoch_nanoseconds: ns,
@@ -133,7 +133,7 @@ impl Interpreter {
                 obj.borrow_mut().class_name = "Temporal.ZonedDateTime".to_string();
                 if let Some(proto_id) = interp.realm().temporal_zoned_date_time_prototype {
                     obj.borrow_mut().prototype_id =
-                        Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+                        Some(proto_id);
                 }
                 obj.borrow_mut().temporal_data = Some(TemporalData::ZonedDateTime {
                     epoch_nanoseconds: ns,
@@ -149,7 +149,7 @@ impl Interpreter {
             .insert_builtin("zonedDateTimeISO".to_string(), zdt_fn);
 
         let now_val = JsValue::Object(crate::types::JsObject { id: now_id });
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "Now".to_string(),

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -44,8 +44,7 @@ impl Interpreter {
                 let obj = interp.create_object();
                 obj.borrow_mut().class_name = "Temporal.Instant".to_string();
                 if let Some(proto_id) = interp.realm().temporal_instant_prototype {
-                    obj.borrow_mut().prototype_id =
-                        Some(proto_id);
+                    obj.borrow_mut().prototype_id = Some(proto_id);
                 }
                 obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
                     epoch_nanoseconds: ns,
@@ -132,8 +131,7 @@ impl Interpreter {
                 let obj = interp.create_object();
                 obj.borrow_mut().class_name = "Temporal.ZonedDateTime".to_string();
                 if let Some(proto_id) = interp.realm().temporal_zoned_date_time_prototype {
-                    obj.borrow_mut().prototype_id =
-                        Some(proto_id);
+                    obj.borrow_mut().prototype_id = Some(proto_id);
                 }
                 obj.borrow_mut().temporal_data = Some(TemporalData::ZonedDateTime {
                     epoch_nanoseconds: ns,

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -4,8 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 impl Interpreter {
     pub(crate) fn setup_temporal_now(&mut self, temporal_obj_id: u64) {
-        let now_obj = self.create_object();
-        let now_id = now_obj.borrow().id.unwrap();
+        let now_obj_id = self.create_object_id();
+        let now_id = now_obj_id;
 
         // @@toStringTag = "Temporal.Now"
         {
@@ -18,8 +18,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            now_obj.borrow_mut().property_order.push(key.clone());
-            now_obj.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(now_obj_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(now_obj_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Temporal.Now.timeZoneId()
@@ -31,7 +37,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&tz)))
             },
         ));
-        now_obj
+        self.get_object_cell_expect(now_obj_id)
             .borrow_mut()
             .insert_builtin("timeZoneId".to_string(), tz_fn);
 
@@ -41,19 +47,28 @@ impl Interpreter {
             0,
             |interp, _this, _args| {
                 let ns = current_epoch_nanoseconds();
-                let obj = interp.create_object();
-                obj.borrow_mut().class_name = "Temporal.Instant".to_string();
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Temporal.Instant".to_string();
                 if let Some(proto_id) = interp.realm().temporal_instant_prototype {
-                    obj.borrow_mut().prototype_id = Some(proto_id);
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(proto_id);
                 }
-                obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .temporal_data = Some(TemporalData::Instant {
                     epoch_nanoseconds: ns,
                 });
-                let id = obj.borrow().id.unwrap();
+                let id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
             },
         ));
-        now_obj
+        self.get_object_cell_expect(now_obj_id)
             .borrow_mut()
             .insert_builtin("instant".to_string(), instant_fn);
 
@@ -75,7 +90,7 @@ impl Interpreter {
                 )
             },
         ));
-        now_obj
+        self.get_object_cell_expect(now_obj_id)
             .borrow_mut()
             .insert_builtin("plainDateTimeISO".to_string(), pdt_fn);
 
@@ -94,7 +109,7 @@ impl Interpreter {
                 super::plain_date::create_plain_date_result(interp, y, m, d, "iso8601")
             },
         ));
-        now_obj
+        self.get_object_cell_expect(now_obj_id)
             .borrow_mut()
             .insert_builtin("plainDateISO".to_string(), pd_fn);
 
@@ -113,7 +128,7 @@ impl Interpreter {
                 super::plain_time::create_plain_time_result(interp, h, mi, s, ms, 0, 0)
             },
         ));
-        now_obj
+        self.get_object_cell_expect(now_obj_id)
             .borrow_mut()
             .insert_builtin("plainTimeISO".to_string(), pt_fn);
 
@@ -128,21 +143,30 @@ impl Interpreter {
                     Err(c) => return c,
                 };
                 let ns = current_epoch_nanoseconds();
-                let obj = interp.create_object();
-                obj.borrow_mut().class_name = "Temporal.ZonedDateTime".to_string();
+                let obj_id = interp.create_object_id();
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Temporal.ZonedDateTime".to_string();
                 if let Some(proto_id) = interp.realm().temporal_zoned_date_time_prototype {
-                    obj.borrow_mut().prototype_id = Some(proto_id);
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(proto_id);
                 }
-                obj.borrow_mut().temporal_data = Some(TemporalData::ZonedDateTime {
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .temporal_data = Some(TemporalData::ZonedDateTime {
                     epoch_nanoseconds: ns,
                     time_zone: tz,
                     calendar: "iso8601".to_string(),
                 });
-                let id = obj.borrow().id.unwrap();
+                let id = obj_id;
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
             },
         ));
-        now_obj
+        self.get_object_cell_expect(now_obj_id)
             .borrow_mut()
             .insert_builtin("zonedDateTimeISO".to_string(), zdt_fn);
 

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -3,7 +3,7 @@ use num_bigint::BigInt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_now(&mut self, temporal_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_temporal_now(&mut self, temporal_obj_id: u64) {
         let now_obj = self.create_object();
         let now_id = now_obj.borrow().id.unwrap();
 
@@ -149,10 +149,12 @@ impl Interpreter {
             .insert_builtin("zonedDateTimeISO".to_string(), zdt_fn);
 
         let now_val = JsValue::Object(crate::types::JsObject { id: now_id });
-        temporal_obj.borrow_mut().insert_property(
-            "Now".to_string(),
-            PropertyDescriptor::data(now_val, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "Now".to_string(),
+                PropertyDescriptor::data(now_val, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -9,8 +9,10 @@ use crate::interpreter::builtins::temporal::{
 
 impl Interpreter {
     pub(crate) fn setup_temporal_plain_date(&mut self, temporal_obj_id: u64) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Temporal.PlainDate".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Temporal.PlainDate".to_string();
         {
             let key = "Symbol(Symbol.toStringTag)".to_string();
             let desc = PropertyDescriptor {
@@ -21,8 +23,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Getter: calendarId
@@ -38,17 +46,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&cal)))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "calendarId".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "calendarId".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getters: year, month, day
@@ -79,17 +89,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(val))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: monthCode
@@ -112,17 +124,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&iso_month_code(m))))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "monthCode".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "monthCode".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: dayOfWeek
@@ -138,17 +152,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(iso_day_of_week(y, m, d) as f64))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "dayOfWeek".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "dayOfWeek".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: dayOfYear
@@ -169,17 +185,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(iso_day_of_year(y, m, d) as f64))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "dayOfYear".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "dayOfYear".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: weekOfYear
@@ -199,17 +217,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(week as f64))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "weekOfYear".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "weekOfYear".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: yearOfWeek
@@ -229,17 +249,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(year_of_week as f64))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "yearOfWeek".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "yearOfWeek".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: daysInWeek (always 7 for iso8601)
@@ -255,17 +277,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(7.0))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "daysInWeek".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "daysInWeek".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: daysInMonth
@@ -286,17 +310,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(iso_days_in_month(y, m) as f64))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "daysInMonth".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "daysInMonth".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: daysInYear
@@ -317,17 +343,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(iso_days_in_year(y) as f64))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "daysInYear".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "daysInYear".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: monthsInYear
@@ -348,17 +376,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(12.0))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "monthsInYear".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "monthsInYear".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: inLeapYear
@@ -379,17 +409,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Boolean(iso_is_leap_year(y)))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "inLeapYear".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "inLeapYear".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: era
@@ -411,17 +443,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Undefined)
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "era".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "era".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Getter: eraYear
@@ -443,17 +477,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Undefined)
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "eraYear".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "eraYear".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // with(temporalDateLike, options?)
@@ -656,7 +692,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("with".to_string(), with_fn);
 
@@ -737,7 +773,9 @@ impl Interpreter {
                     create_plain_date_result(interp, ry, rm, rd, &cal)
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // until(other, options?) / since(other, options?)
@@ -883,7 +921,9 @@ impl Interpreter {
                     )
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // equals(other)
@@ -906,7 +946,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(eq))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("equals".to_string(), equals_fn);
 
@@ -957,7 +997,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), to_string_fn);
 
@@ -974,7 +1014,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toJSON".to_string(), to_json_fn);
 
@@ -1013,7 +1053,7 @@ impl Interpreter {
                 super::temporal_format_with_dtf(interp, &dtf_instance, this)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_fn);
 
@@ -1028,7 +1068,7 @@ impl Interpreter {
                     ))
                 },
             ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("valueOf".to_string(), value_of_fn);
 
@@ -1060,7 +1100,7 @@ impl Interpreter {
                 )
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toPlainDateTime".to_string(), to_pdt_fn);
 
@@ -1093,7 +1133,7 @@ impl Interpreter {
                 super::plain_year_month::create_plain_year_month_result(interp, y, m, 1, &cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toPlainYearMonth".to_string(), to_ym_fn);
 
@@ -1130,7 +1170,7 @@ impl Interpreter {
                 )
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toPlainMonthDay".to_string(), to_md_fn);
 
@@ -1156,7 +1196,7 @@ impl Interpreter {
                 create_plain_date_result(interp, y, m, d, &cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("withCalendar".to_string(), with_cal_fn);
 
@@ -1239,11 +1279,11 @@ impl Interpreter {
                 super::zoned_date_time::create_zdt_pub(interp, epoch_ns, tz, cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toZonedDateTime".to_string(), to_zdt_fn);
 
-        self.realm_mut().temporal_plain_date_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().temporal_plain_date_prototype = Some(proto_id);
 
         // Constructor
         let constructor = self.create_function(JsFunction::constructor(
@@ -1320,18 +1360,18 @@ impl Interpreter {
         if let JsValue::Object(ref o) = constructor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(constructor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(constructor.clone(), true, false, true),
+            );
 
         // PlainDate.from(item, options?)
         let from_fn = self.create_function(JsFunction::native(
@@ -1556,18 +1596,27 @@ pub(super) fn create_plain_date_result(
     d: u8,
     cal: &str,
 ) -> Completion {
-    let obj = interp.create_object();
-    obj.borrow_mut().class_name = "Temporal.PlainDate".to_string();
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Temporal.PlainDate".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_date_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().temporal_data = Some(TemporalData::PlainDate {
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .temporal_data = Some(TemporalData::PlainDate {
         iso_year: y,
         iso_month: m,
         iso_day: d,
         calendar: cal.to_string(),
     });
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
 }
 

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -1559,8 +1559,7 @@ pub(super) fn create_plain_date_result(
     let obj = interp.create_object();
     obj.borrow_mut().class_name = "Temporal.PlainDate".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_date_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(proto_id);
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainDate {
         iso_year: y,

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -1358,7 +1358,7 @@ impl Interpreter {
 
         // Constructor.prototype_id
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
@@ -1399,7 +1399,7 @@ impl Interpreter {
                 }
                 // Check if it's a Temporal object (read overflow first, return copy)
                 let is_temporal = if let JsValue::Object(ref o) = item {
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         let data = obj.borrow();
                         matches!(
                             &data.temporal_data,
@@ -1500,7 +1500,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -1541,7 +1541,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -1560,29 +1560,19 @@ fn get_plain_date_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(i32, u8, u8, String), Completion> {
-    let obj = match this {
-        JsValue::Object(o) => match interp.get_object(o.id) {
-            Some(obj) => obj,
-            None => {
-                return Err(Completion::Throw(
-                    interp.create_type_error("invalid object"),
-                ));
-            }
-        },
-        _ => {
-            return Err(Completion::Throw(
-                interp.create_type_error("not a Temporal.PlainDate"),
-            ));
-        }
+    let snapshot = match this {
+        JsValue::Object(o) => interp
+            .get_object_cell(o.id)
+            .map(|cell| cell.borrow().temporal_data.clone()),
+        _ => None,
     };
-    let data = obj.borrow();
-    match &data.temporal_data {
-        Some(TemporalData::PlainDate {
+    match snapshot {
+        Some(Some(TemporalData::PlainDate {
             iso_year,
             iso_month,
             iso_day,
             calendar,
-        }) => Ok((*iso_year, *iso_month, *iso_day, calendar.clone())),
+        })) => Ok((iso_year, iso_month, iso_day, calendar.clone())),
         _ => Err(Completion::Throw(
             interp.create_type_error("not a Temporal.PlainDate"),
         )),
@@ -1793,7 +1783,7 @@ pub(super) fn to_temporal_plain_date(
 ) -> Result<(i32, u8, u8, String), Completion> {
     match &item {
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 let data = obj.borrow();
                 if let Some(TemporalData::PlainDate {
                     iso_year,

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -1507,7 +1507,7 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "PlainDate".to_string(),
@@ -1560,7 +1560,7 @@ pub(super) fn create_plain_date_result(
     obj.borrow_mut().class_name = "Temporal.PlainDate".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_date_prototype {
         obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+            Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainDate {
         iso_year: y,

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -8,7 +8,7 @@ use crate::interpreter::builtins::temporal::{
 };
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_plain_date(&mut self, temporal_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_temporal_plain_date(&mut self, temporal_obj_id: u64) {
         let proto = self.create_object();
         proto.borrow_mut().class_name = "Temporal.PlainDate".to_string();
         {
@@ -1507,10 +1507,12 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        temporal_obj.borrow_mut().insert_property(
-            "PlainDate".to_string(),
-            PropertyDescriptor::data(constructor, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "PlainDate".to_string(),
+                PropertyDescriptor::data(constructor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -65,7 +65,7 @@ pub(super) fn to_temporal_plain_date_time_with_overflow(
 ) -> Result<(i32, u8, u8, u8, u8, u8, u16, u16, u16, String), Completion> {
     match &item {
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 let data = obj.borrow();
                 if let Some(TemporalData::PlainDateTime {
                     iso_year,
@@ -470,24 +470,14 @@ fn get_pdt_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(i32, u8, u8, u8, u8, u8, u16, u16, u16, String), Completion> {
-    let obj = match this {
-        JsValue::Object(o) => match interp.get_object(o.id) {
-            Some(obj) => obj,
-            None => {
-                return Err(Completion::Throw(
-                    interp.create_type_error("invalid object"),
-                ));
-            }
-        },
-        _ => {
-            return Err(Completion::Throw(
-                interp.create_type_error("not a Temporal.PlainDateTime"),
-            ));
-        }
+    let snapshot = match this {
+        JsValue::Object(o) => interp
+            .get_object_cell(o.id)
+            .map(|cell| cell.borrow().temporal_data.clone()),
+        _ => None,
     };
-    let data = obj.borrow();
-    match &data.temporal_data {
-        Some(TemporalData::PlainDateTime {
+    match snapshot {
+        Some(Some(TemporalData::PlainDateTime {
             iso_year,
             iso_month,
             iso_day,
@@ -498,16 +488,16 @@ fn get_pdt_fields(
             microsecond,
             nanosecond,
             calendar,
-        }) => Ok((
-            *iso_year,
-            *iso_month,
-            *iso_day,
-            *hour,
-            *minute,
-            *second,
-            *millisecond,
-            *microsecond,
-            *nanosecond,
+        })) => Ok((
+            iso_year,
+            iso_month,
+            iso_day,
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+            nanosecond,
             calendar.clone(),
         )),
         _ => Err(Completion::Throw(
@@ -2231,7 +2221,7 @@ impl Interpreter {
 
         // Constructor.prototype_id
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
@@ -2275,7 +2265,7 @@ impl Interpreter {
                 }
                 // Check if it's a Temporal object (read overflow first, then return copy)
                 let is_temporal = if let JsValue::Object(ref o) = item {
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         let data = obj.borrow();
                         matches!(
                             &data.temporal_data,
@@ -2406,7 +2396,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -2441,7 +2431,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -25,7 +25,7 @@ pub(super) fn create_plain_date_time_result(
     obj.borrow_mut().class_name = "Temporal.PlainDateTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_date_time_prototype {
         obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+            Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainDateTime {
         iso_year: y,
@@ -2415,7 +2415,7 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "PlainDateTime".to_string(),

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -541,10 +541,7 @@ fn format_plain_date_time(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_plain_date_time(
-        &mut self,
-        temporal_obj: &Rc<RefCell<JsObjectData>>,
-    ) {
+    pub(crate) fn setup_temporal_plain_date_time(&mut self, temporal_obj_id: u64) {
         let proto = self.create_object();
         proto.borrow_mut().class_name = "Temporal.PlainDateTime".to_string();
         {
@@ -2418,10 +2415,12 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        temporal_obj.borrow_mut().insert_property(
-            "PlainDateTime".to_string(),
-            PropertyDescriptor::data(constructor, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "PlainDateTime".to_string(),
+                PropertyDescriptor::data(constructor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -21,12 +21,21 @@ pub(super) fn create_plain_date_time_result(
     ns: u16,
     cal: &str,
 ) -> Completion {
-    let obj = interp.create_object();
-    obj.borrow_mut().class_name = "Temporal.PlainDateTime".to_string();
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Temporal.PlainDateTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_date_time_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().temporal_data = Some(TemporalData::PlainDateTime {
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .temporal_data = Some(TemporalData::PlainDateTime {
         iso_year: y,
         iso_month: m,
         iso_day: d,
@@ -38,7 +47,7 @@ pub(super) fn create_plain_date_time_result(
         nanosecond: ns,
         calendar: cal.to_string(),
     });
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
 }
 
@@ -541,8 +550,10 @@ fn format_plain_date_time(
 
 impl Interpreter {
     pub(crate) fn setup_temporal_plain_date_time(&mut self, temporal_obj_id: u64) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Temporal.PlainDateTime".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Temporal.PlainDateTime".to_string();
         {
             let key = "Symbol(Symbol.toStringTag)".to_string();
             let desc = PropertyDescriptor {
@@ -555,8 +566,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Getter: calendarId
@@ -572,17 +589,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&cal)))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "calendarId".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "calendarId".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Date getters: year, month, day + calendar computed
@@ -613,17 +632,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(val))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Time getters: hour, minute, second, millisecond, microsecond, nanosecond
@@ -654,17 +675,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(val))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // monthCode
@@ -687,17 +710,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&iso_month_code(m))))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "monthCode".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "monthCode".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Computed date getters
@@ -758,17 +783,19 @@ impl Interpreter {
                     Completion::Normal(val)
                 },
             ));
-            proto.borrow_mut().insert_property(
-                name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // era / eraYear
@@ -799,17 +826,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Undefined)
                 },
             ));
-            proto.borrow_mut().insert_property(
-                name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // with(temporalDateTimeLike, options?)
@@ -1124,7 +1153,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("with".to_string(), with_fn);
 
@@ -1154,7 +1183,7 @@ impl Interpreter {
                 create_plain_date_time_result(interp, y, m, d, h, mi, s, ms, us, ns, &cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("withPlainTime".to_string(), with_time_fn);
 
@@ -1180,7 +1209,7 @@ impl Interpreter {
                 create_plain_date_time_result(interp, y, m, d, h, mi, s, ms, us, ns, &cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("withCalendar".to_string(), with_cal_fn);
 
@@ -1261,7 +1290,9 @@ impl Interpreter {
                     )
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // until(other, options?) / since(other, options?)
@@ -1565,7 +1596,9 @@ impl Interpreter {
                     )
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // round(options)
@@ -1704,7 +1737,7 @@ impl Interpreter {
                 create_plain_date_time_result(interp, ry, rm, rd, nh, nmi, nse, nms, nus, nns, &cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("round".to_string(), round_fn);
 
@@ -1735,7 +1768,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(eq))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("equals".to_string(), equals_fn);
 
@@ -1924,7 +1957,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), to_string_fn);
 
@@ -1942,7 +1975,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toJSON".to_string(), to_json_fn);
 
@@ -1978,7 +2011,7 @@ impl Interpreter {
                 super::temporal_format_with_dtf(interp, &dtf_instance, this)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_fn);
 
@@ -1992,7 +2025,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("valueOf".to_string(), value_of_fn);
 
@@ -2008,7 +2041,7 @@ impl Interpreter {
                 super::plain_date::create_plain_date_result(interp, y, m, d, &cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toPlainDate".to_string(), to_pd_fn);
 
@@ -2024,7 +2057,7 @@ impl Interpreter {
                 super::plain_time::create_plain_time_result(interp, h, mi, s, ms, us, ns)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toPlainTime".to_string(), to_pt_fn);
 
@@ -2093,11 +2126,11 @@ impl Interpreter {
                 super::zoned_date_time::create_zdt_pub(interp, epoch_ns, tz, cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toZonedDateTime".to_string(), to_zdt_fn);
 
-        self.realm_mut().temporal_plain_date_time_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().temporal_plain_date_time_prototype = Some(proto_id);
 
         // Constructor
         let constructor = self.create_function(JsFunction::constructor(
@@ -2200,18 +2233,18 @@ impl Interpreter {
         if let JsValue::Object(ref o) = constructor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(constructor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(constructor.clone(), true, false, true),
+            );
 
         // PlainDateTime.from(item, options?)
         let from_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -24,8 +24,7 @@ pub(super) fn create_plain_date_time_result(
     let obj = interp.create_object();
     obj.borrow_mut().class_name = "Temporal.PlainDateTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_date_time_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(proto_id);
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainDateTime {
         iso_year: y,

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -40,29 +40,19 @@ fn get_md_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(u8, u8, i32, String), Completion> {
-    let obj = match this {
-        JsValue::Object(o) => match interp.get_object(o.id) {
-            Some(obj) => obj,
-            None => {
-                return Err(Completion::Throw(
-                    interp.create_type_error("invalid object"),
-                ));
-            }
-        },
-        _ => {
-            return Err(Completion::Throw(
-                interp.create_type_error("not a Temporal.PlainMonthDay"),
-            ));
-        }
+    let snapshot = match this {
+        JsValue::Object(o) => interp
+            .get_object_cell(o.id)
+            .map(|cell| cell.borrow().temporal_data.clone()),
+        _ => None,
     };
-    let data = obj.borrow();
-    match &data.temporal_data {
-        Some(TemporalData::PlainMonthDay {
+    match snapshot {
+        Some(Some(TemporalData::PlainMonthDay {
             iso_month,
             iso_day,
             reference_iso_year,
             calendar,
-        }) => Ok((*iso_month, *iso_day, *reference_iso_year, calendar.clone())),
+        })) => Ok((iso_month, iso_day, reference_iso_year, calendar.clone())),
         _ => Err(Completion::Throw(
             interp.create_type_error("not a Temporal.PlainMonthDay"),
         )),
@@ -167,7 +157,7 @@ fn to_temporal_plain_month_day(
 ) -> Result<(u8, u8, i32, String), Completion> {
     match &item {
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 let data = obj.borrow();
                 if let Some(TemporalData::PlainMonthDay {
                     iso_month,
@@ -978,7 +968,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
@@ -1014,7 +1004,7 @@ impl Interpreter {
                 }
                 // Check if it's a Temporal PlainMonthDay (read overflow first, return copy)
                 let is_temporal = if let JsValue::Object(ref o) = item {
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         let data = obj.borrow();
                         matches!(
                             &data.temporal_data,
@@ -1234,7 +1224,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -16,7 +16,7 @@ pub(super) fn create_plain_month_day_result(
     obj.borrow_mut().class_name = "Temporal.PlainMonthDay".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_month_day_prototype {
         obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+            Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainMonthDay {
         iso_month: m,
@@ -1217,7 +1217,7 @@ impl Interpreter {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
 
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "PlainMonthDay".to_string(),

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -12,18 +12,27 @@ pub(super) fn create_plain_month_day_result(
     ref_year: i32,
     cal: &str,
 ) -> Completion {
-    let obj = interp.create_object();
-    obj.borrow_mut().class_name = "Temporal.PlainMonthDay".to_string();
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Temporal.PlainMonthDay".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_month_day_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().temporal_data = Some(TemporalData::PlainMonthDay {
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .temporal_data = Some(TemporalData::PlainMonthDay {
         iso_month: m,
         iso_day: d,
         reference_iso_year: ref_year,
         calendar: cal.to_string(),
     });
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
 }
 
@@ -404,8 +413,10 @@ fn to_temporal_plain_month_day(
 
 impl Interpreter {
     pub(crate) fn setup_temporal_plain_month_day(&mut self, temporal_obj_id: u64) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Temporal.PlainMonthDay".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Temporal.PlainMonthDay".to_string();
         {
             let key = "Symbol(Symbol.toStringTag)".to_string();
             let desc = PropertyDescriptor {
@@ -418,8 +429,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Getters: calendarId, monthCode, month, day
@@ -435,17 +452,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&cal)))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "calendarId".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "calendarId".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
         {
             let getter = self.create_function(JsFunction::native(
@@ -466,17 +485,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&iso_month_code(m))))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "monthCode".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "monthCode".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
         {
             let getter = self.create_function(JsFunction::native(
@@ -495,17 +516,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(d as f64))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "day".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "day".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // with(fields)
@@ -612,7 +635,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("with".to_string(), with_fn);
 
@@ -635,7 +658,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("equals".to_string(), equals_fn);
 
@@ -686,7 +709,7 @@ impl Interpreter {
                 ))))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), to_string_fn);
 
@@ -703,7 +726,7 @@ impl Interpreter {
                 ))))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toJSON".to_string(), to_json_fn);
 
@@ -741,7 +764,7 @@ impl Interpreter {
                 super::temporal_format_with_dtf(interp, &dtf_instance, this)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_fn);
 
@@ -755,7 +778,7 @@ impl Interpreter {
                 )
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("valueOf".to_string(), value_of_fn);
 
@@ -867,11 +890,11 @@ impl Interpreter {
                 super::plain_date::create_plain_date_result(interp, y, m, cd, &cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toPlainDate".to_string(), to_pd_fn);
 
-        self.realm_mut().temporal_plain_month_day_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().temporal_plain_month_day_prototype = Some(proto_id);
 
         // Constructor
         let constructor = self.create_function(JsFunction::constructor(
@@ -957,18 +980,18 @@ impl Interpreter {
         if let JsValue::Object(ref o) = constructor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(constructor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(constructor.clone(), true, false, true),
+            );
 
         // from(item, options?)
         let from_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -15,8 +15,7 @@ pub(super) fn create_plain_month_day_result(
     let obj = interp.create_object();
     obj.borrow_mut().class_name = "Temporal.PlainMonthDay".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_month_day_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(proto_id);
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainMonthDay {
         iso_month: m,

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -404,10 +404,7 @@ fn to_temporal_plain_month_day(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_plain_month_day(
-        &mut self,
-        temporal_obj: &Rc<RefCell<JsObjectData>>,
-    ) {
+    pub(crate) fn setup_temporal_plain_month_day(&mut self, temporal_obj_id: u64) {
         let proto = self.create_object();
         proto.borrow_mut().class_name = "Temporal.PlainMonthDay".to_string();
         {
@@ -1220,10 +1217,12 @@ impl Interpreter {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
 
-        temporal_obj.borrow_mut().insert_property(
-            "PlainMonthDay".to_string(),
-            PropertyDescriptor::data(constructor, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "PlainMonthDay".to_string(),
+                PropertyDescriptor::data(constructor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -7,7 +7,7 @@ use crate::interpreter::builtins::temporal::{
 };
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_plain_time(&mut self, temporal_obj: &Rc<RefCell<JsObjectData>>) {
+    pub(crate) fn setup_temporal_plain_time(&mut self, temporal_obj_id: u64) {
         let proto = self.create_object();
         proto.borrow_mut().class_name = "Temporal.PlainTime".to_string();
         {
@@ -816,10 +816,12 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        temporal_obj.borrow_mut().insert_property(
-            "PlainTime".to_string(),
-            PropertyDescriptor::data(constructor, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "PlainTime".to_string(),
+                PropertyDescriptor::data(constructor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -724,7 +724,7 @@ impl Interpreter {
 
         // Constructor.prototype_id
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
@@ -787,7 +787,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -824,7 +824,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -843,38 +843,21 @@ fn get_plain_time_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(u8, u8, u8, u16, u16, u16), Completion> {
-    let obj = match this {
-        JsValue::Object(o) => match interp.get_object(o.id) {
-            Some(obj) => obj,
-            None => {
-                return Err(Completion::Throw(
-                    interp.create_type_error("invalid object"),
-                ));
-            }
-        },
-        _ => {
-            return Err(Completion::Throw(
-                interp.create_type_error("not a Temporal.PlainTime"),
-            ));
-        }
+    let snapshot = match this {
+        JsValue::Object(o) => interp
+            .get_object_cell(o.id)
+            .map(|cell| cell.borrow().temporal_data.clone()),
+        _ => None,
     };
-    let data = obj.borrow();
-    match &data.temporal_data {
-        Some(TemporalData::PlainTime {
+    match snapshot {
+        Some(Some(TemporalData::PlainTime {
             hour,
             minute,
             second,
             millisecond,
             microsecond,
             nanosecond,
-        }) => Ok((
-            *hour,
-            *minute,
-            *second,
-            *millisecond,
-            *microsecond,
-            *nanosecond,
-        )),
+        })) => Ok((hour, minute, second, millisecond, microsecond, nanosecond)),
         _ => Err(Completion::Throw(
             interp.create_type_error("not a Temporal.PlainTime"),
         )),
@@ -965,7 +948,7 @@ fn to_temporal_plain_time_raw(
 ) -> Result<(u8, u8, u8, u16, u16, u16), Completion> {
     match &item {
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 let data = obj.borrow();
                 if let Some(TemporalData::PlainTime {
                     hour,

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -816,7 +816,7 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "PlainTime".to_string(),
@@ -880,7 +880,7 @@ pub(super) fn create_plain_time_result(
     obj.borrow_mut().class_name = "Temporal.PlainTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_time_prototype {
         obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+            Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainTime {
         hour: h,

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -879,8 +879,7 @@ pub(super) fn create_plain_time_result(
     let obj = interp.create_object();
     obj.borrow_mut().class_name = "Temporal.PlainTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_time_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(proto_id);
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainTime {
         hour: h,

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -8,8 +8,10 @@ use crate::interpreter::builtins::temporal::{
 
 impl Interpreter {
     pub(crate) fn setup_temporal_plain_time(&mut self, temporal_obj_id: u64) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Temporal.PlainTime".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Temporal.PlainTime".to_string();
         {
             let key = "Symbol(Symbol.toStringTag)".to_string();
             let desc = PropertyDescriptor {
@@ -20,8 +22,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Getters
@@ -53,17 +61,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(val))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // with(temporalTimeLike)
@@ -151,7 +161,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("with".to_string(), with_fn);
 
@@ -187,7 +197,9 @@ impl Interpreter {
                     create_plain_time_result(interp, rh, rm, rs, rms, rus, rns)
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // until(other, options?) / since(other, options?)
@@ -254,7 +266,9 @@ impl Interpreter {
                     )
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // round(roundTo)
@@ -386,7 +400,7 @@ impl Interpreter {
                 create_plain_time_result(interp, rh, rm, rs, rms, rus, rns)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("round".to_string(), round_fn);
 
@@ -408,7 +422,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(eq))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("equals".to_string(), equals_fn);
 
@@ -456,7 +470,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), to_string_fn);
 
@@ -473,7 +487,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toJSON".to_string(), to_json_fn);
 
@@ -509,7 +523,7 @@ impl Interpreter {
                 super::temporal_format_with_dtf(interp, &dtf_instance, this)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_fn);
 
@@ -524,11 +538,11 @@ impl Interpreter {
                     ))
                 },
             ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("valueOf".to_string(), value_of_fn);
 
-        self.realm_mut().temporal_plain_time_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().temporal_plain_time_prototype = Some(proto_id);
 
         // Constructor
         let constructor = self.create_function(JsFunction::constructor(
@@ -712,18 +726,18 @@ impl Interpreter {
         if let JsValue::Object(ref o) = constructor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(constructor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(constructor.clone(), true, false, true),
+            );
 
         // PlainTime.from(item, options?)
         let from_fn = self.create_function(JsFunction::native(
@@ -876,12 +890,21 @@ pub(super) fn create_plain_time_result(
     us: u16,
     ns: u16,
 ) -> Completion {
-    let obj = interp.create_object();
-    obj.borrow_mut().class_name = "Temporal.PlainTime".to_string();
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Temporal.PlainTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_time_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().temporal_data = Some(TemporalData::PlainTime {
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .temporal_data = Some(TemporalData::PlainTime {
         hour: h,
         minute: m,
         second: s,
@@ -889,7 +912,7 @@ pub(super) fn create_plain_time_result(
         microsecond: us,
         nanosecond: ns,
     });
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
 }
 

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -46,29 +46,19 @@ fn get_ym_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(i32, u8, u8, String), Completion> {
-    let obj = match this {
-        JsValue::Object(o) => match interp.get_object(o.id) {
-            Some(obj) => obj,
-            None => {
-                return Err(Completion::Throw(
-                    interp.create_type_error("invalid object"),
-                ));
-            }
-        },
-        _ => {
-            return Err(Completion::Throw(
-                interp.create_type_error("not a Temporal.PlainYearMonth"),
-            ));
-        }
+    let snapshot = match this {
+        JsValue::Object(o) => interp
+            .get_object_cell(o.id)
+            .map(|cell| cell.borrow().temporal_data.clone()),
+        _ => None,
     };
-    let data = obj.borrow();
-    match &data.temporal_data {
-        Some(TemporalData::PlainYearMonth {
+    match snapshot {
+        Some(Some(TemporalData::PlainYearMonth {
             iso_year,
             iso_month,
             reference_iso_day,
             calendar,
-        }) => Ok((*iso_year, *iso_month, *reference_iso_day, calendar.clone())),
+        })) => Ok((iso_year, iso_month, reference_iso_day, calendar.clone())),
         _ => Err(Completion::Throw(
             interp.create_type_error("not a Temporal.PlainYearMonth"),
         )),
@@ -195,7 +185,7 @@ fn to_temporal_plain_year_month(
 ) -> Result<(i32, u8, u8, String), Completion> {
     match &item {
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 let data = obj.borrow();
                 if let Some(TemporalData::PlainYearMonth {
                     iso_year,
@@ -1284,7 +1274,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
@@ -1322,7 +1312,7 @@ impl Interpreter {
                 }
                 // Check if it's a Temporal PlainYearMonth (read overflow first, return copy)
                 let is_temporal = if let JsValue::Object(ref o) = item {
-                    if let Some(obj) = interp.get_object(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o.id) {
                         let data = obj.borrow();
                         matches!(
                             &data.temporal_data,
@@ -1435,7 +1425,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -1472,7 +1462,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -392,10 +392,7 @@ fn to_temporal_plain_year_month(
 }
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_plain_year_month(
-        &mut self,
-        temporal_obj: &Rc<RefCell<JsObjectData>>,
-    ) {
+    pub(crate) fn setup_temporal_plain_year_month(&mut self, temporal_obj_id: u64) {
         let proto = self.create_object();
         proto.borrow_mut().class_name = "Temporal.PlainYearMonth".to_string();
         {
@@ -1453,10 +1450,12 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        temporal_obj.borrow_mut().insert_property(
-            "PlainYearMonth".to_string(),
-            PropertyDescriptor::data(constructor, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "PlainYearMonth".to_string(),
+                PropertyDescriptor::data(constructor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -22,7 +22,7 @@ pub(super) fn create_plain_year_month_result(
     obj.borrow_mut().class_name = "Temporal.PlainYearMonth".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_year_month_prototype {
         obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+            Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainYearMonth {
         iso_year: y,
@@ -1450,7 +1450,7 @@ impl Interpreter {
                 .insert_builtin("compare".to_string(), compare_fn);
         }
 
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "PlainYearMonth".to_string(),

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -21,8 +21,7 @@ pub(super) fn create_plain_year_month_result(
     let obj = interp.create_object();
     obj.borrow_mut().class_name = "Temporal.PlainYearMonth".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_year_month_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(proto_id);
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::PlainYearMonth {
         iso_year: y,

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -18,18 +18,27 @@ pub(super) fn create_plain_year_month_result(
             interp.create_range_error("PlainYearMonth outside representable range"),
         );
     }
-    let obj = interp.create_object();
-    obj.borrow_mut().class_name = "Temporal.PlainYearMonth".to_string();
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Temporal.PlainYearMonth".to_string();
     if let Some(proto_id) = interp.realm().temporal_plain_year_month_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().temporal_data = Some(TemporalData::PlainYearMonth {
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .temporal_data = Some(TemporalData::PlainYearMonth {
         iso_year: y,
         iso_month: m,
         reference_iso_day: ref_day,
         calendar: cal.to_string(),
     });
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
 }
 
@@ -392,8 +401,10 @@ fn to_temporal_plain_year_month(
 
 impl Interpreter {
     pub(crate) fn setup_temporal_plain_year_month(&mut self, temporal_obj_id: u64) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Temporal.PlainYearMonth".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Temporal.PlainYearMonth".to_string();
         {
             let key = "Symbol(Symbol.toStringTag)".to_string();
             let desc = PropertyDescriptor {
@@ -406,8 +417,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // Getters: calendarId, year, month, monthCode
@@ -423,17 +440,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&cal)))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "calendarId".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "calendarId".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
         for &(name, idx) in &[("year", 0u8), ("month", 1)] {
             let getter = self.create_function(JsFunction::native(
@@ -456,17 +475,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(if idx == 0 { y as f64 } else { m as f64 }))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
         {
             let getter = self.create_function(JsFunction::native(
@@ -487,17 +508,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&iso_month_code(m))))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "monthCode".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "monthCode".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // Computed getters
@@ -545,17 +568,19 @@ impl Interpreter {
                     }
                 },
             ));
-            proto.borrow_mut().insert_property(
-                name.to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    name.to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         // with(fields, options?)
@@ -734,7 +759,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("with".to_string(), with_fn);
 
@@ -815,7 +840,9 @@ impl Interpreter {
                     create_plain_year_month_result(interp, ry, rm, final_rd, &cal)
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // until / since
@@ -951,7 +978,9 @@ impl Interpreter {
                     )
                 },
             ));
-            proto.borrow_mut().insert_builtin(name.to_string(), fn_val);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin(name.to_string(), fn_val);
         }
 
         // equals
@@ -973,7 +1002,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("equals".to_string(), equals_fn);
 
@@ -1019,7 +1048,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toString".to_string(), to_string_fn);
 
@@ -1036,7 +1065,7 @@ impl Interpreter {
                 ))))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toJSON".to_string(), to_json_fn);
 
@@ -1075,7 +1104,7 @@ impl Interpreter {
                 super::temporal_format_with_dtf(interp, &dtf_instance, this)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_fn);
 
@@ -1089,7 +1118,7 @@ impl Interpreter {
                 ))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("valueOf".to_string(), value_of_fn);
 
@@ -1163,11 +1192,11 @@ impl Interpreter {
                 super::plain_date::create_plain_date_result(interp, y, m, cd, &cal)
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toPlainDate".to_string(), to_pd_fn);
 
-        self.realm_mut().temporal_plain_year_month_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().temporal_plain_year_month_prototype = Some(proto_id);
 
         // Constructor
         let constructor = self.create_function(JsFunction::constructor(
@@ -1257,18 +1286,18 @@ impl Interpreter {
         if let JsValue::Object(ref o) = constructor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(constructor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(constructor.clone(), true, false, true),
+            );
 
         // from(item, options?)
         let from_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -1789,10 +1789,7 @@ fn round_ns_to_increment(ns: i128, increment: i128, mode: &str) -> i128 {
 }
 
 impl Interpreter {
-    pub(crate) fn setup_temporal_zoned_date_time(
-        &mut self,
-        temporal_obj: &Rc<RefCell<JsObjectData>>,
-    ) {
+    pub(crate) fn setup_temporal_zoned_date_time(&mut self, temporal_obj_id: u64) {
         let proto = self.create_object();
         proto.borrow_mut().class_name = "Temporal.ZonedDateTime".to_string();
 
@@ -3633,10 +3630,12 @@ impl Interpreter {
             }
         }
 
-        temporal_obj.borrow_mut().insert_property(
-            "ZonedDateTime".to_string(),
-            PropertyDescriptor::data(constructor, true, false, true),
-        );
+        self.get_object_expect(temporal_obj_id)
+            .borrow_mut()
+            .insert_property(
+                "ZonedDateTime".to_string(),
+                PropertyDescriptor::data(constructor, true, false, true),
+            );
     }
 }
 

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -690,8 +690,7 @@ fn create_zdt(interp: &mut Interpreter, ns: BigInt, tz: String, cal: String) -> 
     let obj = interp.create_object();
     obj.borrow_mut().class_name = "Temporal.ZonedDateTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_zoned_date_time_prototype {
-        obj.borrow_mut().prototype_id =
-            Some(proto_id);
+        obj.borrow_mut().prototype_id = Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::ZonedDateTime {
         epoch_nanoseconds: ns,
@@ -2202,8 +2201,7 @@ impl Interpreter {
                     let effective_opts = {
                         let opts_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            opts_obj.borrow_mut().prototype_id =
-                                Some(op_id);
+                            opts_obj.borrow_mut().prototype_id = Some(op_id);
                         }
                         // Copy properties from user options if present
                         if let JsValue::Object(ref o) = options_arg {
@@ -2384,8 +2382,7 @@ impl Interpreter {
                     let obj = interp.create_object();
                     obj.borrow_mut().class_name = "Temporal.Instant".to_string();
                     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
-                        obj.borrow_mut().prototype_id =
-                            Some(proto_id);
+                        obj.borrow_mut().prototype_id = Some(proto_id);
                     }
                     obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
                         epoch_nanoseconds: ns,

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -691,7 +691,7 @@ fn create_zdt(interp: &mut Interpreter, ns: BigInt, tz: String, cal: String) -> 
     obj.borrow_mut().class_name = "Temporal.ZonedDateTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_zoned_date_time_prototype {
         obj.borrow_mut().prototype_id =
-            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+            Some(proto_id);
     }
     obj.borrow_mut().temporal_data = Some(TemporalData::ZonedDateTime {
         epoch_nanoseconds: ns,
@@ -2203,7 +2203,7 @@ impl Interpreter {
                         let opts_obj = interp.create_object();
                         if let Some(op_id) = interp.realm().object_prototype {
                             opts_obj.borrow_mut().prototype_id =
-                                Some(interp.get_object_expect(op_id).borrow().id.unwrap());
+                                Some(op_id);
                         }
                         // Copy properties from user options if present
                         if let JsValue::Object(ref o) = options_arg {
@@ -2385,7 +2385,7 @@ impl Interpreter {
                     obj.borrow_mut().class_name = "Temporal.Instant".to_string();
                     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
                         obj.borrow_mut().prototype_id =
-                            Some(interp.get_object_expect(proto_id).borrow().id.unwrap());
+                            Some(proto_id);
                     }
                     obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
                         epoch_nanoseconds: ns,
@@ -3630,7 +3630,7 @@ impl Interpreter {
             }
         }
 
-        self.get_object_expect(temporal_obj_id)
+        self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(
                 "ZonedDateTime".to_string(),

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -154,18 +154,20 @@ fn get_zdt_fields(
 ) -> Result<(BigInt, String, String), Completion> {
     match this {
         JsValue::Object(o) => {
-            let obj = interp.get_object(o.id).ok_or_else(|| {
-                Completion::Throw(interp.create_type_error("invalid ZonedDateTime"))
-            })?;
-            let data = obj.borrow().temporal_data.clone();
-            match data {
-                Some(TemporalData::ZonedDateTime {
+            let snapshot = interp
+                .get_object_cell(o.id)
+                .map(|cell| cell.borrow().temporal_data.clone());
+            match snapshot {
+                Some(Some(TemporalData::ZonedDateTime {
                     epoch_nanoseconds,
                     time_zone,
                     calendar,
-                }) => Ok((epoch_nanoseconds, time_zone, calendar)),
-                _ => Err(Completion::Throw(
+                })) => Ok((epoch_nanoseconds, time_zone, calendar)),
+                Some(_) => Err(Completion::Throw(
                     interp.create_type_error("this is not a Temporal.ZonedDateTime"),
+                )),
+                None => Err(Completion::Throw(
+                    interp.create_type_error("invalid ZonedDateTime"),
                 )),
             }
         }
@@ -747,7 +749,7 @@ fn to_temporal_zoned_date_time_with_options(
 ) -> Completion {
     match item {
         JsValue::Object(o) => {
-            let obj = match interp.get_object(o.id) {
+            let obj = match interp.get_object_cell(o.id) {
                 Some(o) => o,
                 None => return Completion::Throw(interp.create_type_error("invalid object")),
             };
@@ -2230,7 +2232,7 @@ impl Interpreter {
                         // Copy properties from user options if present
                         if let JsValue::Object(ref o) = options_arg {
                             let keys: Vec<String> = interp
-                                .get_object(o.id)
+                                .get_object_cell(o.id)
                                 .map(|rc| rc.borrow().properties.keys().cloned().collect())
                                 .unwrap_or_default();
                             for key in keys {
@@ -3552,7 +3554,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
@@ -3588,7 +3590,7 @@ impl Interpreter {
                     // Check if item is already a ZDT — read options then clone
                     let is_zdt = if let JsValue::Object(o) = &item {
                         interp
-                            .get_object(o.id)
+                            .get_object_cell(o.id)
                             .map(|obj| {
                                 matches!(
                                     obj.borrow().temporal_data,
@@ -3626,7 +3628,7 @@ impl Interpreter {
                 },
             ));
             if let JsValue::Object(ref o) = constructor
-                && let Some(obj) = self.get_object(o.id)
+                && let Some(obj) = self.get_object_cell(o.id)
             {
                 obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
             }
@@ -3667,7 +3669,7 @@ impl Interpreter {
                 },
             ));
             if let JsValue::Object(ref o) = constructor
-                && let Some(obj) = self.get_object(o.id)
+                && let Some(obj) = self.get_object_cell(o.id)
             {
                 obj.borrow_mut()
                     .insert_builtin("compare".to_string(), compare_fn);

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -687,17 +687,26 @@ fn create_zdt(interp: &mut Interpreter, ns: BigInt, tz: String, cal: String) -> 
     if !is_valid_epoch_ns(&ns) {
         return Completion::Throw(interp.create_range_error("epochNanoseconds out of range"));
     }
-    let obj = interp.create_object();
-    obj.borrow_mut().class_name = "Temporal.ZonedDateTime".to_string();
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .class_name = "Temporal.ZonedDateTime".to_string();
     if let Some(proto_id) = interp.realm().temporal_zoned_date_time_prototype {
-        obj.borrow_mut().prototype_id = Some(proto_id);
+        interp
+            .get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = Some(proto_id);
     }
-    obj.borrow_mut().temporal_data = Some(TemporalData::ZonedDateTime {
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
+        .temporal_data = Some(TemporalData::ZonedDateTime {
         epoch_nanoseconds: ns,
         time_zone: tz,
         calendar: cal,
     });
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
 }
 
@@ -1789,8 +1798,10 @@ fn round_ns_to_increment(ns: i128, increment: i128, mode: &str) -> i128 {
 
 impl Interpreter {
     pub(crate) fn setup_temporal_zoned_date_time(&mut self, temporal_obj_id: u64) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "Temporal.ZonedDateTime".to_string();
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "Temporal.ZonedDateTime".to_string();
 
         // @@toStringTag
         {
@@ -1805,8 +1816,14 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            proto.borrow_mut().property_order.push(key.clone());
-            proto.borrow_mut().properties.insert(key, desc);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .property_order
+                .push(key.clone());
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .properties
+                .insert(key, desc);
         }
 
         // --- Getters ---
@@ -1824,17 +1841,19 @@ impl Interpreter {
                         body_fn(&ns, &tz, &cal)
                     },
                 ));
-                proto.borrow_mut().insert_property(
-                    $name.to_string(),
-                    PropertyDescriptor {
-                        value: None,
-                        writable: None,
-                        enumerable: Some(false),
-                        configurable: Some(true),
-                        get: Some(getter),
-                        set: None,
-                    },
-                );
+                self.get_object_cell_expect(proto_id)
+                    .borrow_mut()
+                    .insert_property(
+                        $name.to_string(),
+                        PropertyDescriptor {
+                            value: None,
+                            writable: None,
+                            enumerable: Some(false),
+                            configurable: Some(true),
+                            get: Some(getter),
+                            set: None,
+                        },
+                    );
             }};
         }
 
@@ -2063,17 +2082,19 @@ impl Interpreter {
                     Completion::Normal(JsValue::Number(hours))
                 },
             ));
-            proto.borrow_mut().insert_property(
-                "hoursInDay".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: Some(getter),
-                    set: None,
-                },
-            );
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "hoursInDay".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                        get: Some(getter),
+                        set: None,
+                    },
+                );
         }
 
         zdt_getter!("era", |ns, tz, cal| {
@@ -2102,7 +2123,7 @@ impl Interpreter {
             Completion::Normal(JsValue::Undefined)
         });
 
-        self.realm_mut().temporal_zoned_date_time_prototype = Some(proto.borrow().id.unwrap());
+        self.realm_mut().temporal_zoned_date_time_prototype = Some(proto_id);
 
         // --- Methods ---
 
@@ -2135,7 +2156,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&result)))
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toString".to_string(), method);
         }
@@ -2155,7 +2176,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::String(JsString::from_str(&result)))
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toJSON".to_string(), method);
         }
@@ -2199,9 +2220,12 @@ impl Interpreter {
                     }
                     // Inject timeZone from ZDT into options
                     let effective_opts = {
-                        let opts_obj = interp.create_object();
+                        let opts_obj_id = interp.create_object_id();
                         if let Some(op_id) = interp.realm().object_prototype {
-                            opts_obj.borrow_mut().prototype_id = Some(op_id);
+                            interp
+                                .get_object_cell_expect(opts_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(op_id);
                         }
                         // Copy properties from user options if present
                         if let JsValue::Object(ref o) = options_arg {
@@ -2216,28 +2240,34 @@ impl Interpreter {
                                     Completion::Throw(e) => return Completion::Throw(e),
                                     _ => JsValue::Undefined,
                                 };
-                                opts_obj.borrow_mut().insert_property(
-                                    key,
-                                    crate::interpreter::types::PropertyDescriptor::data(
-                                        val, true, true, true,
-                                    ),
-                                );
+                                interp
+                                    .get_object_cell_expect(opts_obj_id)
+                                    .borrow_mut()
+                                    .insert_property(
+                                        key,
+                                        crate::interpreter::types::PropertyDescriptor::data(
+                                            val, true, true, true,
+                                        ),
+                                    );
                             }
                         }
                         // Set timeZone from ZDT
-                        opts_obj.borrow_mut().insert_property(
-                            "timeZone".to_string(),
-                            crate::interpreter::types::PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&tz)),
-                                true,
-                                true,
-                                true,
-                            ),
-                        );
+                        interp
+                            .get_object_cell_expect(opts_obj_id)
+                            .borrow_mut()
+                            .insert_property(
+                                "timeZone".to_string(),
+                                crate::interpreter::types::PropertyDescriptor::data(
+                                    JsValue::String(JsString::from_str(&tz)),
+                                    true,
+                                    true,
+                                    true,
+                                ),
+                            );
                         // If no explicit date/time components/styles, set ZDT defaults
                         // (timeZoneName alone doesn't count as explicit)
                         let has_explicit = {
-                            let b = opts_obj.borrow();
+                            let b = interp.get_object_cell_expect(opts_obj_id).borrow();
                             [
                                 "year",
                                 "month",
@@ -2260,7 +2290,7 @@ impl Interpreter {
                         };
                         if !has_explicit {
                             let has_tz_name = {
-                                let b = opts_obj.borrow();
+                                let b = interp.get_object_cell_expect(opts_obj_id).borrow();
                                 b.properties.get("timeZoneName").is_some_and(|pd| {
                                     !matches!(pd.value, Some(JsValue::Undefined) | None)
                                 })
@@ -2273,29 +2303,35 @@ impl Interpreter {
                                 ("minute", "numeric"),
                                 ("second", "numeric"),
                             ] {
-                                opts_obj.borrow_mut().insert_property(
-                                    k.to_string(),
-                                    crate::interpreter::types::PropertyDescriptor::data(
-                                        JsValue::String(JsString::from_str(v)),
-                                        true,
-                                        true,
-                                        true,
-                                    ),
-                                );
+                                interp
+                                    .get_object_cell_expect(opts_obj_id)
+                                    .borrow_mut()
+                                    .insert_property(
+                                        k.to_string(),
+                                        crate::interpreter::types::PropertyDescriptor::data(
+                                            JsValue::String(JsString::from_str(v)),
+                                            true,
+                                            true,
+                                            true,
+                                        ),
+                                    );
                             }
                             if !has_tz_name {
-                                opts_obj.borrow_mut().insert_property(
-                                    "timeZoneName".to_string(),
-                                    crate::interpreter::types::PropertyDescriptor::data(
-                                        JsValue::String(JsString::from_str("short")),
-                                        true,
-                                        true,
-                                        true,
-                                    ),
-                                );
+                                interp
+                                    .get_object_cell_expect(opts_obj_id)
+                                    .borrow_mut()
+                                    .insert_property(
+                                        "timeZoneName".to_string(),
+                                        crate::interpreter::types::PropertyDescriptor::data(
+                                            JsValue::String(JsString::from_str("short")),
+                                            true,
+                                            true,
+                                            true,
+                                        ),
+                                    );
                             }
                         }
-                        let oid = opts_obj.borrow().id.unwrap();
+                        let oid = opts_obj_id;
                         JsValue::Object(crate::types::JsObject { id: oid })
                     };
                     let dtf_instance =
@@ -2319,7 +2355,7 @@ impl Interpreter {
                     super::temporal_format_with_dtf(interp, &dtf_instance, &ms_val)
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toLocaleString".to_string(), method);
         }
@@ -2335,7 +2371,7 @@ impl Interpreter {
                     )
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("valueOf".to_string(), method);
         }
@@ -2364,7 +2400,7 @@ impl Interpreter {
                     Completion::Normal(JsValue::Boolean(ns == ons && tz_equal && cal == ocal))
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("equals".to_string(), method);
         }
@@ -2379,19 +2415,28 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let obj = interp.create_object();
-                    obj.borrow_mut().class_name = "Temporal.Instant".to_string();
+                    let obj_id = interp.create_object_id();
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .class_name = "Temporal.Instant".to_string();
                     if let Some(proto_id) = interp.realm().temporal_instant_prototype {
-                        obj.borrow_mut().prototype_id = Some(proto_id);
+                        interp
+                            .get_object_cell_expect(obj_id)
+                            .borrow_mut()
+                            .prototype_id = Some(proto_id);
                     }
-                    obj.borrow_mut().temporal_data = Some(TemporalData::Instant {
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .temporal_data = Some(TemporalData::Instant {
                         epoch_nanoseconds: ns,
                     });
-                    let id = obj.borrow().id.unwrap();
+                    let id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toInstant".to_string(), method);
         }
@@ -2410,7 +2455,7 @@ impl Interpreter {
                     super::plain_date::create_plain_date_result(interp, y, m, d, &cal)
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toPlainDate".to_string(), method);
         }
@@ -2429,7 +2474,7 @@ impl Interpreter {
                     super::plain_time::create_plain_time_result(interp, h, mi, s, ms, us, nanos)
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toPlainTime".to_string(), method);
         }
@@ -2450,7 +2495,7 @@ impl Interpreter {
                     )
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toPlainDateTime".to_string(), method);
         }
@@ -2471,7 +2516,7 @@ impl Interpreter {
                     create_zdt(interp, BigInt::from(epoch_ns), tz, cal)
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("startOfDay".to_string(), method);
         }
@@ -2499,7 +2544,7 @@ impl Interpreter {
                     create_zdt(interp, ns, tz, new_cal)
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("withCalendar".to_string(), method);
         }
@@ -2522,7 +2567,7 @@ impl Interpreter {
                     create_zdt(interp, ns, new_tz, cal)
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("withTimeZone".to_string(), method);
         }
@@ -2564,7 +2609,7 @@ impl Interpreter {
                     }
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("withPlainTime".to_string(), method);
         }
@@ -3153,7 +3198,7 @@ impl Interpreter {
                     create_zdt(interp, new_epoch_ns, tz, cal)
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("with".to_string(), method);
         }
@@ -3165,7 +3210,9 @@ impl Interpreter {
                 1,
                 |interp, this, args| zdt_add_subtract(interp, this, args, 1),
             ));
-            proto.borrow_mut().insert_builtin("add".to_string(), method);
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_builtin("add".to_string(), method);
         }
 
         // subtract(duration)
@@ -3175,7 +3222,7 @@ impl Interpreter {
                 1,
                 |interp, this, args| zdt_add_subtract(interp, this, args, -1),
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("subtract".to_string(), method);
         }
@@ -3187,7 +3234,7 @@ impl Interpreter {
                 1,
                 |interp, this, args| zdt_until_since(interp, this, args, 1),
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("until".to_string(), method);
         }
@@ -3199,7 +3246,7 @@ impl Interpreter {
                 1,
                 |interp, this, args| zdt_until_since(interp, this, args, -1),
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("since".to_string(), method);
         }
@@ -3386,7 +3433,7 @@ impl Interpreter {
                     create_zdt(interp, BigInt::from(rounded_ns), tz, cal)
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("round".to_string(), method);
         }
@@ -3460,7 +3507,7 @@ impl Interpreter {
                     }
                 },
             ));
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("getTimeZoneTransition".to_string(), method);
         }
@@ -3507,18 +3554,18 @@ impl Interpreter {
         if let JsValue::Object(ref o) = constructor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject {
-                id: proto.borrow().id.unwrap(),
-            });
+            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
             );
         }
-        proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(constructor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(constructor.clone(), true, false, true),
+            );
 
         // --- Static methods ---
 

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -939,7 +939,6 @@ impl Interpreter {
         let buf_rc = Rc::new(RefCell::new(BufferData::Owned(data)));
         let detached = Rc::new(Cell::new(false));
         let obj_id = self.create_object_id();
-        let obj_id = obj_id;
         let ab_proto = self.realm().arraybuffer_prototype;
         {
             let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
@@ -4321,7 +4320,6 @@ impl Interpreter {
                 );
 
             // Store prototype for this kind
-            let type_proto_id = type_proto_id;
             match kind {
                 TypedArrayKind::Int8 => self.realm_mut().int8array_prototype = Some(type_proto_id),
                 TypedArrayKind::Uint8 => {
@@ -4717,7 +4715,6 @@ impl Interpreter {
     ) -> u64 {
         let proto = self.get_typed_array_prototype(info.kind);
         let obj_id = self.create_object_id();
-        let obj_id = obj_id;
         {
             let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
             o.class_name = info.kind.name().to_string();
@@ -4737,7 +4734,6 @@ impl Interpreter {
         proto_id: u64,
     ) -> u64 {
         let obj_id = self.create_object_id();
-        let obj_id = obj_id;
         {
             let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
             o.class_name = info.kind.name().to_string();

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -949,14 +949,17 @@ impl Interpreter {
             JsValue::Object(crate::types::JsObject { id })
         };
         if let JsValue::Object(o) = &ctor
-            && let Some(obj) = self.get_object(o.id)
+            && self.get_object_cell(o.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(ab_proto_val, false, false, false),
-            );
-            obj.borrow_mut()
-                .insert_builtin("isView".to_string(), is_view_fn);
+            let ctor_id = o.id;
+            {
+                let mut b = self.get_object_cell_expect(ctor_id).borrow_mut();
+                b.insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(ab_proto_val, false, false, false),
+                );
+                b.insert_builtin("isView".to_string(), is_view_fn);
+            }
 
             // ArrayBuffer[Symbol.species] getter
             let species_getter = self.create_function(JsFunction::native(
@@ -964,17 +967,19 @@ impl Interpreter {
                 0,
                 |_interp, this_val, _args| Completion::Normal(this_val.clone()),
             ));
-            obj.borrow_mut().insert_property(
-                "Symbol(Symbol.species)".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(species_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "Symbol(Symbol.species)".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        get: Some(species_getter),
+                        set: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                    },
+                );
         }
         self.get_object_cell_expect(ab_proto_id)
             .borrow_mut()
@@ -1466,12 +1471,15 @@ impl Interpreter {
             JsValue::Object(crate::types::JsObject { id })
         };
         if let JsValue::Object(o) = &ctor
-            && let Some(obj) = self.get_object(o.id)
+            && self.get_object_cell(o.id).is_some()
         {
-            obj.borrow_mut().insert_property(
-                "prototype".to_string(),
-                PropertyDescriptor::data(sab_proto_val, false, false, false),
-            );
+            let ctor_id = o.id;
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "prototype".to_string(),
+                    PropertyDescriptor::data(sab_proto_val, false, false, false),
+                );
 
             // SharedArrayBuffer[Symbol.species] getter
             let species_getter = self.create_function(JsFunction::native(
@@ -1479,17 +1487,19 @@ impl Interpreter {
                 0,
                 |_interp, this_val, _args| Completion::Normal(this_val.clone()),
             ));
-            obj.borrow_mut().insert_property(
-                "Symbol(Symbol.species)".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(species_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            self.get_object_cell_expect(ctor_id)
+                .borrow_mut()
+                .insert_property(
+                    "Symbol(Symbol.species)".to_string(),
+                    PropertyDescriptor {
+                        value: None,
+                        writable: None,
+                        get: Some(species_getter),
+                        set: None,
+                        enumerable: Some(false),
+                        configurable: Some(true),
+                    },
+                );
         }
         self.get_object_cell_expect(sab_proto_id)
             .borrow_mut()
@@ -4656,17 +4666,15 @@ impl Interpreter {
         exemplar: &JsValue,
         args: &[JsValue],
     ) -> Result<JsValue, JsValue> {
-        let (kind, _ta) = if let JsValue::Object(o) = exemplar
-            && let Some(obj) = self.get_object(o.id)
-        {
-            let obj_ref = obj.borrow();
-            if let Some(ref ta) = obj_ref.typed_array_info {
-                (ta.kind, ta.clone())
-            } else {
-                return Err(self.create_type_error("not a TypedArray"));
-            }
+        let snapshot = if let JsValue::Object(o) = exemplar {
+            self.get_object_cell(o.id)
+                .and_then(|cell| cell.borrow().typed_array_info.clone())
         } else {
-            return Err(self.create_type_error("not a TypedArray"));
+            None
+        };
+        let (kind, _ta) = match snapshot {
+            Some(ta) => (ta.kind, ta),
+            None => return Err(self.create_type_error("not a TypedArray")),
         };
 
         let default_ctor_name = kind.name();
@@ -4684,22 +4692,39 @@ impl Interpreter {
         };
 
         // Validate result is a TypedArray
-        let result_kind = if let JsValue::Object(o) = &result_val
-            && let Some(obj) = self.get_object(o.id)
-        {
-            let obj_ref = obj.borrow();
-            if let Some(ref ta) = obj_ref.typed_array_info {
-                if ta.is_detached.get() {
-                    return Err(self.create_type_error("new TypedArray is detached"));
-                }
-                ta.kind
-            } else {
+        enum KindProbe {
+            NotTa,
+            Detached,
+            Kind(TypedArrayKind),
+        }
+        let kind_probe = if let JsValue::Object(o) = &result_val {
+            self.get_object_cell(o.id)
+                .map(|cell| {
+                    let r = cell.borrow();
+                    if let Some(ref ta) = r.typed_array_info {
+                        if ta.is_detached.get() {
+                            KindProbe::Detached
+                        } else {
+                            KindProbe::Kind(ta.kind)
+                        }
+                    } else {
+                        KindProbe::NotTa
+                    }
+                })
+                .unwrap_or(KindProbe::NotTa)
+        } else {
+            KindProbe::NotTa
+        };
+        let result_kind = match kind_probe {
+            KindProbe::NotTa => {
                 return Err(
                     self.create_type_error("species constructor did not return a TypedArray")
                 );
             }
-        } else {
-            return Err(self.create_type_error("species constructor did not return a TypedArray"));
+            KindProbe::Detached => {
+                return Err(self.create_type_error("new TypedArray is detached"));
+            }
+            KindProbe::Kind(k) => k,
         };
 
         // ContentType compatibility check (only for single-length-arg case)
@@ -4712,17 +4737,22 @@ impl Interpreter {
         // Validate length >= requested
         if let Some(JsValue::Number(requested_len)) = args.first() {
             let requested = *requested_len as usize;
-            if let JsValue::Object(o) = &result_val
-                && let Some(obj) = self.get_object(o.id)
-            {
-                let obj_ref = obj.borrow();
-                if let Some(ref ta) = obj_ref.typed_array_info
-                    && typed_array_length(ta) < requested
-                {
-                    return Err(self.create_type_error(
-                        "species constructor returned a TypedArray that is too small",
-                    ));
-                }
+            let too_small = if let JsValue::Object(o) = &result_val {
+                self.get_object_cell(o.id)
+                    .and_then(|cell| {
+                        cell.borrow()
+                            .typed_array_info
+                            .as_ref()
+                            .map(|ta| typed_array_length(ta) < requested)
+                    })
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+            if too_small {
+                return Err(self.create_type_error(
+                    "species constructor returned a TypedArray that is too small",
+                ));
             }
         }
 
@@ -5889,7 +5919,7 @@ impl Interpreter {
             );
 
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj.borrow_mut().deferred_construct = true;
         }

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -662,7 +662,7 @@ impl Interpreter {
                     // Create immutable ArrayBuffer
                     let id = interp.create_arraybuffer(new_data);
                     interp
-                        .get_object_expect(id)
+                        .get_object_cell_expect(id)
                         .borrow_mut()
                         .arraybuffer_is_immutable = true;
                     return Completion::Normal(JsValue::Object(JsObject { id }));
@@ -3121,10 +3121,10 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("values".to_string(), values_fn.clone());
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("Symbol(Symbol.iterator)".to_string(), values_fn);
     }
@@ -3155,7 +3155,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("entries".to_string(), entries_fn);
 
@@ -3184,7 +3184,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("keys".to_string(), keys_fn);
     }
@@ -3219,7 +3219,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("find".to_string(), find_fn);
 
@@ -3252,7 +3252,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(-1.0))
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findIndex".to_string(), find_index_fn);
 
@@ -3287,7 +3287,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findLast".to_string(), find_last_fn);
 
@@ -3322,7 +3322,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(-1.0))
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findLastIndex".to_string(), find_last_index_fn);
 
@@ -3351,7 +3351,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("forEach".to_string(), for_each_fn);
 
@@ -3400,7 +3400,7 @@ impl Interpreter {
                 Completion::Normal(new_ta_val)
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("map".to_string(), map_fn);
 
@@ -3452,7 +3452,7 @@ impl Interpreter {
                 Completion::Normal(new_ta_val)
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("filter".to_string(), filter_fn);
 
@@ -3485,7 +3485,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(true))
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("every".to_string(), every_fn);
 
@@ -3518,7 +3518,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("some".to_string(), some_fn);
 
@@ -3560,7 +3560,7 @@ impl Interpreter {
                 Completion::Normal(acc)
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("reduce".to_string(), reduce_fn);
 
@@ -3604,7 +3604,7 @@ impl Interpreter {
                 Completion::Normal(acc)
             },
         ));
-        self.get_object_expect(proto_id)
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("reduceRight".to_string(), reduce_right_fn);
     }

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -57,26 +57,40 @@ impl Interpreter {
             "get byteLength".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if let Some(ref buf_data) = obj_ref.arraybuffer_data {
-                        if obj_ref.arraybuffer_is_shared {
-                            return Completion::Throw(
-                                interp.create_type_error("not an ArrayBuffer"),
-                            );
-                        }
-                        if let Some(ref det) = obj_ref.arraybuffer_detached
-                            && det.get()
-                        {
-                            return Completion::Normal(JsValue::Number(0.0));
-                        }
-                        let len = buffer_len(buf_data);
-                        return Completion::Normal(JsValue::Number(len as f64));
-                    }
+                enum Probe {
+                    NotAB,
+                    Shared,
+                    Detached,
+                    Bytes(usize),
                 }
-                Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                let probe = if let JsValue::Object(o) = this_val {
+                    interp
+                        .get_object_cell(o.id)
+                        .map(|cell| {
+                            let r = cell.borrow();
+                            if let Some(ref buf_data) = r.arraybuffer_data {
+                                if r.arraybuffer_is_shared {
+                                    Probe::Shared
+                                } else if r.arraybuffer_detached.as_ref().is_some_and(|d| d.get()) {
+                                    Probe::Detached
+                                } else {
+                                    Probe::Bytes(buffer_len(buf_data))
+                                }
+                            } else {
+                                Probe::NotAB
+                            }
+                        })
+                        .unwrap_or(Probe::NotAB)
+                } else {
+                    Probe::NotAB
+                };
+                match probe {
+                    Probe::Shared | Probe::NotAB => {
+                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                    }
+                    Probe::Detached => Completion::Normal(JsValue::Number(0.0)),
+                    Probe::Bytes(n) => Completion::Normal(JsValue::Number(n as f64)),
+                }
             },
         ));
         self.get_object_cell_expect(ab_proto_id)
@@ -98,24 +112,38 @@ impl Interpreter {
             "get detached".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.arraybuffer_data.is_some() {
-                        if obj_ref.arraybuffer_is_shared {
-                            return Completion::Throw(
-                                interp.create_type_error("not an ArrayBuffer"),
-                            );
-                        }
-                        let detached = obj_ref
-                            .arraybuffer_detached
-                            .as_ref()
-                            .is_some_and(|d| d.get());
-                        return Completion::Normal(JsValue::Boolean(detached));
-                    }
+                enum Probe {
+                    NotAB,
+                    Shared,
+                    Detached(bool),
                 }
-                Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                let probe = if let JsValue::Object(o) = this_val {
+                    interp
+                        .get_object_cell(o.id)
+                        .map(|cell| {
+                            let r = cell.borrow();
+                            if r.arraybuffer_data.is_some() {
+                                if r.arraybuffer_is_shared {
+                                    Probe::Shared
+                                } else {
+                                    let det =
+                                        r.arraybuffer_detached.as_ref().is_some_and(|d| d.get());
+                                    Probe::Detached(det)
+                                }
+                            } else {
+                                Probe::NotAB
+                            }
+                        })
+                        .unwrap_or(Probe::NotAB)
+                } else {
+                    Probe::NotAB
+                };
+                match probe {
+                    Probe::NotAB | Probe::Shared => {
+                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                    }
+                    Probe::Detached(b) => Completion::Normal(JsValue::Boolean(b)),
+                }
             },
         ));
         self.get_object_cell_expect(ab_proto_id)
@@ -137,21 +165,36 @@ impl Interpreter {
             "get resizable".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.arraybuffer_data.is_some() {
-                        if obj_ref.arraybuffer_is_shared {
-                            return Completion::Throw(
-                                interp.create_type_error("not an ArrayBuffer"),
-                            );
-                        }
-                        let is_resizable = obj_ref.arraybuffer_max_byte_length.is_some();
-                        return Completion::Normal(JsValue::Boolean(is_resizable));
-                    }
+                enum Probe {
+                    NotAB,
+                    Shared,
+                    Resizable(bool),
                 }
-                Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                let probe = if let JsValue::Object(o) = this_val {
+                    interp
+                        .get_object_cell(o.id)
+                        .map(|cell| {
+                            let r = cell.borrow();
+                            if r.arraybuffer_data.is_some() {
+                                if r.arraybuffer_is_shared {
+                                    Probe::Shared
+                                } else {
+                                    Probe::Resizable(r.arraybuffer_max_byte_length.is_some())
+                                }
+                            } else {
+                                Probe::NotAB
+                            }
+                        })
+                        .unwrap_or(Probe::NotAB)
+                } else {
+                    Probe::NotAB
+                };
+                match probe {
+                    Probe::NotAB | Probe::Shared => {
+                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                    }
+                    Probe::Resizable(b) => Completion::Normal(JsValue::Boolean(b)),
+                }
             },
         ));
         self.get_object_cell_expect(ab_proto_id)
@@ -173,22 +216,36 @@ impl Interpreter {
             "get immutable".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.arraybuffer_data.is_some() {
-                        if obj_ref.arraybuffer_is_shared {
-                            return Completion::Throw(
-                                interp.create_type_error("not an ArrayBuffer"),
-                            );
-                        }
-                        return Completion::Normal(JsValue::Boolean(
-                            obj_ref.arraybuffer_is_immutable,
-                        ));
-                    }
+                enum Probe {
+                    NotAB,
+                    Shared,
+                    Immutable(bool),
                 }
-                Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                let probe = if let JsValue::Object(o) = this_val {
+                    interp
+                        .get_object_cell(o.id)
+                        .map(|cell| {
+                            let r = cell.borrow();
+                            if r.arraybuffer_data.is_some() {
+                                if r.arraybuffer_is_shared {
+                                    Probe::Shared
+                                } else {
+                                    Probe::Immutable(r.arraybuffer_is_immutable)
+                                }
+                            } else {
+                                Probe::NotAB
+                            }
+                        })
+                        .unwrap_or(Probe::NotAB)
+                } else {
+                    Probe::NotAB
+                };
+                match probe {
+                    Probe::NotAB | Probe::Shared => {
+                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                    }
+                    Probe::Immutable(b) => Completion::Normal(JsValue::Boolean(b)),
+                }
             },
         ));
         self.get_object_cell_expect(ab_proto_id)
@@ -210,28 +267,43 @@ impl Interpreter {
             "get maxByteLength".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.arraybuffer_data.is_some() {
-                        if obj_ref.arraybuffer_is_shared {
-                            return Completion::Throw(
-                                interp.create_type_error("not an ArrayBuffer"),
-                            );
-                        }
-                        if let Some(ref det) = obj_ref.arraybuffer_detached
-                            && det.get()
-                        {
-                            return Completion::Normal(JsValue::Number(0.0));
-                        }
-                        let max = obj_ref.arraybuffer_max_byte_length.unwrap_or_else(|| {
-                            buffer_len(obj_ref.arraybuffer_data.as_ref().unwrap())
-                        });
-                        return Completion::Normal(JsValue::Number(max as f64));
-                    }
+                enum Probe {
+                    NotAB,
+                    Shared,
+                    Detached,
+                    Max(usize),
                 }
-                Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                let probe = if let JsValue::Object(o) = this_val {
+                    interp
+                        .get_object_cell(o.id)
+                        .map(|cell| {
+                            let r = cell.borrow();
+                            if r.arraybuffer_data.is_some() {
+                                if r.arraybuffer_is_shared {
+                                    Probe::Shared
+                                } else if r.arraybuffer_detached.as_ref().is_some_and(|d| d.get()) {
+                                    Probe::Detached
+                                } else {
+                                    let max = r.arraybuffer_max_byte_length.unwrap_or_else(|| {
+                                        buffer_len(r.arraybuffer_data.as_ref().unwrap())
+                                    });
+                                    Probe::Max(max)
+                                }
+                            } else {
+                                Probe::NotAB
+                            }
+                        })
+                        .unwrap_or(Probe::NotAB)
+                } else {
+                    Probe::NotAB
+                };
+                match probe {
+                    Probe::NotAB | Probe::Shared => {
+                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
+                    }
+                    Probe::Detached => Completion::Normal(JsValue::Number(0.0)),
+                    Probe::Max(n) => Completion::Normal(JsValue::Number(n as f64)),
+                }
             },
         ));
         self.get_object_cell_expect(ab_proto_id)

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -46,9 +46,11 @@ impl Interpreter {
     }
 
     fn setup_arraybuffer(&mut self) {
-        let ab_proto = self.create_object();
-        ab_proto.borrow_mut().class_name = "ArrayBuffer".to_string();
-        self.realm_mut().arraybuffer_prototype = Some(ab_proto.borrow().id.unwrap());
+        let ab_proto_id = self.create_object_id();
+        self.get_object_cell_expect(ab_proto_id)
+            .borrow_mut()
+            .class_name = "ArrayBuffer".to_string();
+        self.realm_mut().arraybuffer_prototype = Some(ab_proto_id);
 
         // byteLength getter
         let byte_length_getter = self.create_function(JsFunction::native(
@@ -77,17 +79,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto.borrow_mut().insert_property(
-            "byteLength".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(byte_length_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(ab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "byteLength".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(byte_length_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // detached getter
         let detached_getter = self.create_function(JsFunction::native(
@@ -114,17 +118,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto.borrow_mut().insert_property(
-            "detached".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(detached_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(ab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "detached".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(detached_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // resizable getter
         let resizable_getter = self.create_function(JsFunction::native(
@@ -148,17 +154,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto.borrow_mut().insert_property(
-            "resizable".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(resizable_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(ab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "resizable".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(resizable_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // immutable getter
         let immutable_getter = self.create_function(JsFunction::native(
@@ -183,17 +191,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto.borrow_mut().insert_property(
-            "immutable".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(immutable_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(ab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "immutable".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(immutable_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // maxByteLength getter
         let max_byte_length_getter = self.create_function(JsFunction::native(
@@ -224,17 +234,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto.borrow_mut().insert_property(
-            "maxByteLength".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(max_byte_length_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(ab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "maxByteLength".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(max_byte_length_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // slice
         let slice_fn =
@@ -400,7 +412,7 @@ impl Interpreter {
                     Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 },
             ));
-        ab_proto
+        self.get_object_cell_expect(ab_proto_id)
             .borrow_mut()
             .insert_builtin("slice".to_string(), slice_fn);
 
@@ -499,7 +511,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto
+        self.get_object_cell_expect(ab_proto_id)
             .borrow_mut()
             .insert_builtin("transfer".to_string(), transfer_fn);
 
@@ -582,7 +594,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto
+        self.get_object_cell_expect(ab_proto_id)
             .borrow_mut()
             .insert_builtin("transferToFixedLength".to_string(), transfer_fixed_fn);
 
@@ -670,7 +682,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto
+        self.get_object_cell_expect(ab_proto_id)
             .borrow_mut()
             .insert_builtin("transferToImmutable".to_string(), transfer_immutable_fn);
 
@@ -742,19 +754,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
         ));
-        ab_proto
+        self.get_object_cell_expect(ab_proto_id)
             .borrow_mut()
             .insert_builtin("resize".to_string(), resize_fn);
 
         // @@toStringTag
         let tag = JsValue::String(JsString::from_str("ArrayBuffer"));
         let sym_key = "Symbol(Symbol.toStringTag)".to_string();
-        ab_proto
+        self.get_object_cell_expect(ab_proto_id)
             .borrow_mut()
             .insert_property(sym_key, PropertyDescriptor::data(tag, false, false, true));
 
         // ArrayBuffer constructor
-        let ab_proto_clone_id = ab_proto.borrow().id.unwrap();
+        let ab_proto_clone_id = ab_proto_id;
         let ctor = self.create_function(JsFunction::constructor(
             "ArrayBuffer".to_string(),
             1,
@@ -827,9 +839,9 @@ impl Interpreter {
                 let buf_len = buf.len();
                 let buf_rc = Rc::new(RefCell::new(BufferData::Owned(buf)));
                 let detached = Rc::new(Cell::new(false));
-                let obj = interp.create_object();
+                let obj_id = interp.create_object_id();
                 {
-                    let mut o = obj.borrow_mut();
+                    let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                     o.class_name = "ArrayBuffer".to_string();
                     o.prototype_id = proto;
                     o.arraybuffer_data = Some(buf_rc);
@@ -837,7 +849,7 @@ impl Interpreter {
                     o.arraybuffer_max_byte_length = max_byte_length;
                 }
                 interp.gc_track_external_bytes(buf_len);
-                let id = obj.borrow().id.unwrap();
+                let id = obj_id;
                 Completion::Normal(JsValue::Object(JsObject { id }))
             },
         ));
@@ -861,7 +873,7 @@ impl Interpreter {
         ));
         // Wire ArrayBuffer.prototype to the proto object with all the methods
         let ab_proto_val = {
-            let id = ab_proto.borrow().id.unwrap();
+            let id = ab_proto_id;
             JsValue::Object(crate::types::JsObject { id })
         };
         if let JsValue::Object(o) = &ctor
@@ -892,10 +904,12 @@ impl Interpreter {
                 },
             );
         }
-        ab_proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(ab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(ctor.clone(), true, false, true),
+            );
 
         // Mark deferred_construct: ArrayBuffer validates args before OrdinaryCreateFromConstructor
         if let JsValue::Object(ref o) = ctor
@@ -924,11 +938,11 @@ impl Interpreter {
         let data_len = data.len();
         let buf_rc = Rc::new(RefCell::new(BufferData::Owned(data)));
         let detached = Rc::new(Cell::new(false));
-        let obj = self.create_object();
-        let obj_id = obj.borrow().id.unwrap();
+        let obj_id = self.create_object_id();
+        let obj_id = obj_id;
         let ab_proto = self.realm().arraybuffer_prototype;
         {
-            let mut o = obj.borrow_mut();
+            let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
             o.class_name = "ArrayBuffer".to_string();
             o.prototype_id = ab_proto;
             o.arraybuffer_data = Some(buf_rc);
@@ -981,9 +995,11 @@ impl Interpreter {
     }
 
     fn setup_shared_arraybuffer(&mut self) {
-        let sab_proto = self.create_object();
-        sab_proto.borrow_mut().class_name = "SharedArrayBuffer".to_string();
-        self.realm_mut().shared_arraybuffer_prototype = Some(sab_proto.borrow().id.unwrap());
+        let sab_proto_id = self.create_object_id();
+        self.get_object_cell_expect(sab_proto_id)
+            .borrow_mut()
+            .class_name = "SharedArrayBuffer".to_string();
+        self.realm_mut().shared_arraybuffer_prototype = Some(sab_proto_id);
 
         // byteLength getter
         let byte_length_getter = self.create_function(JsFunction::native(
@@ -1003,17 +1019,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
             },
         ));
-        sab_proto.borrow_mut().insert_property(
-            "byteLength".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(byte_length_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(sab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "byteLength".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(byte_length_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // maxByteLength getter
         let max_byte_length_getter = self.create_function(JsFunction::native(
@@ -1036,17 +1054,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
             },
         ));
-        sab_proto.borrow_mut().insert_property(
-            "maxByteLength".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(max_byte_length_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(sab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "maxByteLength".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(max_byte_length_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // growable getter
         let growable_getter = self.create_function(JsFunction::native(
@@ -1066,17 +1086,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
             },
         ));
-        sab_proto.borrow_mut().insert_property(
-            "growable".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(growable_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(sab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "growable".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(growable_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // grow(newLength)
         let grow_fn = self.create_function(JsFunction::native(
@@ -1131,7 +1153,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
             },
         ));
-        sab_proto
+        self.get_object_cell_expect(sab_proto_id)
             .borrow_mut()
             .insert_builtin("grow".to_string(), grow_fn);
 
@@ -1262,7 +1284,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
             },
         ));
-        sab_proto
+        self.get_object_cell_expect(sab_proto_id)
             .borrow_mut()
             .insert_builtin("slice".to_string(), slice_fn);
 
@@ -1271,12 +1293,18 @@ impl Interpreter {
             let tag = JsValue::String(JsString::from_str("SharedArrayBuffer"));
             let sym_key = "Symbol(Symbol.toStringTag)".to_string();
             let desc = PropertyDescriptor::data(tag, false, false, true);
-            sab_proto.borrow_mut().property_order.push(sym_key.clone());
-            sab_proto.borrow_mut().properties.insert(sym_key, desc);
+            self.get_object_cell_expect(sab_proto_id)
+                .borrow_mut()
+                .property_order
+                .push(sym_key.clone());
+            self.get_object_cell_expect(sab_proto_id)
+                .borrow_mut()
+                .properties
+                .insert(sym_key, desc);
         }
 
         // SharedArrayBuffer constructor
-        let sab_proto_clone_id = sab_proto.borrow().id.unwrap();
+        let sab_proto_clone_id = sab_proto_id;
         let ctor = self.create_function(JsFunction::constructor(
             "SharedArrayBuffer".to_string(),
             1,
@@ -1341,13 +1369,13 @@ impl Interpreter {
                     ));
                 }
                 let buf = vec![0u8; len];
-                let obj = interp.create_object();
+                let obj_id = interp.create_object_id();
                 {
                     use crate::interpreter::types::{SharedBufferInner, next_sab_id};
                     let sab_id = next_sab_id();
                     let inner = Arc::new(SharedBufferInner::new(buf, sab_id));
                     let buf_rc = Rc::new(RefCell::new(BufferData::Shared(inner.clone())));
-                    let mut o = obj.borrow_mut();
+                    let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                     o.class_name = "SharedArrayBuffer".to_string();
                     o.prototype_id = proto;
                     o.arraybuffer_data = Some(buf_rc);
@@ -1356,14 +1384,14 @@ impl Interpreter {
                     o.arraybuffer_is_shared = true;
                     o.sab_shared = Some(inner);
                 }
-                let id = obj.borrow().id.unwrap();
+                let id = obj_id;
                 Completion::Normal(JsValue::Object(JsObject { id }))
             },
         ));
 
         // Wire SharedArrayBuffer.prototype_id
         let sab_proto_val = {
-            let id = sab_proto.borrow().id.unwrap();
+            let id = sab_proto_id;
             JsValue::Object(crate::types::JsObject { id })
         };
         if let JsValue::Object(o) = &ctor
@@ -1392,10 +1420,12 @@ impl Interpreter {
                 },
             );
         }
-        sab_proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(sab_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(ctor.clone(), true, false, true),
+            );
 
         if let JsValue::Object(ref o) = ctor
             && let Some(func_obj) = self.get_object(o.id)
@@ -1412,9 +1442,11 @@ impl Interpreter {
     }
 
     fn setup_typed_array_base_prototype(&mut self) {
-        let proto = self.create_object();
-        proto.borrow_mut().class_name = "TypedArray".to_string();
-        self.realm_mut().typed_array_prototype = Some(proto.borrow().id.unwrap());
+        let proto_id = self.create_object_id();
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .class_name = "TypedArray".to_string();
+        self.realm_mut().typed_array_prototype = Some(proto_id);
 
         // byteOffset getter
         let byte_offset_getter = self.create_function(JsFunction::native(
@@ -1435,17 +1467,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto.borrow_mut().insert_property(
-            "byteOffset".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(byte_offset_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "byteOffset".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(byte_offset_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
         // byteLength getter
         let byte_length_getter = self.create_function(JsFunction::native(
             "get byteLength".to_string(),
@@ -1467,17 +1501,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto.borrow_mut().insert_property(
-            "byteLength".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(byte_length_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "byteLength".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(byte_length_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
         // length getter
         let length_getter = self.create_function(JsFunction::native(
             "get length".to_string(),
@@ -1497,17 +1533,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto.borrow_mut().insert_property(
-            "length".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(length_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "length".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(length_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // buffer getter (returns the ArrayBuffer object - we need to find it)
         let buffer_getter = self.create_function(JsFunction::native(
@@ -1527,20 +1565,22 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto.borrow_mut().insert_property(
-            "buffer".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(buffer_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "buffer".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(buffer_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // [Symbol.iterator] = values
-        let proto_id_for_iter = proto.borrow().id.unwrap();
+        let proto_id_for_iter = proto_id;
         self.setup_ta_values_method(proto_id_for_iter);
 
         // entries, keys, values
@@ -1585,7 +1625,9 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto.borrow_mut().insert_builtin("at".to_string(), at_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("at".to_string(), at_fn);
 
         // set
         let set_fn = self.create_function(JsFunction::native(
@@ -1745,7 +1787,9 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto.borrow_mut().insert_builtin("set".to_string(), set_fn);
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("set".to_string(), set_fn);
 
         // subarray
         let subarray_fn = self.create_function(JsFunction::native(
@@ -1829,7 +1873,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("subarray".to_string(), subarray_fn);
 
@@ -1966,7 +2010,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("slice".to_string(), slice_fn);
 
@@ -2069,7 +2113,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("copyWithin".to_string(), copy_within_fn);
 
@@ -2154,7 +2198,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("fill".to_string(), fill_fn);
 
@@ -2212,7 +2256,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("indexOf".to_string(), index_of_fn);
 
@@ -2271,7 +2315,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("lastIndexOf".to_string(), last_index_of_fn);
 
@@ -2325,13 +2369,13 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("includes".to_string(), includes_fn);
 
         // Higher-order methods: find, findIndex, findLast, findLastIndex, forEach, map, filter,
         // every, some, reduce, reduceRight
-        let proto_id_for_higher = proto.borrow().id.unwrap();
+        let proto_id_for_higher = proto_id;
         self.setup_ta_higher_order_methods(proto_id_for_higher);
 
         // reverse
@@ -2370,7 +2414,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("reverse".to_string(), reverse_fn);
 
@@ -2490,7 +2534,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("sort".to_string(), sort_fn);
 
@@ -2543,7 +2587,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("join".to_string(), join_fn);
 
@@ -2551,7 +2595,7 @@ impl Interpreter {
         {
             let array_proto_id = self.realm().array_prototype.unwrap();
             let tostring_val = self.get_property_on_id(array_proto_id, "toString");
-            proto
+            self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_builtin("toString".to_string(), tostring_val);
         }
@@ -2636,7 +2680,7 @@ impl Interpreter {
                 }
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toLocaleString".to_string(), to_locale_string_fn);
 
@@ -2680,17 +2724,17 @@ impl Interpreter {
                         let val = typed_array_get_index(&ta, len - 1 - i);
                         typed_array_set_index(&new_ta, i, &val);
                     }
-                    let ab_obj = interp.create_object();
+                    let ab_obj_id = interp.create_object_id();
                     let ab_proto = interp.realm().arraybuffer_prototype;
                     {
-                        let mut ab = ab_obj.borrow_mut();
+                        let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
                         ab.class_name = "ArrayBuffer".to_string();
                         ab.prototype_id = ab_proto;
                         ab.arraybuffer_data = Some(new_buf_rc);
                         ab.arraybuffer_detached = Some(new_detached);
                     }
                     interp.gc_track_external_bytes(buf_byte_len);
-                    let ab_id = ab_obj.borrow().id.unwrap();
+                    let ab_id = ab_obj_id;
                     let buf_val = JsValue::Object(JsObject { id: ab_id });
                     let id = interp.create_typed_array_object(new_ta, buf_val);
                     return Completion::Normal(JsValue::Object(JsObject { id }));
@@ -2698,7 +2742,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toReversed".to_string(), to_reversed_fn);
 
@@ -2822,17 +2866,17 @@ impl Interpreter {
                     for (i, val) in elems.iter().enumerate() {
                         typed_array_set_index(&new_ta, i, val);
                     }
-                    let ab_obj = interp.create_object();
+                    let ab_obj_id = interp.create_object_id();
                     let ab_proto = interp.realm().arraybuffer_prototype;
                     {
-                        let mut ab = ab_obj.borrow_mut();
+                        let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
                         ab.class_name = "ArrayBuffer".to_string();
                         ab.prototype_id = ab_proto;
                         ab.arraybuffer_data = Some(new_buf_rc);
                         ab.arraybuffer_detached = Some(new_detached);
                     }
                     interp.gc_track_external_bytes(buf_byte_len);
-                    let ab_id = ab_obj.borrow().id.unwrap();
+                    let ab_id = ab_obj_id;
                     let buf_val = JsValue::Object(JsObject { id: ab_id });
                     let id = interp.create_typed_array_object(new_ta, buf_val);
                     return Completion::Normal(JsValue::Object(JsObject { id }));
@@ -2840,7 +2884,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("toSorted".to_string(), to_sorted_fn);
 
@@ -3042,17 +3086,17 @@ impl Interpreter {
                         };
                         typed_array_set_index(&new_ta, k, &elem);
                     }
-                    let ab_obj = interp.create_object();
+                    let ab_obj_id = interp.create_object_id();
                     let ab_proto = interp.realm().arraybuffer_prototype;
                     {
-                        let mut ab = ab_obj.borrow_mut();
+                        let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
                         ab.class_name = "ArrayBuffer".to_string();
                         ab.prototype_id = ab_proto;
                         ab.arraybuffer_data = Some(new_buf_rc);
                         ab.arraybuffer_detached = Some(new_detached);
                     }
                     interp.gc_track_external_bytes(buf_byte_len);
-                    let ab_id = ab_obj.borrow().id.unwrap();
+                    let ab_id = ab_obj_id;
                     let buf_val = JsValue::Object(JsObject { id: ab_id });
                     let id = interp.create_typed_array_object(new_ta, buf_val);
                     return Completion::Normal(JsValue::Object(JsObject { id }));
@@ -3060,7 +3104,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_builtin("with".to_string(), with_fn);
 
@@ -3082,17 +3126,19 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(to_string_tag_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(to_string_tag_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
     }
 
     fn setup_ta_values_method(&mut self, proto_id: u64) {
@@ -3972,9 +4018,9 @@ impl Interpreter {
             let ta_ctor_clone = ta_ctor.clone();
 
             // Create per-type prototype
-            let type_proto = self.create_object();
+            let type_proto_id = self.create_object_id();
             {
-                let mut p = type_proto.borrow_mut();
+                let mut p = self.get_object_cell_expect(type_proto_id).borrow_mut();
                 p.prototype_id = Some(ta_proto_clone_id);
                 p.class_name = name.clone();
                 p.insert_property(
@@ -3983,7 +4029,7 @@ impl Interpreter {
                 );
             }
 
-            let type_proto_clone_id = type_proto.borrow().id.unwrap();
+            let type_proto_clone_id = type_proto_id;
             let ctor = self.create_function(JsFunction::constructor(
                 name.clone(), 3,
                 move |interp, _this, args| {
@@ -4145,10 +4191,10 @@ impl Interpreter {
                                         let val = typed_array_get_index(&src_ta, i);
                                         typed_array_set_index(&new_ta, i, &val);
                                     }
-                                    let ab_obj = interp.create_object();
+                                    let ab_obj_id = interp.create_object_id();
                                     let ab_proto = interp.realm().arraybuffer_prototype;
                                     {
-                                        let mut ab = ab_obj.borrow_mut();
+                                        let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
                                         ab.class_name = "ArrayBuffer".to_string();
                                         ab.prototype_id = ab_proto;
                                         ab.arraybuffer_data = Some(new_buf_rc);
@@ -4159,7 +4205,7 @@ impl Interpreter {
                                         Ok(p) => p,
                                         Err(e) => return Completion::Throw(e),
                                     };
-                                    let ab_id = ab_obj.borrow().id.unwrap();
+                                    let ab_id = ab_obj_id;
                                     let buf_val = JsValue::Object(JsObject { id: ab_id });
                                     let id = interp.create_typed_array_object_with_proto(new_ta, buf_val, proto);
                                     return Completion::Normal(JsValue::Object(JsObject { id }));
@@ -4192,10 +4238,10 @@ impl Interpreter {
                                     };
                                     typed_array_set_index(&new_ta, i, &coerced);
                                 }
-                                let ab_obj = interp.create_object();
+                                let ab_obj_id = interp.create_object_id();
                                 let ab_proto = interp.realm().arraybuffer_prototype;
                                 {
-                                    let mut ab = ab_obj.borrow_mut();
+                                    let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
                                     ab.class_name = "ArrayBuffer".to_string();
                                     ab.prototype_id = ab_proto;
                                     ab.arraybuffer_data = Some(new_buf_rc);
@@ -4206,7 +4252,7 @@ impl Interpreter {
                                     Ok(p) => p,
                                     Err(e) => return Completion::Throw(e),
                                 };
-                                let ab_id = ab_obj.borrow().id.unwrap();
+                                let ab_id = ab_obj_id;
                                 let buf_val = JsValue::Object(JsObject { id: ab_id });
                                 let id = interp.create_typed_array_object_with_proto(new_ta, buf_val, proto);
                                 return Completion::Normal(JsValue::Object(JsObject { id }));
@@ -4248,7 +4294,7 @@ impl Interpreter {
                     PropertyDescriptor::data(JsValue::Number(bpe as f64), false, false, false),
                 );
                 // Set prototype property
-                let proto_id = type_proto.borrow().id.unwrap();
+                let proto_id = type_proto_id;
                 obj.borrow_mut().insert_property(
                     "prototype".to_string(),
                     PropertyDescriptor::data(
@@ -4267,13 +4313,15 @@ impl Interpreter {
             }
 
             // Set constructor on prototype
-            type_proto.borrow_mut().insert_property(
-                "constructor".to_string(),
-                PropertyDescriptor::data(ctor.clone(), true, false, true),
-            );
+            self.get_object_cell_expect(type_proto_id)
+                .borrow_mut()
+                .insert_property(
+                    "constructor".to_string(),
+                    PropertyDescriptor::data(ctor.clone(), true, false, true),
+                );
 
             // Store prototype for this kind
-            let type_proto_id = type_proto.borrow().id.unwrap();
+            let type_proto_id = type_proto_id;
             match kind {
                 TypedArrayKind::Int8 => self.realm_mut().int8array_prototype = Some(type_proto_id),
                 TypedArrayKind::Uint8 => {
@@ -4646,17 +4694,17 @@ impl Interpreter {
             is_detached: detached.clone(),
             is_length_tracking: false,
         };
-        let ab_obj = self.create_object();
+        let ab_obj_id = self.create_object_id();
         let ab_proto = self.realm().arraybuffer_prototype;
         {
-            let mut ab = ab_obj.borrow_mut();
+            let mut ab = self.get_object_cell_expect(ab_obj_id).borrow_mut();
             ab.class_name = "ArrayBuffer".to_string();
             ab.prototype_id = ab_proto;
             ab.arraybuffer_data = Some(buf_rc);
             ab.arraybuffer_detached = Some(detached);
         }
         self.gc_track_external_bytes(buf_byte_len);
-        let ab_id = ab_obj.borrow().id.unwrap();
+        let ab_id = ab_obj_id;
         let buf_val = JsValue::Object(JsObject { id: ab_id });
         let id = self.create_typed_array_object_with_proto(ta_info, buf_val, type_proto_id);
         Completion::Normal(JsValue::Object(JsObject { id }))
@@ -4668,10 +4716,10 @@ impl Interpreter {
         buf_val: JsValue,
     ) -> u64 {
         let proto = self.get_typed_array_prototype(info.kind);
-        let obj = self.create_object();
-        let obj_id = obj.borrow().id.unwrap();
+        let obj_id = self.create_object_id();
+        let obj_id = obj_id;
         {
-            let mut o = obj.borrow_mut();
+            let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
             o.class_name = info.kind.name().to_string();
             o.prototype_id = proto;
             if let JsValue::Object(ref bobj) = buf_val {
@@ -4688,10 +4736,10 @@ impl Interpreter {
         buf_val: JsValue,
         proto_id: u64,
     ) -> u64 {
-        let obj = self.create_object();
-        let obj_id = obj.borrow().id.unwrap();
+        let obj_id = self.create_object_id();
+        let obj_id = obj_id;
         {
-            let mut o = obj.borrow_mut();
+            let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
             o.class_name = info.kind.name().to_string();
             o.prototype_id = Some(proto_id);
             if let JsValue::Object(ref bobj) = buf_val {
@@ -4776,26 +4824,26 @@ impl Interpreter {
                         is_detached: new_detached.clone(),
                         is_length_tracking: false,
                     };
-                    let ab_obj = self.create_object();
+                    let ab_obj_id = self.create_object_id();
                     let ab_proto = self.realm().arraybuffer_prototype;
                     {
-                        let mut ab = ab_obj.borrow_mut();
+                        let mut ab = self.get_object_cell_expect(ab_obj_id).borrow_mut();
                         ab.class_name = "ArrayBuffer".to_string();
                         ab.prototype_id = ab_proto;
                         ab.arraybuffer_data = Some(new_buf_rc);
                         ab.arraybuffer_detached = Some(new_detached);
                     }
                     self.gc_track_external_bytes(buf_byte_len);
-                    let ab_id = ab_obj.borrow().id.unwrap();
-                    let result = self.create_object();
+                    let ab_id = ab_obj_id;
+                    let result_id = self.create_object_id();
                     {
-                        let mut r = result.borrow_mut();
+                        let mut r = self.get_object_cell_expect(result_id).borrow_mut();
                         r.class_name = kind.name().to_string();
                         r.prototype_id = proto;
                         r.view_buffer_object_id = Some(ab_id);
                         r.typed_array_info = Some(ta);
                     }
-                    let id = result.borrow().id.unwrap();
+                    let id = result_id;
                     return Completion::Normal(JsValue::Object(JsObject { id }));
                 }
             }
@@ -5004,9 +5052,11 @@ impl Interpreter {
     }
 
     fn setup_dataview(&mut self) {
-        let dv_proto = self.create_object();
-        dv_proto.borrow_mut().class_name = "DataView".to_string();
-        self.realm_mut().dataview_prototype = Some(dv_proto.borrow().id.unwrap());
+        let dv_proto_id = self.create_object_id();
+        self.get_object_cell_expect(dv_proto_id)
+            .borrow_mut()
+            .class_name = "DataView".to_string();
+        self.realm_mut().dataview_prototype = Some(dv_proto_id);
 
         // Getters: buffer, byteOffset, byteLength
         let buffer_getter = self.create_function(JsFunction::native(
@@ -5027,17 +5077,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a DataView"))
             },
         ));
-        dv_proto.borrow_mut().insert_property(
-            "buffer".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(buffer_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(dv_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "buffer".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(buffer_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // byteOffset getter
         let dv_byte_offset_getter = self.create_function(JsFunction::native(
@@ -5072,17 +5124,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a DataView"))
             },
         ));
-        dv_proto.borrow_mut().insert_property(
-            "byteOffset".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(dv_byte_offset_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(dv_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "byteOffset".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(dv_byte_offset_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
         // byteLength getter
         let dv_byte_length_getter = self.create_function(JsFunction::native(
             "get byteLength".to_string(),
@@ -5121,17 +5175,19 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a DataView"))
             },
         ));
-        dv_proto.borrow_mut().insert_property(
-            "byteLength".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(dv_byte_length_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
+        self.get_object_cell_expect(dv_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "byteLength".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(dv_byte_length_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
 
         // DataView get/set methods
         // Spec ordering for GetViewValue:
@@ -5209,7 +5265,7 @@ impl Interpreter {
                         Completion::Throw(interp.create_type_error("not a DataView"))
                     },
                 ));
-                dv_proto
+                self.get_object_cell_expect(dv_proto_id)
                     .borrow_mut()
                     .insert_builtin($method_name.to_string(), getter);
             }};
@@ -5399,7 +5455,7 @@ impl Interpreter {
                         Completion::Throw(interp.create_type_error("not a DataView"))
                     },
                 ));
-                dv_proto
+                self.get_object_cell_expect(dv_proto_id)
                     .borrow_mut()
                     .insert_builtin($method_name.to_string(), setter);
             }};
@@ -5489,7 +5545,7 @@ impl Interpreter {
                         Completion::Throw(interp.create_type_error("not a DataView"))
                     },
                 ));
-                dv_proto
+                self.get_object_cell_expect(dv_proto_id)
                     .borrow_mut()
                     .insert_builtin($method_name.to_string(), setter);
             }};
@@ -5598,13 +5654,15 @@ impl Interpreter {
 
         // @@toStringTag
         let tag = JsValue::String(JsString::from_str("DataView"));
-        dv_proto.borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor::data(tag, false, false, true),
-        );
+        self.get_object_cell_expect(dv_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor::data(tag, false, false, true),
+            );
 
         // DataView constructor
-        let dv_proto_clone_id = dv_proto.borrow().id.unwrap();
+        let dv_proto_clone_id = dv_proto_id;
         let ctor = self.create_function(JsFunction::constructor(
             "DataView".to_string(),
             1,
@@ -5723,9 +5781,9 @@ impl Interpreter {
                             );
                         }
                     }
-                    let result = interp.create_object();
+                    let result_id = interp.create_object_id();
                     {
-                        let mut r = result.borrow_mut();
+                        let mut r = interp.get_object_cell_expect(result_id).borrow_mut();
                         r.class_name = "DataView".to_string();
                         r.prototype_id = Some(dv_proto);
                         if let JsValue::Object(ref bobj) = buf_arg {
@@ -5733,7 +5791,7 @@ impl Interpreter {
                         }
                         r.data_view_info = Some(dv_info);
                     }
-                    let id = result.borrow().id.unwrap();
+                    let id = result_id;
                     return Completion::Normal(JsValue::Object(JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error(
@@ -5744,7 +5802,7 @@ impl Interpreter {
 
         // Wire DataView.prototype to the proto object with all the methods
         let dv_proto_val = {
-            let id = dv_proto.borrow().id.unwrap();
+            let id = dv_proto_id;
             JsValue::Object(crate::types::JsObject { id })
         };
         if let JsValue::Object(o) = &ctor
@@ -5755,10 +5813,12 @@ impl Interpreter {
                 PropertyDescriptor::data(dv_proto_val, false, false, false),
             );
         }
-        dv_proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(dv_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(ctor.clone(), true, false, true),
+            );
 
         if let JsValue::Object(ref o) = ctor
             && let Some(func_obj) = self.get_object(o.id)
@@ -6573,17 +6633,17 @@ fn create_uint8array_from_bytes(interp: &mut Interpreter, bytes: &[u8]) -> Compl
         is_detached: detached.clone(),
         is_length_tracking: false,
     };
-    let ab_obj = interp.create_object();
+    let ab_obj_id = interp.create_object_id();
     let ab_proto = interp.realm().arraybuffer_prototype;
     {
-        let mut ab = ab_obj.borrow_mut();
+        let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
         ab.class_name = "ArrayBuffer".to_string();
         ab.prototype_id = ab_proto;
         ab.arraybuffer_data = Some(buf_rc);
         ab.arraybuffer_detached = Some(detached);
     }
     interp.gc_track_external_bytes(len);
-    let ab_id = ab_obj.borrow().id.unwrap();
+    let ab_id = ab_obj_id;
     let buf_val = JsValue::Object(JsObject { id: ab_id });
 
     let proto_id = interp.realm().uint8array_prototype.unwrap();
@@ -6592,11 +6652,15 @@ fn create_uint8array_from_bytes(interp: &mut Interpreter, bytes: &[u8]) -> Compl
 }
 
 fn make_read_written_result(interp: &mut Interpreter, read: usize, written: usize) -> Completion {
-    let obj = interp.create_object();
-    obj.borrow_mut()
+    let obj_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
         .set_property_value("read", JsValue::Number(read as f64));
-    obj.borrow_mut()
+    interp
+        .get_object_cell_expect(obj_id)
+        .borrow_mut()
         .set_property_value("written", JsValue::Number(written as f64));
-    let id = obj.borrow().id.unwrap();
+    let id = obj_id;
     Completion::Normal(JsValue::Object(JsObject { id }))
 }

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -399,7 +399,7 @@ impl Interpreter {
                         };
                         // Copy data
                         if new_len > 0 {
-                            let new_obj = interp.get_object(new_id).unwrap();
+                            let new_obj = interp.get_object_cell(new_id).unwrap();
                             let new_ref = new_obj.borrow();
                             let new_buf = new_ref.arraybuffer_data.as_ref().unwrap();
                             with_buffer_write(new_buf, |new_buf_ref| {
@@ -861,7 +861,7 @@ impl Interpreter {
             |interp, _this, args| {
                 let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = &arg
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let obj_ref = obj.borrow();
                     if obj_ref.typed_array_info.is_some() || obj_ref.data_view_info.is_some() {
@@ -913,7 +913,7 @@ impl Interpreter {
 
         // Mark deferred_construct: ArrayBuffer validates args before OrdinaryCreateFromConstructor
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj.borrow_mut().deferred_construct = true;
         }
@@ -954,7 +954,7 @@ impl Interpreter {
 
     pub(crate) fn detach_arraybuffer(&mut self, ab_val: &JsValue) -> Completion {
         if let JsValue::Object(o) = ab_val
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let old_len;
             {
@@ -1006,7 +1006,7 @@ impl Interpreter {
             0,
             |interp, this_val, _args| {
                 if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let obj_ref = obj.borrow();
                     if obj_ref.arraybuffer_is_shared
@@ -1038,7 +1038,7 @@ impl Interpreter {
             0,
             |interp, this_val, _args| {
                 if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let obj_ref = obj.borrow();
                     if obj_ref.arraybuffer_is_shared
@@ -1270,7 +1270,7 @@ impl Interpreter {
                             let obj_ref = obj.borrow();
                             buffer_bytes(obj_ref.arraybuffer_data.as_ref().unwrap())
                         };
-                        let new_obj = interp.get_object(new_id).unwrap();
+                        let new_obj = interp.get_object_cell(new_id).unwrap();
                         let new_ref = new_obj.borrow();
                         let new_buf = new_ref.arraybuffer_data.as_ref().unwrap();
                         with_buffer_write(new_buf, |new_buf_ref| {
@@ -1427,7 +1427,7 @@ impl Interpreter {
             );
 
         if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj.borrow_mut().deferred_construct = true;
         }
@@ -1453,7 +1453,7 @@ impl Interpreter {
             0,
             |interp, this_val, _args| {
                 if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let obj_ref = obj.borrow();
                     if let Some(ref ta) = obj_ref.typed_array_info {
@@ -1485,7 +1485,7 @@ impl Interpreter {
             0,
             |interp, this_val, _args| {
                 if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let obj_ref = obj.borrow();
                     if let Some(ref ta) = obj_ref.typed_array_info {
@@ -1519,7 +1519,7 @@ impl Interpreter {
             0,
             |interp, this_val, _args| {
                 if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let obj_ref = obj.borrow();
                     if let Some(ref ta) = obj_ref.typed_array_info {
@@ -1673,7 +1673,7 @@ impl Interpreter {
 
                     // Check if source is a TypedArray
                     if let JsValue::Object(src_o) = &source
-                        && let Some(src_obj) = interp.get_object(src_o.id)
+                        && let Some(src_obj) = interp.get_object_cell(src_o.id)
                     {
                         let is_ta = src_obj.borrow().typed_array_info.is_some();
                         if is_ta {
@@ -2444,7 +2444,7 @@ impl Interpreter {
                     {
                         let is_callable = if let JsValue::Object(co) = cmp {
                             interp
-                                .get_object(co.id)
+                                .get_object_cell(co.id)
                                 .is_some_and(|obj| obj.borrow().callable.is_some())
                         } else {
                             false
@@ -2772,7 +2772,7 @@ impl Interpreter {
                     {
                         let is_callable = if let JsValue::Object(co) = cmp {
                             interp
-                                .get_object(co.id)
+                                .get_object_cell(co.id)
                                 .is_some_and(|obj| obj.borrow().callable.is_some())
                         } else {
                             false
@@ -3422,7 +3422,7 @@ impl Interpreter {
                 interp.gc_root_value(&new_ta_val);
 
                 let new_ta = if let JsValue::Object(o) = &new_ta_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     obj.borrow().typed_array_info.as_ref().unwrap().clone()
                 } else {
@@ -3487,7 +3487,7 @@ impl Interpreter {
                 };
 
                 if let JsValue::Object(o) = &new_ta_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let new_ta = obj.borrow().typed_array_info.as_ref().unwrap().clone();
                     for (i, val) in kept.iter().enumerate() {
@@ -3694,7 +3694,7 @@ impl Interpreter {
 
                 // Step 2: IsConstructor(C)
                 let is_ctor = matches!(this_val, JsValue::Object(o) if {
-                    interp.get_object(o.id).is_some_and(|obj| obj.borrow().callable.is_some())
+                    interp.get_object_cell(o.id).is_some_and(|obj| obj.borrow().callable.is_some())
                 });
                 if !is_ctor {
                     return Completion::Throw(
@@ -3707,7 +3707,7 @@ impl Interpreter {
                     && !matches!(mf, JsValue::Undefined)
                 {
                     let is_callable = matches!(mf, JsValue::Object(o) if {
-                        interp.get_object(o.id).is_some_and(|obj| obj.borrow().callable.is_some())
+                        interp.get_object_cell(o.id).is_some_and(|obj| obj.borrow().callable.is_some())
                     });
                     if !is_callable {
                         return Completion::Throw(
@@ -3774,7 +3774,7 @@ impl Interpreter {
                         other => return other,
                     };
                     let ta_kind = if let JsValue::Object(ref o) = target_obj {
-                        interp.get_object(o.id).and_then(|obj| {
+                        interp.get_object_cell(o.id).and_then(|obj| {
                             obj.borrow().typed_array_info.as_ref().map(|ta| ta.kind)
                         })
                     } else {
@@ -3809,7 +3809,7 @@ impl Interpreter {
                         };
                         let key = k.to_string();
                         if let JsValue::Object(ref o) = target_obj
-                            && let Some(obj) = interp.get_object(o.id)
+                            && let Some(obj) = interp.get_object_cell(o.id)
                         {
                             obj.borrow_mut().set_property_value(&key, coerced);
                         }
@@ -3854,7 +3854,7 @@ impl Interpreter {
                         other => return other,
                     };
                     let ta_kind = if let JsValue::Object(ref o) = target_obj {
-                        interp.get_object(o.id).and_then(|obj| {
+                        interp.get_object_cell(o.id).and_then(|obj| {
                             obj.borrow().typed_array_info.as_ref().map(|ta| ta.kind)
                         })
                     } else {
@@ -3899,7 +3899,7 @@ impl Interpreter {
                         };
                         let key = k.to_string();
                         if let JsValue::Object(ref o) = target_obj
-                            && let Some(obj) = interp.get_object(o.id)
+                            && let Some(obj) = interp.get_object_cell(o.id)
                         {
                             obj.borrow_mut().set_property_value(&key, coerced);
                         }
@@ -3909,7 +3909,7 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(o) = &ta_ctor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("from".to_string(), ta_from_fn);
@@ -3928,7 +3928,7 @@ impl Interpreter {
                 // Get ta_kind for coercion
                 let ta_kind = if let JsValue::Object(ref o) = new_obj {
                     interp
-                        .get_object(o.id)
+                        .get_object_cell(o.id)
                         .and_then(|obj| obj.borrow().typed_array_info.as_ref().map(|ta| ta.kind))
                 } else {
                     None
@@ -3949,7 +3949,7 @@ impl Interpreter {
                     };
                     let key = k.to_string();
                     if let JsValue::Object(ref o) = new_obj
-                        && let Some(obj) = interp.get_object(o.id)
+                        && let Some(obj) = interp.get_object_cell(o.id)
                     {
                         obj.borrow_mut().set_property_value(&key, coerced);
                     }
@@ -3958,14 +3958,14 @@ impl Interpreter {
             },
         ));
         if let JsValue::Object(o) = &ta_ctor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_builtin("of".to_string(), ta_of_fn);
         }
 
         // Set %TypedArray%.prototype → %TypedArray.prototype%
         if let JsValue::Object(o) = &ta_ctor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -3993,7 +3993,7 @@ impl Interpreter {
             |_interp, this_val, _args| Completion::Normal(this_val.clone()),
         ));
         if let JsValue::Object(o) = &ta_ctor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_property(
                 "Symbol(Symbol.species)".to_string(),
@@ -4069,7 +4069,7 @@ impl Interpreter {
                     let first = &args[0];
                     match first {
                         JsValue::Object(o) => {
-                            if let Some(src_obj) = interp.get_object(o.id) {
+                            if let Some(src_obj) = interp.get_object_cell(o.id) {
                                 let src_ref = src_obj.borrow();
                                 // Case: new XArray(arraybuffer, byteOffset?, length?)
                                 if let Some(ref ab_data) = src_ref.arraybuffer_data {
@@ -4279,14 +4279,14 @@ impl Interpreter {
             // Set deferred_construct so construct_with_new_target doesn't access
             // newTarget.prototype before the constructor body runs (spec ordering)
             if let JsValue::Object(o) = &ctor
-                && let Some(obj) = self.get_object(o.id)
+                && let Some(obj) = self.get_object_cell(o.id)
             {
                 obj.borrow_mut().deferred_construct = true;
             }
 
             // Set BYTES_PER_ELEMENT on constructor
             if let JsValue::Object(o) = &ctor
-                && let Some(obj) = self.get_object(o.id)
+                && let Some(obj) = self.get_object_cell(o.id)
             {
                 obj.borrow_mut().insert_property(
                     "BYTES_PER_ELEMENT".to_string(),
@@ -4305,7 +4305,7 @@ impl Interpreter {
                 );
                 // Set __proto__ to %TypedArray% so from/of are inherited
                 if let JsValue::Object(ta_o) = &ta_ctor_clone
-                    && let Some(ta_obj) = self.get_object(ta_o.id)
+                    && let Some(ta_obj) = self.get_object_cell(ta_o.id)
                 {
                     obj.borrow_mut().prototype_id = Some(ta_obj.borrow().id.unwrap());
                 }
@@ -4422,7 +4422,7 @@ impl Interpreter {
         ));
 
         if let JsValue::Object(o) = &uint8_ctor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut()
                 .insert_builtin("fromBase64".to_string(), from_base64_fn);
@@ -4768,7 +4768,7 @@ impl Interpreter {
     fn typed_array_create(&mut self, ctor: &JsValue, len: usize) -> Completion {
         // Fast path for known built-in TypedArray constructors
         if let JsValue::Object(o) = ctor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let name = {
                 let obj_ref = obj.borrow();
@@ -4854,7 +4854,7 @@ impl Interpreter {
             other => return other,
         };
         if let JsValue::Object(ref o) = new_obj
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let ta_len = obj
                 .borrow()
@@ -4949,7 +4949,7 @@ impl Interpreter {
         val: &JsValue,
     ) -> Result<Vec<JsValue>, Completion> {
         if let JsValue::Object(o) = val
-            && let Some(_obj) = self.get_object(o.id)
+            && let Some(_obj) = self.get_object_cell(o.id)
         {
             // Step 5: Let usingIterator be ? GetMethod(object, @@iterator).
             let iter_fn = match self.get_object_property(o.id, "Symbol(Symbol.iterator)", val) {
@@ -5802,7 +5802,7 @@ impl Interpreter {
             JsValue::Object(crate::types::JsObject { id })
         };
         if let JsValue::Object(o) = &ctor
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -5857,7 +5857,7 @@ fn extract_ta_and_callback(
         let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
         let is_callable = if let JsValue::Object(co) = &callback {
             interp
-                .get_object(co.id)
+                .get_object_cell(co.id)
                 .is_some_and(|obj| obj.borrow().callable.is_some())
         } else {
             false

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -304,10 +304,7 @@ impl Interpreter {
 
                         // SpeciesConstructor(O, %ArrayBuffer%)
                         let ab_ctor = interp
-                            .realm()
-                            .global_env
-                            .borrow()
-                            .get("ArrayBuffer")
+                            .get_global_var("ArrayBuffer")
                             .unwrap_or(JsValue::Undefined);
                         let ctor = match interp.species_constructor(this_val, &ab_ctor) {
                             Ok(c) => c,
@@ -911,11 +908,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("ArrayBuffer", BindingKind::Var);
-        let _ = self
-            .realm()
-            .global_env
-            .borrow_mut()
-            .set("ArrayBuffer", ctor);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "ArrayBuffer", ctor);
     }
 
     pub(crate) fn create_arraybuffer(&mut self, data: Vec<u8>) -> Rc<RefCell<JsObjectData>> {
@@ -1198,10 +1192,7 @@ impl Interpreter {
 
                     // SpeciesConstructor(O, %SharedArrayBuffer%)
                     let sab_ctor = interp
-                        .realm()
-                        .global_env
-                        .borrow()
-                        .get("SharedArrayBuffer")
+                        .get_global_var("SharedArrayBuffer")
                         .unwrap_or(JsValue::Undefined);
                     let ctor = match interp.species_constructor(this_val, &sab_ctor) {
                         Ok(c) => c,
@@ -1415,11 +1406,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("SharedArrayBuffer", BindingKind::Var);
-        let _ = self
-            .realm()
-            .global_env
-            .borrow_mut()
-            .set("SharedArrayBuffer", ctor);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "SharedArrayBuffer", ctor);
     }
 
     fn setup_typed_array_base_prototype(&mut self) {
@@ -4327,7 +4315,8 @@ impl Interpreter {
                 .global_env
                 .borrow_mut()
                 .declare(&name, BindingKind::Var);
-            let _ = self.realm().global_env.borrow_mut().set(&name, ctor);
+            let env = self.realm().global_env.clone();
+            let _ = self.env_set(&env, &name, ctor);
         }
     }
 
@@ -4564,10 +4553,7 @@ impl Interpreter {
 
         let default_ctor_name = kind.name();
         let default_ctor = self
-            .realm()
-            .global_env
-            .borrow()
-            .get(default_ctor_name)
+            .get_global_var(default_ctor_name)
             .unwrap_or(JsValue::Undefined);
 
         let ctor = self.species_constructor(exemplar, &default_ctor)?;
@@ -5783,7 +5769,8 @@ impl Interpreter {
             .global_env
             .borrow_mut()
             .declare("DataView", BindingKind::Var);
-        let _ = self.realm().global_env.borrow_mut().set("DataView", ctor);
+        let env = self.realm().global_env.clone();
+        let _ = self.env_set(&env, "DataView", ctor);
     }
 }
 

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1540,10 +1540,11 @@ impl Interpreter {
         );
 
         // [Symbol.iterator] = values
-        self.setup_ta_values_method(&proto);
+        let proto_id_for_iter = proto.borrow().id.unwrap();
+        self.setup_ta_values_method(proto_id_for_iter);
 
         // entries, keys, values
-        self.setup_ta_iterator_methods(&proto);
+        self.setup_ta_iterator_methods(proto_id_for_iter);
 
         // at
         let at_fn = self.create_function(JsFunction::native(
@@ -2330,7 +2331,8 @@ impl Interpreter {
 
         // Higher-order methods: find, findIndex, findLast, findLastIndex, forEach, map, filter,
         // every, some, reduce, reduceRight
-        self.setup_ta_higher_order_methods(&proto);
+        let proto_id_for_higher = proto.borrow().id.unwrap();
+        self.setup_ta_higher_order_methods(proto_id_for_higher);
 
         // reverse
         let reverse_fn = self.create_function(JsFunction::native(
@@ -3093,7 +3095,7 @@ impl Interpreter {
         );
     }
 
-    fn setup_ta_values_method(&mut self, proto: &Rc<RefCell<JsObjectData>>) {
+    fn setup_ta_values_method(&mut self, proto_id: u64) {
         let values_fn = self.create_function(JsFunction::native(
             "values".to_string(),
             0,
@@ -3119,15 +3121,15 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("values".to_string(), values_fn.clone());
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("Symbol(Symbol.iterator)".to_string(), values_fn);
     }
 
-    fn setup_ta_iterator_methods(&mut self, proto: &Rc<RefCell<JsObjectData>>) {
+    fn setup_ta_iterator_methods(&mut self, proto_id: u64) {
         let entries_fn = self.create_function(JsFunction::native(
             "entries".to_string(),
             0,
@@ -3153,7 +3155,7 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("entries".to_string(), entries_fn);
 
@@ -3182,12 +3184,12 @@ impl Interpreter {
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("keys".to_string(), keys_fn);
     }
 
-    fn setup_ta_higher_order_methods(&mut self, proto: &Rc<RefCell<JsObjectData>>) {
+    fn setup_ta_higher_order_methods(&mut self, proto_id: u64) {
         // find
         let find_fn = self.create_function(JsFunction::native(
             "find".to_string(),
@@ -3217,7 +3219,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("find".to_string(), find_fn);
 
@@ -3250,7 +3252,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(-1.0))
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findIndex".to_string(), find_index_fn);
 
@@ -3285,7 +3287,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findLast".to_string(), find_last_fn);
 
@@ -3320,7 +3322,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(-1.0))
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("findLastIndex".to_string(), find_last_index_fn);
 
@@ -3349,7 +3351,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("forEach".to_string(), for_each_fn);
 
@@ -3398,7 +3400,9 @@ impl Interpreter {
                 Completion::Normal(new_ta_val)
             },
         ));
-        proto.borrow_mut().insert_builtin("map".to_string(), map_fn);
+        self.get_object_expect(proto_id)
+            .borrow_mut()
+            .insert_builtin("map".to_string(), map_fn);
 
         // filter
         let filter_fn = self.create_function(JsFunction::native(
@@ -3448,7 +3452,7 @@ impl Interpreter {
                 Completion::Normal(new_ta_val)
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("filter".to_string(), filter_fn);
 
@@ -3481,7 +3485,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(true))
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("every".to_string(), every_fn);
 
@@ -3514,7 +3518,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Boolean(false))
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("some".to_string(), some_fn);
 
@@ -3556,7 +3560,7 @@ impl Interpreter {
                 Completion::Normal(acc)
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("reduce".to_string(), reduce_fn);
 
@@ -3600,7 +3604,7 @@ impl Interpreter {
                 Completion::Normal(acc)
             },
         ));
-        proto
+        self.get_object_expect(proto_id)
             .borrow_mut()
             .insert_builtin("reduceRight".to_string(), reduce_right_fn);
     }

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -493,8 +493,7 @@ impl Interpreter {
                             Some(Rc::new(RefCell::new(BufferData::Owned(Vec::new()))));
                     }
                     interp.gc_untrack_external_bytes(old_data_len);
-                    let new_ab = interp.create_arraybuffer_resizable(new_data, max_byte_length);
-                    let id = new_ab.borrow().id.unwrap();
+                    let id = interp.create_arraybuffer_resizable(new_data, max_byte_length);
                     return Completion::Normal(JsValue::Object(JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
@@ -577,8 +576,7 @@ impl Interpreter {
                             Some(Rc::new(RefCell::new(BufferData::Owned(Vec::new()))));
                     }
                     interp.gc_untrack_external_bytes(old_data_len);
-                    let new_ab = interp.create_arraybuffer(new_data);
-                    let id = new_ab.borrow().id.unwrap();
+                    let id = interp.create_arraybuffer(new_data);
                     return Completion::Normal(JsValue::Object(JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
@@ -662,9 +660,11 @@ impl Interpreter {
                     }
                     interp.gc_untrack_external_bytes(old_data_len);
                     // Create immutable ArrayBuffer
-                    let new_ab = interp.create_arraybuffer(new_data);
-                    new_ab.borrow_mut().arraybuffer_is_immutable = true;
-                    let id = new_ab.borrow().id.unwrap();
+                    let id = interp.create_arraybuffer(new_data);
+                    interp
+                        .get_object_expect(id)
+                        .borrow_mut()
+                        .arraybuffer_is_immutable = true;
                     return Completion::Normal(JsValue::Object(JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
@@ -912,7 +912,7 @@ impl Interpreter {
         let _ = self.env_set(&env, "ArrayBuffer", ctor);
     }
 
-    pub(crate) fn create_arraybuffer(&mut self, data: Vec<u8>) -> Rc<RefCell<JsObjectData>> {
+    pub(crate) fn create_arraybuffer(&mut self, data: Vec<u8>) -> u64 {
         self.create_arraybuffer_resizable(data, None)
     }
 
@@ -920,11 +920,12 @@ impl Interpreter {
         &mut self,
         data: Vec<u8>,
         max_byte_length: Option<usize>,
-    ) -> Rc<RefCell<JsObjectData>> {
+    ) -> u64 {
         let data_len = data.len();
         let buf_rc = Rc::new(RefCell::new(BufferData::Owned(data)));
         let detached = Rc::new(Cell::new(false));
         let obj = self.create_object();
+        let obj_id = obj.borrow().id.unwrap();
         let ab_proto = self.realm().arraybuffer_prototype;
         {
             let mut o = obj.borrow_mut();
@@ -935,7 +936,7 @@ impl Interpreter {
             o.arraybuffer_max_byte_length = max_byte_length;
         }
         self.gc_track_external_bytes(data_len);
-        obj
+        obj_id
     }
 
     pub(crate) fn detach_arraybuffer(&mut self, ab_val: &JsValue) -> Completion {
@@ -2689,8 +2690,7 @@ impl Interpreter {
                     interp.gc_track_external_bytes(buf_byte_len);
                     let ab_id = ab_obj.borrow().id.unwrap();
                     let buf_val = JsValue::Object(JsObject { id: ab_id });
-                    let result = interp.create_typed_array_object(new_ta, buf_val);
-                    let id = result.borrow().id.unwrap();
+                    let id = interp.create_typed_array_object(new_ta, buf_val);
                     return Completion::Normal(JsValue::Object(JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
@@ -2832,8 +2832,7 @@ impl Interpreter {
                     interp.gc_track_external_bytes(buf_byte_len);
                     let ab_id = ab_obj.borrow().id.unwrap();
                     let buf_val = JsValue::Object(JsObject { id: ab_id });
-                    let result = interp.create_typed_array_object(new_ta, buf_val);
-                    let id = result.borrow().id.unwrap();
+                    let id = interp.create_typed_array_object(new_ta, buf_val);
                     return Completion::Normal(JsValue::Object(JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
@@ -3053,8 +3052,7 @@ impl Interpreter {
                     interp.gc_track_external_bytes(buf_byte_len);
                     let ab_id = ab_obj.borrow().id.unwrap();
                     let buf_val = JsValue::Object(JsObject { id: ab_id });
-                    let result = interp.create_typed_array_object(new_ta, buf_val);
-                    let id = result.borrow().id.unwrap();
+                    let id = interp.create_typed_array_object(new_ta, buf_val);
                     return Completion::Normal(JsValue::Object(JsObject { id }));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
@@ -4101,8 +4099,7 @@ impl Interpreter {
                                         is_length_tracking,
                                     };
                                     let buf_val = first.clone();
-                                    let result = interp.create_typed_array_object_with_proto(ta_info, buf_val, proto);
-                                    let id = result.borrow().id.unwrap();
+                                    let id = interp.create_typed_array_object_with_proto(ta_info, buf_val, proto);
                                     return Completion::Normal(JsValue::Object(JsObject { id }));
                                 }
                                 // Case: new XArray(typedArray)
@@ -4159,8 +4156,7 @@ impl Interpreter {
                                     };
                                     let ab_id = ab_obj.borrow().id.unwrap();
                                     let buf_val = JsValue::Object(JsObject { id: ab_id });
-                                    let result = interp.create_typed_array_object_with_proto(new_ta, buf_val, proto);
-                                    let id = result.borrow().id.unwrap();
+                                    let id = interp.create_typed_array_object_with_proto(new_ta, buf_val, proto);
                                     return Completion::Normal(JsValue::Object(JsObject { id }));
                                 }
                                 // Case: new XArray(arrayLike/iterable)
@@ -4207,8 +4203,7 @@ impl Interpreter {
                                 };
                                 let ab_id = ab_obj.borrow().id.unwrap();
                                 let buf_val = JsValue::Object(JsObject { id: ab_id });
-                                let result = interp.create_typed_array_object_with_proto(new_ta, buf_val, proto);
-                                let id = result.borrow().id.unwrap();
+                                let id = interp.create_typed_array_object_with_proto(new_ta, buf_val, proto);
                                 return Completion::Normal(JsValue::Object(JsObject { id }));
                             }
                             Completion::Throw(interp.create_type_error("invalid argument"))
@@ -4658,8 +4653,7 @@ impl Interpreter {
         self.gc_track_external_bytes(buf_byte_len);
         let ab_id = ab_obj.borrow().id.unwrap();
         let buf_val = JsValue::Object(JsObject { id: ab_id });
-        let result = self.create_typed_array_object_with_proto(ta_info, buf_val, type_proto_id);
-        let id = result.borrow().id.unwrap();
+        let id = self.create_typed_array_object_with_proto(ta_info, buf_val, type_proto_id);
         Completion::Normal(JsValue::Object(JsObject { id }))
     }
 
@@ -4667,9 +4661,10 @@ impl Interpreter {
         &mut self,
         info: TypedArrayInfo,
         buf_val: JsValue,
-    ) -> Rc<RefCell<JsObjectData>> {
+    ) -> u64 {
         let proto = self.get_typed_array_prototype(info.kind);
         let obj = self.create_object();
+        let obj_id = obj.borrow().id.unwrap();
         {
             let mut o = obj.borrow_mut();
             o.class_name = info.kind.name().to_string();
@@ -4679,7 +4674,7 @@ impl Interpreter {
             }
             o.typed_array_info = Some(info);
         }
-        obj
+        obj_id
     }
 
     pub(crate) fn create_typed_array_object_with_proto(
@@ -4687,8 +4682,9 @@ impl Interpreter {
         info: TypedArrayInfo,
         buf_val: JsValue,
         proto_id: u64,
-    ) -> Rc<RefCell<JsObjectData>> {
+    ) -> u64 {
         let obj = self.create_object();
+        let obj_id = obj.borrow().id.unwrap();
         {
             let mut o = obj.borrow_mut();
             o.class_name = info.kind.name().to_string();
@@ -4698,7 +4694,7 @@ impl Interpreter {
             }
             o.typed_array_info = Some(info);
         }
-        obj
+        obj_id
     }
 
     fn get_typed_array_prototype(&self, kind: TypedArrayKind) -> Option<u64> {
@@ -6586,8 +6582,7 @@ fn create_uint8array_from_bytes(interp: &mut Interpreter, bytes: &[u8]) -> Compl
     let buf_val = JsValue::Object(JsObject { id: ab_id });
 
     let proto_id = interp.realm().uint8array_prototype.unwrap();
-    let result = interp.create_typed_array_object_with_proto(ta_info, buf_val, proto_id);
-    let id = result.borrow().id.unwrap();
+    let id = interp.create_typed_array_object_with_proto(ta_info, buf_val, proto_id);
     Completion::Normal(JsValue::Object(JsObject { id }))
 }
 

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -3626,7 +3626,7 @@ impl Interpreter {
         ];
 
         // %TypedArray% constructor (not directly constructible, but holds from/of)
-        let ta_proto = self.get_object_expect(self.realm().typed_array_prototype.unwrap());
+        let ta_proto_id = self.realm().typed_array_prototype.unwrap();
         let ta_ctor = self.create_function(JsFunction::constructor(
             "TypedArray".to_string(),
             0,
@@ -3922,11 +3922,10 @@ impl Interpreter {
         if let JsValue::Object(o) = &ta_ctor
             && let Some(obj) = self.get_object(o.id)
         {
-            let proto_id = ta_proto.borrow().id.unwrap();
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(
-                    JsValue::Object(JsObject { id: proto_id }),
+                    JsValue::Object(JsObject { id: ta_proto_id }),
                     false,
                     false,
                     false,
@@ -3935,10 +3934,12 @@ impl Interpreter {
         }
 
         // Set %TypedArray.prototype%.constructor → %TypedArray%
-        ta_proto.borrow_mut().insert_property(
-            "constructor".to_string(),
-            PropertyDescriptor::data(ta_ctor.clone(), true, false, true),
-        );
+        self.get_object_cell_expect(ta_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "constructor".to_string(),
+                PropertyDescriptor::data(ta_ctor.clone(), true, false, true),
+            );
 
         // Add @@species getter on %TypedArray%
         let species_getter = self.create_function(JsFunction::native(
@@ -3967,7 +3968,7 @@ impl Interpreter {
         for kind in kinds {
             let name = kind.name().to_string();
             let bpe = kind.bytes_per_element();
-            let ta_proto_clone_id = ta_proto.borrow().id.unwrap();
+            let ta_proto_clone_id = ta_proto_id;
             let ta_ctor_clone = ta_ctor.clone();
 
             // Create per-type prototype
@@ -4322,7 +4323,7 @@ impl Interpreter {
     fn setup_uint8array_base64_hex(&mut self) {
         // Get Uint8Array constructor from global env
         let uint8_ctor = self.get_global_var("Uint8Array").unwrap();
-        let uint8_proto = self.get_object_expect(self.realm().uint8array_prototype.unwrap());
+        let uint8_proto_id = self.realm().uint8array_prototype.unwrap();
 
         // --- Static methods on Uint8Array constructor ---
 
@@ -4405,7 +4406,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        uint8_proto
+        self.get_object_cell_expect(uint8_proto_id)
             .borrow_mut()
             .insert_builtin("toHex".to_string(), to_hex_fn);
 
@@ -4437,7 +4438,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::String(JsString::from_str(&result)))
             },
         ));
-        uint8_proto
+        self.get_object_cell_expect(uint8_proto_id)
             .borrow_mut()
             .insert_builtin("toBase64".to_string(), to_base64_fn);
 
@@ -4476,7 +4477,7 @@ impl Interpreter {
                 make_read_written_result(interp, result.read, written)
             },
         ));
-        uint8_proto
+        self.get_object_cell_expect(uint8_proto_id)
             .borrow_mut()
             .insert_builtin("setFromHex".to_string(), set_from_hex_fn);
 
@@ -4525,7 +4526,7 @@ impl Interpreter {
                 make_read_written_result(interp, result.read, written)
             },
         ));
-        uint8_proto
+        self.get_object_cell_expect(uint8_proto_id)
             .borrow_mut()
             .insert_builtin("setFromBase64".to_string(), set_from_base64_fn);
     }

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -33,8 +33,9 @@ fn eval_with_mode(source: &str, bytecode: bool) -> (JsValue, usize) {
     let mut interp = Interpreter::new();
     interp.bytecode_enabled = bytecode;
     let _ = interp.run(&program);
-    let env = interp.realm().global_env.clone();
-    let v = env.borrow().get("__r").unwrap_or(JsValue::Undefined);
+    let v = interp
+        .get_global_var_ref("__r")
+        .unwrap_or(JsValue::Undefined);
     (v, interp.bytecode_chunks_executed)
 }
 

--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -33,7 +33,7 @@ impl Interpreter {
         }
         let gid = env.global_object_id?;
         drop(env);
-        self.get_object(gid)
+        self.get_object_cell(gid)
             .and_then(|go| go.borrow().own_property_lookup(name))
     }
 
@@ -103,7 +103,7 @@ impl Interpreter {
                     if let Some(gid) = mirror_gid {
                         // Borrow on `current` is dropped above; safe to call
                         // out to the slab (re-entrant set traps OK).
-                        if let Some(go) = self.get_object(gid) {
+                        if let Some(go) = self.get_object_cell(gid) {
                             let ok = go.borrow_mut().set_property_value(name, value.clone());
                             if !ok {
                                 if strict {
@@ -171,7 +171,7 @@ impl Interpreter {
             }
             if let Some(gid) = e.global_object_id {
                 drop(e);
-                if let Some(go) = self.get_object(gid)
+                if let Some(go) = self.get_object_cell(gid)
                     && let Some(v) = go.borrow().own_property_lookup(name)
                 {
                     return Some(v);
@@ -196,7 +196,7 @@ impl Interpreter {
             }
             if let Some(gid) = e.global_object_id {
                 drop(e);
-                if let Some(go) = self.get_object(gid) {
+                if let Some(go) = self.get_object_cell(gid) {
                     return go.borrow().own_has_property(name).unwrap_or(false);
                 }
                 return false;
@@ -212,7 +212,7 @@ impl Interpreter {
     pub(crate) fn env_declare_global_var(&mut self, env: &EnvRef, name: &str) {
         let gid = env.borrow().global_object_id;
         if let Some(gid) = gid {
-            if let Some(go) = self.get_object(gid) {
+            if let Some(go) = self.get_object_cell(gid) {
                 let mut g = go.borrow_mut();
                 if !g.properties.contains_key(name) {
                     g.property_order.push(name.to_string());
@@ -239,7 +239,7 @@ impl Interpreter {
                     env.borrow_mut().declare(name, BindingKind::Var);
                 }
             }
-            if let Some(go) = self.get_object(gid) {
+            if let Some(go) = self.get_object_cell(gid) {
                 let mut g = go.borrow_mut();
                 if !g.properties.contains_key(name) {
                     g.property_order.push(name.to_string());
@@ -282,7 +282,7 @@ impl Interpreter {
                 }
                 if let Some(gid) = e.global_object_id {
                     drop(e);
-                    if let Some(go) = self.get_object(gid)
+                    if let Some(go) = self.get_object_cell(gid)
                         && matches!(go.borrow().own_has_property(name), Some(true))
                     {
                         return SetBindingCheck::Ok;
@@ -310,7 +310,7 @@ impl Interpreter {
             .declare_global_function_binding(name, value.clone(), configurable);
         let gid = env.borrow().global_object_id;
         if let Some(gid) = gid
-            && let Some(go) = self.get_object(gid)
+            && let Some(go) = self.get_object_cell(gid)
         {
             let mut g = go.borrow_mut();
             let existing = g.properties.get(name);

--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -254,6 +254,50 @@ impl Interpreter {
         }
     }
 
+    /// Walk the scope chain and check what error (if any) setting a binding
+    /// would produce. Mirrors the static `Environment::check_set_binding` but
+    /// reads the global object via the slab.
+    pub(crate) fn env_check_set_binding(&self, env: &EnvRef, name: &str) -> SetBindingCheck {
+        let mut current = env.clone();
+        loop {
+            let next = {
+                let e = current.borrow();
+                if e.is_indirect_binding(name) {
+                    return SetBindingCheck::ConstAssign;
+                }
+                if let Some(binding) = e.bindings.get(name) {
+                    if !binding.initialized && binding.kind != BindingKind::Var {
+                        return SetBindingCheck::TdzError;
+                    }
+                    if binding.kind == BindingKind::Const && binding.initialized {
+                        return SetBindingCheck::ConstAssign;
+                    }
+                    if (binding.kind == BindingKind::FunctionName
+                        || binding.kind == BindingKind::ImmutableValue)
+                        && binding.initialized
+                    {
+                        return SetBindingCheck::FunctionNameAssign;
+                    }
+                    return SetBindingCheck::Ok;
+                }
+                if let Some(gid) = e.global_object_id {
+                    drop(e);
+                    if let Some(go) = self.get_object(gid)
+                        && matches!(go.borrow().own_has_property(name), Some(true))
+                    {
+                        return SetBindingCheck::Ok;
+                    }
+                    return SetBindingCheck::Unresolvable;
+                }
+                e.parent.clone()
+            };
+            match next {
+                Some(parent) => current = parent,
+                None => return SetBindingCheck::Unresolvable,
+            }
+        }
+    }
+
     /// CreateGlobalFunctionBinding (eval-declared functions).
     pub(crate) fn env_declare_global_function_binding(
         &mut self,

--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -127,10 +127,10 @@ impl Interpreter {
                 }
                 EnvSetAction::ImplicitGlobal { gid } => {
                     let already_on_global = self
-                        .get_object(gid)
+                        .get_object_cell(gid)
                         .is_some_and(|go| go.borrow().has_own_property(name));
                     let ok = self
-                        .get_object(gid)
+                        .get_object_cell(gid)
                         .is_some_and(|go| go.borrow_mut().set_property_value(name, value.clone()));
                     if !ok {
                         return Ok(());
@@ -233,7 +233,7 @@ impl Interpreter {
         if let Some(gid) = gid {
             if !env.borrow().bindings.contains_key(name) {
                 let has_global_prop = self
-                    .get_object(gid)
+                    .get_object_cell(gid)
                     .is_some_and(|g| g.borrow().properties.contains_key(name));
                 if !has_global_prop {
                     env.borrow_mut().declare(name, BindingKind::Var);

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -983,11 +983,11 @@ impl Interpreter {
                         return Completion::Normal(cached.clone());
                     }
                 }
-                let meta = self.create_object();
-                meta.borrow_mut().prototype_id = None;
+                let meta_id = self.create_object_id();
+                self.get_object_cell_expect(meta_id).borrow_mut().prototype_id = None;
                 if let Some(ref path) = module_path {
                     let url = format!("file://{}", path.display());
-                    meta.borrow_mut().insert_property(
+                    self.get_object_cell_expect(meta_id).borrow_mut().insert_property(
                         "url".to_string(),
                         PropertyDescriptor::data(
                             JsValue::String(JsString::from_str(&url)),
@@ -997,7 +997,7 @@ impl Interpreter {
                         ),
                     );
                 }
-                let id = meta.borrow().id.unwrap();
+                let id = meta_id;
                 let meta_val = JsValue::Object(crate::types::JsObject { id });
                 if let Some(ref path) = module_path {
                     let canon = path.canonicalize().unwrap_or_else(|_| path.clone());
@@ -4843,17 +4843,17 @@ impl Interpreter {
         for prop in props {
             // Handle rest: {...rest} = obj
             if let Expression::Spread(inner) = &prop.value {
-                let rest_obj = self.create_object();
+                let rest_obj_id = self.create_object_id();
                 if let JsValue::Object(o) = &obj_val {
                     let pairs = match self.copy_data_properties(o.id, &obj_val, &excluded_keys) {
                         Ok(p) => p,
                         Err(e) => return Completion::Throw(e),
                     };
                     for (k, v) in pairs {
-                        rest_obj.borrow_mut().insert_value(k, v);
+                        self.get_object_cell_expect(rest_obj_id).borrow_mut().insert_value(k, v);
                     }
                 }
-                let rest_id = rest_obj.borrow().id.unwrap();
+                let rest_id = rest_obj_id;
                 let rest_val = JsValue::Object(crate::types::JsObject { id: rest_id });
                 match self.put_value_to_target(inner, rest_val, env) {
                     Completion::Normal(_) | Completion::Empty => {}
@@ -12113,13 +12113,13 @@ impl Interpreter {
                                 }
                             }
                             // §14.5.10 step 2: OrdinaryCreateFromConstructor AFTER decl inst
-                            let gen_obj = self.create_object();
+                            let gen_obj_id = self.create_object_id();
                             let mut proto_set = false;
                             if let Some(func_obj_rc) = self.get_object(o.id) {
                                 let proto_val =
                                     func_obj_rc.borrow().get_property_value("prototype");
                                 if let Some(JsValue::Object(ref p)) = proto_val {
-                                    gen_obj.borrow_mut().prototype_id = Some(p.id);
+                                    self.get_object_cell_expect(gen_obj_id).borrow_mut().prototype_id = Some(p.id);
                                     proto_set = true;
                                 }
                             }
@@ -12129,9 +12129,9 @@ impl Interpreter {
                                     Err(e) => return Completion::Throw(e),
                                 };
                                 let agp_id = self.realms[fn_realm_id].async_generator_prototype;
-                                gen_obj.borrow_mut().prototype_id = agp_id;
+                                self.get_object_cell_expect(gen_obj_id).borrow_mut().prototype_id = agp_id;
                             }
-                            gen_obj.borrow_mut().class_name = "AsyncGenerator".to_string();
+                            self.get_object_cell_expect(gen_obj_id).borrow_mut().class_name = "AsyncGenerator".to_string();
                             let is_simple =
                                 params.iter().all(|p| matches!(p, Pattern::Identifier(_)));
                             let exec_env = if !is_simple {
@@ -12185,7 +12185,7 @@ impl Interpreter {
                                     exec_env.borrow_mut().declare(&lv.name, bk);
                                 }
                             }
-                            gen_obj.borrow_mut().iterator_state =
+                            self.get_object_cell_expect(gen_obj_id).borrow_mut().iterator_state =
                                 Some(IteratorState::StateMachineAsyncGenerator {
                                     state_machine,
                                     func_env: exec_env,
@@ -12198,7 +12198,7 @@ impl Interpreter {
                                     pending_exception: None,
                                     pending_return: None,
                                 });
-                            let gen_id = gen_obj.borrow().id.unwrap();
+                            let gen_id = gen_obj_id;
                             if let Some(obj_rc) = self.get_object(gen_id) {
                                 obj_rc.borrow_mut().generator_realm_id =
                                     Some(self.current_realm_id);
@@ -12305,13 +12305,13 @@ impl Interpreter {
                                 }
                             }
                             // §14.4.10 step 2: OrdinaryCreateFromConstructor AFTER decl inst
-                            let gen_obj = self.create_object();
+                            let gen_obj_id = self.create_object_id();
                             let mut proto_set = false;
                             if let Some(func_obj_rc) = self.get_object(o.id) {
                                 let proto_val =
                                     func_obj_rc.borrow().get_property_value("prototype");
                                 if let Some(JsValue::Object(ref p)) = proto_val {
-                                    gen_obj.borrow_mut().prototype_id = Some(p.id);
+                                    self.get_object_cell_expect(gen_obj_id).borrow_mut().prototype_id = Some(p.id);
                                     proto_set = true;
                                 }
                             }
@@ -12321,9 +12321,9 @@ impl Interpreter {
                                     Err(e) => return Completion::Throw(e),
                                 };
                                 let gp_id = self.realms[fn_realm_id].generator_prototype;
-                                gen_obj.borrow_mut().prototype_id = gp_id;
+                                self.get_object_cell_expect(gen_obj_id).borrow_mut().prototype_id = gp_id;
                             }
-                            gen_obj.borrow_mut().class_name = "Generator".to_string();
+                            self.get_object_cell_expect(gen_obj_id).borrow_mut().class_name = "Generator".to_string();
                             let is_simple =
                                 params.iter().all(|p| matches!(p, Pattern::Identifier(_)));
                             let exec_env = if !is_simple {
@@ -12377,7 +12377,7 @@ impl Interpreter {
                                     exec_env.borrow_mut().declare(&lv.name, bk);
                                 }
                             }
-                            gen_obj.borrow_mut().iterator_state =
+                            self.get_object_cell_expect(gen_obj_id).borrow_mut().iterator_state =
                                 Some(IteratorState::StateMachineGenerator {
                                     state_machine,
                                     func_env: exec_env,
@@ -12390,7 +12390,7 @@ impl Interpreter {
                                     pending_exception: None,
                                     pending_return: None,
                                 });
-                            let gen_id = gen_obj.borrow().id.unwrap();
+                            let gen_id = gen_obj_id;
                             if let Some(obj_rc) = self.get_object(gen_id) {
                                 obj_rc.borrow_mut().generator_realm_id =
                                     Some(self.current_realm_id);
@@ -13673,13 +13673,13 @@ impl Interpreter {
             }
         } else {
             // Base constructor: create this object as before
-            let new_obj = self.create_object();
+            let new_obj_id = self.create_object_id();
             if let JsValue::Object(o) = &callee_val
                 && let Some(func_obj) = self.get_object(o.id)
             {
                 let proto = func_obj.borrow().get_property_value("prototype");
                 if let Some(JsValue::Object(proto_obj)) = proto {
-                    new_obj.borrow_mut().prototype_id = Some(proto_obj.id);
+                    self.get_object_cell_expect(new_obj_id).borrow_mut().prototype_id = Some(proto_obj.id);
                 }
             }
             let instance_field_defs = if let JsValue::Object(o) = &callee_val
@@ -13689,7 +13689,7 @@ impl Interpreter {
             } else {
                 Vec::new()
             };
-            let new_obj_id = new_obj.borrow().id.unwrap();
+            let new_obj_id = new_obj_id;
             let this_val = JsValue::Object(crate::types::JsObject { id: new_obj_id });
             // Use constructor's closure (class_env) so the class name binding
             // is accessible in field initializers (spec §15.7.14 step 28.e.i).
@@ -14003,7 +14003,7 @@ impl Interpreter {
             let (this_val, new_obj_id) = if deferred {
                 (JsValue::Undefined, 0)
             } else {
-                let new_obj = self.create_object();
+                let new_obj_id = self.create_object_id();
                 // Use new_target's .prototype for the new object's [[Prototype]]
                 // Must use get_object_property to invoke proxy get traps
                 if let JsValue::Object(nt_o) = &new_target {
@@ -14014,7 +14014,7 @@ impl Interpreter {
                         _ => JsValue::Undefined,
                     };
                     if let JsValue::Object(proto_obj) = proto {
-                        new_obj.borrow_mut().prototype_id = Some(proto_obj.id);
+                        self.get_object_cell_expect(new_obj_id).borrow_mut().prototype_id = Some(proto_obj.id);
                     } else {
                         // proto is not an Object: GetFunctionRealm(newTarget) → realm's %ObjectPrototype%
                         let nt_realm_id =
@@ -14024,11 +14024,11 @@ impl Interpreter {
                             };
                         let op_id = self.realms[nt_realm_id].object_prototype;
                         if let Some(proto_rc) = op_id {
-                            new_obj.borrow_mut().prototype_id = Some(proto_rc);
+                            self.get_object_cell_expect(new_obj_id).borrow_mut().prototype_id = Some(proto_rc);
                         }
                     }
                 }
-                let id = new_obj.borrow().id.unwrap();
+                let id = new_obj_id;
                 (JsValue::Object(crate::types::JsObject { id }), id)
             };
 

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -984,18 +984,22 @@ impl Interpreter {
                     }
                 }
                 let meta_id = self.create_object_id();
-                self.get_object_cell_expect(meta_id).borrow_mut().prototype_id = None;
+                self.get_object_cell_expect(meta_id)
+                    .borrow_mut()
+                    .prototype_id = None;
                 if let Some(ref path) = module_path {
                     let url = format!("file://{}", path.display());
-                    self.get_object_cell_expect(meta_id).borrow_mut().insert_property(
-                        "url".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(&url)),
-                            true,
-                            true,
-                            true,
-                        ),
-                    );
+                    self.get_object_cell_expect(meta_id)
+                        .borrow_mut()
+                        .insert_property(
+                            "url".to_string(),
+                            PropertyDescriptor::data(
+                                JsValue::String(JsString::from_str(&url)),
+                                true,
+                                true,
+                                true,
+                            ),
+                        );
                 }
                 let id = meta_id;
                 let meta_val = JsValue::Object(crate::types::JsObject { id });
@@ -4850,7 +4854,9 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     for (k, v) in pairs {
-                        self.get_object_cell_expect(rest_obj_id).borrow_mut().insert_value(k, v);
+                        self.get_object_cell_expect(rest_obj_id)
+                            .borrow_mut()
+                            .insert_value(k, v);
                     }
                 }
                 let rest_id = rest_obj_id;
@@ -12119,7 +12125,9 @@ impl Interpreter {
                                 let proto_val =
                                     func_obj_rc.borrow().get_property_value("prototype");
                                 if let Some(JsValue::Object(ref p)) = proto_val {
-                                    self.get_object_cell_expect(gen_obj_id).borrow_mut().prototype_id = Some(p.id);
+                                    self.get_object_cell_expect(gen_obj_id)
+                                        .borrow_mut()
+                                        .prototype_id = Some(p.id);
                                     proto_set = true;
                                 }
                             }
@@ -12129,9 +12137,13 @@ impl Interpreter {
                                     Err(e) => return Completion::Throw(e),
                                 };
                                 let agp_id = self.realms[fn_realm_id].async_generator_prototype;
-                                self.get_object_cell_expect(gen_obj_id).borrow_mut().prototype_id = agp_id;
+                                self.get_object_cell_expect(gen_obj_id)
+                                    .borrow_mut()
+                                    .prototype_id = agp_id;
                             }
-                            self.get_object_cell_expect(gen_obj_id).borrow_mut().class_name = "AsyncGenerator".to_string();
+                            self.get_object_cell_expect(gen_obj_id)
+                                .borrow_mut()
+                                .class_name = "AsyncGenerator".to_string();
                             let is_simple =
                                 params.iter().all(|p| matches!(p, Pattern::Identifier(_)));
                             let exec_env = if !is_simple {
@@ -12185,19 +12197,20 @@ impl Interpreter {
                                     exec_env.borrow_mut().declare(&lv.name, bk);
                                 }
                             }
-                            self.get_object_cell_expect(gen_obj_id).borrow_mut().iterator_state =
-                                Some(IteratorState::StateMachineAsyncGenerator {
-                                    state_machine,
-                                    func_env: exec_env,
-                                    is_strict,
-                                    execution_state: StateMachineExecutionState::SuspendedStart,
-                                    _sent_value: JsValue::Undefined,
-                                    try_stack: vec![],
-                                    pending_binding: None,
-                                    delegated_iterator: None,
-                                    pending_exception: None,
-                                    pending_return: None,
-                                });
+                            self.get_object_cell_expect(gen_obj_id)
+                                .borrow_mut()
+                                .iterator_state = Some(IteratorState::StateMachineAsyncGenerator {
+                                state_machine,
+                                func_env: exec_env,
+                                is_strict,
+                                execution_state: StateMachineExecutionState::SuspendedStart,
+                                _sent_value: JsValue::Undefined,
+                                try_stack: vec![],
+                                pending_binding: None,
+                                delegated_iterator: None,
+                                pending_exception: None,
+                                pending_return: None,
+                            });
                             let gen_id = gen_obj_id;
                             if let Some(obj_rc) = self.get_object(gen_id) {
                                 obj_rc.borrow_mut().generator_realm_id =
@@ -12311,7 +12324,9 @@ impl Interpreter {
                                 let proto_val =
                                     func_obj_rc.borrow().get_property_value("prototype");
                                 if let Some(JsValue::Object(ref p)) = proto_val {
-                                    self.get_object_cell_expect(gen_obj_id).borrow_mut().prototype_id = Some(p.id);
+                                    self.get_object_cell_expect(gen_obj_id)
+                                        .borrow_mut()
+                                        .prototype_id = Some(p.id);
                                     proto_set = true;
                                 }
                             }
@@ -12321,9 +12336,13 @@ impl Interpreter {
                                     Err(e) => return Completion::Throw(e),
                                 };
                                 let gp_id = self.realms[fn_realm_id].generator_prototype;
-                                self.get_object_cell_expect(gen_obj_id).borrow_mut().prototype_id = gp_id;
+                                self.get_object_cell_expect(gen_obj_id)
+                                    .borrow_mut()
+                                    .prototype_id = gp_id;
                             }
-                            self.get_object_cell_expect(gen_obj_id).borrow_mut().class_name = "Generator".to_string();
+                            self.get_object_cell_expect(gen_obj_id)
+                                .borrow_mut()
+                                .class_name = "Generator".to_string();
                             let is_simple =
                                 params.iter().all(|p| matches!(p, Pattern::Identifier(_)));
                             let exec_env = if !is_simple {
@@ -12377,19 +12396,20 @@ impl Interpreter {
                                     exec_env.borrow_mut().declare(&lv.name, bk);
                                 }
                             }
-                            self.get_object_cell_expect(gen_obj_id).borrow_mut().iterator_state =
-                                Some(IteratorState::StateMachineGenerator {
-                                    state_machine,
-                                    func_env: exec_env,
-                                    is_strict,
-                                    execution_state: StateMachineExecutionState::SuspendedStart,
-                                    _sent_value: JsValue::Undefined,
-                                    try_stack: vec![],
-                                    pending_binding: None,
-                                    delegated_iterator: None,
-                                    pending_exception: None,
-                                    pending_return: None,
-                                });
+                            self.get_object_cell_expect(gen_obj_id)
+                                .borrow_mut()
+                                .iterator_state = Some(IteratorState::StateMachineGenerator {
+                                state_machine,
+                                func_env: exec_env,
+                                is_strict,
+                                execution_state: StateMachineExecutionState::SuspendedStart,
+                                _sent_value: JsValue::Undefined,
+                                try_stack: vec![],
+                                pending_binding: None,
+                                delegated_iterator: None,
+                                pending_exception: None,
+                                pending_return: None,
+                            });
                             let gen_id = gen_obj_id;
                             if let Some(obj_rc) = self.get_object(gen_id) {
                                 obj_rc.borrow_mut().generator_realm_id =
@@ -13679,7 +13699,9 @@ impl Interpreter {
             {
                 let proto = func_obj.borrow().get_property_value("prototype");
                 if let Some(JsValue::Object(proto_obj)) = proto {
-                    self.get_object_cell_expect(new_obj_id).borrow_mut().prototype_id = Some(proto_obj.id);
+                    self.get_object_cell_expect(new_obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(proto_obj.id);
                 }
             }
             let instance_field_defs = if let JsValue::Object(o) = &callee_val
@@ -14014,7 +14036,9 @@ impl Interpreter {
                         _ => JsValue::Undefined,
                     };
                     if let JsValue::Object(proto_obj) = proto {
-                        self.get_object_cell_expect(new_obj_id).borrow_mut().prototype_id = Some(proto_obj.id);
+                        self.get_object_cell_expect(new_obj_id)
+                            .borrow_mut()
+                            .prototype_id = Some(proto_obj.id);
                     } else {
                         // proto is not an Object: GetFunctionRealm(newTarget) → realm's %ObjectPrototype%
                         let nt_realm_id =
@@ -14024,7 +14048,9 @@ impl Interpreter {
                             };
                         let op_id = self.realms[nt_realm_id].object_prototype;
                         if let Some(proto_rc) = op_id {
-                            self.get_object_cell_expect(new_obj_id).borrow_mut().prototype_id = Some(proto_rc);
+                            self.get_object_cell_expect(new_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(proto_rc);
                         }
                     }
                 }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -115,7 +115,7 @@ impl Interpreter {
             return Ok(());
         };
         let instance_field_defs = if let JsValue::Object(ref o) = new_target_val
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj.borrow().class_instance_field_defs.clone()
         } else {
@@ -130,7 +130,7 @@ impl Interpreter {
         // Use the class constructor's closure (class_env) so the class name binding
         // is accessible in field initializers (spec §15.7.14 step 28.e.i).
         let (ctor_closure, class_pn) = if let JsValue::Object(ref o) = new_target_val
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             if let Some(JsFunction::User { ref closure, .. }) = func_obj.borrow().callable {
                 let cls_env = closure.borrow();
@@ -174,7 +174,7 @@ impl Interpreter {
         for idef in &instance_field_defs {
             match idef {
                 InstanceFieldDef::Private(PrivateFieldDef::Method { name, value }) => {
-                    if let Some(obj) = self.get_object(this_obj_id) {
+                    if let Some(obj) = self.get_object_cell(this_obj_id) {
                         if !obj.borrow().extensible {
                             return Err(self.create_type_error(
                                 "Cannot define private method on non-extensible object",
@@ -191,7 +191,7 @@ impl Interpreter {
                     }
                 }
                 InstanceFieldDef::Private(PrivateFieldDef::Accessor { name, get, set }) => {
-                    if let Some(obj) = self.get_object(this_obj_id) {
+                    if let Some(obj) = self.get_object_cell(this_obj_id) {
                         if !obj.borrow().extensible {
                             return Err(self.create_type_error(
                                 "Cannot define private accessor on non-extensible object",
@@ -233,7 +233,7 @@ impl Interpreter {
                     } else {
                         JsValue::Undefined
                     };
-                    if let Some(obj) = self.get_object(this_obj_id) {
+                    if let Some(obj) = self.get_object_cell(this_obj_id) {
                         if !obj.borrow().extensible {
                             return Err(self.create_type_error(
                                 "Cannot define private field on non-extensible object",
@@ -278,7 +278,7 @@ impl Interpreter {
                     } else {
                         JsValue::Undefined
                     };
-                    if let Some(obj) = self.get_object(this_obj_id) {
+                    if let Some(obj) = self.get_object_cell(this_obj_id) {
                         obj.borrow_mut()
                             .private_fields
                             .insert(slot_name.clone(), PrivateElement::Field(val));
@@ -341,7 +341,7 @@ impl Interpreter {
                     };
                     return match &rval {
                             JsValue::Object(o) => {
-                                if let Some(obj) = self.get_object(o.id) {
+                                if let Some(obj) = self.get_object_cell(o.id) {
                                     Completion::Normal(JsValue::Boolean(
                                         obj.borrow().private_fields.contains_key(&branded),
                                     ))
@@ -625,7 +625,7 @@ impl Interpreter {
                             _ => return Completion::Normal(JsValue::Boolean(true)),
                         }
                     };
-                    if let Some(obj) = self.get_object(obj_ref.id) {
+                    if let Some(obj) = self.get_object_cell(obj_ref.id) {
                         // Proxy deleteProperty trap
                         if obj.borrow().is_proxy() || obj.borrow().proxy_revoked {
                             match self.proxy_delete_property(obj_ref.id, &key) {
@@ -781,7 +781,7 @@ impl Interpreter {
                     // At global level — check global object property descriptor
                     let global_id = self.realm().global_env.borrow().global_object_id;
                     if let Some(gid) = global_id
-                        && let Some(global) = self.get_object(gid)
+                        && let Some(global) = self.get_object_cell(gid)
                     {
                         let gb = global.borrow();
                         if let Some(desc) = gb.properties.get(name) {
@@ -1484,7 +1484,7 @@ impl Interpreter {
                 if !matches!(exotic_to_prim, JsValue::Undefined | JsValue::Null) {
                     if let JsValue::Object(fo) = &exotic_to_prim
                         && self
-                            .get_object(fo.id)
+                            .get_object_cell(fo.id)
                             .map(|o| o.borrow().callable.is_some())
                             .unwrap_or(false)
                     {
@@ -1521,7 +1521,7 @@ impl Interpreter {
                     };
                     if let JsValue::Object(fo) = &method_val
                         && self
-                            .get_object(fo.id)
+                            .get_object_cell(fo.id)
                             .map(|o| o.borrow().callable.is_some())
                             .unwrap_or(false)
                     {
@@ -2632,7 +2632,7 @@ impl Interpreter {
                     let branded = self.resolve_private_name(name, env);
                     return match &obj_val {
                         JsValue::Object(o) => {
-                            if let Some(obj) = self.get_object(o.id) {
+                            if let Some(obj) = self.get_object_cell(o.id) {
                                 let elem = obj.borrow().private_fields.get(&branded).cloned();
                                 match elem {
                                     Some(PrivateElement::Field(_)) => {
@@ -3394,7 +3394,7 @@ impl Interpreter {
                                         "Cannot assign to read only property 'length'",
                                     ));
                                 }
-                                let obj_rc = self.get_object(o.id).unwrap();
+                                let obj_rc = self.get_object_cell(o.id).unwrap();
                                 let len_val = obj_rc
                                     .borrow()
                                     .properties
@@ -3455,7 +3455,7 @@ impl Interpreter {
                         };
                     }
                     // Check for proxy in prototype chain
-                    if let Some(obj) = self.get_object(o.id) {
+                    if let Some(obj) = self.get_object_cell(o.id) {
                         let mut proto_opt = obj.borrow().prototype_id;
                         while let Some(proto_rc) = proto_opt {
                             let proto_id = proto_rc;
@@ -3613,7 +3613,7 @@ impl Interpreter {
                 };
                 let lval = match &obj_val {
                     JsValue::Object(o) => {
-                        if let Some(obj) = self.get_object(o.id) {
+                        if let Some(obj) = self.get_object_cell(o.id) {
                             let elem = obj.borrow().private_fields.get(&branded).cloned();
                             match elem {
                                 Some(PrivateElement::Field(v)) => v,
@@ -3659,7 +3659,7 @@ impl Interpreter {
                 };
                 match &obj_val {
                     JsValue::Object(o) => {
-                        if let Some(obj) = self.get_object(o.id) {
+                        if let Some(obj) = self.get_object_cell(o.id) {
                             let elem = obj.borrow().private_fields.get(&branded).cloned();
                             match elem {
                                 Some(PrivateElement::Field(_)) => {
@@ -3822,7 +3822,7 @@ impl Interpreter {
                 };
                 // Write back (boxed_obj is already the ToObject result)
                 if let JsValue::Object(ref o) = boxed_obj
-                    && let Some(obj) = self.get_object(o.id)
+                    && let Some(obj) = self.get_object_cell(o.id)
                 {
                     if obj.borrow().is_proxy() || obj.borrow().proxy_revoked {
                         let receiver = boxed_obj.clone();
@@ -3902,7 +3902,7 @@ impl Interpreter {
                                         "Cannot assign to read only property 'length'",
                                     ));
                                 }
-                                let obj_rc = self.get_object(o.id).unwrap();
+                                let obj_rc = self.get_object_cell(o.id).unwrap();
                                 let len_val = obj_rc
                                     .borrow()
                                     .properties
@@ -4274,7 +4274,7 @@ impl Interpreter {
         let branded = self.resolve_private_name(name, env);
         match obj_val {
             JsValue::Object(o) => {
-                if let Some(obj) = self.get_object(o.id) {
+                if let Some(obj) = self.get_object_cell(o.id) {
                     let elem = obj.borrow().private_fields.get(&branded).cloned();
                     match elem {
                         Some(PrivateElement::Field(_)) => {
@@ -5003,7 +5003,7 @@ impl Interpreter {
             // §13.3.7.2 GetSuperConstructor: dynamically resolve via activeFunction.__proto__
             let super_ctor = if let Some(ctor_func) = env.borrow().get("__constructor_func__") {
                 if let JsValue::Object(o) = &ctor_func {
-                    if let Some(obj_rc) = self.get_object(o.id) {
+                    if let Some(obj_rc) = self.get_object_cell(o.id) {
                         if let Some(proto) = &obj_rc.borrow().prototype_id {
                             if let Some(id) = Some(*proto) {
                                 JsValue::Object(crate::types::JsObject { id })
@@ -5084,7 +5084,7 @@ impl Interpreter {
                     MemberProperty::Private(name) => {
                         let branded = self.resolve_private_name(name, env);
                         if let JsValue::Object(ref o) = obj_val
-                            && let Some(obj) = self.get_object(o.id)
+                            && let Some(obj) = self.get_object_cell(o.id)
                         {
                             let elem = obj.borrow().private_fields.get(&branded).cloned();
                             let func_val = match elem {
@@ -5152,7 +5152,7 @@ impl Interpreter {
                     let home = env.borrow().get("__home_object__");
                     if let Some(JsValue::Object(ref ho)) = home {
                         let proto_id = self
-                            .get_object(ho.id)
+                            .get_object_cell(ho.id)
                             .and_then(|ho_obj| ho_obj.borrow().prototype_id.as_ref().copied());
                         if let Some(pid) = proto_id {
                             let method = self.get_property_on_id(pid, &key);
@@ -7819,7 +7819,7 @@ impl Interpreter {
         };
 
         // Check generator state before mutating the queue
-        let is_executing = if let Some(obj_rc) = self.get_object(gen_id) {
+        let is_executing = if let Some(obj_rc) = self.get_object_cell(gen_id) {
             matches!(
                 obj_rc.borrow().iterator_state,
                 Some(IteratorState::StateMachineAsyncGenerator {
@@ -8270,7 +8270,7 @@ impl Interpreter {
                             ));
                         }
                         Some(PromiseState::Pending) => {
-                            if let Some(obj) = self.get_object(unwrap_id) {
+                            if let Some(obj) = self.get_object_cell(unwrap_id) {
                                 let mut ob = obj.borrow_mut();
                                 if let Some(ref mut pd) = ob.promise_data {
                                     pd.is_handled = true;
@@ -9939,7 +9939,7 @@ impl Interpreter {
                                 ));
                             }
                             Some(PromiseState::Pending) => {
-                                if let Some(obj) = self.get_object(wrapped_id) {
+                                if let Some(obj) = self.get_object_cell(wrapped_id) {
                                     let mut ob = obj.borrow_mut();
                                     if let Some(ref mut pd) = ob.promise_data {
                                         pd.is_handled = true;
@@ -10056,7 +10056,7 @@ impl Interpreter {
                             },
                         ));
 
-                        if let Some(obj) = self.get_object(wrapped_id) {
+                        if let Some(obj) = self.get_object_cell(wrapped_id) {
                             let mut ob = obj.borrow_mut();
                             if let Some(ref mut pd) = ob.promise_data {
                                 pd.is_handled = true;
@@ -11218,7 +11218,7 @@ impl Interpreter {
         reject_fn: &JsValue,
         gen_id: u64,
     ) {
-        let Some(obj_rc) = self.get_object(gen_id) else {
+        let Some(obj_rc) = self.get_object_cell(gen_id) else {
             return;
         };
 
@@ -11234,7 +11234,7 @@ impl Interpreter {
 
         if is_reject {
             // Set pending_exception so the executor routes through try_stack
-            if let Some(obj) = self.get_object(gen_id) {
+            if let Some(obj) = self.get_object_cell(gen_id) {
                 let mut o = obj.borrow_mut();
                 if let Some(IteratorState::StateMachineAsyncGenerator {
                     ref mut pending_exception,
@@ -11913,7 +11913,7 @@ impl Interpreter {
         skip_entry_checks: bool,
     ) -> Completion {
         if let JsValue::Object(o) = func_val
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             // Single borrow to check proxy/wrapped/class-ctor status. Skipped
             // when an IC hit already validated the callable category — see
@@ -12121,7 +12121,7 @@ impl Interpreter {
                             // §14.5.10 step 2: OrdinaryCreateFromConstructor AFTER decl inst
                             let gen_obj_id = self.create_object_id();
                             let mut proto_set = false;
-                            if let Some(func_obj_rc) = self.get_object(o.id) {
+                            if let Some(func_obj_rc) = self.get_object_cell(o.id) {
                                 let proto_val =
                                     func_obj_rc.borrow().get_property_value("prototype");
                                 if let Some(JsValue::Object(ref p)) = proto_val {
@@ -12212,7 +12212,7 @@ impl Interpreter {
                                 pending_return: None,
                             });
                             let gen_id = gen_obj_id;
-                            if let Some(obj_rc) = self.get_object(gen_id) {
+                            if let Some(obj_rc) = self.get_object_cell(gen_id) {
                                 obj_rc.borrow_mut().generator_realm_id =
                                     Some(self.current_realm_id);
                             }
@@ -12320,7 +12320,7 @@ impl Interpreter {
                             // §14.4.10 step 2: OrdinaryCreateFromConstructor AFTER decl inst
                             let gen_obj_id = self.create_object_id();
                             let mut proto_set = false;
-                            if let Some(func_obj_rc) = self.get_object(o.id) {
+                            if let Some(func_obj_rc) = self.get_object_cell(o.id) {
                                 let proto_val =
                                     func_obj_rc.borrow().get_property_value("prototype");
                                 if let Some(JsValue::Object(ref p)) = proto_val {
@@ -12411,7 +12411,7 @@ impl Interpreter {
                                 pending_return: None,
                             });
                             let gen_id = gen_obj_id;
-                            if let Some(obj_rc) = self.get_object(gen_id) {
+                            if let Some(obj_rc) = self.get_object_cell(gen_id) {
                                 obj_rc.borrow_mut().generator_realm_id =
                                     Some(self.current_realm_id);
                             }
@@ -12614,7 +12614,7 @@ impl Interpreter {
                 format!("\"{}\" is not a function", preview)
             }
             JsValue::Object(o) => {
-                if let Some(obj) = self.get_object(o.id) {
+                if let Some(obj) = self.get_object_cell(o.id) {
                     let class = obj.borrow().class_name.clone();
                     let has_callable = obj.borrow().callable.is_some();
                     let keys: Vec<String> = obj
@@ -13224,7 +13224,7 @@ impl Interpreter {
                     .cloned()
                     .collect();
                 let global_id = var_env.borrow().global_object_id;
-                let global_obj = global_id.and_then(|id| self.get_object(id));
+                let global_obj = global_id.and_then(|id| self.get_object_cell(id));
                 let env_b = var_env.borrow();
                 for name in &all_names {
                     if let Some(binding) = env_b.bindings.get(name)
@@ -13525,7 +13525,7 @@ impl Interpreter {
         // Check if callee is a constructor
         if let JsValue::Object(ref co) = callee_val {
             let is_proxy = self.get_proxy_info(co.id).is_some();
-            if !is_proxy && let Some(func_obj) = self.get_object(co.id) {
+            if !is_proxy && let Some(func_obj) = self.get_object_cell(co.id) {
                 let b = func_obj.borrow();
                 let is_ctor = match &b.callable {
                     Some(JsFunction::User {
@@ -13591,7 +13591,7 @@ impl Interpreter {
         }
         // Bound functions: delegate to construct_with_new_target which handles new_target resolution
         if let JsValue::Object(ref co) = callee_val
-            && let Some(func_obj) = self.get_object(co.id)
+            && let Some(func_obj) = self.get_object_cell(co.id)
             && func_obj.borrow().bound_target_function.is_some()
         {
             self.gc_unroot_frame(gc_frame);
@@ -13603,7 +13603,7 @@ impl Interpreter {
         }
         // Check if this is a derived class constructor
         let is_derived = if let JsValue::Object(o) = &callee_val
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj.borrow().is_derived_class_constructor
         } else {
@@ -13614,7 +13614,7 @@ impl Interpreter {
         // invoking Symbol.iterator on the rest parameter (spec §15.7.14).
         if is_derived {
             let is_default_derived = if let JsValue::Object(o) = &callee_val
-                && let Some(func_obj) = self.get_object(o.id)
+                && let Some(func_obj) = self.get_object_cell(o.id)
             {
                 func_obj.borrow().is_default_derived_constructor
             } else {
@@ -13623,7 +13623,7 @@ impl Interpreter {
             if is_default_derived {
                 // Use dynamic [[Prototype]] lookup so setPrototypeOf takes effect
                 let super_ctor = if let JsValue::Object(o) = &callee_val
-                    && let Some(func_obj) = self.get_object(o.id)
+                    && let Some(func_obj) = self.get_object_cell(o.id)
                 {
                     if let Some(id) = func_obj.borrow().prototype_id {
                         JsValue::Object(crate::types::JsObject { id })
@@ -13695,7 +13695,7 @@ impl Interpreter {
             // Base constructor: create this object as before
             let new_obj_id = self.create_object_id();
             if let JsValue::Object(o) = &callee_val
-                && let Some(func_obj) = self.get_object(o.id)
+                && let Some(func_obj) = self.get_object_cell(o.id)
             {
                 let proto = func_obj.borrow().get_property_value("prototype");
                 if let Some(JsValue::Object(proto_obj)) = proto {
@@ -13705,7 +13705,7 @@ impl Interpreter {
                 }
             }
             let instance_field_defs = if let JsValue::Object(o) = &callee_val
-                && let Some(func_obj) = self.get_object(o.id)
+                && let Some(func_obj) = self.get_object_cell(o.id)
             {
                 func_obj.borrow().class_instance_field_defs.clone()
             } else {
@@ -13715,7 +13715,7 @@ impl Interpreter {
             // Use constructor's closure (class_env) so the class name binding
             // is accessible in field initializers (spec §15.7.14 step 28.e.i).
             let init_parent = if let JsValue::Object(o) = &callee_val
-                && let Some(func_obj) = self.get_object(o.id)
+                && let Some(func_obj) = self.get_object_cell(o.id)
                 && let Some(JsFunction::User { ref closure, .. }) = func_obj.borrow().callable
             {
                 closure.clone()
@@ -13729,7 +13729,7 @@ impl Interpreter {
                 .initialize_binding("this", this_val.clone());
             init_env.borrow_mut().is_field_initializer = true;
             if let JsValue::Object(o) = &callee_val
-                && let Some(func_obj) = self.get_object(o.id)
+                && let Some(func_obj) = self.get_object_cell(o.id)
             {
                 if let Some(JsFunction::User { ref closure, .. }) = func_obj.borrow().callable {
                     let cls_env = closure.borrow();
@@ -13756,7 +13756,7 @@ impl Interpreter {
             for idef in &instance_field_defs {
                 match idef {
                     InstanceFieldDef::Private(PrivateFieldDef::Method { name, value }) => {
-                        if let Some(obj) = self.get_object(new_obj_id) {
+                        if let Some(obj) = self.get_object_cell(new_obj_id) {
                             if !obj.borrow().extensible {
                                 return Completion::Throw(self.create_type_error(
                                     "Cannot define private method on non-extensible object",
@@ -13773,7 +13773,7 @@ impl Interpreter {
                         }
                     }
                     InstanceFieldDef::Private(PrivateFieldDef::Accessor { name, get, set }) => {
-                        if let Some(obj) = self.get_object(new_obj_id) {
+                        if let Some(obj) = self.get_object_cell(new_obj_id) {
                             if !obj.borrow().extensible {
                                 return Completion::Throw(self.create_type_error(
                                     "Cannot define private accessor on non-extensible object",
@@ -13815,7 +13815,7 @@ impl Interpreter {
                         } else {
                             JsValue::Undefined
                         };
-                        if let Some(obj) = self.get_object(new_obj_id) {
+                        if let Some(obj) = self.get_object_cell(new_obj_id) {
                             if !obj.borrow().extensible {
                                 return Completion::Throw(self.create_type_error(
                                     "Cannot define private field on non-extensible object",
@@ -13861,7 +13861,7 @@ impl Interpreter {
                         } else {
                             JsValue::Undefined
                         };
-                        if let Some(obj) = self.get_object(new_obj_id) {
+                        if let Some(obj) = self.get_object_cell(new_obj_id) {
                             obj.borrow_mut()
                                 .private_fields
                                 .insert(slot_name.clone(), PrivateElement::Field(val));
@@ -13935,7 +13935,7 @@ impl Interpreter {
         }
 
         // Bound function [[Construct]]: resolve newTarget through bound chain
-        if let Some(func_obj) = self.get_object(co.id) {
+        if let Some(func_obj) = self.get_object_cell(co.id) {
             let b = func_obj.borrow();
             if let Some(target) = b.bound_target_function.clone() {
                 let ba = b.bound_args.clone().unwrap_or_default();
@@ -13952,7 +13952,7 @@ impl Interpreter {
         }
 
         // Check is_constructor
-        if let Some(func_obj) = self.get_object(co.id) {
+        if let Some(func_obj) = self.get_object_cell(co.id) {
             let b = func_obj.borrow();
             let is_ctor = match &b.callable {
                 Some(JsFunction::User {
@@ -13970,7 +13970,7 @@ impl Interpreter {
             }
         }
 
-        let is_derived = if let Some(func_obj) = self.get_object(co.id) {
+        let is_derived = if let Some(func_obj) = self.get_object_cell(co.id) {
             func_obj.borrow().is_derived_class_constructor
         } else {
             false
@@ -14015,7 +14015,7 @@ impl Interpreter {
             // Constructors with deferred_construct skip the early prototype access
             // to let their body run pre-construction checks first (e.g., Promise checks
             // executor callable before OrdinaryCreateFromConstructor).
-            let deferred = if let Some(func_obj) = self.get_object(co.id) {
+            let deferred = if let Some(func_obj) = self.get_object_cell(co.id) {
                 func_obj.borrow().deferred_construct
             } else {
                 false
@@ -14059,7 +14059,7 @@ impl Interpreter {
 
             // Initialize instance fields from the constructor's class_instance_field_defs.
             let instance_field_defs = if let JsValue::Object(co) = constructor
-                && let Some(func_obj) = self.get_object(co.id)
+                && let Some(func_obj) = self.get_object_cell(co.id)
             {
                 func_obj.borrow().class_instance_field_defs.clone()
             } else {
@@ -14067,7 +14067,7 @@ impl Interpreter {
             };
             if !instance_field_defs.is_empty() {
                 let (class_pn, proto_val, outer_env) = if let JsValue::Object(co) = constructor
-                    && let Some(func_obj) = self.get_object(co.id)
+                    && let Some(func_obj) = self.get_object_cell(co.id)
                 {
                     let (pn, oe) = if let Some(JsFunction::User { ref closure, .. }) =
                         func_obj.borrow().callable
@@ -14107,14 +14107,14 @@ impl Interpreter {
                 for idef in &instance_field_defs {
                     match idef {
                         InstanceFieldDef::Private(PrivateFieldDef::Method { name, value }) => {
-                            if let Some(obj) = self.get_object(new_obj_id) {
+                            if let Some(obj) = self.get_object_cell(new_obj_id) {
                                 obj.borrow_mut()
                                     .private_fields
                                     .insert(name.clone(), PrivateElement::Method(value.clone()));
                             }
                         }
                         InstanceFieldDef::Private(PrivateFieldDef::Accessor { name, get, set }) => {
-                            if let Some(obj) = self.get_object(new_obj_id) {
+                            if let Some(obj) = self.get_object_cell(new_obj_id) {
                                 obj.borrow_mut().private_fields.insert(
                                     name.clone(),
                                     PrivateElement::Accessor {
@@ -14146,7 +14146,7 @@ impl Interpreter {
                             } else {
                                 JsValue::Undefined
                             };
-                            if let Some(obj) = self.get_object(new_obj_id) {
+                            if let Some(obj) = self.get_object_cell(new_obj_id) {
                                 obj.borrow_mut()
                                     .private_fields
                                     .insert(name.clone(), PrivateElement::Field(val));
@@ -14166,7 +14166,7 @@ impl Interpreter {
                             } else {
                                 JsValue::Undefined
                             };
-                            if let Some(obj) = self.get_object(new_obj_id) {
+                            if let Some(obj) = self.get_object_cell(new_obj_id) {
                                 obj.borrow_mut().insert_value(key.clone(), val);
                             }
                         }
@@ -14179,7 +14179,7 @@ impl Interpreter {
                             } else {
                                 JsValue::Undefined
                             };
-                            if let Some(obj) = self.get_object(new_obj_id) {
+                            if let Some(obj) = self.get_object_cell(new_obj_id) {
                                 obj.borrow_mut()
                                     .private_fields
                                     .insert(slot_name.clone(), PrivateElement::Field(val));
@@ -14224,7 +14224,7 @@ impl Interpreter {
         if let Some(ref nt) = self.new_target.clone()
             && let JsValue::Object(nt_o) = nt
         {
-            let nt_proto_id = if let Some(nt_obj) = self.get_object(nt_o.id) {
+            let nt_proto_id = if let Some(nt_obj) = self.get_object_cell(nt_o.id) {
                 nt_obj.borrow().id
             } else {
                 None
@@ -14241,7 +14241,7 @@ impl Interpreter {
                     _ => return,
                 };
                 if let JsValue::Object(po) = proto_val
-                    && let Some(obj_rc) = self.get_object(obj_id)
+                    && let Some(obj_rc) = self.get_object_cell(obj_id)
                 {
                     obj_rc.borrow_mut().prototype_id = Some(po.id);
                 } else {
@@ -14253,7 +14253,7 @@ impl Interpreter {
                     };
                     let fallback_id = realm_fallback(&self.realms[nt_realm_id]);
                     if let Some(proto_rc) = fallback_id
-                        && let Some(obj_rc) = self.get_object(obj_id)
+                        && let Some(obj_rc) = self.get_object_cell(obj_id)
                     {
                         obj_rc.borrow_mut().prototype_id = Some(proto_rc);
                     }
@@ -14263,7 +14263,7 @@ impl Interpreter {
     }
 
     pub(crate) fn get_proxy_info(&self, obj_id: u64) -> Option<(bool, Option<u64>, Option<u64>)> {
-        if let Some(obj) = self.get_object(obj_id) {
+        if let Some(obj) = self.get_object_cell(obj_id) {
             let b = obj.borrow();
             if b.is_proxy() || b.proxy_revoked {
                 let target_id = b.proxy_target_id;
@@ -14317,7 +14317,7 @@ impl Interpreter {
     }
 
     pub(crate) fn get_proxy_target_val(&self, proxy_id: u64) -> JsValue {
-        if let Some(obj) = self.get_object(proxy_id)
+        if let Some(obj) = self.get_object_cell(proxy_id)
             && let Some(tid) = obj.borrow().proxy_target_id
         {
             return JsValue::Object(crate::types::JsObject { id: tid });
@@ -14357,7 +14357,7 @@ impl Interpreter {
         };
 
         if let JsValue::Object(t) = target_val
-            && let Some(tobj) = self.get_object(t.id)
+            && let Some(tobj) = self.get_object_cell(t.id)
         {
             let target_extensible = tobj.borrow().extensible;
             let (target_nonconfig, target_config): (Vec<String>, Vec<String>) = {
@@ -14476,7 +14476,7 @@ impl Interpreter {
         let JsValue::Object(lhs) = obj else {
             return Completion::Normal(JsValue::Boolean(false));
         };
-        let Some(_inst_obj) = self.get_object(lhs.id) else {
+        let Some(_inst_obj) = self.get_object_cell(lhs.id) else {
             return Completion::Normal(JsValue::Boolean(false));
         };
         let ctor_obj_ref = match ctor {
@@ -14533,7 +14533,7 @@ impl Interpreter {
                     (true, None)
                 } else if let Some(gid) = e.global_object_id {
                     let own = self
-                        .get_object(gid)
+                        .get_object_cell(gid)
                         .is_some_and(|g| g.borrow().properties.contains_key(name));
                     (own, if !own { Some(gid) } else { None })
                 } else {
@@ -14767,7 +14767,7 @@ impl Interpreter {
                 {
                     // Check own property first
                     let own_prop = self
-                        .get_object(gid)
+                        .get_object_cell(gid)
                         .and_then(|o| o.borrow().get_own_property(name));
                     if let Some(ref desc) = own_prop {
                         if desc.get.is_some() {
@@ -14819,7 +14819,7 @@ impl Interpreter {
                 drop(env_borrow);
                 // Check own property first (fast path)
                 let own_prop = self
-                    .get_object(gid)
+                    .get_object_cell(gid)
                     .and_then(|o| o.borrow().get_own_property(name));
                 if let Some(ref desc) = own_prop {
                     if desc.get.is_some() {
@@ -15038,7 +15038,7 @@ impl Interpreter {
             if let JsValue::Object(recv_o) = receiver {
                 let recv_id = recv_o.id;
                 let is_proxy_recv = self
-                    .get_object(recv_id)
+                    .get_object_cell(recv_id)
                     .is_some_and(|o| o.borrow().is_proxy() || o.borrow().proxy_revoked);
                 if is_proxy_recv {
                     let existing = self.proxy_get_own_property_descriptor(recv_id, key)?;
@@ -15078,7 +15078,7 @@ impl Interpreter {
                         return self.proxy_define_own_property(recv_id, key.to_string(), &desc_val);
                     }
                 }
-                if let Some(recv_obj) = self.get_object(recv_id) {
+                if let Some(recv_obj) = self.get_object_cell(recv_id) {
                     return Ok(recv_obj.borrow_mut().set_property_value(key, value));
                 }
             }
@@ -15094,7 +15094,7 @@ impl Interpreter {
             if self.get_proxy_info(id).is_some() {
                 return true;
             }
-            let Some(obj) = self.get_object(id) else {
+            let Some(obj) = self.get_object_cell(id) else {
                 return false;
             };
             let b = obj.borrow();
@@ -15121,7 +15121,7 @@ impl Interpreter {
                     let trap_result = self.to_boolean_val(&v);
                     if trap_result
                         && let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object(t.id)
+                        && let Some(tobj) = self.get_object_cell(t.id)
                     {
                         let target_desc = tobj.borrow().get_own_property(key);
                         if let Some(ref desc) = target_desc {
@@ -15147,7 +15147,7 @@ impl Interpreter {
                 }
                 Err(e) => Err(e),
             }
-        } else if let Some(obj) = self.get_object(obj_id) {
+        } else if let Some(obj) = self.get_object_cell(obj_id) {
             // String exotic [[Delete]]: "length" and valid indices are non-configurable
             {
                 let borrow = obj.borrow();
@@ -15262,7 +15262,7 @@ impl Interpreter {
         use crate::interpreter::types::{canonical_numeric_index_string, is_valid_integer_index};
 
         let (is_ta, is_bigint) = {
-            if let Some(obj) = self.get_object(obj_id) {
+            if let Some(obj) = self.get_object_cell(obj_id) {
                 let b = obj.borrow();
                 if let Some(ref ta) = b.typed_array_info {
                     (true, ta.kind.is_bigint())
@@ -15285,7 +15285,7 @@ impl Interpreter {
 
         // §10.4.5.6 step 3b.i: if not a valid integer index, return false
         {
-            let valid = if let Some(obj) = self.get_object(obj_id) {
+            let valid = if let Some(obj) = self.get_object_cell(obj_id) {
                 let b = obj.borrow();
                 b.typed_array_info
                     .as_ref()
@@ -15325,7 +15325,7 @@ impl Interpreter {
                 JsValue::Number(self.to_number_value(value)?)
             };
             // After conversion, re-read ta info (buffer may have been detached during conversion)
-            if let Some(obj) = self.get_object(obj_id) {
+            if let Some(obj) = self.get_object_cell(obj_id) {
                 let b = obj.borrow();
                 if let Some(ref ta) = b.typed_array_info
                     && is_valid_integer_index(ta, index)
@@ -15365,7 +15365,7 @@ impl Interpreter {
                         return Ok(false);
                     }
                     if let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object(t.id)
+                        && let Some(tobj) = self.get_object_cell(t.id)
                     {
                         let target_desc = tobj.borrow().get_own_property(&key);
                         let target_extensible = tobj.borrow().extensible;
@@ -15424,7 +15424,7 @@ impl Interpreter {
                 }
                 Err(e) => Err(e),
             }
-        } else if let Some(obj) = self.get_object(obj_id) {
+        } else if let Some(obj) = self.get_object_cell(obj_id) {
             // Deferred namespace: trigger evaluation on [[DefineOwnProperty]] with non-symbol-like key
             {
                 let is_deferred_ns = obj
@@ -15476,7 +15476,7 @@ impl Interpreter {
                         ));
                     }
                     if let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object(t.id)
+                        && let Some(tobj) = self.get_object_cell(t.id)
                     {
                         let target_desc = tobj.borrow().get_own_property(key);
                         let target_extensible = tobj.borrow().extensible;
@@ -15703,7 +15703,7 @@ impl Interpreter {
                 }
                 Err(e) => Err(e),
             }
-        } else if let Some(obj) = self.get_object(obj_id) {
+        } else if let Some(obj) = self.get_object_cell(obj_id) {
             // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
             {
                 let is_deferred_ns = obj
@@ -15882,7 +15882,7 @@ impl Interpreter {
                 }
                 Err(e) => Err(e),
             }
-        } else if let Some(obj) = self.get_object(obj_id) {
+        } else if let Some(obj) = self.get_object_cell(obj_id) {
             if let Some(id) = obj.borrow().prototype_id {
                 Ok(JsValue::Object(crate::types::JsObject { id }))
             } else {
@@ -15943,7 +15943,7 @@ impl Interpreter {
                 }
                 Err(e) => Err(e),
             }
-        } else if let Some(obj) = self.get_object(obj_id) {
+        } else if let Some(obj) = self.get_object_cell(obj_id) {
             // OrdinarySetPrototypeOf
             let current_proto_id = obj.borrow().prototype_id;
             let new_proto_id = if let JsValue::Object(p) = proto {
@@ -15967,7 +15967,7 @@ impl Interpreter {
                         return Ok(false);
                     }
                     check_id = self
-                        .get_object(cid)
+                        .get_object_cell(cid)
                         .and_then(|o| o.borrow().prototype_id.as_ref().copied());
                 }
             }
@@ -15976,7 +15976,7 @@ impl Interpreter {
                     obj.borrow_mut().prototype_id = None;
                 }
                 JsValue::Object(p) => {
-                    if let Some(po) = self.get_object(p.id) {
+                    if let Some(po) = self.get_object_cell(p.id) {
                         obj.borrow_mut().prototype_id = Some(po.borrow().id.unwrap());
                     }
                 }
@@ -15996,7 +15996,7 @@ impl Interpreter {
                 Ok(Some(v)) => {
                     let trap_result = self.to_boolean_val(&v);
                     if let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object(t.id)
+                        && let Some(tobj) = self.get_object_cell(t.id)
                     {
                         let target_extensible = tobj.borrow().extensible;
                         if trap_result != target_extensible {
@@ -16015,7 +16015,7 @@ impl Interpreter {
                 }
                 Err(e) => Err(e),
             }
-        } else if let Some(obj) = self.get_object(obj_id) {
+        } else if let Some(obj) = self.get_object_cell(obj_id) {
             Ok(obj.borrow().extensible)
         } else {
             Ok(false)
@@ -16031,7 +16031,7 @@ impl Interpreter {
                     let trap_result = self.to_boolean_val(&v);
                     if trap_result
                         && let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object(t.id)
+                        && let Some(tobj) = self.get_object_cell(t.id)
                         && tobj.borrow().extensible
                     {
                         return Err(self.create_type_error(
@@ -16048,7 +16048,7 @@ impl Interpreter {
                 }
                 Err(e) => Err(e),
             }
-        } else if let Some(obj) = self.get_object(obj_id) {
+        } else if let Some(obj) = self.get_object_cell(obj_id) {
             obj.borrow_mut().extensible = false;
             Ok(true)
         } else {
@@ -16062,7 +16062,7 @@ impl Interpreter {
     fn get_super_base_id(&self, env: &EnvRef) -> Option<u64> {
         let home = env.borrow().get("__home_object__");
         if let Some(JsValue::Object(ref ho)) = home
-            && let Some(home_obj) = self.get_object(ho.id)
+            && let Some(home_obj) = self.get_object_cell(ho.id)
         {
             return home_obj.borrow().prototype_id;
         }
@@ -16105,7 +16105,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 }
             }
-            if let Some(obj) = self.get_object(id) {
+            if let Some(obj) = self.get_object_cell(id) {
                 desc = obj.borrow().get_own_property_full(key);
                 if desc.is_some() {
                     break;
@@ -16146,7 +16146,7 @@ impl Interpreter {
             _ => {
                 // §10.1.9.2 OrdinarySetWithOwnDescriptor: set on Receiver
                 if let JsValue::Object(o) = receiver
-                    && let Some(obj) = self.get_object(o.id)
+                    && let Some(obj) = self.get_object_cell(o.id)
                 {
                     let existing = obj.borrow().get_own_property_full(key);
                     match &existing {
@@ -17296,7 +17296,7 @@ impl Interpreter {
                     },
                 ));
 
-                if let Some(obj) = self.get_object(promise_id) {
+                if let Some(obj) = self.get_object_cell(promise_id) {
                     let mut ob = obj.borrow_mut();
                     if let Some(ref mut pd) = ob.promise_data {
                         pd.is_handled = true;
@@ -17325,7 +17325,7 @@ impl Interpreter {
         if let JsValue::Object(o) = obj_val {
             let mut current_id = Some(o.id);
             while let Some(id) = current_id {
-                if let Some(obj) = self.get_object(id) {
+                if let Some(obj) = self.get_object_cell(id) {
                     let b = obj.borrow();
                     if let Some(desc) = b.properties.get(key) {
                         if let Some(ref getter) = desc.get {
@@ -17428,7 +17428,7 @@ impl Interpreter {
                     },
                 ));
 
-                if let Some(obj) = self.get_object(promise_id) {
+                if let Some(obj) = self.get_object_cell(promise_id) {
                     let mut o = obj.borrow_mut();
                     if let Some(ref mut pd) = o.promise_data {
                         pd.is_handled = true;

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -429,7 +429,6 @@ impl Interpreter {
                         with_object: None,
                         dispose_stack: None,
                         global_object_id: None,
-                        global_object_rc: None,
                         annexb_function_names: None,
                         class_private_names: None,
                         is_field_initializer: false,
@@ -466,7 +465,7 @@ impl Interpreter {
                 };
                 let func_val = self.create_function(func);
                 if let Some(name) = &f.name {
-                    let _ = closure_env.borrow_mut().set(name, func_val.clone());
+                    let _ = self.env_set(&closure_env, name, func_val.clone());
                 }
                 Completion::Normal(func_val)
             }
@@ -530,14 +529,14 @@ impl Interpreter {
                             other => other,
                         };
                     }
-                    match env.borrow().get(name) {
+                    match self.env_get(env, name) {
                         Some(val) => {
                             return Completion::Normal(JsValue::String(JsString::from_str(
                                 typeof_val(&val, &self.objects),
                             )));
                         }
                         None => {
-                            if env.borrow().has(name) {
+                            if self.env_has(env, name) {
                                 return Completion::Throw(self.create_reference_error(&format!(
                                     "Cannot access '{name}' before initialization"
                                 )));
@@ -2362,7 +2361,7 @@ impl Interpreter {
                     };
                     let new_val = JsValue::Number(new_num);
                     drop(env_borrow);
-                    if let Err(e) = env.borrow_mut().set(name, new_val) {
+                    if let Err(e) = self.env_set(env, name, new_val) {
                         return Completion::Throw(e);
                     }
                     return Completion::Normal(JsValue::Number(if prefix {
@@ -2397,7 +2396,7 @@ impl Interpreter {
                             other => return other,
                         }
                     } else {
-                        match env.borrow().get(name) {
+                        match self.env_get(env, name) {
                             Some(v) => v,
                             None => {
                                 let err =
@@ -2831,7 +2830,7 @@ impl Interpreter {
                                 Completion::Normal(v) => v,
                                 other => return other,
                             };
-                            match env.borrow_mut().set(name, rval.clone()) {
+                            match self.env_set(env, name, rval.clone()) {
                                 Ok(()) => return Completion::Normal(rval),
                                 Err(e) => return Completion::Throw(e),
                             }
@@ -2879,7 +2878,7 @@ impl Interpreter {
                             })
                     };
                     if has_mutable_local {
-                        let lval = match env.borrow().get(name) {
+                        let lval = match self.env_get(env, name) {
                             Some(v) => v,
                             None => {
                                 return Completion::Throw(
@@ -2895,7 +2894,7 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        match env.borrow_mut().set(name, final_val.clone()) {
+                        match self.env_set(env, name, final_val.clone()) {
                             Ok(()) => return Completion::Normal(final_val),
                             Err(e) => return Completion::Throw(e),
                         }
@@ -2926,7 +2925,7 @@ impl Interpreter {
                                 other => return other,
                             }
                         } else {
-                            match env.borrow().get(name) {
+                            match self.env_get(env, name) {
                                 Some(v) => v,
                                 None => {
                                     return Completion::Throw(self.create_reference_error(
@@ -3574,7 +3573,7 @@ impl Interpreter {
                                 other => return other,
                             }
                         } else {
-                            match env.borrow().get(name) {
+                            match self.env_get(env, name) {
                                 Some(v) => v,
                                 None => {
                                     return Completion::Throw(self.create_reference_error(
@@ -3949,7 +3948,7 @@ impl Interpreter {
                                     other => return other,
                                 }
                             } else {
-                                match env.borrow().get(name) {
+                                match self.env_get(env, name) {
                                     Some(v) => v,
                                     None => {
                                         return Completion::Throw(self.create_reference_error(
@@ -6478,7 +6477,7 @@ impl Interpreter {
                             if let Some(binding) = sent_value_binding {
                                 match &binding.kind {
                                     SentValueBindingKind::Variable(name) => {
-                                        func_env.borrow_mut().set(name, value.clone()).ok();
+                                        self.env_set(&func_env, name, value.clone()).ok();
                                     }
                                     SentValueBindingKind::Pattern(pattern) => {
                                         let _ = self.bind_pattern(
@@ -7592,7 +7591,7 @@ impl Interpreter {
                             if let Some(ref bind) = binding {
                                 match &bind.kind {
                                     SentValueBindingKind::Variable(name) => {
-                                        func_env.borrow_mut().set(name, result_value.clone()).ok();
+                                        self.env_set(&func_env, name, result_value.clone()).ok();
                                     }
                                     SentValueBindingKind::Pattern(pattern) => {
                                         let _ = self.bind_pattern(
@@ -8084,7 +8083,7 @@ impl Interpreter {
             if let Some(ref binding) = pending_binding {
                 match &binding.kind {
                     SentValueBindingKind::Variable(name) => {
-                        func_env.borrow_mut().set(name, value.clone()).ok();
+                        self.env_set(&func_env, name, value.clone()).ok();
                     }
                     SentValueBindingKind::Pattern(pattern) => {
                         let _ =
@@ -8936,7 +8935,7 @@ impl Interpreter {
                                 use crate::interpreter::generator_transform::SentValueBindingKind;
                                 match &bind.kind {
                                     SentValueBindingKind::Variable(name) => {
-                                        func_env.borrow_mut().set(name, value.clone()).ok();
+                                        self.env_set(&func_env, name, value.clone()).ok();
                                     }
                                     SentValueBindingKind::Pattern(pattern) => {
                                         let _ = self.bind_pattern(
@@ -11196,7 +11195,7 @@ impl Interpreter {
         use crate::interpreter::generator_transform::SentValueBindingKind;
         match &binding.kind {
             SentValueBindingKind::Variable(name) => {
-                env.borrow_mut().set(name, value.clone()).ok();
+                self.env_set(env, name, value.clone()).ok();
             }
             SentValueBindingKind::Pattern(pattern) => {
                 let _ = self.bind_pattern(pattern, value.clone(), BindingKind::Var, env);
@@ -12081,7 +12080,7 @@ impl Interpreter {
                                     &param_names_ag,
                                 );
                                 func_env.borrow_mut().declare("arguments", BindingKind::Var);
-                                let _ = func_env.borrow_mut().set("arguments", arguments_obj);
+                                let _ = self.env_set(&func_env, "arguments", arguments_obj);
                                 if is_strict || !is_simple_ag {
                                     func_env.borrow_mut().arguments_immutable = true;
                                 }
@@ -12155,7 +12154,7 @@ impl Interpreter {
                                             .borrow()
                                             .get(name)
                                             .unwrap_or(JsValue::Undefined);
-                                        let _ = body_env.borrow_mut().set(name, val);
+                                        let _ = self.env_set(&body_env, name, val);
                                     }
                                 }
                                 body_env
@@ -12273,7 +12272,7 @@ impl Interpreter {
                                     &param_names_g,
                                 );
                                 func_env.borrow_mut().declare("arguments", BindingKind::Var);
-                                let _ = func_env.borrow_mut().set("arguments", arguments_obj);
+                                let _ = self.env_set(&func_env, "arguments", arguments_obj);
                                 if is_strict || !is_simple_g {
                                     func_env.borrow_mut().arguments_immutable = true;
                                 }
@@ -12347,7 +12346,7 @@ impl Interpreter {
                                             .borrow()
                                             .get(name)
                                             .unwrap_or(JsValue::Undefined);
-                                        let _ = body_env.borrow_mut().set(name, val);
+                                        let _ = self.env_set(&body_env, name, val);
                                     }
                                 }
                                 body_env
@@ -12485,7 +12484,7 @@ impl Interpreter {
                                 );
                                 call_frame_args = arguments_obj.clone();
                                 func_env.borrow_mut().declare("arguments", BindingKind::Var);
-                                let _ = func_env.borrow_mut().set("arguments", arguments_obj);
+                                let _ = self.env_set(&func_env, "arguments", arguments_obj);
                                 if is_strict || !is_simple {
                                     func_env.borrow_mut().arguments_immutable = true;
                                 }
@@ -12541,8 +12540,8 @@ impl Interpreter {
                                 body_env.borrow_mut().declare(name, BindingKind::Var);
                                 if param_names.contains(name) || name == "arguments" {
                                     let val =
-                                        func_env.borrow().get(name).unwrap_or(JsValue::Undefined);
-                                    let _ = body_env.borrow_mut().set(name, val);
+                                        self.env_get(&func_env, name).unwrap_or(JsValue::Undefined);
+                                    let _ = self.env_set(&body_env, name, val);
                                 }
                             }
                             body_env
@@ -14553,15 +14552,13 @@ impl Interpreter {
     /// Sync a property set on an object to the corresponding global env binding,
     /// if the object is a realm's global object.
     fn sync_global_object_binding(&mut self, obj_id: u64, key: &str, value: &JsValue) {
-        for realm in &self.realms {
-            let is_global = realm.global_object == Some(obj_id);
-            if is_global {
-                let env = realm.global_env.clone();
-                if env.borrow().bindings.contains_key(key) {
-                    let _ = env.borrow_mut().set(key, value.clone());
-                }
-                return;
-            }
+        let env = self.realms.iter().find_map(|realm| {
+            (realm.global_object == Some(obj_id)).then(|| realm.global_env.clone())
+        });
+        if let Some(env) = env
+            && env.borrow().bindings.contains_key(key)
+        {
+            let _ = self.env_set(&env, key, value.clone());
         }
     }
 
@@ -14582,7 +14579,7 @@ impl Interpreter {
                 }
             }
             IdentifierRef::SpecificEnv(specific_env) => {
-                match Environment::check_set_binding(specific_env, name) {
+                match self.env_check_set_binding(specific_env, name) {
                     SetBindingCheck::TdzError => Completion::Throw(self.create_reference_error(
                         &format!("Cannot access '{}' before initialization", name),
                     )),
@@ -16254,7 +16251,7 @@ impl Interpreter {
                     &param_names,
                 );
                 func_env.borrow_mut().declare("arguments", BindingKind::Var);
-                let _ = func_env.borrow_mut().set("arguments", arguments_obj);
+                let _ = self.env_set(&func_env, "arguments", arguments_obj);
                 if is_strict || !is_simple {
                     func_env.borrow_mut().arguments_immutable = true;
                 }
@@ -16972,7 +16969,7 @@ impl Interpreter {
                     };
                     self.gc_root_value(&iterator);
                     self.pending_iter_close.push(iterator.clone());
-                    func_env.borrow_mut().set(iter_var, iterator).ok();
+                    self.env_set(&func_env, iter_var, iterator).ok();
                     for_of_stack.push((iter_var.clone(), head_state, forinit_after));
                     current_id = head_state;
                 }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1677,14 +1677,14 @@ impl Interpreter {
         }
         // B.3.6.2: IsHTMLDDA == null/undefined
         if let JsValue::Object(o) = left
-            && let Some(Some(obj)) = self.objects.get(o.id as usize)
+            && let Some(obj) = self.objects.get(o.id)
             && obj.borrow().is_htmldda
             && (right.is_null() || right.is_undefined())
         {
             return Ok(true);
         }
         if let JsValue::Object(o) = right
-            && let Some(Some(obj)) = self.objects.get(o.id as usize)
+            && let Some(obj) = self.objects.get(o.id)
             && obj.borrow().is_htmldda
             && (left.is_null() || left.is_undefined())
         {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2785,7 +2785,7 @@ impl Interpreter {
                                 }
                                 break;
                             }
-                            proto_opt = self.get_object_expect(proto_id).borrow().prototype_id;
+                            proto_opt = self.get_object_cell_expect(proto_id).borrow().prototype_id;
                         }
                     }
                     obj.borrow_mut().set_property_value(&key, value);
@@ -3303,8 +3303,7 @@ impl Interpreter {
                             let proto_id = proto_rc;
                             // TypedArray [[Set]] §10.4.5.5: canonical numeric index in TA prototype
                             {
-                                let proto_borrow = self.get_object_expect(proto_rc);
-                                let proto_borrow = proto_borrow.borrow();
+                                let proto_borrow = self.get_object_cell_expect(proto_rc).borrow();
                                 if let Some(ref ta) = proto_borrow.typed_array_info
                                     && let Some(index) = canonical_numeric_index_string(&key)
                                     && !is_valid_integer_index(ta, index)
@@ -3371,7 +3370,7 @@ impl Interpreter {
                                 }
                                 break;
                             }
-                            proto_opt = self.get_object_expect(proto_rc).borrow().prototype_id;
+                            proto_opt = self.get_object_cell_expect(proto_rc).borrow().prototype_id;
                         }
                     }
                     // ArraySetLength §10.4.2.4 via [[Set]]
@@ -3471,7 +3470,7 @@ impl Interpreter {
                                     Err(e) => return Completion::Throw(e),
                                 }
                             }
-                            proto_opt = self.get_object_expect(proto_rc).borrow().prototype_id;
+                            proto_opt = self.get_object_cell_expect(proto_rc).borrow().prototype_id;
                         }
                     }
                 }
@@ -4144,8 +4143,7 @@ impl Interpreter {
                     let proto_id = proto_rc;
                     // TypedArray [[Set]] §10.4.5.5: canonical numeric index in TA prototype
                     {
-                        let proto_borrow = self.get_object_expect(proto_rc);
-                        let proto_borrow = proto_borrow.borrow();
+                        let proto_borrow = self.get_object_cell_expect(proto_rc).borrow();
                         if let Some(ref ta) = proto_borrow.typed_array_info
                             && let Some(index) = canonical_numeric_index_string(key)
                             && !is_valid_integer_index(ta, index)
@@ -4204,7 +4202,7 @@ impl Interpreter {
                         }
                         break;
                     }
-                    proto_opt = self.get_object_expect(proto_rc).borrow().prototype_id;
+                    proto_opt = self.get_object_cell_expect(proto_rc).borrow().prototype_id;
                 }
             }
             let success = obj.borrow_mut().set_property_value(key, val);

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -13711,7 +13711,6 @@ impl Interpreter {
             } else {
                 Vec::new()
             };
-            let new_obj_id = new_obj_id;
             let this_val = JsValue::Object(crate::types::JsObject { id: new_obj_id });
             // Use constructor's closure (class_env) so the class name binding
             // is accessible in field initializers (spec §15.7.14 step 28.e.i).

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -43,7 +43,7 @@ impl Interpreter {
                         MemberProperty::Private(name) => {
                             let branded = self.resolve_private_name(name, env);
                             if let JsValue::Object(ref o) = this_val
-                                && let Some(obj) = self.get_object(o.id)
+                                && let Some(obj) = self.get_object_cell(o.id)
                             {
                                 let elem = obj.borrow().private_fields.get(&branded).cloned();
                                 match elem {
@@ -105,7 +105,7 @@ impl Interpreter {
                         MemberProperty::Private(name) => {
                             let branded = self.resolve_private_name(name, env);
                             if let JsValue::Object(ref o) = obj_val
-                                && let Some(obj) = self.get_object(o.id)
+                                && let Some(obj) = self.get_object_cell(o.id)
                             {
                                 let elem = obj.borrow().private_fields.get(&branded).cloned();
                                 match elem {
@@ -273,7 +273,7 @@ impl Interpreter {
                     MemberProperty::Private(name) => {
                         let branded = self.resolve_private_name(name, env);
                         if let JsValue::Object(o) = &inner_val
-                            && let Some(obj) = self.get_object(o.id)
+                            && let Some(obj) = self.get_object_cell(o.id)
                         {
                             let elem = obj.borrow().private_fields.get(&branded).cloned();
                             match elem {
@@ -450,7 +450,7 @@ impl Interpreter {
             obj_val.clone()
         };
         if let JsValue::Object(ref o) = obj_val
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             if obj.borrow().is_proxy() || obj.borrow().proxy_revoked {
                 match self.proxy_delete_property(o.id, key) {
@@ -577,7 +577,7 @@ impl Interpreter {
                 let branded = self.resolve_private_name(name, env);
                 return match &obj_val {
                     JsValue::Object(o) => {
-                        if let Some(obj_rc) = self.get_object(o.id) {
+                        if let Some(obj_rc) = self.get_object_cell(o.id) {
                             let elem = obj_rc.borrow().private_fields.get(&branded).cloned();
                             match elem {
                                 Some(PrivateElement::Field(v))
@@ -655,7 +655,7 @@ impl Interpreter {
             let branded = self.resolve_private_name(name, env);
             return match &obj_val {
                 JsValue::Object(o) => {
-                    if let Some(obj) = self.get_object(o.id) {
+                    if let Some(obj) = self.get_object_cell(o.id) {
                         let elem = obj.borrow().private_fields.get(&branded).cloned();
                         match elem {
                             Some(PrivateElement::Field(v)) | Some(PrivateElement::Method(v)) => {
@@ -702,7 +702,7 @@ impl Interpreter {
                 // Fast path: numeric index on typed array or array object
                 if let JsValue::Number(index) = &v
                     && let JsValue::Object(o) = &obj_val
-                    && let Some(obj_rc) = self.get_object(o.id)
+                    && let Some(obj_rc) = self.get_object_cell(o.id)
                 {
                     let obj_borrow = obj_rc.borrow();
                     // Typed array: direct element access

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -4,7 +4,7 @@ impl Interpreter {
     pub(super) fn get_template_object(&mut self, tmpl: &TemplateLiteral) -> JsValue {
         let cache_key = tmpl.id;
         if let Some(&obj_id) = self.realm().template_cache.get(&cache_key)
-            && self.get_object(obj_id).is_some()
+            && self.get_object_cell(obj_id).is_some()
         {
             return JsValue::Object(crate::types::JsObject { id: obj_id });
         }
@@ -27,7 +27,7 @@ impl Interpreter {
         let template_arr = self.create_frozen_template_array(cooked_vals);
 
         if let JsValue::Object(o) = &template_arr
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_property(
                 "raw".to_string(),
@@ -362,7 +362,7 @@ impl Interpreter {
 
         // Mark derived class constructors and make .prototype writable:false
         if let JsValue::Object(ref o) = ctor_val
-            && let Some(func_obj) = self.get_object(o.id)
+            && let Some(func_obj) = self.get_object_cell(o.id)
         {
             func_obj.borrow_mut().is_class_constructor = true;
             if super_val.is_some() {
@@ -425,15 +425,15 @@ impl Interpreter {
                 }
             }
             if let JsValue::Object(ref sp) = super_proto_val
-                && let Some(super_proto) = self.get_object(sp.id)
+                && let Some(super_proto) = self.get_object_cell(sp.id)
                 && let Some(ref proto) = proto_obj
             {
                 proto.borrow_mut().prototype_id = Some(super_proto.borrow().id.unwrap());
             }
             // Step 7.a: F.[[Prototype]] = superclass (for static method inheritance)
             if let JsValue::Object(ref o) = ctor_val
-                && let Some(ctor_obj) = self.get_object(o.id)
-                && let Some(super_obj) = self.get_object(super_o_id)
+                && let Some(ctor_obj) = self.get_object_cell(o.id)
+                && let Some(super_obj) = self.get_object_cell(super_o_id)
             {
                 ctor_obj.borrow_mut().prototype_id = Some(super_obj.borrow().id.unwrap());
             }
@@ -573,7 +573,7 @@ impl Interpreter {
 
                             if m.is_static {
                                 if let JsValue::Object(ref o) = ctor_val
-                                    && let Some(func_obj) = self.get_object(o.id)
+                                    && let Some(func_obj) = self.get_object_cell(o.id)
                                 {
                                     match m.kind {
                                         ClassMethodKind::Get => {
@@ -637,7 +637,7 @@ impl Interpreter {
                                     }
                                 }
                             } else if let JsValue::Object(ref o) = ctor_val
-                                && let Some(func_obj) = self.get_object(o.id)
+                                && let Some(func_obj) = self.get_object_cell(o.id)
                             {
                                 match m.kind {
                                     ClassMethodKind::Get => {
@@ -923,7 +923,7 @@ impl Interpreter {
                                     ));
                                 }
                             };
-                            if let Some(obj) = interp.get_object(obj_id)
+                            if let Some(obj) = interp.get_object_cell(obj_id)
                                 && let Some(PrivateElement::Field(v)) =
                                     obj.borrow().private_fields.get(&getter_slot)
                             {
@@ -950,7 +950,7 @@ impl Interpreter {
                                 }
                             };
                             let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                            if let Some(obj) = interp.get_object(obj_id)
+                            if let Some(obj) = interp.get_object_cell(obj_id)
                                 && obj.borrow().private_fields.contains_key(&setter_slot)
                             {
                                 obj.borrow_mut()
@@ -993,7 +993,7 @@ impl Interpreter {
                             p.value.clone(),
                         ));
                     } else if let JsValue::Object(ref o) = ctor_val
-                        && let Some(func_obj) = self.get_object(o.id)
+                        && let Some(func_obj) = self.get_object_cell(o.id)
                     {
                         func_obj.borrow_mut().class_instance_field_defs.push(
                             InstanceFieldDef::AutoAccessorStorage(storage_slot, p.value.clone()),
@@ -1032,7 +1032,7 @@ impl Interpreter {
                         JsValue::Undefined
                     };
                     if let JsValue::Object(ref o) = ctor_val
-                        && let Some(func_obj) = self.get_object(o.id)
+                        && let Some(func_obj) = self.get_object_cell(o.id)
                     {
                         func_obj.borrow_mut().insert_value(key, val);
                     }
@@ -1053,7 +1053,7 @@ impl Interpreter {
                         JsValue::Undefined
                     };
                     if let JsValue::Object(ref o) = ctor_val
-                        && let Some(func_obj) = self.get_object(o.id)
+                        && let Some(func_obj) = self.get_object_cell(o.id)
                     {
                         if !func_obj.borrow().extensible {
                             return Completion::Throw(self.create_type_error(
@@ -1081,7 +1081,7 @@ impl Interpreter {
                         JsValue::Undefined
                     };
                     if let JsValue::Object(ref o) = ctor_val
-                        && let Some(func_obj) = self.get_object(o.id)
+                        && let Some(func_obj) = self.get_object_cell(o.id)
                     {
                         func_obj
                             .borrow_mut()
@@ -1155,7 +1155,7 @@ impl Interpreter {
                             continue;
                         }
                         if let JsValue::Object(ref dobj) = v
-                            && let Some(desc_rc) = self.get_object(dobj.id)
+                            && let Some(desc_rc) = self.get_object_cell(dobj.id)
                         {
                             match desc_rc.borrow().get_property_value("enumerable") {
                                 Some(ev) => self.to_boolean_val(&ev),
@@ -1166,7 +1166,7 @@ impl Interpreter {
                         }
                     }
                     Ok(None) => {
-                        if let Some(obj) = self.get_object(src_id) {
+                        if let Some(obj) = self.get_object_cell(src_id) {
                             let desc = obj.borrow().get_own_property(&key_str);
                             match desc {
                                 Some(d) => d.enumerable != Some(false),
@@ -1178,7 +1178,7 @@ impl Interpreter {
                     }
                     Err(e) => return Err(e),
                 }
-            } else if let Some(obj) = self.get_object(src_id) {
+            } else if let Some(obj) = self.get_object_cell(src_id) {
                 let desc = obj.borrow().get_own_property(&key_str);
                 match desc {
                     Some(d) => d.enumerable != Some(false),
@@ -1345,7 +1345,7 @@ impl Interpreter {
         {
             for val in &method_values {
                 if let JsValue::Object(fo) = val
-                    && let Some(func_obj) = self.get_object(fo.id)
+                    && let Some(func_obj) = self.get_object_cell(fo.id)
                 {
                     let old_closure = if let Some(JsFunction::User { ref closure, .. }) =
                         func_obj.borrow().callable

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -113,7 +113,7 @@ impl Interpreter {
         if key.starts_with("Symbol(") {
             return Ok(());
         }
-        let ns_data = if let Some(obj) = self.get_object(obj_id) {
+        let ns_data = if let Some(obj) = self.get_object_cell(obj_id) {
             obj.borrow().module_namespace.clone()
         } else {
             None
@@ -173,7 +173,7 @@ impl Interpreter {
         &mut self,
         obj_id: u64,
     ) -> Result<(), JsValue> {
-        let (deferred, module_path) = if let Some(obj) = self.get_object(obj_id) {
+        let (deferred, module_path) = if let Some(obj) = self.get_object_cell(obj_id) {
             let b = obj.borrow();
             if let Some(ref ns) = b.module_namespace {
                 (ns.deferred, ns.module_path.clone())
@@ -203,7 +203,7 @@ impl Interpreter {
             if let Some(ref err) = module.borrow().error {
                 return Err(err.clone());
             }
-            if let Some(obj) = self.get_object(obj_id)
+            if let Some(obj) = self.get_object_cell(obj_id)
                 && let Some(ref mut ns) = obj.borrow_mut().module_namespace
             {
                 ns.deferred = false;
@@ -228,7 +228,7 @@ impl Interpreter {
 
         match result {
             Ok(_) => {
-                if let Some(obj) = self.get_object(obj_id)
+                if let Some(obj) = self.get_object_cell(obj_id)
                     && let Some(ref mut ns) = obj.borrow_mut().module_namespace
                 {
                     ns.deferred = false;
@@ -259,7 +259,7 @@ impl Interpreter {
         this_val: &JsValue,
     ) -> Completion {
         // Single-borrow fast path: classify object and check own property in one borrow
-        if let Some(obj) = self.get_object(obj_id) {
+        if let Some(obj) = self.get_object_cell(obj_id) {
             let b = obj.borrow();
             let is_proxy = b.proxy_target_id.is_some() || b.proxy_revoked;
             let has_module_ns = b.module_namespace.is_some();
@@ -334,7 +334,7 @@ impl Interpreter {
                 Ok(Some(v)) => {
                     // Invariant checks
                     if let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object(t.id)
+                        && let Some(tobj) = self.get_object_cell(t.id)
                     {
                         let target_desc = tobj.borrow().get_own_property(key);
                         if let Some(ref desc) = target_desc
@@ -380,7 +380,7 @@ impl Interpreter {
         // Module namespace: look up live binding from environment
         {
             let ns_data = self
-                .get_object(obj_id)
+                .get_object_cell(obj_id)
                 .and_then(|obj| obj.borrow().module_namespace.clone());
             if let Some(ns_data) = ns_data {
                 // Deferred namespace: IsSymbolLikeNamespaceKey check
@@ -413,7 +413,7 @@ impl Interpreter {
         }
 
         // Fallback: own property + prototype chain (for rare non-proxy, non-module cases)
-        let own_desc = if let Some(obj) = self.get_object(obj_id) {
+        let own_desc = if let Some(obj) = self.get_object_cell(obj_id) {
             obj.borrow().get_own_property_full(key)
         } else {
             None
@@ -426,7 +426,7 @@ impl Interpreter {
             Some(ref d) if d.get.is_some() => Completion::Normal(JsValue::Undefined),
             Some(ref d) => Completion::Normal(d.value.clone().unwrap_or(JsValue::Undefined)),
             None => {
-                let proto = if let Some(obj) = self.get_object(obj_id) {
+                let proto = if let Some(obj) = self.get_object_cell(obj_id) {
                     obj.borrow().prototype_id
                 } else {
                     None
@@ -451,7 +451,7 @@ impl Interpreter {
                     let trap_result = self.to_boolean_val(&v);
                     if !trap_result
                         && let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object(t.id)
+                        && let Some(tobj) = self.get_object_cell(t.id)
                     {
                         let target_desc = tobj.borrow().get_own_property(key);
                         if let Some(ref desc) = target_desc {
@@ -960,7 +960,7 @@ impl Interpreter {
             String::new()
         };
 
-        if let Some(obj) = self.get_object(func_id) {
+        if let Some(obj) = self.get_object_cell(func_id) {
             obj.borrow_mut().insert_property(
                 "length".to_string(),
                 PropertyDescriptor::data(JsValue::Number(computed_length), false, false, true),

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -878,11 +878,11 @@ impl Interpreter {
         let old_realm = self.current_realm_id;
         self.current_realm_id = caller_realm_id;
 
-        let func_obj = self.create_object();
-        let func_id = func_obj.borrow().id.unwrap();
+        let func_obj_id = self.create_object_id();
+        let func_id = func_obj_id;
         let fp_id = self.realms[caller_realm_id].function_prototype;
         {
-            let mut o = func_obj.borrow_mut();
+            let mut o = self.get_object_cell_expect(func_obj_id).borrow_mut();
             o.prototype_id = fp_id;
             o.class_name = "Function".to_string();
             o.callable = Some(JsFunction::native("".to_string(), 0, |_, _, _| {

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -151,8 +151,7 @@ impl Interpreter {
     }
 
     /// §9.1.1.4.16 CanDeclareGlobalFunction
-    fn can_declare_global_function(global_obj: &Rc<RefCell<JsObjectData>>, name: &str) -> bool {
-        let gb = global_obj.borrow();
+    fn can_declare_global_function(gb: &JsObjectData, name: &str) -> bool {
         if let Some(desc) = gb.properties.get(name) {
             if desc.configurable == Some(true) {
                 return true;
@@ -168,8 +167,7 @@ impl Interpreter {
     }
 
     /// §9.1.1.4.15 CanDeclareGlobalVar
-    fn can_declare_global_var(global_obj: &Rc<RefCell<JsObjectData>>, name: &str) -> bool {
-        let gb = global_obj.borrow();
+    fn can_declare_global_var(gb: &JsObjectData, name: &str) -> bool {
         if gb.properties.contains_key(name) {
             return true;
         }
@@ -196,8 +194,7 @@ impl Interpreter {
     }
 
     /// §9.1.1.4.13 HasRestrictedGlobalProperty
-    fn has_restricted_global_property(global_obj: &Rc<RefCell<JsObjectData>>, name: &str) -> bool {
-        let gb = global_obj.borrow();
+    fn has_restricted_global_property(gb: &JsObjectData, name: &str) -> bool {
         if let Some(desc) = gb.properties.get(name) {
             desc.configurable == Some(false)
         } else {
@@ -231,7 +228,7 @@ impl Interpreter {
             // Step 3b-d: If HasRestrictedGlobalProperty(name) is true, throw SyntaxError
             // Non-eval var/function declarations create non-configurable global properties,
             // so this also catches var-lex collisions for non-eval declarations.
-            if Self::has_restricted_global_property(&global_obj, name) {
+            if Self::has_restricted_global_property(&global_obj.borrow(), name) {
                 let err = self.create_error(
                     "SyntaxError",
                     &format!("Identifier '{}' has already been declared", name),
@@ -271,7 +268,7 @@ impl Interpreter {
                     );
                     return Some(Completion::Throw(err));
                 }
-                if !Self::can_declare_global_function(&global_obj, &f.name) {
+                if !Self::can_declare_global_function(&global_obj.borrow(), &f.name) {
                     let err = self
                         .create_type_error(&format!("Cannot declare global function '{}'", f.name));
                     return Some(Completion::Throw(err));
@@ -283,7 +280,7 @@ impl Interpreter {
         // Collect var declaration names (step 12)
         for name in &var_names {
             if !declared_function_names.contains(name)
-                && !Self::can_declare_global_var(&global_obj, name)
+                && !Self::can_declare_global_var(&global_obj.borrow(), name)
             {
                 let err =
                     self.create_type_error(&format!("Cannot declare global variable '{}'", name));

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -210,7 +210,7 @@ impl Interpreter {
         env: &EnvRef,
     ) -> Option<Completion> {
         let gid = env.borrow().global_object_id?;
-        let global_obj = self.get_object(gid)?;
+        let global_obj = self.get_object_cell(gid)?;
 
         // §16.1.7 step 3: Check lexical names
         let lex_names = Self::collect_lex_names(stmts);
@@ -938,7 +938,7 @@ impl Interpreter {
                     other => return other,
                 };
                 if let JsValue::Object(obj_ref) = &obj_val {
-                    if self.get_object(obj_ref.id).is_some() {
+                    if self.get_object_cell(obj_ref.id).is_some() {
                         let with_env = Rc::new(RefCell::new(Environment {
                             bindings: HashMap::new(),
                             parent: Some(env.clone()),
@@ -1162,7 +1162,7 @@ impl Interpreter {
                         let vs = var_scope.borrow();
                         vs.bindings.contains_key(name)
                             || gid
-                                .and_then(|id| self.get_object(id))
+                                .and_then(|id| self.get_object_cell(id))
                                 .is_some_and(|g| g.borrow().properties.contains_key(name))
                     };
                     if !already_declared {
@@ -1415,9 +1415,9 @@ impl Interpreter {
                                     let gid = var_scope.borrow().global_object_id;
                                     let vs = var_scope.borrow();
                                     vs.bindings.contains_key(binding_name)
-                                        || gid.and_then(|id| self.get_object(id)).is_some_and(|g| {
-                                            g.borrow().properties.contains_key(binding_name)
-                                        })
+                                        || gid.and_then(|id| self.get_object_cell(id)).is_some_and(
+                                            |g| g.borrow().properties.contains_key(binding_name),
+                                        )
                                 };
                                 if !already {
                                     var_scope.borrow_mut().declare(binding_name, kind);
@@ -1845,7 +1845,7 @@ impl Interpreter {
                 let obj_id = o.id;
                 let keys = {
                     let needs_proxy_path = self
-                        .get_object(obj_id)
+                        .get_object_cell(obj_id)
                         .map(|obj| {
                             let b = obj.borrow();
                             b.is_proxy() || b.module_namespace.is_some()
@@ -1856,7 +1856,7 @@ impl Interpreter {
                             Ok(k) => k,
                             Err(e) => break 'unroot Completion::Throw(e),
                         }
-                    } else if self.get_object(obj_id).is_some() {
+                    } else if self.get_object_cell(obj_id).is_some() {
                         self.enumerable_keys_with_proto_on_id(obj_id)
                     } else {
                         break 'unroot Completion::Normal(JsValue::Undefined);
@@ -2557,7 +2557,7 @@ impl Interpreter {
         if let Some(ctor_val) = ctor {
             let new_obj_id = self.create_object_id();
             if let JsValue::Object(ref o) = ctor_val
-                && let Some(func_obj) = self.get_object(o.id)
+                && let Some(func_obj) = self.get_object_cell(o.id)
             {
                 let proto = func_obj.borrow().get_property_value("prototype");
                 if let Some(JsValue::Object(proto_obj)) = proto {

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -316,7 +316,7 @@ impl Interpreter {
             self.env_declare_global_function_binding(env, &f.name, val, false);
         } else {
             env.borrow_mut().declare(&f.name, BindingKind::Var);
-            let _ = env.borrow_mut().set(&f.name, val);
+            let _ = self.env_set(env, &f.name, val);
         }
     }
 
@@ -951,7 +951,6 @@ impl Interpreter {
                             with_object: Some(WithObject { obj_id: obj_ref.id }),
                             dispose_stack: None,
                             global_object_id: None,
-                            global_object_rc: None,
                             annexb_function_names: None,
                             class_private_names: None,
                             is_field_initializer: false,
@@ -1020,8 +1019,8 @@ impl Interpreter {
                                 cursor = cur_b.parent.clone();
                             }
                             if !blocked_by_intermediate {
-                                let val = env.borrow().get(&f.name).unwrap_or(JsValue::Undefined);
-                                let _ = var_scope.borrow_mut().set(&f.name, val);
+                                let val = self.env_get(env, &f.name).unwrap_or(JsValue::Undefined);
+                                let _ = self.env_set(&var_scope, &f.name, val);
                             }
                         }
                     }
@@ -1369,7 +1368,7 @@ impl Interpreter {
                                 if !var_scope.borrow().bindings.contains_key(name) {
                                     var_scope.borrow_mut().declare(name, kind);
                                 }
-                                env.borrow_mut().set(name, v)?;
+                                self.env_set(env, name, v)?;
                             } else {
                                 env.borrow_mut().declare(name, kind);
                                 env.borrow_mut().initialize_binding(name, v);
@@ -1467,7 +1466,7 @@ impl Interpreter {
                                         v,
                                         strict,
                                     )?,
-                                    None => env.borrow_mut().set(binding_name, v)?,
+                                    None => self.env_set(env, binding_name, v)?,
                                 }
                             } else {
                                 let v = if let JsValue::Object(o) = &obj_val {
@@ -1706,7 +1705,7 @@ impl Interpreter {
         let mut iter_env = if !per_iteration_bindings.is_empty() {
             let new_env = Environment::new(Some(env.clone()));
             for (name, kind) in &per_iteration_bindings {
-                let val = for_env.borrow().get(name).unwrap_or(JsValue::Undefined);
+                let val = self.env_get(&for_env, name).unwrap_or(JsValue::Undefined);
                 new_env.borrow_mut().declare(name, *kind);
                 new_env.borrow_mut().initialize_binding(name, val);
             }
@@ -1757,7 +1756,7 @@ impl Interpreter {
                 if !per_iteration_bindings.is_empty() {
                     let new_env = Environment::new(Some(env.clone()));
                     for (name, kind) in &per_iteration_bindings {
-                        let val = iter_env.borrow().get(name).unwrap_or(JsValue::Undefined);
+                        let val = self.env_get(&iter_env, name).unwrap_or(JsValue::Undefined);
                         new_env.borrow_mut().declare(name, *kind);
                         new_env.borrow_mut().initialize_binding(name, val);
                     }
@@ -1797,7 +1796,7 @@ impl Interpreter {
             };
             if let Pattern::Identifier(name) = &d.pattern {
                 self.set_function_name(&init_val, name);
-                let _ = env.borrow_mut().set(name, init_val);
+                let _ = self.env_set(env, name, init_val);
             }
         }
 
@@ -2304,7 +2303,7 @@ impl Interpreter {
                         uses_arguments: func_uses_arguments(&f.params, &f.body),
                     };
                     let val = self.create_function(func);
-                    let _ = switch_env.borrow_mut().set(&f.name, val);
+                    let _ = self.env_set(&switch_env, &f.name, val);
                 }
             }
         }
@@ -2555,7 +2554,7 @@ impl Interpreter {
         args: &[JsValue],
         env: &EnvRef,
     ) -> Completion {
-        let ctor = env.borrow().get(name);
+        let ctor = self.env_get(env, name);
         if let Some(ctor_val) = ctor {
             let new_obj = self.create_object();
             if let JsValue::Object(ref o) = ctor_val

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -2566,7 +2566,6 @@ impl Interpreter {
                         .prototype_id = Some(proto_obj.id);
                 }
             }
-            let new_obj_id = new_obj_id;
             let this_val = JsValue::Object(crate::types::JsObject { id: new_obj_id });
             let prev_new_target = self.new_target.take();
             self.new_target = Some(ctor_val.clone());

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -1479,15 +1479,17 @@ impl Interpreter {
                             }
                         }
                         ObjectPatternProperty::Rest(pat) => {
-                            let rest_obj = self.create_object();
+                            let rest_obj_id = self.create_object_id();
                             if let JsValue::Object(o) = &obj_val {
                                 let pairs =
                                     self.copy_data_properties(o.id, &obj_val, &excluded_keys)?;
                                 for (k, v) in pairs {
-                                    rest_obj.borrow_mut().insert_value(k, v);
+                                    self.get_object_cell_expect(rest_obj_id)
+                                        .borrow_mut()
+                                        .insert_value(k, v);
                                 }
                             }
-                            let rest_id = rest_obj.borrow().id.unwrap();
+                            let rest_id = rest_obj_id;
                             let rest_val = JsValue::Object(crate::types::JsObject { id: rest_id });
                             self.bind_pattern(pat, rest_val, kind, env)?;
                         }
@@ -2553,16 +2555,18 @@ impl Interpreter {
     ) -> Completion {
         let ctor = self.env_get(env, name);
         if let Some(ctor_val) = ctor {
-            let new_obj = self.create_object();
+            let new_obj_id = self.create_object_id();
             if let JsValue::Object(ref o) = ctor_val
                 && let Some(func_obj) = self.get_object(o.id)
             {
                 let proto = func_obj.borrow().get_property_value("prototype");
                 if let Some(JsValue::Object(proto_obj)) = proto {
-                    new_obj.borrow_mut().prototype_id = Some(proto_obj.id);
+                    self.get_object_cell_expect(new_obj_id)
+                        .borrow_mut()
+                        .prototype_id = Some(proto_obj.id);
                 }
             }
-            let new_obj_id = new_obj.borrow().id.unwrap();
+            let new_obj_id = new_obj_id;
             let this_val = JsValue::Object(crate::types::JsObject { id: new_obj_id });
             let prev_new_target = self.new_target.take();
             self.new_target = Some(ctor_val.clone());

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -2,23 +2,13 @@ use super::*;
 
 impl Interpreter {
     /// Allocate a fresh object slot for `data` and return its id. The id is
-    /// written to `data.id` *before* wrapping in `Rc<RefCell<>>`, so the field
-    /// is set exactly once at allocation and never reassigned.
+    /// written to `data.id` inside the arena's `alloc`, so the field is set
+    /// exactly once at allocation and never reassigned.
     pub(crate) fn alloc_object(&mut self, mut data: JsObjectData) -> u64 {
         self.gc_alloc_count += 1;
-        let is_reuse = !self.free_list.is_empty();
         data.shape_id = crate::interpreter::types::fresh_shape_id();
-        let id = if let Some(idx) = self.free_list.pop() {
-            data.id = Some(idx as u64);
-            self.objects[idx] = Some(Rc::new(RefCell::new(data)));
-            idx as u64
-        } else {
-            let idx = self.objects.len();
-            data.id = Some(idx as u64);
-            self.objects.push(Some(Rc::new(RefCell::new(data))));
-            idx as u64
-        };
-        let cost = if is_reuse {
+        let (id, was_reuse) = self.objects.alloc(data);
+        let cost = if was_reuse {
             GC_OBJECT_OVERHEAD / 2
         } else {
             GC_OBJECT_OVERHEAD
@@ -49,7 +39,7 @@ impl Interpreter {
         }
         self.gc_requested = false;
         self.gc_alloc_count = 0;
-        let obj_count = self.objects.len();
+        let obj_count = self.objects.capacity() as usize;
         let mut marks = vec![false; obj_count];
 
         // Collect roots from all realms
@@ -132,8 +122,8 @@ impl Interpreter {
                 continue;
             }
             marks[idx] = true;
-            let obj_rc = match &self.objects[idx] {
-                Some(rc) => rc.clone(),
+            let obj_rc = match self.objects.get(id) {
+                Some(rc) => rc,
                 None => continue,
             };
             let obj = obj_rc.borrow();
@@ -147,8 +137,8 @@ impl Interpreter {
                 if !marks[i] {
                     continue;
                 }
-                let obj_rc = match &self.objects[i] {
-                    Some(rc) => rc.clone(),
+                let obj_rc = match self.objects.get(i as u64) {
+                    Some(rc) => rc,
                     None => continue,
                 };
                 let obj = obj_rc.borrow();
@@ -182,8 +172,8 @@ impl Interpreter {
                 }
                 marks[idx] = true;
                 new_marks = true;
-                let obj_rc = match &self.objects[idx] {
-                    Some(rc) => rc.clone(),
+                let obj_rc = match self.objects.get(id) {
+                    Some(rc) => rc,
                     None => continue,
                 };
                 let obj = obj_rc.borrow();
@@ -196,8 +186,10 @@ impl Interpreter {
 
         // Sweep phase
         for (i, mark) in marks.iter().enumerate().take(obj_count) {
-            if !mark && self.objects[i].is_some() {
-                if let Some(ref obj_rc) = self.objects[i] {
+            let id = i as u64;
+            let live = self.objects.slot_at(id).is_some_and(|s| s.is_some());
+            if !mark && live {
+                if let Some(obj_rc) = self.objects.get(id) {
                     let obj = obj_rc.borrow();
                     if let Some(ref buf_data) = obj.arraybuffer_data
                         && let BufferData::Owned(ref v) = *buf_data.borrow()
@@ -205,15 +197,14 @@ impl Interpreter {
                         self.gc_external_bytes = self.gc_external_bytes.saturating_sub(v.len());
                     }
                 }
-                self.objects[i] = None;
-                self.free_list.push(i);
-                self.function_realm_map.remove(&(i as u64));
-                self.iterator_next_cache.remove(&(i as u64));
-                self.generator_inline_iters.remove(&(i as u64));
+                self.objects.free(id);
+                self.function_realm_map.remove(&id);
+                self.iterator_next_cache.remove(&id);
+                self.generator_inline_iters.remove(&id);
             }
         }
         // Adaptive threshold: scale next GC budget from live heap size
-        let live_count = self.objects.iter().filter(|o| o.is_some()).count();
+        let live_count = self.objects.live_count();
         let live_bytes = live_count * GC_OBJECT_OVERHEAD + self.gc_external_bytes;
         self.gc_threshold_bytes =
             std::cmp::max(GC_MIN_THRESHOLD_BYTES, live_bytes * GC_GROWTH_FACTOR);
@@ -223,8 +214,8 @@ impl Interpreter {
             if !marks[i] {
                 continue;
             }
-            let obj_rc = match &self.objects[i] {
-                Some(rc) => rc.clone(),
+            let obj_rc = match self.objects.get(i as u64) {
+                Some(rc) => rc,
                 None => continue,
             };
             let mut obj = obj_rc.borrow_mut();

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -299,7 +299,7 @@ pub(crate) fn enumerable_own_keys(
     interp: &mut Interpreter,
     obj_id: u64,
 ) -> Result<Vec<String>, JsValue> {
-    if let Some(obj) = interp.get_object(obj_id) {
+    if let Some(obj) = interp.get_object_cell(obj_id) {
         if obj.borrow().is_proxy() || obj.borrow().proxy_revoked {
             let target_val = interp.get_proxy_target_val(obj_id);
             match interp.invoke_proxy_trap(obj_id, "ownKeys", vec![target_val.clone()]) {
@@ -341,7 +341,7 @@ pub(crate) fn enumerable_own_keys(
                                     }
                                     Ok(None) => {
                                         if let JsValue::Object(ref t) = target_val
-                                            && let Some(tobj) = interp.get_object(t.id)
+                                            && let Some(tobj) = interp.get_object_cell(t.id)
                                             && let Some(d) = tobj.borrow().properties.get(&key_str)
                                             && d.enumerable != Some(false)
                                         {
@@ -419,7 +419,7 @@ pub(crate) fn json_stringify_full(
 
     if let Some(rep) = replacer
         && let JsValue::Object(o) = rep
-        && let Some(obj) = interp.get_object(o.id)
+        && let Some(obj) = interp.get_object_cell(o.id)
     {
         if obj.borrow().callable.is_some() {
             replacer_fn = Some(rep.clone());
@@ -445,7 +445,7 @@ pub(crate) fn json_stringify_full(
                     JsValue::String(s) => Some(s.to_rust_string()),
                     JsValue::Number(n) => Some(number_ops::to_string(*n)),
                     JsValue::Object(oo) => {
-                        if let Some(inner) = interp.get_object(oo.id) {
+                        if let Some(inner) = interp.get_object_cell(oo.id) {
                             let cn = inner.borrow().class_name.clone();
                             if cn == "String" || cn == "Number" {
                                 match interp.to_string_value(&item) {
@@ -533,7 +533,7 @@ fn json_stringify_internal(
             JsValue::Undefined
         };
         if let JsValue::Object(fobj) = &to_json
-            && let Some(fdata) = interp.get_object(fobj.id)
+            && let Some(fdata) = interp.get_object_cell(fobj.id)
             && fdata.borrow().callable.is_some()
         {
             let key_val = JsValue::String(JsString::from_str(key));
@@ -605,7 +605,7 @@ fn json_stringify_internal(
             Err(interp.create_error("TypeError", "Do not know how to serialize a BigInt"))
         }
         JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object(o.id) {
+            if let Some(obj) = interp.get_object_cell(o.id) {
                 if obj.borrow().is_raw_json
                     && let Some(raw) = obj.borrow().get_property_value("rawJSON")
                 {
@@ -986,7 +986,7 @@ fn json_internalize_apply(
                 Ok(None) => {
                     // No trap, delete on target directly
                     if let JsValue::Object(t) = &interp.get_proxy_target_val(obj_id)
-                        && let Some(tobj) = interp.get_object(t.id)
+                        && let Some(tobj) = interp.get_object_cell(t.id)
                     {
                         tobj.borrow_mut().properties.remove(key);
                         tobj.borrow_mut().property_order.retain(|k| k != key);
@@ -1030,7 +1030,7 @@ fn json_internalize_apply(
                 Ok(None) => {
                     // No trap, define on target directly
                     if let JsValue::Object(t) = &interp.get_proxy_target_val(obj_id)
-                        && let Some(tobj) = interp.get_object(t.id)
+                        && let Some(tobj) = interp.get_object_cell(t.id)
                     {
                         tobj.borrow_mut().insert_value(key.to_string(), new_val);
                     }

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -164,10 +164,7 @@ pub(crate) fn strict_equality(left: &JsValue, right: &JsValue) -> bool {
     }
 }
 
-pub(crate) fn typeof_val<'a>(
-    val: &JsValue,
-    objects: &[Option<Rc<RefCell<JsObjectData>>>],
-) -> &'a str {
+pub(crate) fn typeof_val<'a>(val: &JsValue, objects: &super::object_arena::ObjectArena) -> &'a str {
     match val {
         JsValue::Undefined => "undefined",
         JsValue::Null => "object",
@@ -177,11 +174,12 @@ pub(crate) fn typeof_val<'a>(
         JsValue::Symbol(_) => "symbol",
         JsValue::BigInt(_) => "bigint",
         JsValue::Object(o) => {
-            if let Some(Some(obj)) = objects.get(o.id as usize) {
-                if obj.borrow().is_htmldda {
+            if let Some(obj) = objects.get(o.id) {
+                let b = obj.borrow();
+                if b.is_htmldda {
                     return "undefined";
                 }
-                if obj.borrow().callable.is_some() {
+                if b.callable.is_some() {
                     return "function";
                 }
             }

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -471,11 +471,12 @@ pub(crate) fn json_stringify_full(
         }
     }
 
-    let wrapper = interp.create_object();
-    wrapper
+    let wrapper_id = interp.create_object_id();
+    interp
+        .get_object_cell_expect(wrapper_id)
         .borrow_mut()
         .insert_value("".to_string(), val.clone());
-    let holder_id = wrapper.borrow().id.unwrap();
+    let holder_id = wrapper_id;
 
     json_stringify_internal(
         interp,
@@ -844,8 +845,8 @@ fn json_parse_value_inner(
             return Completion::Throw(err);
         }
         let pairs = json_split_items(inner);
-        let obj = interp.create_object();
-        let obj_id = obj.borrow().id.unwrap();
+        let obj_id = interp.create_object_id();
+        let obj_id = obj_id;
         for pair in &pairs {
             let pair = pair.trim();
             if pair.is_empty() {
@@ -879,7 +880,10 @@ fn json_parse_value_inner(
                     {
                         smap.insert((obj_id, key.clone()), val_src);
                     }
-                    obj.borrow_mut().insert_value(key, v);
+                    interp
+                        .get_object_cell_expect(obj_id)
+                        .borrow_mut()
+                        .insert_value(key, v);
                 }
                 other => return other,
             }
@@ -994,22 +998,24 @@ fn json_internalize_apply(
         } else {
             // CreateDataProperty via proxy defineProperty trap
             let key_val = JsValue::String(JsString::from_str(key));
-            let desc_obj = interp.create_object();
-            desc_obj
+            let desc_obj_id = interp.create_object_id();
+            interp
+                .get_object_cell_expect(desc_obj_id)
                 .borrow_mut()
                 .insert_value("value".to_string(), new_val.clone());
-            desc_obj
+            interp
+                .get_object_cell_expect(desc_obj_id)
                 .borrow_mut()
                 .insert_value("writable".to_string(), JsValue::Boolean(true));
-            desc_obj
+            interp
+                .get_object_cell_expect(desc_obj_id)
                 .borrow_mut()
                 .insert_value("enumerable".to_string(), JsValue::Boolean(true));
-            desc_obj
+            interp
+                .get_object_cell_expect(desc_obj_id)
                 .borrow_mut()
                 .insert_value("configurable".to_string(), JsValue::Boolean(true));
-            let desc_val = JsValue::Object(crate::types::JsObject {
-                id: desc_obj.borrow().id.unwrap(),
-            });
+            let desc_val = JsValue::Object(crate::types::JsObject { id: desc_obj_id });
             match interp.invoke_proxy_trap(
                 obj_id,
                 "defineProperty",
@@ -1135,7 +1141,7 @@ pub(crate) fn json_internalize(
 
     // Build context argument for reviver
     let context = {
-        let ctx = interp.create_object();
+        let ctx_id = interp.create_object_id();
         if is_json_primitive(&walked)
             && let Some(smap) = source_map
             && let JsValue::Object(o) = holder
@@ -1159,13 +1165,16 @@ pub(crate) fn json_internalize(
                 _ => false,
             };
             if source_matches {
-                ctx.borrow_mut().insert_value(
-                    "source".to_string(),
-                    JsValue::String(JsString::from_str(src)),
-                );
+                interp
+                    .get_object_cell_expect(ctx_id)
+                    .borrow_mut()
+                    .insert_value(
+                        "source".to_string(),
+                        JsValue::String(JsString::from_str(src)),
+                    );
             }
         }
-        let id = ctx.borrow().id.unwrap();
+        let id = ctx_id;
         JsValue::Object(crate::types::JsObject { id })
     };
     let key_val = JsValue::String(JsString::from_str(name));

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -245,16 +245,16 @@ fn json_quote_js_string(s: &JsString) -> String {
 
 // Proxy-aware IsArray (§7.2.2)
 pub(crate) fn is_array_value(interp: &mut Interpreter, obj_id: u64) -> Result<bool, JsValue> {
-    if let Some(obj) = interp.get_object(obj_id) {
-        let (is_revoked, is_proxy, target_id, class) = {
-            let b = obj.borrow();
-            let tid = if b.is_proxy() {
-                b.proxy_target_id
-            } else {
-                None
-            };
-            (b.proxy_revoked, b.is_proxy(), tid, b.class_name.clone())
+    let snapshot = interp.get_object_cell(obj_id).map(|cell| {
+        let b = cell.borrow();
+        let tid = if b.is_proxy() {
+            b.proxy_target_id
+        } else {
+            None
         };
+        (b.proxy_revoked, b.is_proxy(), tid, b.class_name.clone())
+    });
+    if let Some((is_revoked, is_proxy, target_id, class)) = snapshot {
         if is_revoked {
             return Err(interp.create_error(
                 "TypeError",
@@ -558,8 +558,8 @@ fn json_stringify_internal(
 
     // Step 4: Unwrap wrapper objects per spec (ToNumber/ToString trigger valueOf/toString)
     if let JsValue::Object(o) = &value {
-        let class = if let Some(obj) = interp.get_object(o.id) {
-            obj.borrow().class_name.clone()
+        let class = if let Some(cell) = interp.get_object_cell(o.id) {
+            cell.borrow().class_name.clone()
         } else {
             String::new()
         };
@@ -573,15 +573,15 @@ fn json_stringify_internal(
                 Err(e) => return Err(e),
             },
             "Boolean" => {
-                if let Some(obj) = interp.get_object(o.id)
-                    && let Some(pv) = obj.borrow().primitive_value.clone()
+                if let Some(cell) = interp.get_object_cell(o.id)
+                    && let Some(pv) = cell.borrow().primitive_value.clone()
                 {
                     value = pv;
                 }
             }
             "BigInt" => {
-                if let Some(obj) = interp.get_object(o.id)
-                    && let Some(pv) = obj.borrow().primitive_value.clone()
+                if let Some(cell) = interp.get_object_cell(o.id)
+                    && let Some(pv) = cell.borrow().primitive_value.clone()
                 {
                     value = pv;
                 }
@@ -966,8 +966,8 @@ fn json_internalize_apply(
     new_val: JsValue,
 ) -> Result<(), JsValue> {
     let is_proxy = interp
-        .get_object(obj_id)
-        .map(|o| o.borrow().is_proxy() || o.borrow().proxy_revoked)
+        .get_object_cell(obj_id)
+        .map(|c| c.borrow().is_proxy() || c.borrow().proxy_revoked)
         .unwrap_or(false);
 
     if is_proxy {
@@ -1042,8 +1042,8 @@ fn json_internalize_apply(
     }
 
     // Non-proxy path
-    if let Some(obj) = interp.get_object(obj_id) {
-        let configurable = obj
+    if let Some(cell) = interp.get_object_cell(obj_id) {
+        let configurable = cell
             .borrow()
             .properties
             .get(key)
@@ -1053,11 +1053,11 @@ fn json_internalize_apply(
             return Ok(());
         }
         if let JsValue::Undefined = &new_val {
-            obj.borrow_mut().properties.remove(key);
-            obj.borrow_mut().property_order.retain(|k| k != key);
+            cell.borrow_mut().properties.remove(key);
+            cell.borrow_mut().property_order.retain(|k| k != key);
             // Also clear dense array storage so get_property doesn't find stale values
             if let Ok(idx) = key.parse::<usize>() {
-                let mut b = obj.borrow_mut();
+                let mut b = cell.borrow_mut();
                 if let Some(ref mut elems) = b.array_elements
                     && idx < elems.len()
                 {
@@ -1065,7 +1065,7 @@ fn json_internalize_apply(
                 }
             }
         } else {
-            obj.borrow_mut().insert_value(key.to_string(), new_val);
+            cell.borrow_mut().insert_value(key.to_string(), new_val);
         }
     }
     Ok(())

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -846,7 +846,6 @@ fn json_parse_value_inner(
         }
         let pairs = json_split_items(inner);
         let obj_id = interp.create_object_id();
-        let obj_id = obj_id;
         for pair in &pairs {
             let pair = pair.trim();
             if pair.is_empty() {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2719,8 +2719,7 @@ impl Interpreter {
         };
 
         let proto_id = self.realm().uint8array_prototype.unwrap();
-        let ta_obj = self.create_typed_array_object_with_proto(ta_info, buf_val, proto_id);
-        let ta_id = ta_obj.borrow().id.unwrap();
+        let ta_id = self.create_typed_array_object_with_proto(ta_info, buf_val, proto_id);
         JsValue::Object(crate::types::JsObject { id: ta_id })
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1237,6 +1237,21 @@ impl Interpreter {
         self.objects.get_expect(id)
     }
 
+    /// Borrow the object's `RefCell` directly without bumping the slot's
+    /// `Rc`. Lifetime tied to `&self`; drop the borrow before any
+    /// `&mut self` call. Use this at new sites to avoid the per-call
+    /// `Rc::clone`; existing `get_object{,_expect}` callers can migrate
+    /// gradually.
+    #[allow(dead_code)] // migration target — see PR 2b.2 step 4 commit message
+    pub(crate) fn get_object_cell(&self, id: u64) -> Option<&RefCell<JsObjectData>> {
+        self.objects.get_cell(id)
+    }
+
+    #[allow(dead_code)] // migration target — see PR 2b.2 step 4 commit message
+    pub(crate) fn get_object_cell_expect(&self, id: u64) -> &RefCell<JsObjectData> {
+        self.objects.get_cell_expect(id)
+    }
+
     /// Iterative prototype-chain walk of `get_property`. Returns
     /// `JsValue::Undefined` when the key is not found anywhere in the chain.
     /// Each frame is pinned by the Rc returned from `get_object_expect` so

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -985,6 +985,17 @@ impl Interpreter {
         self.get_object_expect(id)
     }
 
+    /// Same as `create_object` but returns the slot id directly without
+    /// the legacy `Rc<RefCell<…>>` wrapper. New callers should use this
+    /// (paired with `get_object_cell_expect(id)` for mutation) to avoid
+    /// the per-call `Rc::clone` and to be forward-compatible with the
+    /// final PR 2b.2 API flip that drops `create_object` altogether.
+    pub(crate) fn create_object_id(&mut self) -> u64 {
+        let mut data = JsObjectData::new();
+        data.prototype_id = self.realm().object_prototype;
+        self.alloc_object(data)
+    }
+
     fn create_thrower_function(&mut self) -> JsValue {
         let realm_id = self.current_realm_id;
         let func = JsFunction::native(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -27,6 +27,7 @@ mod gc;
 pub(crate) mod generator_analysis;
 pub(crate) mod generator_transform;
 pub(crate) mod ic;
+mod object_arena;
 mod property_map;
 pub(crate) use property_map::PropertyMap;
 mod scheduler;
@@ -52,16 +53,14 @@ fn import_module_type(attrs: &[(String, String)]) -> Option<ImportModuleType> {
     None
 }
 
-#[allow(clippy::type_complexity)]
 pub struct Interpreter {
     pub(crate) realms: Vec<Realm>,
     pub(crate) current_realm_id: usize,
-    objects: Vec<Option<Rc<RefCell<JsObjectData>>>>,
+    objects: object_arena::ObjectArena,
     global_symbol_registry: HashMap<String, crate::types::JsSymbol>,
     pub(crate) well_known_symbols: HashMap<String, crate::types::JsSymbol>,
     next_symbol_id: u64,
     new_target: Option<JsValue>,
-    free_list: Vec<usize>,
     gc_alloc_count: usize,
     gc_requested: bool,
     gc_bytes_since_gc: usize,
@@ -214,12 +213,11 @@ impl Interpreter {
         let mut interp = Self {
             realms: vec![realm],
             current_realm_id: 0,
-            objects: Vec::new(),
+            objects: object_arena::ObjectArena::new(),
             global_symbol_registry: HashMap::new(),
             well_known_symbols: HashMap::new(),
             next_symbol_id: 1,
             new_target: None,
-            free_list: Vec::new(),
             gc_alloc_count: 0,
             gc_requested: false,
             gc_bytes_since_gc: 0,
@@ -972,7 +970,7 @@ impl Interpreter {
 
     pub(crate) fn to_boolean_val(&self, val: &JsValue) -> bool {
         if let JsValue::Object(o) = val
-            && let Some(Some(obj)) = self.objects.get(o.id as usize)
+            && let Some(obj) = self.objects.get(o.id)
             && obj.borrow().is_htmldda
         {
             return false;
@@ -1167,7 +1165,7 @@ impl Interpreter {
     }
 
     pub(crate) fn get_object(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
-        self.objects.get(id as usize).and_then(|slot| slot.clone())
+        self.objects.get(id)
     }
 
     /// Total IC hits since interpreter construction. Whitebox accessor used
@@ -1236,10 +1234,7 @@ impl Interpreter {
     /// `self.objects[id as usize].as_ref().unwrap().clone()` used at most
     /// call sites where the id is known live (held by a live JsValue).
     pub(crate) fn get_object_expect(&self, id: u64) -> Rc<RefCell<JsObjectData>> {
-        self.objects[id as usize]
-            .as_ref()
-            .expect("dead object id")
-            .clone()
+        self.objects.get_expect(id)
     }
 
     /// Iterative prototype-chain walk of `get_property`. Returns

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4137,7 +4137,7 @@ impl Interpreter {
                     uses_arguments: func_uses_arguments(&f.params, &f.body),
                 };
                 let val = self.create_function(func);
-                let _ = env.borrow_mut().set(&f.name, val);
+                let _ = self.env_set(env, &f.name, val);
             }
             Statement::ClassDeclaration(c) => {
                 if !c.name.is_empty() {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -342,7 +342,8 @@ impl Interpreter {
                 interp.detach_arraybuffer(&buf)
             },
         ));
-        self.get_object_cell_expect(dollar_262_id).borrow_mut()
+        self.get_object_cell_expect(dollar_262_id)
+            .borrow_mut()
             .insert_builtin("detachArrayBuffer".to_string(), detach_fn);
 
         // $262.gc
@@ -355,16 +356,19 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_cell_expect(dollar_262_id).borrow_mut()
+        self.get_object_cell_expect(dollar_262_id)
+            .borrow_mut()
             .insert_builtin("gc".to_string(), gc_fn);
 
         // $262.global — reference to the realm's global object
         let global_env = self.realms[realm_id].global_env.clone();
         if let Some(go_id) = global_env.borrow().global_object_id {
-            self.get_object_cell_expect(dollar_262_id).borrow_mut().insert_builtin(
-                "global".to_string(),
-                JsValue::Object(crate::types::JsObject { id: go_id }),
-            );
+            self.get_object_cell_expect(dollar_262_id)
+                .borrow_mut()
+                .insert_builtin(
+                    "global".to_string(),
+                    JsValue::Object(crate::types::JsObject { id: go_id }),
+                );
         }
 
         // $262.createRealm
@@ -377,7 +381,8 @@ impl Interpreter {
                 Completion::Normal(new_dollar_262)
             },
         ));
-        self.get_object_cell_expect(dollar_262_id).borrow_mut()
+        self.get_object_cell_expect(dollar_262_id)
+            .borrow_mut()
             .insert_builtin("createRealm".to_string(), create_realm_fn);
 
         // $262.evalScript — parse and execute code in this $262's realm
@@ -422,21 +427,25 @@ impl Interpreter {
                 }
             },
         ));
-        self.get_object_cell_expect(dollar_262_id).borrow_mut()
+        self.get_object_cell_expect(dollar_262_id)
+            .borrow_mut()
             .insert_builtin("evalScript".to_string(), eval_script_fn);
 
         // $262.IsHTMLDDA — B.3.6 [[IsHTMLDDA]] internal slot
         let htmldda_obj_id = self.create_object_id();
-        self.get_object_cell_expect(htmldda_obj_id).borrow_mut().callable = Some(JsFunction::native(
+        self.get_object_cell_expect(htmldda_obj_id)
+            .borrow_mut()
+            .callable = Some(JsFunction::native(
             "".to_string(),
             0,
             |_interp, _this, _args| Completion::Normal(JsValue::Null),
         ));
-        self.get_object_cell_expect(htmldda_obj_id).borrow_mut().is_htmldda = true;
-        let htmldda_val = JsValue::Object(crate::types::JsObject {
-            id: htmldda_obj_id,
-        });
-        self.get_object_cell_expect(dollar_262_id).borrow_mut()
+        self.get_object_cell_expect(htmldda_obj_id)
+            .borrow_mut()
+            .is_htmldda = true;
+        let htmldda_val = JsValue::Object(crate::types::JsObject { id: htmldda_obj_id });
+        self.get_object_cell_expect(dollar_262_id)
+            .borrow_mut()
             .insert_builtin("IsHTMLDDA".to_string(), htmldda_val);
 
         // $262.agent
@@ -485,7 +494,8 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_cell_expect(agent_obj_id).borrow_mut()
+        self.get_object_cell_expect(agent_obj_id)
+            .borrow_mut()
             .insert_builtin("start".to_string(), start_fn);
 
         // $262.agent.broadcast(sab)
@@ -509,7 +519,8 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_cell_expect(agent_obj_id).borrow_mut()
+        self.get_object_cell_expect(agent_obj_id)
+            .borrow_mut()
             .insert_builtin("broadcast".to_string(), broadcast_fn);
 
         // $262.agent.getReport()
@@ -526,7 +537,8 @@ impl Interpreter {
                 }
             },
         ));
-        self.get_object_cell_expect(agent_obj_id).borrow_mut()
+        self.get_object_cell_expect(agent_obj_id)
+            .borrow_mut()
             .insert_builtin("getReport".to_string(), get_report_fn);
 
         // $262.agent.getReportAsync()
@@ -593,7 +605,8 @@ impl Interpreter {
                 Completion::Normal(promise_val)
             },
         ));
-        self.get_object_cell_expect(agent_obj_id).borrow_mut()
+        self.get_object_cell_expect(agent_obj_id)
+            .borrow_mut()
             .insert_builtin("getReportAsync".to_string(), get_report_async_fn);
 
         // $262.agent.sleep(ms)
@@ -610,7 +623,8 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_cell_expect(agent_obj_id).borrow_mut()
+        self.get_object_cell_expect(agent_obj_id)
+            .borrow_mut()
             .insert_builtin("sleep".to_string(), sleep_fn);
 
         // $262.agent.monotonicNow()
@@ -623,7 +637,8 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(elapsed))
             },
         ));
-        self.get_object_cell_expect(agent_obj_id).borrow_mut()
+        self.get_object_cell_expect(agent_obj_id)
+            .borrow_mut()
             .insert_builtin("monotonicNow".to_string(), monotonic_fn);
 
         // $262.agent.leaving()
@@ -632,11 +647,13 @@ impl Interpreter {
             0,
             |_interp, _this, _args| Completion::Normal(JsValue::Undefined),
         ));
-        self.get_object_cell_expect(agent_obj_id).borrow_mut()
+        self.get_object_cell_expect(agent_obj_id)
+            .borrow_mut()
             .insert_builtin("leaving".to_string(), leaving_fn);
 
         let agent_val = JsValue::Object(crate::types::JsObject { id: agent_obj_id });
-        self.get_object_cell_expect(dollar_262_id).borrow_mut()
+        self.get_object_cell_expect(dollar_262_id)
+            .borrow_mut()
             .insert_builtin("agent".to_string(), agent_val);
 
         // $262.AbstractModuleSource — §28.1.1.1
@@ -658,7 +675,8 @@ impl Interpreter {
         // AbstractModuleSource.prototype_id
         let ams_proto_id = self.create_object_id();
         // constructor property
-        self.get_object_cell_expect(ams_proto_id).borrow_mut()
+        self.get_object_cell_expect(ams_proto_id)
+            .borrow_mut()
             .insert_builtin("constructor".to_string(), ams_fn.clone());
         // @@toStringTag getter — returns undefined (no [[ModuleSourceClassName]] slot)
         let tag_getter = self.create_function(JsFunction::native(
@@ -671,20 +689,20 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        self.get_object_cell_expect(ams_proto_id).borrow_mut().insert_property(
-            "Symbol(Symbol.toStringTag)".to_string(),
-            PropertyDescriptor {
-                value: None,
-                writable: None,
-                get: Some(tag_getter),
-                set: None,
-                enumerable: Some(false),
-                configurable: Some(true),
-            },
-        );
-        let ams_proto_val = JsValue::Object(crate::types::JsObject {
-            id: ams_proto_id,
-        });
+        self.get_object_cell_expect(ams_proto_id)
+            .borrow_mut()
+            .insert_property(
+                "Symbol(Symbol.toStringTag)".to_string(),
+                PropertyDescriptor {
+                    value: None,
+                    writable: None,
+                    get: Some(tag_getter),
+                    set: None,
+                    enumerable: Some(false),
+                    configurable: Some(true),
+                },
+            );
+        let ams_proto_val = JsValue::Object(crate::types::JsObject { id: ams_proto_id });
 
         // Wire prototype on the constructor: {writable: false, enumerable: false, configurable: false}
         if let Some(obj) = self.get_object(ams_fn_id) {
@@ -694,7 +712,8 @@ impl Interpreter {
             );
         }
 
-        self.get_object_cell_expect(dollar_262_id).borrow_mut()
+        self.get_object_cell_expect(dollar_262_id)
+            .borrow_mut()
             .insert_builtin("AbstractModuleSource".to_string(), ams_fn);
 
         JsValue::Object(crate::types::JsObject { id: dollar_262_id })
@@ -963,18 +982,10 @@ impl Interpreter {
         to_boolean(val)
     }
 
-    fn create_object(&mut self) -> Rc<RefCell<JsObjectData>> {
-        let mut data = JsObjectData::new();
-        data.prototype_id = self.realm().object_prototype;
-        let id = self.alloc_object(data);
-        self.get_object_expect(id)
-    }
-
-    /// Same as `create_object` but returns the slot id directly without
-    /// the legacy `Rc<RefCell<…>>` wrapper. New callers should use this
-    /// (paired with `get_object_cell_expect(id)` for mutation) to avoid
-    /// the per-call `Rc::clone` and to be forward-compatible with the
-    /// final PR 2b.2 API flip that drops `create_object` altogether.
+    /// Allocate a new JS object on the slab, prototype-linked to the
+    /// realm's `Object.prototype`, and return its slot id. Callers that
+    /// need to mutate the new object should follow with
+    /// `get_object_cell_expect(id).borrow_mut()`.
     pub(crate) fn create_object_id(&mut self) -> u64 {
         let mut data = JsObjectData::new();
         data.prototype_id = self.realm().object_prototype;
@@ -1129,9 +1140,13 @@ impl Interpreter {
         if needs_prototype {
             let proto_id = self.create_object_id();
             if is_async_gen {
-                self.get_object_cell_expect(proto_id).borrow_mut().prototype_id = self.realm().async_generator_prototype;
+                self.get_object_cell_expect(proto_id)
+                    .borrow_mut()
+                    .prototype_id = self.realm().async_generator_prototype;
             } else if is_gen {
-                self.get_object_cell_expect(proto_id).borrow_mut().prototype_id = self.realm().generator_prototype;
+                self.get_object_cell_expect(proto_id)
+                    .borrow_mut()
+                    .prototype_id = self.realm().generator_prototype;
             }
             let proto_id = proto_id;
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
@@ -3969,7 +3984,9 @@ impl Interpreter {
         }; // module_ref borrow dropped here
 
         // Set module namespace data for live bindings
-        self.get_object_cell_expect(obj_id).borrow_mut().module_namespace = Some(ModuleNamespaceData {
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .module_namespace = Some(ModuleNamespaceData {
             env: env.clone(),
             export_names: export_names.clone(),
             export_to_binding: export_bindings,
@@ -3978,16 +3995,20 @@ impl Interpreter {
         });
         self.get_object_cell_expect(obj_id).borrow_mut().class_name = "Module".to_string();
         self.get_object_cell_expect(obj_id).borrow_mut().extensible = false; // Module namespaces are non-extensible
-        self.get_object_cell_expect(obj_id).borrow_mut().prototype_id = None; // Module namespaces have null prototype
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = None; // Module namespaces have null prototype
 
         // Add property descriptors for each export (values will be looked up dynamically)
         for name in &export_names {
             // Exports: writable=true, enumerable=true, configurable=false
             // Value is left as undefined - will be looked up dynamically
-            self.get_object_cell_expect(obj_id).borrow_mut().insert_property(
-                name.clone(),
-                PropertyDescriptor::data(JsValue::Undefined, true, true, false),
-            );
+            self.get_object_cell_expect(obj_id)
+                .borrow_mut()
+                .insert_property(
+                    name.clone(),
+                    PropertyDescriptor::data(JsValue::Undefined, true, true, false),
+                );
         }
 
         // Set Symbol.toStringTag to "Module"
@@ -3995,15 +4016,17 @@ impl Interpreter {
         let sym_key = self
             .get_symbol_key("toStringTag")
             .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
-        self.get_object_cell_expect(obj_id).borrow_mut().insert_property(
-            sym_key,
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Module")),
-                false,
-                false,
-                false,
-            ),
-        );
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .insert_property(
+                sym_key,
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Module")),
+                    false,
+                    false,
+                    false,
+                ),
+            );
 
         let id = obj_id;
         let ns = JsValue::Object(crate::types::JsObject { id });
@@ -4043,7 +4066,9 @@ impl Interpreter {
             (env, export_bindings, module_path, export_names)
         };
 
-        self.get_object_cell_expect(obj_id).borrow_mut().module_namespace = Some(ModuleNamespaceData {
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .module_namespace = Some(ModuleNamespaceData {
             env: env.clone(),
             export_names: export_names.clone(),
             export_to_binding: export_bindings,
@@ -4052,27 +4077,33 @@ impl Interpreter {
         });
         self.get_object_cell_expect(obj_id).borrow_mut().class_name = "Module".to_string();
         self.get_object_cell_expect(obj_id).borrow_mut().extensible = false;
-        self.get_object_cell_expect(obj_id).borrow_mut().prototype_id = None;
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .prototype_id = None;
 
         for name in &export_names {
-            self.get_object_cell_expect(obj_id).borrow_mut().insert_property(
-                name.clone(),
-                PropertyDescriptor::data(JsValue::Undefined, true, true, false),
-            );
+            self.get_object_cell_expect(obj_id)
+                .borrow_mut()
+                .insert_property(
+                    name.clone(),
+                    PropertyDescriptor::data(JsValue::Undefined, true, true, false),
+                );
         }
 
         let sym_key = self
             .get_symbol_key("toStringTag")
             .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
-        self.get_object_cell_expect(obj_id).borrow_mut().insert_property(
-            sym_key,
-            PropertyDescriptor::data(
-                JsValue::String(JsString::from_str("Deferred Module")),
-                false,
-                false,
-                false,
-            ),
-        );
+        self.get_object_cell_expect(obj_id)
+            .borrow_mut()
+            .insert_property(
+                sym_key,
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str("Deferred Module")),
+                    false,
+                    false,
+                    false,
+                ),
+            );
 
         let id = obj_id;
         let ns = JsValue::Object(crate::types::JsObject { id });
@@ -4901,9 +4932,7 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
                         o.arraybuffer_is_shared = true;
                         o.sab_shared = Some(sab_inner);
                     }
-                    let sab_val = JsValue::Object(JsObject {
-                        id: sab_obj_id,
-                    });
+                    let sab_val = JsValue::Object(JsObject { id: sab_obj_id });
                     interp.agent_broadcast_rx = Some(rx);
                     let _ = interp.call_function(&callback, &JsValue::Undefined, &[sab_val]);
                     interp.drain_microtasks();
@@ -4914,7 +4943,9 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
             Completion::Normal(JsValue::Undefined)
         },
     ));
-    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
+    interp
+        .get_object_cell_expect(agent_obj_id)
+        .borrow_mut()
         .insert_builtin("receiveBroadcast".to_string(), receive_fn);
 
     // $262.agent.report(value)
@@ -4933,7 +4964,9 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
             Completion::Normal(JsValue::Undefined)
         },
     ));
-    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
+    interp
+        .get_object_cell_expect(agent_obj_id)
+        .borrow_mut()
         .insert_builtin("report".to_string(), report_fn);
 
     // $262.agent.sleep(ms)
@@ -4950,7 +4983,9 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
             Completion::Normal(JsValue::Undefined)
         },
     ));
-    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
+    interp
+        .get_object_cell_expect(agent_obj_id)
+        .borrow_mut()
         .insert_builtin("sleep".to_string(), sleep_fn);
 
     // $262.agent.leaving()
@@ -4959,7 +4994,9 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
         0,
         |_interp, _this, _args| Completion::Normal(JsValue::Undefined),
     ));
-    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
+    interp
+        .get_object_cell_expect(agent_obj_id)
+        .borrow_mut()
         .insert_builtin("leaving".to_string(), leaving_fn);
 
     // $262.agent.monotonicNow()
@@ -4972,11 +5009,15 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
             Completion::Normal(JsValue::Number(elapsed))
         },
     ));
-    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
+    interp
+        .get_object_cell_expect(agent_obj_id)
+        .borrow_mut()
         .insert_builtin("monotonicNow".to_string(), monotonic_fn);
 
     let agent_val = JsValue::Object(JsObject { id: agent_obj_id });
-    interp.get_object_cell_expect(dollar_262_id).borrow_mut()
+    interp
+        .get_object_cell_expect(dollar_262_id)
+        .borrow_mut()
         .insert_builtin("agent".to_string(), agent_val);
 
     let dollar_262_val = JsValue::Object(JsObject { id: dollar_262_id });

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1175,6 +1175,13 @@ impl Interpreter {
         func_val
     }
 
+    /// Get a fresh `Rc::clone` of the slot's `Rc<RefCell<…>>` if live.
+    /// New callers should prefer `get_object_cell` / `get_object_cell_expect`
+    /// (returns `&RefCell<…>`) to avoid the per-call `Rc::clone`; this
+    /// function remains for the (large) set of legacy callers that
+    /// pattern-match `if let Some(obj) = interp.get_object(id) { obj.borrow*() }`
+    /// and need a value-type binding outliving any inner `&mut self`
+    /// callback (proxy traps, getter dispatch, error allocation).
     pub(crate) fn get_object(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
         self.objects.get(id)
     }
@@ -1241,19 +1248,9 @@ impl Interpreter {
         result
     }
 
-    /// Like `get_object` but panics if the id is dead. Matches the pattern
-    /// `self.objects[id as usize].as_ref().unwrap().clone()` used at most
-    /// call sites where the id is known live (held by a live JsValue).
-    pub(crate) fn get_object_expect(&self, id: u64) -> Rc<RefCell<JsObjectData>> {
-        self.objects.get_expect(id)
-    }
-
-    /// Borrow the object's `RefCell` directly without bumping the slot's
-    /// `Rc`. Lifetime tied to `&self`; drop the borrow before any
-    /// `&mut self` call. Use this at new sites to avoid the per-call
-    /// `Rc::clone`; existing `get_object{,_expect}` callers can migrate
-    /// gradually.
-    #[allow(dead_code)] // get_object_cell isn't yet used; get_object_cell_expect is
+    /// Borrow the slot's `RefCell` if live, else `None`. Lifetime tied
+    /// to `&self`; drop the borrow before any `&mut self` call.
+    #[allow(dead_code)] // get_object_cell isn't yet hot; get_object_cell_expect is
     pub(crate) fn get_object_cell(&self, id: u64) -> Option<&RefCell<JsObjectData>> {
         self.objects.get_cell(id)
     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1242,25 +1242,24 @@ impl Interpreter {
     /// `&mut self` call. Use this at new sites to avoid the per-call
     /// `Rc::clone`; existing `get_object{,_expect}` callers can migrate
     /// gradually.
-    #[allow(dead_code)] // migration target — see PR 2b.2 step 4 commit message
+    #[allow(dead_code)] // get_object_cell isn't yet used; get_object_cell_expect is
     pub(crate) fn get_object_cell(&self, id: u64) -> Option<&RefCell<JsObjectData>> {
         self.objects.get_cell(id)
     }
 
-    #[allow(dead_code)] // migration target — see PR 2b.2 step 4 commit message
     pub(crate) fn get_object_cell_expect(&self, id: u64) -> &RefCell<JsObjectData> {
         self.objects.get_cell_expect(id)
     }
 
     /// Iterative prototype-chain walk of `get_property`. Returns
     /// `JsValue::Undefined` when the key is not found anywhere in the chain.
-    /// Each frame is pinned by the Rc returned from `get_object_expect` so
-    /// intermediate safepoints cannot sweep the next prototype before we reach it.
+    /// Each frame borrows the slot's `RefCell` directly via `get_object_cell_expect`,
+    /// avoiding an `Rc::clone` per prototype hop. The walk holds no state across
+    /// `&mut self` calls, so the `&self`-tied lifetime is safe.
     pub(crate) fn get_property_on_id(&self, start_id: u64, key: &str) -> JsValue {
         let mut current = Some(start_id);
         while let Some(id) = current {
-            let obj_rc = self.get_object_expect(id);
-            let b = obj_rc.borrow();
+            let b = self.get_object_cell_expect(id).borrow();
             if let Some(v) = b.own_property_lookup(key) {
                 return v;
             }
@@ -1279,8 +1278,7 @@ impl Interpreter {
     ) -> Option<PropertyDescriptor> {
         let mut current = Some(start_id);
         while let Some(id) = current {
-            let obj_rc = self.get_object_expect(id);
-            let b = obj_rc.borrow();
+            let b = self.get_object_cell_expect(id).borrow();
             if let Some(d) = b.own_property_descriptor_lookup(key) {
                 return Some(d);
             }
@@ -1296,8 +1294,7 @@ impl Interpreter {
     pub(crate) fn has_property_on_id(&self, start_id: u64, key: &str) -> bool {
         let mut current = Some(start_id);
         while let Some(id) = current {
-            let obj_rc = self.get_object_expect(id);
-            let b = obj_rc.borrow();
+            let b = self.get_object_cell_expect(id).borrow();
             if let Some(result) = b.own_has_property(key) {
                 return result;
             }
@@ -1317,8 +1314,7 @@ impl Interpreter {
         let mut result: Vec<String> = Vec::new();
         let mut current = Some(start_id);
         while let Some(id) = current {
-            let obj_rc = self.get_object_expect(id);
-            let b = obj_rc.borrow();
+            let b = self.get_object_cell_expect(id).borrow();
             let (keys, shadow) = b.own_enumerable_keys_with_shadow();
             for k in keys {
                 if global_seen.insert(k.clone()) {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1152,7 +1152,7 @@ impl Interpreter {
         if is_constructable
             && !is_gen
             && let Some(JsValue::Object(proto_ref)) = self
-                .get_object_expect(func_id)
+                .get_object_cell_expect(func_id)
                 .borrow()
                 .get_property_value("prototype")
             && let Some(proto_obj) = self.get_object(proto_ref.id)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -330,8 +330,8 @@ impl Interpreter {
     }
 
     pub(crate) fn create_dollar_262(&mut self, realm_id: usize) -> JsValue {
-        let dollar_262 = self.create_object();
-        let dollar_262_id = dollar_262.borrow().id.unwrap();
+        let dollar_262_id = self.create_object_id();
+        let dollar_262_id = dollar_262_id;
 
         // $262.detachArrayBuffer
         let detach_fn = self.create_function(JsFunction::native(
@@ -342,8 +342,7 @@ impl Interpreter {
                 interp.detach_arraybuffer(&buf)
             },
         ));
-        dollar_262
-            .borrow_mut()
+        self.get_object_cell_expect(dollar_262_id).borrow_mut()
             .insert_builtin("detachArrayBuffer".to_string(), detach_fn);
 
         // $262.gc
@@ -356,14 +355,13 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        dollar_262
-            .borrow_mut()
+        self.get_object_cell_expect(dollar_262_id).borrow_mut()
             .insert_builtin("gc".to_string(), gc_fn);
 
         // $262.global — reference to the realm's global object
         let global_env = self.realms[realm_id].global_env.clone();
         if let Some(go_id) = global_env.borrow().global_object_id {
-            dollar_262.borrow_mut().insert_builtin(
+            self.get_object_cell_expect(dollar_262_id).borrow_mut().insert_builtin(
                 "global".to_string(),
                 JsValue::Object(crate::types::JsObject { id: go_id }),
             );
@@ -379,8 +377,7 @@ impl Interpreter {
                 Completion::Normal(new_dollar_262)
             },
         ));
-        dollar_262
-            .borrow_mut()
+        self.get_object_cell_expect(dollar_262_id).borrow_mut()
             .insert_builtin("createRealm".to_string(), create_realm_fn);
 
         // $262.evalScript — parse and execute code in this $262's realm
@@ -425,28 +422,26 @@ impl Interpreter {
                 }
             },
         ));
-        dollar_262
-            .borrow_mut()
+        self.get_object_cell_expect(dollar_262_id).borrow_mut()
             .insert_builtin("evalScript".to_string(), eval_script_fn);
 
         // $262.IsHTMLDDA — B.3.6 [[IsHTMLDDA]] internal slot
-        let htmldda_obj = self.create_object();
-        htmldda_obj.borrow_mut().callable = Some(JsFunction::native(
+        let htmldda_obj_id = self.create_object_id();
+        self.get_object_cell_expect(htmldda_obj_id).borrow_mut().callable = Some(JsFunction::native(
             "".to_string(),
             0,
             |_interp, _this, _args| Completion::Normal(JsValue::Null),
         ));
-        htmldda_obj.borrow_mut().is_htmldda = true;
+        self.get_object_cell_expect(htmldda_obj_id).borrow_mut().is_htmldda = true;
         let htmldda_val = JsValue::Object(crate::types::JsObject {
-            id: htmldda_obj.borrow().id.unwrap(),
+            id: htmldda_obj_id,
         });
-        dollar_262
-            .borrow_mut()
+        self.get_object_cell_expect(dollar_262_id).borrow_mut()
             .insert_builtin("IsHTMLDDA".to_string(), htmldda_val);
 
         // $262.agent
-        let agent_obj = self.create_object();
-        let agent_obj_id = agent_obj.borrow().id.unwrap();
+        let agent_obj_id = self.create_object_id();
+        let agent_obj_id = agent_obj_id;
 
         // $262.agent.start(script)
         let _reports_clone = self.agent_reports.clone();
@@ -490,8 +485,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        agent_obj
-            .borrow_mut()
+        self.get_object_cell_expect(agent_obj_id).borrow_mut()
             .insert_builtin("start".to_string(), start_fn);
 
         // $262.agent.broadcast(sab)
@@ -515,8 +509,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        agent_obj
-            .borrow_mut()
+        self.get_object_cell_expect(agent_obj_id).borrow_mut()
             .insert_builtin("broadcast".to_string(), broadcast_fn);
 
         // $262.agent.getReport()
@@ -533,8 +526,7 @@ impl Interpreter {
                 }
             },
         ));
-        agent_obj
-            .borrow_mut()
+        self.get_object_cell_expect(agent_obj_id).borrow_mut()
             .insert_builtin("getReport".to_string(), get_report_fn);
 
         // $262.agent.getReportAsync()
@@ -601,8 +593,7 @@ impl Interpreter {
                 Completion::Normal(promise_val)
             },
         ));
-        agent_obj
-            .borrow_mut()
+        self.get_object_cell_expect(agent_obj_id).borrow_mut()
             .insert_builtin("getReportAsync".to_string(), get_report_async_fn);
 
         // $262.agent.sleep(ms)
@@ -619,8 +610,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        agent_obj
-            .borrow_mut()
+        self.get_object_cell_expect(agent_obj_id).borrow_mut()
             .insert_builtin("sleep".to_string(), sleep_fn);
 
         // $262.agent.monotonicNow()
@@ -633,8 +623,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Number(elapsed))
             },
         ));
-        agent_obj
-            .borrow_mut()
+        self.get_object_cell_expect(agent_obj_id).borrow_mut()
             .insert_builtin("monotonicNow".to_string(), monotonic_fn);
 
         // $262.agent.leaving()
@@ -643,13 +632,11 @@ impl Interpreter {
             0,
             |_interp, _this, _args| Completion::Normal(JsValue::Undefined),
         ));
-        agent_obj
-            .borrow_mut()
+        self.get_object_cell_expect(agent_obj_id).borrow_mut()
             .insert_builtin("leaving".to_string(), leaving_fn);
 
         let agent_val = JsValue::Object(crate::types::JsObject { id: agent_obj_id });
-        dollar_262
-            .borrow_mut()
+        self.get_object_cell_expect(dollar_262_id).borrow_mut()
             .insert_builtin("agent".to_string(), agent_val);
 
         // $262.AbstractModuleSource — §28.1.1.1
@@ -669,10 +656,9 @@ impl Interpreter {
         };
 
         // AbstractModuleSource.prototype_id
-        let ams_proto = self.create_object();
+        let ams_proto_id = self.create_object_id();
         // constructor property
-        ams_proto
-            .borrow_mut()
+        self.get_object_cell_expect(ams_proto_id).borrow_mut()
             .insert_builtin("constructor".to_string(), ams_fn.clone());
         // @@toStringTag getter — returns undefined (no [[ModuleSourceClassName]] slot)
         let tag_getter = self.create_function(JsFunction::native(
@@ -685,7 +671,7 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        ams_proto.borrow_mut().insert_property(
+        self.get_object_cell_expect(ams_proto_id).borrow_mut().insert_property(
             "Symbol(Symbol.toStringTag)".to_string(),
             PropertyDescriptor {
                 value: None,
@@ -697,7 +683,7 @@ impl Interpreter {
             },
         );
         let ams_proto_val = JsValue::Object(crate::types::JsObject {
-            id: ams_proto.borrow().id.unwrap(),
+            id: ams_proto_id,
         });
 
         // Wire prototype on the constructor: {writable: false, enumerable: false, configurable: false}
@@ -708,8 +694,7 @@ impl Interpreter {
             );
         }
 
-        dollar_262
-            .borrow_mut()
+        self.get_object_cell_expect(dollar_262_id).borrow_mut()
             .insert_builtin("AbstractModuleSource".to_string(), ams_fn);
 
         JsValue::Object(crate::types::JsObject { id: dollar_262_id })
@@ -941,9 +926,9 @@ impl Interpreter {
 
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn from_property_descriptor(&mut self, desc: &PropertyDescriptor) -> JsValue {
-        let result = self.create_object();
+        let result_id = self.create_object_id();
         {
-            let mut r = result.borrow_mut();
+            let mut r = self.get_object_cell_expect(result_id).borrow_mut();
             // §6.2.6.4 FromPropertyDescriptor — only include fields that are present
             if let Some(ref val) = desc.value {
                 r.insert_value("value".to_string(), val.clone());
@@ -964,7 +949,7 @@ impl Interpreter {
                 r.insert_value("configurable".to_string(), JsValue::Boolean(c));
             }
         }
-        let id = result.borrow().id.unwrap();
+        let id = result_id;
         JsValue::Object(crate::types::JsObject { id })
     }
 
@@ -1142,13 +1127,13 @@ impl Interpreter {
         // even when they are class methods (non-constructable)
         let needs_prototype = is_constructable || is_gen || is_async_gen;
         if needs_prototype {
-            let proto = self.create_object();
+            let proto_id = self.create_object_id();
             if is_async_gen {
-                proto.borrow_mut().prototype_id = self.realm().async_generator_prototype;
+                self.get_object_cell_expect(proto_id).borrow_mut().prototype_id = self.realm().async_generator_prototype;
             } else if is_gen {
-                proto.borrow_mut().prototype_id = self.realm().generator_prototype;
+                self.get_object_cell_expect(proto_id).borrow_mut().prototype_id = self.realm().generator_prototype;
             }
-            let proto_id = proto.borrow().id.unwrap();
+            let proto_id = proto_id;
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj_data.insert_property(
                 "prototype".to_string(),
@@ -1382,9 +1367,9 @@ impl Interpreter {
         func_env: Option<&EnvRef>,
         param_names: &[String],
     ) -> JsValue {
-        let obj = self.create_object();
+        let obj_id = self.create_object_id();
         {
-            let mut o = obj.borrow_mut();
+            let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
             o.class_name = "Arguments".to_string();
 
             // length property: writable, not enumerable, configurable
@@ -1447,7 +1432,7 @@ impl Interpreter {
             }
         }
 
-        let result_id = obj.borrow().id.unwrap();
+        let result_id = obj_id;
         let result = JsValue::Object(crate::types::JsObject { id: result_id });
 
         // Unmapped (strict OR non-simple params): callee is a throw accessor
@@ -2717,9 +2702,9 @@ impl Interpreter {
         let buf_rc = Rc::new(RefCell::new(BufferData::Owned(bytes.to_vec())));
         let detached = Rc::new(Cell::new(false));
 
-        let ab_obj = self.create_object();
+        let ab_obj_id = self.create_object_id();
         {
-            let mut ab = ab_obj.borrow_mut();
+            let mut ab = self.get_object_cell_expect(ab_obj_id).borrow_mut();
             ab.class_name = "ArrayBuffer".to_string();
             ab.prototype_id = self.realm().arraybuffer_prototype;
             ab.arraybuffer_data = Some(buf_rc.clone());
@@ -2727,7 +2712,7 @@ impl Interpreter {
             ab.arraybuffer_is_immutable = true;
         }
         self.gc_track_external_bytes(len);
-        let ab_id = ab_obj.borrow().id.unwrap();
+        let ab_id = ab_obj_id;
         let buf_val = JsValue::Object(crate::types::JsObject { id: ab_id });
 
         let ta_info = TypedArrayInfo {
@@ -3958,7 +3943,7 @@ impl Interpreter {
             return cached;
         }
 
-        let obj = self.create_object();
+        let obj_id = self.create_object_id();
         let (env, export_bindings, module_path, export_names) = {
             let module_ref = module.borrow();
             let env = module_ref.env.clone();
@@ -3984,22 +3969,22 @@ impl Interpreter {
         }; // module_ref borrow dropped here
 
         // Set module namespace data for live bindings
-        obj.borrow_mut().module_namespace = Some(ModuleNamespaceData {
+        self.get_object_cell_expect(obj_id).borrow_mut().module_namespace = Some(ModuleNamespaceData {
             env: env.clone(),
             export_names: export_names.clone(),
             export_to_binding: export_bindings,
             module_path,
             deferred: false,
         });
-        obj.borrow_mut().class_name = "Module".to_string();
-        obj.borrow_mut().extensible = false; // Module namespaces are non-extensible
-        obj.borrow_mut().prototype_id = None; // Module namespaces have null prototype
+        self.get_object_cell_expect(obj_id).borrow_mut().class_name = "Module".to_string();
+        self.get_object_cell_expect(obj_id).borrow_mut().extensible = false; // Module namespaces are non-extensible
+        self.get_object_cell_expect(obj_id).borrow_mut().prototype_id = None; // Module namespaces have null prototype
 
         // Add property descriptors for each export (values will be looked up dynamically)
         for name in &export_names {
             // Exports: writable=true, enumerable=true, configurable=false
             // Value is left as undefined - will be looked up dynamically
-            obj.borrow_mut().insert_property(
+            self.get_object_cell_expect(obj_id).borrow_mut().insert_property(
                 name.clone(),
                 PropertyDescriptor::data(JsValue::Undefined, true, true, false),
             );
@@ -4010,7 +3995,7 @@ impl Interpreter {
         let sym_key = self
             .get_symbol_key("toStringTag")
             .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
-        obj.borrow_mut().insert_property(
+        self.get_object_cell_expect(obj_id).borrow_mut().insert_property(
             sym_key,
             PropertyDescriptor::data(
                 JsValue::String(JsString::from_str("Module")),
@@ -4020,7 +4005,7 @@ impl Interpreter {
             ),
         );
 
-        let id = obj.borrow().id.unwrap();
+        let id = obj_id;
         let ns = JsValue::Object(crate::types::JsObject { id });
         module.borrow_mut().cached_namespace = Some(ns.clone());
         ns
@@ -4033,7 +4018,7 @@ impl Interpreter {
             return cached;
         }
 
-        let obj = self.create_object();
+        let obj_id = self.create_object_id();
         let (env, export_bindings, module_path, export_names) = {
             let module_ref = module.borrow();
             let env = module_ref.env.clone();
@@ -4058,19 +4043,19 @@ impl Interpreter {
             (env, export_bindings, module_path, export_names)
         };
 
-        obj.borrow_mut().module_namespace = Some(ModuleNamespaceData {
+        self.get_object_cell_expect(obj_id).borrow_mut().module_namespace = Some(ModuleNamespaceData {
             env: env.clone(),
             export_names: export_names.clone(),
             export_to_binding: export_bindings,
             module_path,
             deferred: true,
         });
-        obj.borrow_mut().class_name = "Module".to_string();
-        obj.borrow_mut().extensible = false;
-        obj.borrow_mut().prototype_id = None;
+        self.get_object_cell_expect(obj_id).borrow_mut().class_name = "Module".to_string();
+        self.get_object_cell_expect(obj_id).borrow_mut().extensible = false;
+        self.get_object_cell_expect(obj_id).borrow_mut().prototype_id = None;
 
         for name in &export_names {
-            obj.borrow_mut().insert_property(
+            self.get_object_cell_expect(obj_id).borrow_mut().insert_property(
                 name.clone(),
                 PropertyDescriptor::data(JsValue::Undefined, true, true, false),
             );
@@ -4079,7 +4064,7 @@ impl Interpreter {
         let sym_key = self
             .get_symbol_key("toStringTag")
             .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
-        obj.borrow_mut().insert_property(
+        self.get_object_cell_expect(obj_id).borrow_mut().insert_property(
             sym_key,
             PropertyDescriptor::data(
                 JsValue::String(JsString::from_str("Deferred Module")),
@@ -4089,7 +4074,7 @@ impl Interpreter {
             ),
         );
 
-        let id = obj.borrow().id.unwrap();
+        let id = obj_id;
         let ns = JsValue::Object(crate::types::JsObject { id });
         module.borrow_mut().cached_deferred_namespace = Some(ns.clone());
         ns
@@ -4887,11 +4872,11 @@ fn to_uint32_f64(n: f64) -> u32 {
 fn setup_agent_side_262(interp: &mut Interpreter) {
     use crate::types::JsObject;
 
-    let dollar_262 = interp.create_object();
-    let dollar_262_id = dollar_262.borrow().id.unwrap();
+    let dollar_262_id = interp.create_object_id();
+    let dollar_262_id = dollar_262_id;
 
-    let agent_obj = interp.create_object();
-    let agent_obj_id = agent_obj.borrow().id.unwrap();
+    let agent_obj_id = interp.create_object_id();
+    let agent_obj_id = agent_obj_id;
 
     // $262.agent.receiveBroadcast(callback)
     let receive_fn = interp.create_function(JsFunction::native(
@@ -4905,10 +4890,10 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
                     let sab_inner = msg.sab_shared;
                     let buf = BufferData::Shared(sab_inner.clone());
                     let buf_rc = Rc::new(RefCell::new(buf));
-                    let sab_obj = interp.create_object();
+                    let sab_obj_id = interp.create_object_id();
                     let sab_proto = interp.realm().shared_arraybuffer_prototype;
                     {
-                        let mut o = sab_obj.borrow_mut();
+                        let mut o = interp.get_object_cell_expect(sab_obj_id).borrow_mut();
                         o.class_name = "SharedArrayBuffer".to_string();
                         o.prototype_id = sab_proto;
                         o.arraybuffer_data = Some(buf_rc);
@@ -4917,7 +4902,7 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
                         o.sab_shared = Some(sab_inner);
                     }
                     let sab_val = JsValue::Object(JsObject {
-                        id: sab_obj.borrow().id.unwrap(),
+                        id: sab_obj_id,
                     });
                     interp.agent_broadcast_rx = Some(rx);
                     let _ = interp.call_function(&callback, &JsValue::Undefined, &[sab_val]);
@@ -4929,8 +4914,7 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
             Completion::Normal(JsValue::Undefined)
         },
     ));
-    agent_obj
-        .borrow_mut()
+    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
         .insert_builtin("receiveBroadcast".to_string(), receive_fn);
 
     // $262.agent.report(value)
@@ -4949,8 +4933,7 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
             Completion::Normal(JsValue::Undefined)
         },
     ));
-    agent_obj
-        .borrow_mut()
+    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
         .insert_builtin("report".to_string(), report_fn);
 
     // $262.agent.sleep(ms)
@@ -4967,8 +4950,7 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
             Completion::Normal(JsValue::Undefined)
         },
     ));
-    agent_obj
-        .borrow_mut()
+    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
         .insert_builtin("sleep".to_string(), sleep_fn);
 
     // $262.agent.leaving()
@@ -4977,8 +4959,7 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
         0,
         |_interp, _this, _args| Completion::Normal(JsValue::Undefined),
     ));
-    agent_obj
-        .borrow_mut()
+    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
         .insert_builtin("leaving".to_string(), leaving_fn);
 
     // $262.agent.monotonicNow()
@@ -4991,13 +4972,11 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
             Completion::Normal(JsValue::Number(elapsed))
         },
     ));
-    agent_obj
-        .borrow_mut()
+    interp.get_object_cell_expect(agent_obj_id).borrow_mut()
         .insert_builtin("monotonicNow".to_string(), monotonic_fn);
 
     let agent_val = JsValue::Object(JsObject { id: agent_obj_id });
-    dollar_262
-        .borrow_mut()
+    interp.get_object_cell_expect(dollar_262_id).borrow_mut()
         .insert_builtin("agent".to_string(), agent_val);
 
     let dollar_262_val = JsValue::Object(JsObject { id: dollar_262_id });

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -331,7 +331,6 @@ impl Interpreter {
 
     pub(crate) fn create_dollar_262(&mut self, realm_id: usize) -> JsValue {
         let dollar_262_id = self.create_object_id();
-        let dollar_262_id = dollar_262_id;
 
         // $262.detachArrayBuffer
         let detach_fn = self.create_function(JsFunction::native(
@@ -450,7 +449,6 @@ impl Interpreter {
 
         // $262.agent
         let agent_obj_id = self.create_object_id();
-        let agent_obj_id = agent_obj_id;
 
         // $262.agent.start(script)
         let _reports_clone = self.agent_reports.clone();
@@ -1148,7 +1146,6 @@ impl Interpreter {
                     .borrow_mut()
                     .prototype_id = self.realm().generator_prototype;
             }
-            let proto_id = proto_id;
             let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
             obj_data.insert_property(
                 "prototype".to_string(),
@@ -4901,10 +4898,8 @@ fn setup_agent_side_262(interp: &mut Interpreter) {
     use crate::types::JsObject;
 
     let dollar_262_id = interp.create_object_id();
-    let dollar_262_id = dollar_262_id;
 
     let agent_obj_id = interp.create_object_id();
-    let agent_obj_id = agent_obj_id;
 
     // $262.agent.receiveBroadcast(callback)
     let receive_fn = interp.create_function(JsFunction::native(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -503,9 +503,9 @@ impl Interpreter {
             |interp, _this, args| {
                 let sab_val = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if let JsValue::Object(o) = &sab_val
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(cell) = interp.get_object_cell(o.id)
                 {
-                    let sab_shared = obj.borrow().sab_shared.clone();
+                    let sab_shared = cell.borrow().sab_shared.clone();
                     if let Some(inner) = sab_shared {
                         for tx in &interp.agent_broadcast_txs {
                             let _ = tx.send(AgentBroadcastMsg {
@@ -703,7 +703,7 @@ impl Interpreter {
         let ams_proto_val = JsValue::Object(crate::types::JsObject { id: ams_proto_id });
 
         // Wire prototype on the constructor: {writable: false, enumerable: false, configurable: false}
-        if let Some(obj) = self.get_object(ams_fn_id) {
+        if let Some(obj) = self.get_object_cell(ams_fn_id) {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(ams_proto_val, false, false, false),
@@ -777,7 +777,7 @@ impl Interpreter {
     // GetFunctionRealm — §10.2.4
     pub(crate) fn get_function_realm(&mut self, func_val: &JsValue) -> Result<usize, JsValue> {
         if let JsValue::Object(o) = func_val
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let obj_ref = obj.borrow();
             // Bound function: recurse on [[BoundTargetFunction]]
@@ -893,7 +893,7 @@ impl Interpreter {
                 && !matches!(getter, JsValue::Undefined)
             {
                 let is_callable = if let JsValue::Object(o) = getter
-                    && let Some(obj) = self.get_object(o.id)
+                    && let Some(obj) = self.get_object_cell(o.id)
                 {
                     obj.borrow().callable.is_some()
                 } else {
@@ -907,7 +907,7 @@ impl Interpreter {
                 && !matches!(setter, JsValue::Undefined)
             {
                 let is_callable = if let JsValue::Object(o) = setter
-                    && let Some(obj) = self.get_object(o.id)
+                    && let Some(obj) = self.get_object_cell(o.id)
                 {
                     obj.borrow().callable.is_some()
                 } else {
@@ -1163,7 +1163,7 @@ impl Interpreter {
                 .get_object_cell_expect(func_id)
                 .borrow()
                 .get_property_value("prototype")
-            && let Some(proto_obj) = self.get_object(proto_ref.id)
+            && let Some(proto_obj) = self.get_object_cell(proto_ref.id)
         {
             proto_obj
                 .borrow_mut()
@@ -1338,7 +1338,7 @@ impl Interpreter {
 
     pub(crate) fn set_function_name(&self, val: &JsValue, name: &str) {
         if let JsValue::Object(o) = val
-            && let Some(obj) = self.get_object(o.id)
+            && let Some(obj) = self.get_object_cell(o.id)
         {
             let obj_ref = obj.borrow();
             if obj_ref.callable.is_none() {
@@ -1452,7 +1452,7 @@ impl Interpreter {
                 .clone()
                 .unwrap_or_else(|| self.create_thrower_function());
             if let JsValue::Object(ref o) = result
-                && let Some(obj_rc) = self.get_object(o.id)
+                && let Some(obj_rc) = self.get_object_cell(o.id)
             {
                 obj_rc.borrow_mut().define_own_property(
                     "callee".to_string(),
@@ -1478,7 +1478,7 @@ impl Interpreter {
             if let Some(iter_fn) = array_iter_fn
                 && !matches!(iter_fn, JsValue::Undefined)
                 && let JsValue::Object(ref o) = result
-                && let Some(obj_rc) = self.get_object(o.id)
+                && let Some(obj_rc) = self.get_object_cell(o.id)
             {
                 obj_rc
                     .borrow_mut()
@@ -4537,7 +4537,7 @@ impl Interpreter {
         }
         let ids = self.scheduler.pending_async_promise_ids_lock();
         for &id in ids.iter() {
-            if let Some(obj) = self.get_object(id)
+            if let Some(obj) = self.get_object_cell(id)
                 && let Some(ref pd) = obj.borrow().promise_data
                 && (!pd.fulfill_reactions.is_empty() || !pd.reject_reactions.is_empty())
             {
@@ -4599,7 +4599,7 @@ impl Interpreter {
     ) -> Result<bool, JsValue> {
         // 1. If Desc does not have [[Value]], just do OrdinaryDefineOwnProperty(A, "length", Desc)
         if desc.value.is_none() {
-            let obj_rc = self.get_object(obj_id as u64).unwrap();
+            let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
             return Ok(obj_rc
                 .borrow_mut()
                 .define_own_property("length".to_string(), desc));
@@ -4628,7 +4628,7 @@ impl Interpreter {
 
         // 6. Let oldLenDesc be OrdinaryGetOwnProperty(A, "length").
         let (old_len, old_len_writable) = {
-            let obj_rc = self.get_object(obj_id as u64).unwrap();
+            let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
             let obj = obj_rc.borrow();
             let old_len_desc = obj.properties.get("length").cloned();
             match old_len_desc {
@@ -4653,7 +4653,7 @@ impl Interpreter {
 
         // 7. If newLen >= oldLen, return OrdinaryDefineOwnProperty(A, "length", newLenDesc).
         if new_len >= old_len {
-            let obj_rc = self.get_object(obj_id as u64).unwrap();
+            let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
             let result = obj_rc
                 .borrow_mut()
                 .define_own_property("length".to_string(), new_len_desc);
@@ -4676,7 +4676,7 @@ impl Interpreter {
 
         // 11. Let succeeded be OrdinaryDefineOwnProperty(A, "length", newLenDesc).
         {
-            let obj_rc = self.get_object(obj_id as u64).unwrap();
+            let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
             let succeeded = obj_rc
                 .borrow_mut()
                 .define_own_property("length".to_string(), new_len_desc);
@@ -4690,7 +4690,7 @@ impl Interpreter {
         //     Stop if a deletion fails (non-configurable).
         let mut actual_new_len = new_len;
         {
-            let obj_rc = self.get_object(obj_id as u64).unwrap();
+            let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
             let mut obj = obj_rc.borrow_mut();
 
             // Collect array index keys >= newLen and < oldLen, sorted descending.
@@ -4731,7 +4731,7 @@ impl Interpreter {
 
         // If we were blocked by a non-configurable element, update length and handle writable.
         if actual_new_len != new_len {
-            let obj_rc = self.get_object(obj_id as u64).unwrap();
+            let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
             let mut obj = obj_rc.borrow_mut();
             if let Some(len_desc) = obj.properties.get_mut("length") {
                 len_desc.value = Some(JsValue::Number(actual_new_len as f64));
@@ -4745,7 +4745,7 @@ impl Interpreter {
 
         // 14. If newWritable is false, set [[Writable]] on length to false.
         if !new_writable {
-            let obj_rc = self.get_object(obj_id as u64).unwrap();
+            let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
             let mut obj = obj_rc.borrow_mut();
             if let Some(len_desc) = obj.properties.get_mut("length") {
                 len_desc.writable = Some(false);
@@ -4776,7 +4776,7 @@ impl Interpreter {
 
             // 2.a. Let oldLen be the current length value.
             let (old_len, length_writable) = {
-                let obj_rc = self.get_object(obj_id as u64).unwrap();
+                let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
                 let obj = obj_rc.borrow();
                 let len_desc = obj.properties.get("length");
                 let ol = len_desc
@@ -4800,7 +4800,7 @@ impl Interpreter {
 
             // 2.c. Let succeeded be OrdinaryDefineOwnProperty(A, P, Desc).
             let succeeded = {
-                let obj_rc = self.get_object(obj_id as u64).unwrap();
+                let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
                 obj_rc
                     .borrow_mut()
                     .define_own_property(key.to_string(), desc.clone())
@@ -4814,7 +4814,7 @@ impl Interpreter {
             // 2.e. If index >= oldLen, set length to index + 1.
             if index_u32 >= old_len {
                 let new_len = index_u32 + 1;
-                let obj_rc = self.get_object(obj_id as u64).unwrap();
+                let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
                 let mut obj = obj_rc.borrow_mut();
                 if let Some(len_desc) = obj.properties.get_mut("length") {
                     len_desc.value = Some(JsValue::Number(new_len as f64));
@@ -4832,7 +4832,7 @@ impl Interpreter {
                     }
                 }
             } else {
-                let obj_rc = self.get_object(obj_id as u64).unwrap();
+                let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
                 let mut obj = obj_rc.borrow_mut();
                 if let Some(ref mut elems) = obj.array_elements {
                     let idx = index_u32 as usize;
@@ -4848,7 +4848,7 @@ impl Interpreter {
         }
 
         // 3. Return OrdinaryDefineOwnProperty(A, P, Desc).
-        let obj_rc = self.get_object(obj_id as u64).unwrap();
+        let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
         Ok(obj_rc
             .borrow_mut()
             .define_own_property(key.to_string(), desc))
@@ -4857,7 +4857,7 @@ impl Interpreter {
     pub fn format_value(&self, val: &JsValue) -> String {
         match val {
             JsValue::Object(o) => {
-                if self.get_object(o.id).is_some() {
+                if self.get_object_cell(o.id).is_some() {
                     let name = self.get_property_on_id(o.id, "name");
                     let message = self.get_property_on_id(o.id, "message");
                     if let JsValue::String(ref msg) = message {

--- a/src/interpreter/object_arena.rs
+++ b/src/interpreter/object_arena.rs
@@ -65,14 +65,13 @@ impl ObjectArena {
     /// is tied to `&self`; callers must drop the borrow before any
     /// `&mut self` call. Forward-compatible with the eventual PR 2b.2.final
     /// API flip that drops the slot's `Rc` wrapper entirely.
-    #[allow(dead_code)] // migration target — see PR 2b.2 step 4 commit message
+    #[allow(dead_code)] // get_cell isn't yet used; get_cell_expect is
     pub(crate) fn get_cell(&self, id: u64) -> Option<&RefCell<JsObjectData>> {
         self.slot_at(id)
             .and_then(|s| s.as_ref().map(|rc| rc.as_ref()))
     }
 
     /// Like `get_cell`, but panics for dead ids.
-    #[allow(dead_code)] // migration target — see PR 2b.2 step 4 commit message
     pub(crate) fn get_cell_expect(&self, id: u64) -> &RefCell<JsObjectData> {
         self.get_cell(id).expect("dead object id")
     }

--- a/src/interpreter/object_arena.rs
+++ b/src/interpreter/object_arena.rs
@@ -1,0 +1,119 @@
+//! Chunked arena for `JsObjectData` slots.
+//!
+//! Replaces the prior `Vec<Option<Rc<RefCell<JsObjectData>>>>` slab with
+//! `Vec<Box<[Option<Rc<RefCell<JsObjectData>>>; CHUNK_SIZE]>>`. Per-slot
+//! `Rc<RefCell<…>>` storage is preserved (PR 2b.1) so existing call sites
+//! keep their `Rc<RefCell<JsObjectData>>` API. The chunked layout makes
+//! slot addresses stable across `Vec` growth, paving the way for a future
+//! PR 2b.2 that drops the per-slot `Rc` and yields `&RefCell<JsObjectData>`
+//! borrows directly.
+
+use super::types::JsObjectData;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub(crate) const CHUNK_SIZE: usize = 1024;
+
+type Slot = Option<Rc<RefCell<JsObjectData>>>;
+type Chunk = Box<[Slot; CHUNK_SIZE]>;
+
+pub(crate) struct ObjectArena {
+    chunks: Vec<Chunk>,
+    free_list: Vec<u64>,
+    live_count: usize,
+}
+
+impl ObjectArena {
+    pub(crate) fn new() -> Self {
+        Self {
+            chunks: Vec::new(),
+            free_list: Vec::new(),
+            live_count: 0,
+        }
+    }
+
+    /// Allocate a slot for `data`. Writes `data.id = Some(id)` before wrapping
+    /// in `Rc<RefCell<>>`. Returns `(id, was_reuse)` so callers can adjust GC
+    /// pressure accounting (a reused slot is cheaper than a fresh chunk
+    /// growth).
+    pub(crate) fn alloc(&mut self, mut data: JsObjectData) -> (u64, bool) {
+        let (id, was_reuse) = if let Some(idx) = self.free_list.pop() {
+            (idx, true)
+        } else {
+            let idx = (self.chunks.len() * CHUNK_SIZE) as u64;
+            self.grow_one_chunk();
+            (idx, false)
+        };
+        data.id = Some(id);
+        let rc = Rc::new(RefCell::new(data));
+        self.set_slot(id, Some(rc));
+        self.live_count += 1;
+        (id, was_reuse)
+    }
+
+    /// Return a fresh `Rc::clone` of the slot if live, else `None`.
+    pub(crate) fn get(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
+        self.slot_at(id).and_then(|s| s.clone())
+    }
+
+    /// Like `get`, but panics for dead ids.
+    pub(crate) fn get_expect(&self, id: u64) -> Rc<RefCell<JsObjectData>> {
+        self.get(id).expect("dead object id")
+    }
+
+    /// Drop the slot at `id`. Caller is responsible for any external
+    /// bookkeeping (e.g. ArrayBuffer external bytes) before calling.
+    pub(crate) fn free(&mut self, id: u64) {
+        debug_assert!(
+            self.slot_at(id).is_some_and(|s| s.is_some()),
+            "ObjectArena::free called on dead id {id}"
+        );
+        self.set_slot(id, None);
+        self.free_list.push(id);
+        self.live_count -= 1;
+    }
+
+    /// Number of currently-occupied slots.
+    pub(crate) fn live_count(&self) -> usize {
+        self.live_count
+    }
+
+    /// Total slot capacity (live + dead). Used as the upper bound for
+    /// sweep iteration and sizing the `marks` vector.
+    pub(crate) fn capacity(&self) -> u64 {
+        (self.chunks.len() * CHUNK_SIZE) as u64
+    }
+
+    /// Direct slot inspection — returns `&Slot` for the underlying
+    /// `Option<Rc<…>>`. Used by sweep to test `is_some()` and to access
+    /// the inner `Rc` without cloning.
+    pub(crate) fn slot_at(&self, id: u64) -> Option<&Slot> {
+        let (chunk_idx, slot_idx) = Self::split(id);
+        self.chunks.get(chunk_idx).map(|c| &c[slot_idx])
+    }
+
+    fn split(id: u64) -> (usize, usize) {
+        let id = id as usize;
+        (id / CHUNK_SIZE, id % CHUNK_SIZE)
+    }
+
+    fn set_slot(&mut self, id: u64, slot: Slot) {
+        let (chunk_idx, slot_idx) = Self::split(id);
+        self.chunks[chunk_idx][slot_idx] = slot;
+    }
+
+    fn grow_one_chunk(&mut self) {
+        let chunk: Vec<Slot> = (0..CHUNK_SIZE).map(|_| None).collect();
+        let boxed: Box<[Slot]> = chunk.into_boxed_slice();
+        let array: Chunk = boxed
+            .try_into()
+            .unwrap_or_else(|_| panic!("ObjectArena: chunk size {CHUNK_SIZE} mismatch"));
+        self.chunks.push(array);
+    }
+}
+
+impl Default for ObjectArena {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/interpreter/object_arena.rs
+++ b/src/interpreter/object_arena.rs
@@ -51,21 +51,17 @@ impl ObjectArena {
         (id, was_reuse)
     }
 
-    /// Return a fresh `Rc::clone` of the slot if live, else `None`.
+    /// Return a fresh `Rc::clone` of the slot's `Rc<RefCell<…>>` if live.
+    /// Used by the legacy `Interpreter::get_object` API; new callers should
+    /// use `get_cell` / `get_cell_expect` instead.
     pub(crate) fn get(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
         self.slot_at(id).and_then(|s| s.clone())
     }
 
-    /// Like `get`, but panics for dead ids.
-    pub(crate) fn get_expect(&self, id: u64) -> Rc<RefCell<JsObjectData>> {
-        self.get(id).expect("dead object id")
-    }
-
-    /// Return a borrow of the slot's `RefCell` if live, else `None`. Lifetime
-    /// is tied to `&self`; callers must drop the borrow before any
-    /// `&mut self` call. Forward-compatible with the eventual PR 2b.2.final
-    /// API flip that drops the slot's `Rc` wrapper entirely.
-    #[allow(dead_code)] // get_cell isn't yet used; get_cell_expect is
+    /// Borrow the slot's `RefCell` if live, else `None`. Lifetime is
+    /// tied to `&self`; callers must drop the borrow before any
+    /// `&mut self` call.
+    #[allow(dead_code)] // get_cell isn't yet hot; get_cell_expect is
     pub(crate) fn get_cell(&self, id: u64) -> Option<&RefCell<JsObjectData>> {
         self.slot_at(id)
             .and_then(|s| s.as_ref().map(|rc| rc.as_ref()))

--- a/src/interpreter/object_arena.rs
+++ b/src/interpreter/object_arena.rs
@@ -61,6 +61,22 @@ impl ObjectArena {
         self.get(id).expect("dead object id")
     }
 
+    /// Return a borrow of the slot's `RefCell` if live, else `None`. Lifetime
+    /// is tied to `&self`; callers must drop the borrow before any
+    /// `&mut self` call. Forward-compatible with the eventual PR 2b.2.final
+    /// API flip that drops the slot's `Rc` wrapper entirely.
+    #[allow(dead_code)] // migration target — see PR 2b.2 step 4 commit message
+    pub(crate) fn get_cell(&self, id: u64) -> Option<&RefCell<JsObjectData>> {
+        self.slot_at(id)
+            .and_then(|s| s.as_ref().map(|rc| rc.as_ref()))
+    }
+
+    /// Like `get_cell`, but panics for dead ids.
+    #[allow(dead_code)] // migration target — see PR 2b.2 step 4 commit message
+    pub(crate) fn get_cell_expect(&self, id: u64) -> &RefCell<JsObjectData> {
+        self.get_cell(id).expect("dead object id")
+    }
+
     /// Drop the slot at `id`. Caller is responsible for any external
     /// bookkeeping (e.g. ArrayBuffer external bytes) before calling.
     pub(crate) fn free(&mut self, id: u64) {

--- a/src/interpreter/object_arena.rs
+++ b/src/interpreter/object_arena.rs
@@ -20,6 +20,7 @@ type Chunk = Box<[Slot; CHUNK_SIZE]>;
 pub(crate) struct ObjectArena {
     chunks: Vec<Chunk>,
     free_list: Vec<u64>,
+    next_slot: u64,
     live_count: usize,
 }
 
@@ -28,6 +29,7 @@ impl ObjectArena {
         Self {
             chunks: Vec::new(),
             free_list: Vec::new(),
+            next_slot: 0,
             live_count: 0,
         }
     }
@@ -40,8 +42,11 @@ impl ObjectArena {
         let (id, was_reuse) = if let Some(idx) = self.free_list.pop() {
             (idx, true)
         } else {
-            let idx = (self.chunks.len() * CHUNK_SIZE) as u64;
-            self.grow_one_chunk();
+            if self.next_slot == self.capacity() {
+                self.grow_one_chunk();
+            }
+            let idx = self.next_slot;
+            self.next_slot += 1;
             (idx, false)
         };
         data.id = Some(id);
@@ -126,5 +131,45 @@ impl ObjectArena {
 impl Default for ObjectArena {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_allocations_fill_current_chunk_before_growing() {
+        let mut arena = ObjectArena::new();
+
+        for expected in 0..CHUNK_SIZE as u64 {
+            let (id, was_reuse) = arena.alloc(JsObjectData::new());
+            assert_eq!(id, expected);
+            assert!(!was_reuse);
+            assert_eq!(arena.capacity(), CHUNK_SIZE as u64);
+        }
+
+        let (id, was_reuse) = arena.alloc(JsObjectData::new());
+        assert_eq!(id, CHUNK_SIZE as u64);
+        assert!(!was_reuse);
+        assert_eq!(arena.capacity(), (CHUNK_SIZE * 2) as u64);
+    }
+
+    #[test]
+    fn freed_slots_are_reused_before_next_fresh_slot() {
+        let mut arena = ObjectArena::new();
+        let (first, _) = arena.alloc(JsObjectData::new());
+        let (second, _) = arena.alloc(JsObjectData::new());
+
+        arena.free(first);
+
+        let (reused, was_reuse) = arena.alloc(JsObjectData::new());
+        assert_eq!(reused, first);
+        assert!(was_reuse);
+        assert_eq!(arena.live_count(), 2);
+
+        let (fresh, was_reuse) = arena.alloc(JsObjectData::new());
+        assert_eq!(fresh, second + 1);
+        assert!(!was_reuse);
     }
 }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -50,10 +50,22 @@ fn run_module_with_path(source: &str, path: &Path) -> Interpreter {
 }
 
 fn global_string(interp: &Interpreter, name: &str) -> String {
-    let env = interp.realm().global_env.borrow();
-    match env.get(name).unwrap_or(JsValue::Undefined) {
+    match interp
+        .get_global_var_ref(name)
+        .unwrap_or(JsValue::Undefined)
+    {
         JsValue::String(s) => s.to_string(),
         other => panic!("expected global string for {name}, got {other:?}"),
+    }
+}
+
+fn global_number(interp: &Interpreter, name: &str) -> f64 {
+    match interp
+        .get_global_var_ref(name)
+        .unwrap_or(JsValue::Undefined)
+    {
+        JsValue::Number(n) => n,
+        other => panic!("expected global number for {name}, got {other:?}"),
     }
 }
 
@@ -356,7 +368,7 @@ fn transitive_module_import_link_error_aborts_parent_before_evaluation() {
     };
     assert!(err.contains("SyntaxError"), "unexpected error: {err}");
     assert!(err.contains("nonExistent"), "unexpected error: {err}");
-    assert!(interp.realm().global_env.borrow().get("marker").is_none());
+    assert!(interp.get_global_var_ref("marker").is_none());
 
     let broken_canon = broken_path.canonicalize().unwrap_or(broken_path.clone());
     let realm_id = interp.current_realm_id;
@@ -414,7 +426,7 @@ fn transitive_reexport_link_error_aborts_parent_before_evaluation() {
     };
     assert!(err.contains("SyntaxError"), "unexpected error: {err}");
     assert!(err.contains("nonExistent"), "unexpected error: {err}");
-    assert!(interp.realm().global_env.borrow().get("marker").is_none());
+    assert!(interp.get_global_var_ref("marker").is_none());
 
     let _ = fs::remove_dir_all(&dir);
 }
@@ -456,7 +468,7 @@ fn default_cannot_be_reexported_through_star_resolution() {
     };
     assert!(err.contains("SyntaxError"), "unexpected error: {err}");
     assert!(err.contains("default"), "unexpected error: {err}");
-    assert!(interp.realm().global_env.borrow().get("marker").is_none());
+    assert!(interp.get_global_var_ref("marker").is_none());
 
     let _ = fs::remove_dir_all(&dir);
 }
@@ -781,11 +793,11 @@ fn ic_records_after_repeated_dot_access() {
         }
         "#,
     );
-    let env = interp.realm().global_env.borrow();
-    match env.get("sum").unwrap_or(JsValue::Undefined) {
-        JsValue::Number(n) => assert_eq!(n, 4200.0, "behavioral correctness"),
-        other => panic!("expected sum=4200, got {other:?}"),
-    }
+    assert_eq!(
+        global_number(&interp, "sum"),
+        4200.0,
+        "behavioral correctness"
+    );
     assert!(
         interp.ic_hit_count() > 0,
         "expected IC hits after 100-iteration hot loop on o.x; got 0 \
@@ -840,11 +852,11 @@ fn call_ic_records_after_repeated_call() {
         for (var i = 0; i < 100; i++) sum += f();
         "#,
     );
-    let env = interp.realm().global_env.borrow();
-    match env.get("sum").unwrap_or(JsValue::Undefined) {
-        JsValue::Number(n) => assert_eq!(n, 4200.0, "behavioral correctness"),
-        other => panic!("expected sum=4200, got {other:?}"),
-    }
+    assert_eq!(
+        global_number(&interp, "sum"),
+        4200.0,
+        "behavioral correctness"
+    );
     assert!(
         interp.call_ic_hit_count() > 0,
         "expected call-IC hits after 100-iteration hot loop on f(); got 0"
@@ -865,11 +877,11 @@ fn call_ic_fast_dispatch_actually_skips_entry_checks() {
         for (var i = 0; i < 100; i++) sum += f();
         "#,
     );
-    let env = interp.realm().global_env.borrow();
-    match env.get("sum").unwrap_or(JsValue::Undefined) {
-        JsValue::Number(n) => assert_eq!(n, 700.0, "behavioral correctness"),
-        other => panic!("expected sum=700, got {other:?}"),
-    }
+    assert_eq!(
+        global_number(&interp, "sum"),
+        700.0,
+        "behavioral correctness"
+    );
     assert!(
         interp.call_ic_fast_dispatch_count() > 0,
         "expected fast-dispatch path to fire on IC hits; got 0 \
@@ -918,11 +930,11 @@ fn call_ic_does_not_cache_class_ctor_without_new() {
         var result = threw_count;
         "#,
     );
-    let env = interp.realm().global_env.borrow();
-    match env.get("result").unwrap_or(JsValue::Undefined) {
-        JsValue::Number(n) => assert_eq!(n, 5.0, "expected 5 TypeErrors"),
-        other => panic!("expected 5, got {other:?}"),
-    }
+    assert_eq!(
+        global_number(&interp, "result"),
+        5.0,
+        "expected 5 TypeErrors"
+    );
 }
 
 #[test]
@@ -981,11 +993,11 @@ fn ic_megamorphic_stays_terminal_after_non_cacheable_miss() {
         var result = sum;
         "#,
     );
-    let env = interp.realm().global_env.borrow();
-    match env.get("result").unwrap_or(JsValue::Undefined) {
-        JsValue::Number(n) => assert_eq!(n, 16.0, "behavioral correctness"),
-        other => panic!("expected result=16, got {other:?}"),
-    }
+    assert_eq!(
+        global_number(&interp, "result"),
+        16.0,
+        "behavioral correctness"
+    );
     assert_eq!(
         interp.ic_hit_count(),
         0,
@@ -1010,11 +1022,11 @@ fn call_ic_megamorphic_stays_terminal_after_non_cacheable_miss() {
         var result = sum;
         "#,
     );
-    let env = interp.realm().global_env.borrow();
-    match env.get("result").unwrap_or(JsValue::Undefined) {
-        JsValue::Number(n) => assert_eq!(n, 16.0, "behavioral correctness"),
-        other => panic!("expected result=16, got {other:?}"),
-    }
+    assert_eq!(
+        global_number(&interp, "result"),
+        16.0,
+        "behavioral correctness"
+    );
     assert_eq!(
         interp.call_ic_hit_count(),
         0,

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -491,8 +491,7 @@ fn missing_named_module_import_throws_syntax_error() {
 #[test]
 fn gc_keeps_microtask_roots_alive_until_queue_is_cleared() {
     let mut interp = Interpreter::new();
-    let obj = interp.create_object();
-    let id = obj.borrow().id.expect("object id");
+    let id = interp.create_object_id();
     let obj_val = JsValue::Object(crate::types::JsObject { id });
 
     interp.scheduler.enqueue_microtask((

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -501,7 +501,7 @@ fn gc_keeps_microtask_roots_alive_until_queue_is_cleared() {
     interp.gc_requested = true;
     interp.gc_safepoint();
     assert!(
-        interp.get_object(id).is_some(),
+        interp.get_object_cell(id).is_some(),
         "microtask root should keep object alive"
     );
 
@@ -509,7 +509,7 @@ fn gc_keeps_microtask_roots_alive_until_queue_is_cleared() {
     interp.gc_requested = true;
     interp.gc_safepoint();
     assert!(
-        interp.get_object(id).is_none(),
+        interp.get_object_cell(id).is_none(),
         "object should be collectable after queue clears"
     );
 }
@@ -540,12 +540,12 @@ fn gc_keeps_module_exports_alive_until_registry_entry_is_removed() {
 
     interp.gc_requested = true;
     interp.gc_safepoint();
-    assert!(interp.get_object(obj_ref.id).is_some());
+    assert!(interp.get_object_cell(obj_ref.id).is_some());
 
     interp.module_registry.remove(&key);
     interp.gc_requested = true;
     interp.gc_safepoint();
-    assert!(interp.get_object(obj_ref.id).is_none());
+    assert!(interp.get_object_cell(obj_ref.id).is_none());
 
     let _ = fs::remove_dir_all(&dir);
 }

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -625,13 +625,9 @@ pub struct Environment {
     pub(crate) with_object: Option<WithObject>,
     pub(crate) dispose_stack: Option<Vec<DisposableResource>>,
     /// Slab id of the realm's global object. The canonical identity reference.
+    /// External callers reach the global object via `Interpreter::env_*`
+    /// wrappers in `env_helpers.rs`, never by holding a borrow here.
     pub(crate) global_object_id: Option<u64>,
-    /// Rc handle to the same global object kept in sync with `global_object_id`.
-    /// Used only by `Environment` methods that need property access without an
-    /// `Interpreter` reference (e.g. `Environment::get/set/has/declare_global_*`).
-    /// `setup_globals` writes both fields atomically; nothing else mutates them.
-    /// PR 2 will drop this field when the slab itself loses `Rc<RefCell<>>`.
-    pub(crate) global_object_rc: Option<Rc<RefCell<JsObjectData>>>,
     // Annex B.3.3: names registered for block-level function var hoisting
     pub(crate) annexb_function_names: Option<Vec<String>>,
     pub(crate) class_private_names: Option<HashMap<String, String>>,
@@ -725,7 +721,6 @@ impl Environment {
             with_object: None,
             dispose_stack: None,
             global_object_id: None,
-            global_object_rc: None,
             annexb_function_names: None,
             class_private_names: None,
             is_field_initializer: false,
@@ -750,7 +745,6 @@ impl Environment {
             with_object: None,
             dispose_stack: None,
             global_object_id: None,
-            global_object_rc: None,
             annexb_function_names: None,
             class_private_names: None,
             is_field_initializer: false,
@@ -866,76 +860,41 @@ impl Environment {
         );
     }
 
-    /// Like declare, but also creates a non-configurable property on the global object.
-    /// Per §9.1.1.4.17 CreateGlobalVarBinding: var declarations in global scope
-    /// create non-configurable properties on the global object.
+    /// Bindings-only fallback for `Interpreter::env_declare_global_var` (used
+    /// when the env has no `global_object_id`). The wrapper handles the
+    /// global-object property side via the slab.
     pub fn declare_global_var(&mut self, name: &str) {
-        if let Some(ref global_obj) = self.global_object_rc {
-            let mut gb = global_obj.borrow_mut();
-            if !gb.properties.contains_key(name) {
-                gb.property_order.push(name.to_string());
-                gb.properties.insert(
-                    name.to_string(),
-                    PropertyDescriptor::data(JsValue::Undefined, true, true, false),
-                );
-            }
-        } else if !self.bindings.contains_key(name) {
+        if !self.bindings.contains_key(name) {
             self.declare(name, BindingKind::Var);
         }
     }
 
-    /// CreateGlobalVarBinding with configurable:true (for eval-declared vars).
+    /// Bindings-only fallback for
+    /// `Interpreter::env_declare_global_var_configurable`.
     pub fn declare_global_var_configurable(&mut self, name: &str) {
         if !self.bindings.contains_key(name) {
-            let has_global_prop = self
-                .global_object_rc
-                .as_ref()
-                .is_some_and(|g| g.borrow().properties.contains_key(name));
-            if !has_global_prop {
-                self.declare(name, BindingKind::Var);
-            }
-        }
-        if let Some(ref global_obj) = self.global_object_rc {
-            let mut gb = global_obj.borrow_mut();
-            if !gb.properties.contains_key(name) {
-                gb.property_order.push(name.to_string());
-                gb.properties.insert(
-                    name.to_string(),
-                    PropertyDescriptor::data(JsValue::Undefined, true, true, true),
-                );
-            }
+            self.declare(name, BindingKind::Var);
         }
     }
 
-    /// CreateGlobalFunctionBinding(fn, fo, configurable) for eval-declared functions.
+    /// Bindings-only fallback for
+    /// `Interpreter::env_declare_global_function_binding`. The wrapper sets the
+    /// value mirror on the global object via the slab.
     pub fn declare_global_function_binding(
         &mut self,
         name: &str,
         value: JsValue,
-        configurable: bool,
+        _configurable: bool,
     ) {
         self.declare(name, BindingKind::Var);
         if let Some(binding) = self.bindings.get_mut(name) {
-            binding.value = value.clone();
+            binding.value = value;
             binding.initialized = true;
-        }
-        if let Some(ref global_obj) = self.global_object_rc {
-            let mut gb = global_obj.borrow_mut();
-            let existing = gb.properties.get(name);
-            let need_full_desc =
-                existing.is_none() || existing.is_some_and(|d| d.configurable == Some(true));
-            if need_full_desc {
-                let desc = PropertyDescriptor::data(value, true, true, configurable);
-                if !gb.properties.contains_key(name) {
-                    gb.property_order.push(name.to_string());
-                }
-                gb.properties.insert(name.to_string(), desc);
-            } else {
-                gb.set_property_value(name, value);
-            }
         }
     }
 
+    /// Bindings-only set. Mirroring to the realm's global object lives in
+    /// `Interpreter::env_set`. External callers should always use that wrapper.
     pub fn set(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         // Indirect bindings (module imports) are immutable
         if self.is_indirect_binding(name) {
@@ -967,40 +926,12 @@ impl Environment {
                 }
                 return Ok(());
             }
-            if binding.kind == BindingKind::Var
-                && let Some(ref global_obj) = self.global_object_rc
-            {
-                let ok = global_obj
-                    .borrow_mut()
-                    .set_property_value(name, value.clone());
-                if !ok {
-                    if self.strict {
-                        return Err(JsValue::String(JsString::from_str(&format!(
-                            "Cannot assign to read only property '{name}' of object '#<Object>'"
-                        ))));
-                    }
-                    return Ok(());
-                }
-            }
             binding.value = value;
             binding.initialized = true;
             Ok(())
         } else if let Some(parent) = &self.parent {
             parent.borrow_mut().set(name, value)
         } else {
-            // Global implicit declaration (sloppy mode)
-            if let Some(ref global_obj) = self.global_object_rc {
-                let already_on_global = global_obj.borrow().has_own_property(name);
-                let ok = global_obj
-                    .borrow_mut()
-                    .set_property_value(name, value.clone());
-                if !ok {
-                    return Ok(());
-                }
-                if already_on_global {
-                    return Ok(());
-                }
-            }
             self.bindings.insert(
                 name.to_string(),
                 Binding::new(value, BindingKind::Var, true),
@@ -1009,6 +940,9 @@ impl Environment {
         }
     }
 
+    /// Bindings-only get. Falls through to `None` at the chain root; the
+    /// global-object fall-through lives in `Interpreter::env_get` /
+    /// `env_get_ref`.
     pub fn get(&self, name: &str) -> Option<JsValue> {
         // Check indirect bindings first (module imports)
         if let Some(resolved) = self.resolve_indirect_binding(name) {
@@ -1021,13 +955,6 @@ impl Environment {
             Some(binding.value.clone())
         } else if let Some(parent) = &self.parent {
             parent.borrow().get(name)
-        } else if let Some(ref global_obj) = self.global_object_rc {
-            let b = global_obj.borrow();
-            if let Some(true) = b.own_has_property(name) {
-                b.own_property_lookup(name)
-            } else {
-                None
-            }
         } else {
             None
         }
@@ -1047,47 +974,13 @@ impl Environment {
         }
     }
 
-    /// Walk the scope chain and check what error (if any) setting a binding would produce.
-    pub fn check_set_binding(env: &EnvRef, name: &str) -> SetBindingCheck {
-        let e = env.borrow();
-        // Indirect bindings (module imports) are immutable
-        if e.is_indirect_binding(name) {
-            return SetBindingCheck::ConstAssign;
-        }
-        if let Some(binding) = e.bindings.get(name) {
-            if !binding.initialized && binding.kind != BindingKind::Var {
-                return SetBindingCheck::TdzError;
-            }
-            if binding.kind == BindingKind::Const && binding.initialized {
-                return SetBindingCheck::ConstAssign;
-            }
-            if (binding.kind == BindingKind::FunctionName
-                || binding.kind == BindingKind::ImmutableValue)
-                && binding.initialized
-            {
-                return SetBindingCheck::FunctionNameAssign;
-            }
-            return SetBindingCheck::Ok;
-        }
-        if let Some(ref global_obj) = e.global_object_rc {
-            if matches!(global_obj.borrow().own_has_property(name), Some(true)) {
-                return SetBindingCheck::Ok;
-            }
-            return SetBindingCheck::Unresolvable;
-        }
-        if let Some(ref parent) = e.parent {
-            return Self::check_set_binding(parent, name);
-        }
-        SetBindingCheck::Unresolvable
-    }
-
+    /// Bindings-only `has`. Global-object fall-through lives in
+    /// `Interpreter::env_has`.
     pub fn has(&self, name: &str) -> bool {
         if self.is_indirect_binding(name) || self.bindings.contains_key(name) {
             true
         } else if let Some(parent) = &self.parent {
             parent.borrow().has(name)
-        } else if let Some(ref global_obj) = self.global_object_rc {
-            matches!(global_obj.borrow().own_has_property(name), Some(true))
         } else {
             false
         }


### PR DESCRIPTION
Closes #108. Drives toward eliminating the 36% malloc/free runtime cost on the splay benchmark (issue #66) by moving the JS object slab to a chunked arena with stable inline `RefCell` addresses.

Implements the plan at `.ultraplan/object-slab-arena-refactor.md`. Built incrementally so each commit is independently bisectable; CI validates per commit.

## Commits

- **PR 2a** — `3921234` Drop transitional `Environment.global_object_rc` field. All `Environment::set/get/has/declare_global_*` callers route through `Interpreter::env_*` wrappers in `env_helpers.rs`. Strips the global-mirror branches from the slim `Environment` methods. Perf-neutral. Prerequisite for the slab change.
- **PR 2b.1** — `c5d95eb` Replace `Vec<Option<Rc<RefCell<JsObjectData>>>>` with chunked `Vec<Box<[Option<Rc<RefCell<JsObjectData>>>; 1024]>>`. New `src/interpreter/object_arena.rs` exposes the arena. Per-slot `Rc` storage preserved for API compatibility. Stable inline addresses unblock the per-slot Rc drop in subsequent commits.
- **PR 2b.2 step 1** — `017105f` `create_arraybuffer{,_resizable}` and `create_typed_array_object{,_with_proto}` now return `u64` instead of `Rc<RefCell<JsObjectData>>` — 11 callsites updated.
- **PR 2b.2 step 2** — `41d8405` ~25 `setup_intl_*` / `setup_temporal_*` / `setup_iterator_*` / `setup_function_prototype` / `setup_ta_*` helpers now take `u64` instead of `&Rc<RefCell<JsObjectData>>`. 24 files touched.
- **PR 2b.2 step 3** — `f007a94` Free-fn helpers (`can_declare_global_function`, `can_declare_global_var`, `has_restricted_global_property`, `fix_callable`, `has_prop`) take `&JsObjectData` / `&RefCell<JsObjectData>` instead of `&Rc<RefCell<JsObjectData>>`.
- **PR 2b.2 step 4** — `25ab66d` New transitional `Interpreter::get_object_cell{,_expect}` accessor returning `&RefCell<JsObjectData>` directly without `Rc::clone`. Lifetime tied to `&Interpreter`; callers must drop the borrow before `&mut self`. Forward-compatible with the eventual per-slot Rc drop.
- **PR 2b.2 step 5** — `c416bbe` The four prototype-chain walks (`get_property_on_id`, `get_property_descriptor_on_id`, `has_property_on_id`, `enumerable_keys_with_proto_on_id`) use `get_object_cell_expect` — saves an `Rc::clone` per chain frame on every property access.
- **PR 2b.2 step 6** — `5c80fa5` 50 hot setup-time sites (iterators, typedarray, intl, temporal, mod) migrated to cell variant. 42 redundant `Some(get_object_expect(<id>).borrow().id.unwrap())` collapsed to `Some(<id>)` (the `id` variable was already a u64 after PR 1b.2's prototype-id intern).
- **PR 2b.2 step 7** — `f1f5c7c` eval.rs prototype walks + builtins/mod.rs setup sites + 4 more redundant id-unwrap collapses. Brings remaining `get_object_expect` callers down to 3 — `mod.rs:981` (inside `create_object`'s own conversion to Rc) and two long-lived `ta_proto`/`uint8_proto` holds in typedarray.rs.

## Validation

Per commit: `cargo build --release`, `cargo fmt --check`, `cargo clippy --release -- -D warnings`, custom tests 3/3, targeted test262 subsets per change area (ArrayBuffer/TypedArrayConstructors 1834/1834, intl/Locale + Iterator 1324/1324, Object + property-access 6802/6802, intl + Iterator + Date 8854/8854, TypedArray + property-access 2860/2860). The 32 fails on full test262 are pre-existing baseline drift on `origin/main` (35 fails) — same flaky `Atomics/waitAsync` set as PR 2a (#124).

## Status

Open. PR 2a + PR 2b.1 are mergeable as-is. PR 2b.2 steps 1-7 land structural progress but **don't yet eliminate the per-object `Rc::new`** — that's the final slot-Rc drop + create_object → u64 cascade, which I'll keep pushing to this PR.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo fmt --check` + `cargo clippy --release -- -D warnings` clean
- [x] Custom tests 3/3 per commit
- [x] Targeted test262 subsets per commit
- [ ] Full `uv run python scripts/run-test262.py -j 32` after the final perf-win commit
- [ ] JetStream splay benchmark before/after

## References
- Plan: `.ultraplan/object-slab-arena-refactor.md`
- Issue #108 (PR 2): https://github.com/pmatos/jsse/issues/108
- Parent issue #66: arena allocator for JS objects