### PR TITLE
[refactor] Extract JobScheduler from Interpreter

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -405,7 +405,7 @@ fn from_async_attach_await(
             let value = v.clone();
             let state_c = state.clone();
             let roots = from_async_collect_roots(&state);
-            interp.microtask_queue.push((
+            interp.scheduler.enqueue_microtask((
                 roots,
                 Box::new(move |interp| {
                     on_fulfill(interp, value, state_c);

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -922,7 +922,7 @@ impl Interpreter {
             if let Some(pid) = reaction.promise_id {
                 roots.push(JsValue::Object(crate::types::JsObject { id: pid }));
             }
-            self.microtask_queue.push((
+            self.scheduler.enqueue_microtask((
                 roots,
                 Box::new(move |interp| {
                     let handler_result = if let Some(ref handler) = reaction.handler {
@@ -991,7 +991,7 @@ impl Interpreter {
             reject_fn.clone(),
             JsValue::Object(crate::types::JsObject { id: promise_id }),
         ];
-        self.microtask_queue.push((
+        self.scheduler.enqueue_microtask((
             roots,
             Box::new(move |interp| {
                 let result =

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -7678,7 +7678,7 @@ impl Interpreter {
             false
         };
 
-        let queue = self.async_gen_queues.entry(gen_id).or_default();
+        let queue = self.scheduler.async_gen_queue_or_default(gen_id);
         queue.push_back(request);
         let queue_len = queue.len();
 
@@ -7700,13 +7700,13 @@ impl Interpreter {
         };
 
         let request = {
-            let queue = self.async_gen_queues.get(&gen_id);
+            let queue = self.scheduler.async_gen_queue(gen_id);
             match queue.and_then(|q| q.front().cloned()) {
                 Some(r) => r,
                 None => return,
             }
         };
-        self.async_gen_yield_pending = false;
+        self.scheduler.set_async_gen_yield_pending(false);
         let result = match request.kind {
             super::AsyncGenRequestKind::Next => self
                 .async_generator_next_state_machine_with_promise(
@@ -7736,13 +7736,13 @@ impl Interpreter {
 
         // If the yield suspended asynchronously (pending promise), don't pop — the
         // fulfill/reject handler will pop and schedule the next request
-        if self.async_gen_yield_pending {
-            self.async_gen_yield_pending = false;
+        if self.scheduler.is_async_gen_yield_pending() {
+            self.scheduler.set_async_gen_yield_pending(false);
             let _ = result;
             return;
         }
 
-        if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+        if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
             queue.pop_front();
         }
 
@@ -7804,7 +7804,7 @@ impl Interpreter {
                 pending_return: None,
             });
             let _ = self.call_function(reject_fn, &JsValue::Undefined, &[awaited_result]);
-            if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+            if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                 queue.pop_front();
             }
             self.async_gen_process_queue(gen_this);
@@ -7828,7 +7828,7 @@ impl Interpreter {
                 pending_return: None,
             });
             let _ = self.call_function(reject_fn, &JsValue::Undefined, &[err]);
-            if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+            if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                 queue.pop_front();
             }
             self.async_gen_process_queue(gen_this);
@@ -7854,7 +7854,7 @@ impl Interpreter {
                         pending_return: None,
                     });
                 let _ = self.call_function(reject_fn, &JsValue::Undefined, &[e]);
-                if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                     queue.pop_front();
                 }
                 self.async_gen_process_queue(gen_this);
@@ -7886,7 +7886,7 @@ impl Interpreter {
                             pending_exception: Some(e),
                             pending_return: None,
                         });
-                    self.async_gen_yield_pending = false;
+                    self.scheduler.set_async_gen_yield_pending(false);
                     let _ = self.async_generator_next_state_machine_with_promise(
                         gen_this,
                         JsValue::Undefined,
@@ -7894,11 +7894,11 @@ impl Interpreter {
                         resolve_fn.clone(),
                         reject_fn.clone(),
                     );
-                    if self.async_gen_yield_pending {
-                        self.async_gen_yield_pending = false;
+                    if self.scheduler.is_async_gen_yield_pending() {
+                        self.scheduler.set_async_gen_yield_pending(false);
                         return;
                     }
-                    if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                    if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                         queue.pop_front();
                     }
                     self.async_gen_process_queue(gen_this);
@@ -7919,7 +7919,7 @@ impl Interpreter {
                         pending_return: None,
                     });
                 let _ = self.call_function(reject_fn, &JsValue::Undefined, &[e]);
-                if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                     queue.pop_front();
                 }
                 self.async_gen_process_queue(gen_this);
@@ -7957,7 +7957,7 @@ impl Interpreter {
                 pending_exception: None,
                 pending_return: None,
             });
-            self.async_gen_yield_pending = false;
+            self.scheduler.set_async_gen_yield_pending(false);
             let _ = self.async_generator_next_state_machine_with_promise(
                 gen_this,
                 value,
@@ -7965,11 +7965,11 @@ impl Interpreter {
                 resolve_fn.clone(),
                 reject_fn.clone(),
             );
-            if self.async_gen_yield_pending {
-                self.async_gen_yield_pending = false;
+            if self.scheduler.is_async_gen_yield_pending() {
+                self.scheduler.set_async_gen_yield_pending(false);
                 return;
             }
-            if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+            if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                 queue.pop_front();
             }
             self.async_gen_process_queue(gen_this);
@@ -7982,15 +7982,15 @@ impl Interpreter {
         let _ = self.call_function(resolve_fn, &JsValue::Undefined, &[iter_result]);
 
         // Pop the current (Next) request from the queue
-        if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+        if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
             queue.pop_front();
         }
 
         // Step 10-11: Check if queue has more requests (e.g. .return()/.throw())
         // If so, process via AsyncGeneratorUnwrapYieldResumption inline
         let next_request = self
-            .async_gen_queues
-            .get(&gen_id)
+            .scheduler
+            .async_gen_queue(gen_id)
             .and_then(|q| q.front().cloned());
 
         if let Some(request) = next_request {
@@ -8079,7 +8079,7 @@ impl Interpreter {
                                 &JsValue::Undefined,
                                 &[reason],
                             );
-                            if let Some(queue) = interp.async_gen_queues.get_mut(&gen_id_r2) {
+                            if let Some(queue) = interp.scheduler.async_gen_queue_mut(gen_id_r2) {
                                 queue.pop_front();
                             }
                             interp.async_gen_process_queue(&gen_this_r2);
@@ -8092,7 +8092,7 @@ impl Interpreter {
                         Some(PromiseState::Fulfilled(v)) => {
                             let handler = on_fulfilled;
                             let val = v.clone();
-                            self.microtask_queue.push((
+                            self.scheduler.enqueue_microtask((
                                 vec![val.clone(), handler.clone()],
                                 Box::new(move |interp| {
                                     let _ =
@@ -8104,7 +8104,7 @@ impl Interpreter {
                         Some(PromiseState::Rejected(r)) => {
                             let handler = on_rejected;
                             let reason = r.clone();
-                            self.microtask_queue.push((
+                            self.scheduler.enqueue_microtask((
                                 vec![reason.clone(), handler.clone()],
                                 Box::new(move |interp| {
                                     let _ = interp.call_function(
@@ -8141,7 +8141,7 @@ impl Interpreter {
                         None => {
                             let handler = on_fulfilled;
                             let val = ret_val.clone();
-                            self.microtask_queue.push((
+                            self.scheduler.enqueue_microtask((
                                 vec![val.clone(), handler.clone()],
                                 Box::new(move |interp| {
                                     let _ =
@@ -8151,7 +8151,7 @@ impl Interpreter {
                             ));
                         }
                     }
-                    self.async_gen_yield_pending = true;
+                    self.scheduler.set_async_gen_yield_pending(true);
                 }
                 _ => {
                     // Normal/Throw: save state and let process_queue handle it
@@ -8251,7 +8251,7 @@ impl Interpreter {
                                 pending_return: None,
                             });
                         let _ = self.call_function(ret_reject, &JsValue::Undefined, &[e]);
-                        if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                        if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                             queue.pop_front();
                         }
                         self.async_gen_process_queue(gen_this);
@@ -8277,7 +8277,7 @@ impl Interpreter {
                                 pending_return: None,
                             });
                         let _ = self.call_function(ret_reject, &JsValue::Undefined, &[e]);
-                        if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                        if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                             queue.pop_front();
                         }
                         self.async_gen_process_queue(gen_this);
@@ -8302,7 +8302,7 @@ impl Interpreter {
                                 pending_return: None,
                             });
                         let _ = self.call_function(ret_reject, &JsValue::Undefined, &[e]);
-                        if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                        if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                             queue.pop_front();
                         }
                         self.async_gen_process_queue(gen_this);
@@ -8330,7 +8330,7 @@ impl Interpreter {
                         0
                     };
                     let _ = self.async_generator_await_return(value, ret_promise_id);
-                    if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                    if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                         queue.pop_front();
                     }
                     self.async_gen_process_queue(gen_this);
@@ -8353,7 +8353,7 @@ impl Interpreter {
                         });
                     let iter_result = self.create_iter_result_object(value, false);
                     let _ = self.call_function(ret_resolve, &JsValue::Undefined, &[iter_result]);
-                    if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                    if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                         queue.pop_front();
                     }
                     self.async_gen_process_queue(gen_this);
@@ -8381,7 +8381,7 @@ impl Interpreter {
                     0
                 };
                 let _ = self.async_generator_await_return(awaited_val, ret_promise_id);
-                if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                     queue.pop_front();
                 }
                 self.async_gen_process_queue(gen_this);
@@ -8402,7 +8402,7 @@ impl Interpreter {
                         pending_return: None,
                     });
                 let _ = self.call_function(ret_reject, &JsValue::Undefined, &[e]);
-                if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+                if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
                     queue.pop_front();
                 }
                 self.async_gen_process_queue(gen_this);
@@ -9758,7 +9758,7 @@ impl Interpreter {
                             Some(PromiseState::Fulfilled(v)) => {
                                 let handler = fulfill_handler;
                                 let val = v.clone();
-                                self.microtask_queue.push((
+                                self.scheduler.enqueue_microtask((
                                     vec![val.clone(), handler.clone()],
                                     Box::new(move |interp| {
                                         let _ = interp.call_function(
@@ -9773,7 +9773,7 @@ impl Interpreter {
                             Some(PromiseState::Rejected(r)) => {
                                 let handler = reject_handler;
                                 let reason = r.clone();
-                                self.microtask_queue.push((
+                                self.scheduler.enqueue_microtask((
                                     vec![reason.clone(), handler.clone()],
                                     Box::new(move |interp| {
                                         let _ = interp.call_function(
@@ -9811,7 +9811,7 @@ impl Interpreter {
                                 // Not a promise — treat as immediately fulfilled
                                 let handler = fulfill_handler;
                                 let val = iter_result.clone();
-                                self.microtask_queue.push((
+                                self.scheduler.enqueue_microtask((
                                     vec![val.clone(), handler.clone()],
                                     Box::new(move |interp| {
                                         let _ = interp.call_function(
@@ -9825,7 +9825,7 @@ impl Interpreter {
                             }
                         }
 
-                        self.async_gen_yield_pending = true;
+                        self.scheduler.set_async_gen_yield_pending(true);
                         return Completion::Normal(promise);
                     }
 
@@ -9878,7 +9878,7 @@ impl Interpreter {
                                     &JsValue::Undefined,
                                     &[iter_result],
                                 );
-                                if let Some(queue) = interp.async_gen_queues.get_mut(&gen_id) {
+                                if let Some(queue) = interp.scheduler.async_gen_queue_mut(gen_id) {
                                     queue.pop_front();
                                 }
                                 interp.async_gen_process_queue(&gen_this);
@@ -9895,7 +9895,7 @@ impl Interpreter {
                                 let e = args.first().cloned().unwrap_or(JsValue::Undefined);
                                 let _ =
                                     interp.call_function(&reject_fn_c, &JsValue::Undefined, &[e]);
-                                if let Some(queue) = interp.async_gen_queues.get_mut(&gen_id2) {
+                                if let Some(queue) = interp.scheduler.async_gen_queue_mut(gen_id2) {
                                     queue.pop_front();
                                 }
                                 interp.async_gen_process_queue(&gen_this2);
@@ -9924,7 +9924,7 @@ impl Interpreter {
                             }
                         }
 
-                        self.async_gen_yield_pending = true;
+                        self.scheduler.set_async_gen_yield_pending(true);
                         return Completion::Normal(promise);
                     }
 
@@ -9951,19 +9951,19 @@ impl Interpreter {
                         let reject_fn_c2 = reject_fn.clone();
                         let gen_this3 = this.clone();
                         let gen_id3 = o.id;
-                        self.microtask_queue.push((
+                        self.scheduler.enqueue_microtask((
                             vec![e.clone(), reject_fn_c2.clone(), gen_this3.clone()],
                             Box::new(move |interp| {
                                 let _ =
                                     interp.call_function(&reject_fn_c2, &JsValue::Undefined, &[e]);
-                                if let Some(queue) = interp.async_gen_queues.get_mut(&gen_id3) {
+                                if let Some(queue) = interp.scheduler.async_gen_queue_mut(gen_id3) {
                                     queue.pop_front();
                                 }
                                 interp.async_gen_process_queue(&gen_this3);
                                 Completion::Normal(JsValue::Undefined)
                             }),
                         ));
-                        self.async_gen_yield_pending = true;
+                        self.scheduler.set_async_gen_yield_pending(true);
                         return Completion::Normal(promise);
                     } else {
                         yield_val
@@ -9995,7 +9995,7 @@ impl Interpreter {
                     let resolve_fn_c2 = resolve_fn.clone();
                     let gen_this3 = this.clone();
                     let gen_id3 = o.id;
-                    self.microtask_queue.push((
+                    self.scheduler.enqueue_microtask((
                         vec![
                             awaited_val.clone(),
                             resolve_fn_c2.clone(),
@@ -10008,7 +10008,7 @@ impl Interpreter {
                                 &JsValue::Undefined,
                                 &[iter_result],
                             );
-                            if let Some(queue) = interp.async_gen_queues.get_mut(&gen_id3) {
+                            if let Some(queue) = interp.scheduler.async_gen_queue_mut(gen_id3) {
                                 queue.pop_front();
                             }
                             // Process next queue item inline (not via microtask) per spec
@@ -10016,7 +10016,7 @@ impl Interpreter {
                             Completion::Normal(JsValue::Undefined)
                         }),
                     ));
-                    self.async_gen_yield_pending = true;
+                    self.scheduler.set_async_gen_yield_pending(true);
                     return Completion::Normal(promise);
                 }
 
@@ -10122,7 +10122,9 @@ impl Interpreter {
                                         &JsValue::Undefined,
                                         &[iter_result],
                                     );
-                                    if let Some(queue) = interp.async_gen_queues.get_mut(&gen_id) {
+                                    if let Some(queue) =
+                                        interp.scheduler.async_gen_queue_mut(gen_id)
+                                    {
                                         queue.pop_front();
                                     }
                                     interp.async_gen_process_queue(&gen_this_f);
@@ -10140,7 +10142,9 @@ impl Interpreter {
                                         &JsValue::Undefined,
                                         &[e],
                                     );
-                                    if let Some(queue) = interp.async_gen_queues.get_mut(&gen_id2) {
+                                    if let Some(queue) =
+                                        interp.scheduler.async_gen_queue_mut(gen_id2)
+                                    {
                                         queue.pop_front();
                                     }
                                     interp.async_gen_process_queue(&gen_this_r);
@@ -10164,7 +10168,7 @@ impl Interpreter {
                             cp_reject,
                         );
 
-                        self.async_gen_yield_pending = true;
+                        self.scheduler.set_async_gen_yield_pending(true);
                         return Completion::Normal(promise);
                     } else {
                         // return; — no expression, no Await per §13.10.1
@@ -11025,7 +11029,7 @@ impl Interpreter {
 
                         let _ = self.promise_then(&p, &fulfill_handler, &reject_handler);
 
-                        self.async_gen_yield_pending = true;
+                        self.scheduler.set_async_gen_yield_pending(true);
                         return Completion::Normal(promise);
                     }
                 }
@@ -11102,7 +11106,7 @@ impl Interpreter {
             }
         }
 
-        self.async_gen_yield_pending = false;
+        self.scheduler.set_async_gen_yield_pending(false);
         let _ = self.async_generator_next_state_machine_with_promise(
             this,
             JsValue::Undefined,
@@ -11110,22 +11114,22 @@ impl Interpreter {
             resolve_fn.clone(),
             reject_fn.clone(),
         );
-        if self.async_gen_yield_pending {
-            self.async_gen_yield_pending = false;
+        if self.scheduler.is_async_gen_yield_pending() {
+            self.scheduler.set_async_gen_yield_pending(false);
             return;
         }
 
         // Pop the queue entry and process next
-        if let Some(queue) = self.async_gen_queues.get_mut(&gen_id) {
+        if let Some(queue) = self.scheduler.async_gen_queue_mut(gen_id) {
             queue.pop_front();
         }
         let this_clone = this.clone();
         if self
-            .async_gen_queues
-            .get(&gen_id)
+            .scheduler
+            .async_gen_queue(gen_id)
             .is_some_and(|q| !q.is_empty())
         {
-            self.microtask_queue.push((
+            self.scheduler.enqueue_microtask((
                 vec![this_clone.clone()],
                 Box::new(move |interp| {
                     interp.async_gen_process_queue(&this_clone);
@@ -16112,10 +16116,9 @@ impl Interpreter {
             }
         }
 
-        let async_id = self.next_async_function_id;
-        self.next_async_function_id += 1;
+        let async_id = self.scheduler.alloc_async_function_id();
 
-        self.async_function_states.insert(
+        self.scheduler.insert_async_function_state(
             async_id,
             AsyncFunctionState {
                 state_machine: sm,
@@ -16148,7 +16151,7 @@ impl Interpreter {
     ) {
         use crate::interpreter::generator_transform::{SentValueBindingKind, StateTerminator};
 
-        let Some(state) = self.async_function_states.remove(&async_id) else {
+        let Some(state) = self.scheduler.remove_async_function_state(async_id) else {
             return;
         };
 
@@ -16198,7 +16201,7 @@ impl Interpreter {
         let mut pending_exception: Option<JsValue> = if is_error { Some(sent_value) } else { None };
 
         // Re-insert state so GC can trace it during execution
-        self.async_function_states.insert(
+        self.scheduler.insert_async_function_state(
             async_id,
             AsyncFunctionState {
                 state_machine: state_machine.clone(),
@@ -16246,7 +16249,7 @@ impl Interpreter {
                     let disp = self.dispose_resources(&func_env, Completion::Return(ret_val));
                     match disp {
                         Completion::Return(v) => {
-                            self.async_function_states.remove(&async_id);
+                            self.scheduler.remove_async_function_state(async_id);
                             let _ = self.call_function(&resolve_fn, &JsValue::Undefined, &[v]);
                             return;
                         }
@@ -16331,7 +16334,7 @@ impl Interpreter {
                     Completion::Throw(e) => e,
                     _ => JsValue::Undefined,
                 };
-                self.async_function_states.remove(&async_id);
+                self.scheduler.remove_async_function_state(async_id);
                 let _ = self.call_function(&reject_fn, &JsValue::Undefined, &[exc]);
                 return;
             }
@@ -16982,7 +16985,7 @@ impl Interpreter {
         reject_fn: &JsValue,
     ) {
         let disp = self.dispose_resources(func_env, Completion::Normal(JsValue::Undefined));
-        self.async_function_states.remove(&async_id);
+        self.scheduler.remove_async_function_state(async_id);
         match disp {
             Completion::Throw(e) => {
                 let _ = self.call_function(reject_fn, &JsValue::Undefined, &[e]);
@@ -17018,7 +17021,7 @@ impl Interpreter {
         };
 
         // Save state for resumption
-        self.async_function_states.insert(
+        self.scheduler.insert_async_function_state(
             async_id,
             AsyncFunctionState {
                 state_machine: state_machine.clone(),
@@ -17042,7 +17045,7 @@ impl Interpreter {
         match pstate {
             Some(PromiseState::Fulfilled(v)) => {
                 let value = v.clone();
-                self.microtask_queue.push((
+                self.scheduler.enqueue_microtask((
                     vec![resolve_fn.clone(), reject_fn.clone(), value.clone()],
                     Box::new(move |interp| {
                         interp.async_function_resume(async_id, value, false);
@@ -17052,7 +17055,7 @@ impl Interpreter {
             }
             Some(PromiseState::Rejected(e)) => {
                 let err = e.clone();
-                self.microtask_queue.push((
+                self.scheduler.enqueue_microtask((
                     vec![resolve_fn.clone(), reject_fn.clone(), err.clone()],
                     Box::new(move |interp| {
                         interp.async_function_resume(async_id, err, true);
@@ -17167,7 +17170,7 @@ impl Interpreter {
                 let done_c = done.clone();
                 let result_c = result.clone();
                 let value = v.clone();
-                self.microtask_queue.push((
+                self.scheduler.enqueue_microtask((
                     vec![value.clone()],
                     Box::new(move |_interp| {
                         done_c.set(true);
@@ -17180,7 +17183,7 @@ impl Interpreter {
                 let done_c = done.clone();
                 let result_c = result.clone();
                 let reason = r.clone();
-                self.microtask_queue.push((
+                self.scheduler.enqueue_microtask((
                     vec![reason.clone()],
                     Box::new(move |_interp| {
                         done_c.set(true);
@@ -17252,8 +17255,7 @@ impl Interpreter {
             if done.get() {
                 break;
             }
-            if !self.microtask_queue.is_empty() {
-                let (roots, job) = self.microtask_queue.remove(0);
+            if let Some((roots, job)) = self.scheduler.pop_microtask() {
                 let mt_frame = self.gc_root_frame();
                 for val in &roots {
                     self.gc_root_value(val);

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -708,7 +708,7 @@ impl Interpreter {
         let resolve_root = resolve.clone();
         let reject_root = reject.clone();
 
-        self.microtask_queue.push((
+        self.scheduler.enqueue_microtask((
             vec![promise_root, resolve_root.clone(), reject_root.clone()],
             Box::new(move |interp: &mut Interpreter| {
                 match interp.load_module(&resolved_path) {

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -92,7 +92,7 @@ impl Interpreter {
         // Temporary roots (iterators, etc.)
         worklist.extend_from_slice(&self.gc_temp_roots);
         // Root values captured in pending microtask closures
-        for (roots, _) in &self.microtask_queue {
+        for roots in self.scheduler.iter_microtask_roots() {
             for val in roots {
                 Self::collect_value_roots(val, &mut worklist);
             }
@@ -109,7 +109,7 @@ impl Interpreter {
         for val in self.iterator_next_cache.values() {
             Self::collect_value_roots(val, &mut worklist);
         }
-        for afs in self.async_function_states.values() {
+        for afs in self.scheduler.iter_async_function_states() {
             Self::collect_env_roots(&afs.func_env, &mut worklist);
             Self::collect_value_roots(&afs.resolve_fn, &mut worklist);
             Self::collect_value_roots(&afs.reject_fn, &mut worklist);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod generator_analysis;
 pub(crate) mod generator_transform;
 mod property_map;
 pub(crate) use property_map::PropertyMap;
+mod scheduler;
 #[cfg(test)]
 mod tests;
 
@@ -69,10 +70,7 @@ pub struct Interpreter {
     pub(crate) destructuring_yield: bool,
     pub(crate) pending_iter_close: Vec<JsValue>,
     pub(crate) generator_inline_iters: FxHashMap<u64, Vec<JsValue>>,
-    microtask_queue: Vec<(
-        Vec<JsValue>,
-        Box<dyn FnOnce(&mut Interpreter) -> Completion>,
-    )>,
+    pub(crate) scheduler: scheduler::JobScheduler,
     cached_has_instance_key: Option<String>,
     module_registry: HashMap<(usize, PathBuf), Rc<RefCell<LoadedModule>>>,
     synthetic_module_registry: HashMap<(PathBuf, ImportModuleType), Rc<RefCell<LoadedModule>>>,
@@ -85,7 +83,7 @@ pub struct Interpreter {
     pub(crate) call_stack_envs: Vec<EnvRef>,
     pub(crate) call_stack_frames: Vec<CallFrame>,
     pub(crate) gc_temp_roots: Vec<u64>,
-    // microtask roots are now stored inline in the microtask_queue tuples
+    // microtask roots are stored inline alongside their jobs in JobScheduler
     pub(crate) class_private_names: Vec<HashMap<String, String>>,
     next_class_brand_id: u64,
     next_auto_accessor_id: u64,
@@ -122,10 +120,6 @@ pub struct Interpreter {
     pub(crate) regex_cache: HashMap<(String, String), Rc<builtins::regexp::CachedRegex>>,
     pub(crate) iterator_next_cache: FxHashMap<u64, JsValue>,
     last_identifier_with_base: Option<u64>,
-    pub(crate) async_gen_queues: FxHashMap<u64, std::collections::VecDeque<AsyncGenRequest>>,
-    pub(crate) async_gen_yield_pending: bool,
-    pub(crate) async_function_states: FxHashMap<u64, AsyncFunctionState>,
-    next_async_function_id: u64,
     pub(crate) pending_async_dispose_await: bool,
     pub(crate) static_module_load_depth: u32,
     module_async_evaluation_count: u64,
@@ -224,7 +218,7 @@ impl Interpreter {
             destructuring_yield: false,
             pending_iter_close: Vec::new(),
             generator_inline_iters: FxHashMap::default(),
-            microtask_queue: Vec::new(),
+            scheduler: scheduler::JobScheduler::default(),
             cached_has_instance_key: None,
             module_registry: HashMap::new(),
             synthetic_module_registry: HashMap::new(),
@@ -271,10 +265,6 @@ impl Interpreter {
             regex_cache: HashMap::new(),
             iterator_next_cache: FxHashMap::default(),
             last_identifier_with_base: None,
-            async_gen_queues: FxHashMap::default(),
-            async_gen_yield_pending: false,
-            async_function_states: FxHashMap::default(),
-            next_async_function_id: 0,
             pending_async_dispose_await: false,
             static_module_load_depth: 0,
             module_async_evaluation_count: 0,
@@ -2815,11 +2805,10 @@ impl Interpreter {
                 Completion::Normal(JsValue::Undefined)
             },
         ));
-        let async_id = self.next_async_function_id;
-        self.next_async_function_id += 1;
+        let async_id = self.scheduler.alloc_async_function_id();
         self.module_async_info
             .insert(async_id, module_path.to_path_buf());
-        self.async_function_states.insert(
+        self.scheduler.insert_async_function_state(
             async_id,
             AsyncFunctionState {
                 state_machine: sm,
@@ -4344,8 +4333,7 @@ impl Interpreter {
     pub(crate) fn drain_microtasks(&mut self) {
         let mut iterations = 0u64;
         loop {
-            if !self.microtask_queue.is_empty() {
-                let (roots, job) = self.microtask_queue.remove(0);
+            if let Some((roots, job)) = self.scheduler.pop_microtask() {
                 let mt_frame = self.gc_root_frame();
                 for val in &roots {
                     self.gc_root_value(val);
@@ -4446,8 +4434,7 @@ impl Interpreter {
     pub(crate) fn drain_microtasks_blocking(&mut self) {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
         loop {
-            while !self.microtask_queue.is_empty() {
-                let (roots, job) = self.microtask_queue.remove(0);
+            while let Some((roots, job)) = self.scheduler.pop_microtask() {
                 let mt_frame = self.gc_root_frame();
                 for val in &roots {
                     self.gc_root_value(val);

--- a/src/interpreter/scheduler.rs
+++ b/src/interpreter/scheduler.rs
@@ -1,0 +1,227 @@
+use std::collections::VecDeque;
+
+use rustc_hash::FxHashMap;
+
+use crate::types::JsValue;
+
+use super::AsyncFunctionState;
+use super::AsyncGenRequest;
+use super::Completion;
+use super::Interpreter;
+
+pub(crate) type MicrotaskJob = Box<dyn FnOnce(&mut Interpreter) -> Completion>;
+
+#[derive(Default)]
+pub(crate) struct JobScheduler {
+    microtask_queue: Vec<(Vec<JsValue>, MicrotaskJob)>,
+    async_gen_queues: FxHashMap<u64, VecDeque<AsyncGenRequest>>,
+    async_gen_yield_pending: bool,
+    async_function_states: FxHashMap<u64, AsyncFunctionState>,
+    next_async_function_id: u64,
+}
+
+impl JobScheduler {
+    pub(crate) fn enqueue_microtask(&mut self, item: (Vec<JsValue>, MicrotaskJob)) {
+        self.microtask_queue.push(item);
+    }
+
+    pub(crate) fn pop_microtask(&mut self) -> Option<(Vec<JsValue>, MicrotaskJob)> {
+        if self.microtask_queue.is_empty() {
+            None
+        } else {
+            Some(self.microtask_queue.remove(0))
+        }
+    }
+
+    pub(crate) fn iter_microtask_roots(&self) -> impl Iterator<Item = &[JsValue]> {
+        self.microtask_queue
+            .iter()
+            .map(|(roots, _)| roots.as_slice())
+    }
+
+    pub(crate) fn async_gen_queue_or_default(
+        &mut self,
+        gen_id: u64,
+    ) -> &mut VecDeque<AsyncGenRequest> {
+        self.async_gen_queues.entry(gen_id).or_default()
+    }
+
+    pub(crate) fn async_gen_queue(&self, gen_id: u64) -> Option<&VecDeque<AsyncGenRequest>> {
+        self.async_gen_queues.get(&gen_id)
+    }
+
+    pub(crate) fn async_gen_queue_mut(
+        &mut self,
+        gen_id: u64,
+    ) -> Option<&mut VecDeque<AsyncGenRequest>> {
+        self.async_gen_queues.get_mut(&gen_id)
+    }
+
+    pub(crate) fn set_async_gen_yield_pending(&mut self, value: bool) {
+        self.async_gen_yield_pending = value;
+    }
+
+    pub(crate) fn is_async_gen_yield_pending(&self) -> bool {
+        self.async_gen_yield_pending
+    }
+
+    pub(crate) fn alloc_async_function_id(&mut self) -> u64 {
+        let id = self.next_async_function_id;
+        self.next_async_function_id += 1;
+        id
+    }
+
+    pub(crate) fn insert_async_function_state(&mut self, id: u64, state: AsyncFunctionState) {
+        self.async_function_states.insert(id, state);
+    }
+
+    pub(crate) fn remove_async_function_state(&mut self, id: u64) -> Option<AsyncFunctionState> {
+        self.async_function_states.remove(&id)
+    }
+
+    pub(crate) fn iter_async_function_states(&self) -> impl Iterator<Item = &AsyncFunctionState> {
+        self.async_function_states.values()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn microtask_queue_is_empty(&self) -> bool {
+        self.microtask_queue.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn clear_microtasks(&mut self) {
+        self.microtask_queue.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::JsValue;
+
+    #[test]
+    fn microtask_queue_round_trip() {
+        let mut sched = JobScheduler::default();
+
+        assert!(
+            sched.microtask_queue_is_empty(),
+            "fresh scheduler must be idle"
+        );
+
+        let job: MicrotaskJob = Box::new(|_interp| Completion::Normal(JsValue::Undefined));
+        sched.enqueue_microtask((Vec::new(), job));
+
+        assert!(
+            !sched.microtask_queue_is_empty(),
+            "queue must be non-empty after enqueue"
+        );
+
+        let popped = sched.pop_microtask();
+        assert!(popped.is_some(), "pop must return the queued job");
+
+        assert!(
+            sched.microtask_queue_is_empty(),
+            "queue must be empty after the only job is popped"
+        );
+        assert!(
+            sched.pop_microtask().is_none(),
+            "pop on empty queue returns None"
+        );
+    }
+
+    #[test]
+    fn microtask_queue_drains_in_fifo_order() {
+        // Tag each job via its roots — the roots vector holds a single Number.
+        fn job() -> MicrotaskJob {
+            Box::new(|_interp| Completion::Normal(JsValue::Undefined))
+        }
+        fn tag(n: f64) -> Vec<JsValue> {
+            vec![JsValue::Number(n)]
+        }
+
+        let mut sched = JobScheduler::default();
+        sched.enqueue_microtask((tag(1.0), job()));
+        sched.enqueue_microtask((tag(2.0), job()));
+        sched.enqueue_microtask((tag(3.0), job()));
+
+        let popped_tags: Vec<f64> = std::iter::from_fn(|| sched.pop_microtask())
+            .map(|(roots, _)| match roots.as_slice() {
+                [JsValue::Number(n)] => *n,
+                _ => panic!("unexpected roots shape"),
+            })
+            .collect();
+
+        assert_eq!(popped_tags, vec![1.0, 2.0, 3.0]);
+    }
+
+    fn next_request(tag: f64) -> super::super::AsyncGenRequest {
+        super::super::AsyncGenRequest {
+            kind: super::super::AsyncGenRequestKind::Next,
+            value: JsValue::Number(tag),
+            promise: JsValue::Undefined,
+            resolve_fn: JsValue::Undefined,
+            reject_fn: JsValue::Undefined,
+        }
+    }
+
+    #[test]
+    fn async_gen_queues_are_isolated_per_generator() {
+        let mut sched = JobScheduler::default();
+        sched
+            .async_gen_queue_or_default(1)
+            .push_back(next_request(1.0));
+
+        assert!(
+            sched.async_gen_queue(2).is_none(),
+            "pushing to gen 1 must not create or populate gen 2"
+        );
+        assert_eq!(
+            sched.async_gen_queue(1).map(|q| q.len()),
+            Some(1),
+            "gen 1 must hold exactly one request"
+        );
+    }
+
+    #[test]
+    fn async_gen_requests_pop_in_fifo_order() {
+        let mut sched = JobScheduler::default();
+        let q = sched.async_gen_queue_or_default(42);
+        q.push_back(next_request(1.0));
+        q.push_back(next_request(2.0));
+        q.push_back(next_request(3.0));
+
+        let q = sched
+            .async_gen_queue_mut(42)
+            .expect("gen 42 must have a queue");
+        let tags: Vec<f64> = std::iter::from_fn(|| q.pop_front())
+            .map(|r| match r.value {
+                JsValue::Number(n) => n,
+                _ => panic!("unexpected value type"),
+            })
+            .collect();
+
+        assert_eq!(tags, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn async_function_ids_are_monotonic_and_unique() {
+        let mut sched = JobScheduler::default();
+        let ids: Vec<u64> = (0..3).map(|_| sched.alloc_async_function_id()).collect();
+        assert_eq!(ids, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn async_gen_yield_pending_round_trip() {
+        let mut sched = JobScheduler::default();
+        assert!(
+            !sched.is_async_gen_yield_pending(),
+            "yield-pending must default to false"
+        );
+
+        sched.set_async_gen_yield_pending(true);
+        assert!(sched.is_async_gen_yield_pending());
+
+        sched.set_async_gen_yield_pending(false);
+        assert!(!sched.is_async_gen_yield_pending());
+    }
+}

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -85,7 +85,7 @@ fn microtask_queue_drains_before_run_returns() {
         "#,
     );
     assert_eq!(global_string(&interp, "result"), "done");
-    assert!(interp.microtask_queue.is_empty());
+    assert!(interp.scheduler.microtask_queue_is_empty());
 }
 
 #[test]
@@ -101,7 +101,7 @@ fn nested_microtasks_run_to_quiescence_in_order() {
         "#,
     );
     assert_eq!(global_string(&interp, "order"), "abc");
-    assert!(interp.microtask_queue.is_empty());
+    assert!(interp.scheduler.microtask_queue_is_empty());
 }
 
 #[test]
@@ -495,7 +495,7 @@ fn gc_keeps_microtask_roots_alive_until_queue_is_cleared() {
     let id = obj.borrow().id.expect("object id");
     let obj_val = JsValue::Object(crate::types::JsObject { id });
 
-    interp.microtask_queue.push((
+    interp.scheduler.enqueue_microtask((
         vec![obj_val.clone()],
         Box::new(|_| Completion::Normal(JsValue::Undefined)),
     ));
@@ -506,7 +506,7 @@ fn gc_keeps_microtask_roots_alive_until_queue_is_cleared() {
         "microtask root should keep object alive"
     );
 
-    interp.microtask_queue.clear();
+    interp.scheduler.clear_microtasks();
     interp.gc_requested = true;
     interp.gc_safepoint();
     assert!(


### PR DESCRIPTION
## Summary

Architectural deepening: concentrate scheduling state behind a single owner instead of smearing it across ~15 ad-hoc fields on `Interpreter` and dozens of direct accesses in `eval.rs` / builtins / GC.

This PR is the first three slices of a planned refactor surfaced by `/improve-codebase-architecture`. The deletion test passes — concentrating these fields gives them a real seam, isolating *what's in flight and what runs next* from object allocation, name resolution, and statement execution.

## What moved into `JobScheduler`

| Was on `Interpreter` | Now on `JobScheduler` |
|---|---|
| `microtask_queue: Vec<(Vec<JsValue>, MicrotaskJob)>` | ✓ |
| `async_gen_queues: FxHashMap<u64, VecDeque<AsyncGenRequest>>` | ✓ |
| `async_gen_yield_pending: bool` | ✓ |
| `async_function_states: FxHashMap<u64, AsyncFunctionState>` | ✓ |
| `next_async_function_id: u64` | ✓ |

## What stays on `Interpreter`

- The drain driver (`drain_microtasks`, `drain_microtasks_until_idle`, `drain_microtasks_blocking`) — still needs `&mut Interpreter` to run jobs and root values; now loops over `scheduler.pop_microtask()`.
- Agent thread plumbing (`agent_handles`, `agent_broadcast_*`) and the `pending_async_*` `Arc` handles — separate concerns, planned for a follow-up.
- Generator runtime state (`generator_context`, `pending_iter_close`, `generator_inline_iters`, `destructuring_yield`) — distinct from scheduling, will be evaluated separately.

## Scheduler interface (13 methods, all owner-private)

```rust
enqueue_microtask, pop_microtask, iter_microtask_roots
async_gen_queue_or_default, async_gen_queue, async_gen_queue_mut
set_async_gen_yield_pending, is_async_gen_yield_pending
alloc_async_function_id
insert_async_function_state, remove_async_function_state
iter_async_function_states
```

The drain driver, GC walks (`iter_microtask_roots`, `iter_async_function_states`), and producers (`enqueue_microtask`, `async_gen_queue_or_default`, `alloc_async_function_id`) all go through this interface — no direct field access from outside `scheduler.rs`.

## Test surface

`src/interpreter/scheduler.rs::tests` — 6 unit tests verify scheduler invariants directly, previously only reachable end-to-end via test262:

- `microtask_queue_round_trip`
- `microtask_queue_drains_in_fifo_order`
- `async_gen_queues_are_isolated_per_generator`
- `async_gen_requests_pop_in_fifo_order`
- `async_gen_yield_pending_round_trip`
- `async_function_ids_are_monotonic_and_unique`

## Test plan

- [x] `cargo build --release` clean, no warnings
- [x] `cargo test --release` — 76/76 pass (6 new scheduler + 70 pre-existing)
- [x] Targeted test262 across the microtask-driven surface — 11,133 / 11,133 scenarios, **0 regressions**:
  - `built-ins/Promise/`, `language/expressions/await/`, `language/expressions/dynamic-import/`
  - `language/statements/async-function/`, `language/expressions/async-function/`, `language/expressions/async-arrow-function/`
  - `language/statements/async-generator/`, `language/expressions/async-generator/`, `language/statements/for-await-of/`
  - `built-ins/AsyncFunction/`, `built-ins/AsyncGenerator/`, `built-ins/AsyncGeneratorFunction/`, `built-ins/AsyncGeneratorPrototype/`
- [ ] Full test262 (`scripts/run-test262.py -j 32`) — pending (deferred while another agent's run is in flight)

## Note on history

A prior push briefly landed the working commit on `main` directly (8fb5ef6) due to a misconfigured upstream tracking. Reverted via forward commit 9754c39 (no force push). The current PR re-applies the change as commit 3a539cc on a proper feature branch. The merge commit on `main` records that history.