### PR TITLE
[codex] Move host async tracking into JobScheduler

### DIFF
--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -673,8 +673,9 @@ impl Interpreter {
                         let resolve_clone = resolve_fn.clone();
                         let timeout_ms = timeout;
                         let pending = interp.agent_async_completions.clone();
-                        let pending_jobs = interp.pending_async_jobs.clone();
-                        let pending_promise_ids = interp.pending_async_promise_ids.clone();
+                        let pending_jobs = interp.scheduler.pending_async_jobs_handle();
+                        let pending_promise_ids =
+                            interp.scheduler.pending_async_promise_ids_handle();
                         let promise_id = if let JsValue::Object(ref o) = promise_val {
                             o.id
                         } else {
@@ -683,7 +684,7 @@ impl Interpreter {
                         if promise_id != 0 {
                             pending_promise_ids.lock().unwrap().insert(promise_id);
                         }
-                        pending_jobs.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        pending_jobs.fetch_add(1, Ordering::SeqCst);
                         std::thread::spawn(move || {
                             let (lock, cvar) = &*pair_clone;
                             let mut notified = lock.lock().unwrap();
@@ -728,11 +729,11 @@ impl Interpreter {
                                         &[result_val],
                                     );
                                     interp.gc_unroot_value(&resolve);
+                                    if promise_id != 0 {
+                                        pending_promise_ids.lock().unwrap().remove(&promise_id);
+                                    }
+                                    pending_jobs.fetch_sub(1, Ordering::SeqCst);
                                 }));
-                            if promise_id != 0 {
-                                pending_promise_ids.lock().unwrap().remove(&promise_id);
-                            }
-                            pending_jobs.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
                             completion_cvar.notify_one();
                         });
                     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -7,7 +7,6 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub struct AgentBroadcastMsg {
     pub sab_shared: Arc<types::SharedBufferInner>,
@@ -112,12 +111,6 @@ pub struct Interpreter {
         std::sync::Mutex<Vec<Box<dyn FnOnce(&mut Interpreter) + Send>>>,
         std::sync::Condvar,
     )>,
-    pub(crate) pending_async_jobs: Arc<AtomicUsize>,
-    /// Promise IDs whose resolution is blocked on a host-async worker thread
-    /// (e.g. Atomics.waitAsync, $262.agent.getReportAsync). Used by
-    /// drain_microtasks_until_idle to decide whether pending host work is
-    /// actually awaited by JS code (Promise has reactions) versus detached.
-    pub(crate) pending_async_promise_ids: Arc<std::sync::Mutex<std::collections::HashSet<u64>>>,
     pub(crate) regex_cache: HashMap<(String, String), Rc<builtins::regexp::CachedRegex>>,
     pub(crate) iterator_next_cache: FxHashMap<u64, JsValue>,
     last_identifier_with_base: Option<u64>,
@@ -272,10 +265,6 @@ impl Interpreter {
             agent_async_completions: Arc::new((
                 std::sync::Mutex::new(Vec::new()),
                 std::sync::Condvar::new(),
-            )),
-            pending_async_jobs: Arc::new(AtomicUsize::new(0)),
-            pending_async_promise_ids: Arc::new(std::sync::Mutex::new(
-                std::collections::HashSet::new(),
             )),
             regex_cache: HashMap::new(),
             iterator_next_cache: FxHashMap::default(),
@@ -564,12 +553,12 @@ impl Interpreter {
                     return Completion::Normal(promise_val);
                 }
 
-                interp.pending_async_jobs.fetch_add(1, Ordering::SeqCst);
+                interp.scheduler.incr_pending_async_jobs();
                 let reports = interp.agent_reports.clone();
                 let resolve = resolve_fn;
                 let pending = interp.agent_async_completions.clone();
-                let pending_jobs = interp.pending_async_jobs.clone();
-                let pending_promise_ids = interp.pending_async_promise_ids.clone();
+                let pending_jobs = interp.scheduler.pending_async_jobs_handle();
+                let pending_promise_ids = interp.scheduler.pending_async_promise_ids_handle();
                 let promise_id = if let JsValue::Object(ref o) = promise_val {
                     o.id
                 } else {
@@ -598,11 +587,11 @@ impl Interpreter {
                             let _ =
                                 interp.call_function(&resolve, &JsValue::Undefined, &[report_val]);
                             interp.gc_unroot_value(&resolve);
+                            if promise_id != 0 {
+                                pending_promise_ids.lock().unwrap().remove(&promise_id);
+                            }
+                            pending_jobs.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
                         }));
-                    if promise_id != 0 {
-                        pending_promise_ids.lock().unwrap().remove(&promise_id);
-                    }
-                    pending_jobs.fetch_sub(1, Ordering::SeqCst);
                     completion_cvar.notify_one();
                 });
 
