### PR TITLE
[perf] Keep IC megamorphic slots terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An agent-coded JS engine in Rust. I didn't touch a single line of code here. Not
 
 Read more: [jsse - a JavaScript engine built by an agent](https://p.ocmatos.com/blog/jsse-a-javascript-engine-built-by-an-agent.html).
 
-Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **99,020 / 99,020 (100.00%)**.
+Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **98,985 / 99,020 (99.96%)**.
 
 *ES Modules now supported with dynamic `import()` and `import.meta`. Async tests run with Promise/async-await support.*
 

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -5312,6 +5312,7 @@ impl Interpreter {
             if !probe_hit && matches!(result, Completion::Normal(_)) {
                 let new_slot = self.classify_for_call_ic(o.id);
                 let next = match (slot, new_slot) {
+                    (CallIcSlot::Megamorphic, _) => CallIcSlot::Megamorphic,
                     (_, None) => CallIcSlot::Empty,
                     (CallIcSlot::Empty, Some(s)) => s,
                     (
@@ -5326,7 +5327,6 @@ impl Interpreter {
                         ),
                     ) if prev == new => s,
                     (CallIcSlot::Mono { .. }, Some(_)) => CallIcSlot::Megamorphic,
-                    (CallIcSlot::Megamorphic, _) => CallIcSlot::Megamorphic,
                 };
                 cell.set(next);
             }

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -801,6 +801,7 @@ impl Interpreter {
                         // Apply the state-machine transition (plan Step 10):
                         // Empty → Mono(new); Mono(A)→same-obj refresh; Mono(A)→different-obj Megamorphic.
                         let next = match (slot, new_slot) {
+                            (PropIcSlot::Megamorphic, _) => PropIcSlot::Megamorphic,
                             (_, None) => PropIcSlot::Empty, // not IC-able; leave Empty
                             (PropIcSlot::Empty, Some(s)) => s,
                             (
@@ -810,7 +811,6 @@ impl Interpreter {
                                 Some(s @ PropIcSlot::Mono { obj_id: new_id, .. }),
                             ) if prev_id == new_id => s,
                             (PropIcSlot::Mono { .. }, Some(_)) => PropIcSlot::Megamorphic,
-                            (PropIcSlot::Megamorphic, _) => PropIcSlot::Megamorphic,
                         };
                         cell.set(next);
                     }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -964,6 +964,71 @@ fn ic_megamorphic_after_distinct_objects_at_same_site() {
 }
 
 #[test]
+fn ic_megamorphic_stays_terminal_after_non_cacheable_miss() {
+    // A site that has already gone Megamorphic must not be demoted back to
+    // Empty when it later sees a non-cacheable proxy lookup. If it were
+    // demoted, the final hot reads of `a.x` would re-enter Mono and hit.
+    let interp = run_script(
+        r#"
+        var a = {x: 1};
+        var b = {x: 2};
+        var p = new Proxy({x: 3}, {});
+        function read(o) { return o.x; }
+        var sum = 0;
+        sum += read(a);  // Empty -> Mono(a)
+        sum += read(b);  // Mono(a) -> Megamorphic
+        sum += read(p);  // non-cacheable; must stay Megamorphic
+        for (var i = 0; i < 10; i++) sum += read(a);
+        var result = sum;
+        "#,
+    );
+    let env = interp.realm().global_env.borrow();
+    match env.get("result").unwrap_or(JsValue::Undefined) {
+        JsValue::Number(n) => assert_eq!(n, 16.0, "behavioral correctness"),
+        other => panic!("expected result=16, got {other:?}"),
+    }
+    assert_eq!(
+        interp.ic_hit_count(),
+        0,
+        "Megamorphic property IC slot was demoted and started hitting again"
+    );
+}
+
+#[test]
+fn call_ic_megamorphic_stays_terminal_after_non_cacheable_miss() {
+    // Same state-machine guard for call ICs: proxy callables classify as None,
+    // but a previously Megamorphic site must remain terminal afterwards.
+    let interp = run_script(
+        r#"
+        function a() { return 1; }
+        function b() { return 2; }
+        var p = new Proxy(function() { return 3; }, {
+            apply: function(target, thisArg, args) { return 3; }
+        });
+        var fns = [a, b, p, a, a, a, a, a, a, a, a, a, a];
+        var sum = 0;
+        for (var i = 0; i < fns.length; i++) sum += fns[i]();
+        var result = sum;
+        "#,
+    );
+    let env = interp.realm().global_env.borrow();
+    match env.get("result").unwrap_or(JsValue::Undefined) {
+        JsValue::Number(n) => assert_eq!(n, 16.0, "behavioral correctness"),
+        other => panic!("expected result=16, got {other:?}"),
+    }
+    assert_eq!(
+        interp.call_ic_hit_count(),
+        0,
+        "Megamorphic call IC slot was demoted and started hitting again"
+    );
+    assert_eq!(
+        interp.call_ic_fast_dispatch_count(),
+        0,
+        "Megamorphic call IC slot reached fast dispatch after demotion"
+    );
+}
+
+#[test]
 fn behavioral_engine_passes_property_value_round_trip() {
     // Behavioral cross-check: even with shape bumps in place, basic
     // assignment/read round-trips still work via the public engine.


### PR DESCRIPTION
## Summary

- Keep `CallIcSlot::Megamorphic` and `PropIcSlot::Megamorphic` terminal before handling non-cacheable `None` classifications.
- Add regression tests that exercise `Mono -> Megamorphic -> non-cacheable -> cacheable` property and call IC sequences.
- Update the README test262 count from the full validation run.

## Background

This addresses the two unresolved Codex review threads from PR #127. The old transition order allowed a megamorphic IC slot to demote back to `Empty` when a later lookup/call could not be classified, which let the site re-enter monomorphic caching and defeated the intended terminal state.

## Validation

Post-republish checks on this PR branch:

- `cargo test --quiet` — 97 passed
- `./scripts/lint.sh` — passed

Earlier validation of the same patch before republishing the branch:

- `cargo build --release --quiet` — passed
- `uv run python scripts/run-custom-tests.py` — 3 passed
- Focused test262 (`Proxy`, `Function`, call expressions, property accessors) — 1,713 / 1,713 passed
- Full test262 — 98,985 / 99,020 (99.96%); remaining failures are existing RegExp baseline drift plus flaky Atomics.waitAsync timeout cases observed on clean `origin/main` too.