@@ -4426,10 +4415,26 @@ impl Interpreter {
                 // Periodically check agent async completions (e.g. waitAsync timeouts)
                 // so they get processed even when the microtask queue stays busy
                 if iterations.is_multiple_of(64) {
-                    let completions: Vec<_> = {
+                    let mut completions: Vec<_> = {
                         let mut lock = self.agent_async_completions.0.lock().unwrap();
                         lock.drain(..).collect()
                     };
+                    if completions.is_empty() && self.has_awaited_pending_async() {
+                        let (ref mtx, ref cvar) = *self.agent_async_completions;
+                        let lock = mtx.lock().unwrap();
+                        if lock.is_empty() {
+                            let (_guard, _) = cvar
+                                .wait_timeout(lock, std::time::Duration::from_millis(1))
+                                .unwrap();
+                            drop(_guard);
+                        } else {
+                            drop(lock);
+                        }
+                        completions = {
+                            let mut lock = self.agent_async_completions.0.lock().unwrap();
+                            lock.drain(..).collect()
+                        };
+                    }
                     for f in completions {
                         f(self);
                     }
@@ -4496,10 +4501,10 @@ impl Interpreter {
     /// functions or queued microtasks do not count — only per-promise evidence
     /// tied to an in-flight host worker.
     fn has_awaited_pending_async(&self) -> bool {
-        if self.pending_async_jobs.load(Ordering::SeqCst) == 0 {
+        if self.scheduler.pending_async_jobs_count() == 0 {
             return false;
         }
-        let ids = self.pending_async_promise_ids.lock().unwrap();
+        let ids = self.scheduler.pending_async_promise_ids_lock();
         for &id in ids.iter() {
             if let Some(obj) = self.get_object(id)
                 && let Some(ref pd) = obj.borrow().promise_data

--- a/src/interpreter/scheduler.rs
+++ b/src/interpreter/scheduler.rs
@@ -1,4 +1,6 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use rustc_hash::FxHashMap;
 
@@ -18,6 +20,11 @@ pub(crate) struct JobScheduler {
     async_gen_yield_pending: bool,
     async_function_states: FxHashMap<u64, AsyncFunctionState>,
     next_async_function_id: u64,
+    /// Count of host-async worker jobs that may later enqueue completions.
+    pending_async_jobs: Arc<AtomicUsize>,
+    /// Promise IDs whose resolution is blocked on a host-async worker thread
+    /// (e.g. Atomics.waitAsync, $262.agent.getReportAsync).
+    pending_async_promise_ids: Arc<Mutex<HashSet<u64>>>,
 }
 
 impl JobScheduler {
@@ -81,6 +88,26 @@ impl JobScheduler {
 
     pub(crate) fn iter_async_function_states(&self) -> impl Iterator<Item = &AsyncFunctionState> {
         self.async_function_states.values()
+    }
+
+    pub(crate) fn pending_async_jobs_handle(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.pending_async_jobs)
+    }
+
+    pub(crate) fn incr_pending_async_jobs(&self) {
+        self.pending_async_jobs.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn pending_async_jobs_count(&self) -> usize {
+        self.pending_async_jobs.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn pending_async_promise_ids_handle(&self) -> Arc<Mutex<HashSet<u64>>> {
+        Arc::clone(&self.pending_async_promise_ids)
+    }
+
+    pub(crate) fn pending_async_promise_ids_lock(&self) -> MutexGuard<'_, HashSet<u64>> {
+        self.pending_async_promise_ids.lock().unwrap()
     }
 
     #[cfg(test)]
@@ -201,6 +228,38 @@ mod tests {
             .collect();
 
         assert_eq!(tags, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn pending_async_jobs_count_reflects_increments() {
+        let sched = JobScheduler::default();
+        assert_eq!(sched.pending_async_jobs_count(), 0);
+        sched.incr_pending_async_jobs();
+        sched.incr_pending_async_jobs();
+        assert_eq!(sched.pending_async_jobs_count(), 2);
+    }
+
+    #[test]
+    fn pending_async_jobs_handle_shares_state_with_scheduler() {
+        let sched = JobScheduler::default();
+        let handle = sched.pending_async_jobs_handle();
+        handle.fetch_add(3, std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            sched.pending_async_jobs_count(),
+            3,
+            "external handle increments must be visible through the scheduler"
+        );
+    }
+
+    #[test]
+    fn pending_async_promise_ids_handle_shares_state_with_scheduler() {
+        let sched = JobScheduler::default();
+        let handle = sched.pending_async_promise_ids_handle();
+        handle.lock().unwrap().insert(42);
+        assert!(
+            sched.pending_async_promise_ids_lock().contains(&42),
+            "external handle updates must be visible through the scheduler"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the follow-up from PR #129 by moving host-async tracking state into `JobScheduler`:

- moves `pending_async_jobs` and `pending_async_promise_ids` off `Interpreter`
- routes `$262.agent.getReportAsync`, `Atomics.waitAsync`, and `has_awaited_pending_async()` through scheduler-owned handles/accessors
- keeps pending host-async jobs marked pending until their queued completion closure has actually run on the interpreter thread
- lets long microtask drains briefly wait for awaited host-async completions so Promise-based polling loops do not starve worker completions

## Why

PR #129 intentionally left the `pending_async_*` Arc handles on `Interpreter` as a planned follow-up. This makes `JobScheduler` the single owner for scheduling and host-async in-flight state, while leaving agent reports, broadcasts, handles, and completion plumbing on `Interpreter`.

While validating, the move exposed a race in timeout-driven `Atomics.waitAsync` tests: worker threads could enqueue a completion and decrement pending state before the interpreter had processed that completion. The fix keeps the pending state alive until the interpreter-thread completion closure runs.

## Validation

- `cargo test --release` — 98/98 passed
- `./scripts/lint.sh` — rustfmt and clippy passed
- `uv run python scripts/run-test262.py --binary /home/igalia/pmatos/dev/jsse/.claude/worktrees/scheduler-host-async/target/release/jsse test262/test/built-ins/Atomics/waitAsync/ -j 1 --timeout 120` — 202/202 passed

Note: during publishing, the first commit was accidentally pushed directly to `main` because the local branch still tracked `origin/main`. I immediately repaired `main` with forward revert `8b7d246`; this PR branch (`812ac8b`) reapplies the same validated patch on top of repaired `main`.