### PR TITLE
[codex] Fail CI on test262 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,12 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
+      - name: Run Python script tests
+        run: uv run python -m unittest discover -s scripts -p 'test_*.py'
+
       - name: Run test262 smoke set
         run: |
-          uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 \
+          uv run python scripts/run-test262.py --fail-on-failures --jsse ./target/release/jsse --test262 ./test262 \
             test262/test/built-ins/Atomics/ \
             test262/test/built-ins/SharedArrayBuffer/ \
             test262/test/language/module-code/ \
@@ -49,4 +52,4 @@ jobs:
             test262/test/language/expressions/dynamic-import/import-attributes/
 
       - name: Run test262 (10% sample, fixed seed ${{ env.TEST262_SAMPLE_SEED }})
-        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1 --seed $TEST262_SAMPLE_SEED
+        run: uv run python scripts/run-test262.py --fail-on-failures --jsse ./target/release/jsse --test262 ./test262 --sample 0.1 --seed $TEST262_SAMPLE_SEED

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ uv run python scripts/run-test262.py
 ```
 
 Options: `-j <n>` for parallelism (default: nproc/2), `--timeout <s>` (default: 120).
+The runner exits non-zero for baseline regressions. Use `--fail-on-failures`
+when a selected test set must be 100% passing, as CI does for smoke/sample runs.
 
 The runner supports multiple engines via `--engine`:
 

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -610,6 +610,14 @@ examples:
         help="Pass --bytecode to jsse so eligible functions run through the bytecode VM (jsse only).",
     )
     parser.add_argument(
+        "--fail-on-failures",
+        action="store_true",
+        help=(
+            "Exit non-zero if any scenario fails, even if it is not a baseline "
+            "regression. CI smoke/sample gates should use this."
+        ),
+    )
+    parser.add_argument(
         "paths",
         nargs="*",
         help="Specific test files or directories to run (default: all tests)",
@@ -845,6 +853,13 @@ def main():
     print(f"Fail:    {failed}")
     print(f"Rate:    {percentage:.2f}%")
 
+    if fail_list:
+        print(f"\n--- Failures: {len(fail_list)} tests ---")
+        for f in sorted(fail_list)[:20]:
+            print(f"  FAILED: {f}")
+        if len(fail_list) > 20:
+            print(f"  ... and {len(fail_list) - 20} more")
+
     if regressions:
         print(f"\n!!! REGRESSIONS: {len(regressions)} tests that previously passed now fail:")
         for r in regressions[:20]:
@@ -893,6 +908,23 @@ def main():
         'new_passes': len(new_passes),
     }
     print(f"JSON: {json.dumps(json_obj)}")
+
+    should_fail = False
+    sys.stdout.flush()
+    if regressions:
+        print(
+            f"Error: {len(regressions)} baseline regression(s) detected.",
+            file=sys.stderr,
+        )
+        should_fail = True
+    if args.fail_on_failures and failed:
+        print(
+            f"Error: {failed} test262 scenario(s) failed.",
+            file=sys.stderr,
+        )
+        should_fail = True
+    if should_fail:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -1,0 +1,101 @@
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNNER = REPO_ROOT / "scripts" / "run-test262.py"
+
+
+class RunTest262ExitStatusTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.test262 = self.root / "test262"
+        test_dir = self.test262 / "test"
+        test_dir.mkdir(parents=True)
+        self.test_file = test_dir / "sample.js"
+        self.test_file.write_text(
+            textwrap.dedent(
+                """\
+                /*---
+                flags: [raw]
+                ---*/
+                """
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_engine(self, exit_code: int) -> Path:
+        engine = self.root / f"engine_exit_{exit_code}.py"
+        engine.write_text(
+            textwrap.dedent(
+                f"""\
+                #!{sys.executable}
+                import sys
+                sys.exit({exit_code})
+                """
+            ),
+            encoding="utf-8",
+        )
+        engine.chmod(engine.stat().st_mode | stat.S_IXUSR)
+        return engine
+
+    def run_runner(self, engine: Path, *extra_args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--jsse",
+                str(engine),
+                "--test262",
+                "test262",
+                "--baseline-ref",
+                "refs/does-not-exist",
+                "-j",
+                "1",
+                *extra_args,
+                "test262/test/sample.js",
+            ],
+            cwd=self.root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_fail_on_failures_exits_non_zero_for_non_regression_failures(self):
+        result = self.run_runner(self.write_engine(1), "--fail-on-failures")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Fail:    1", result.stdout)
+        self.assertIn("FAILED: test262/test/sample.js", result.stdout)
+        self.assertIn("Error: 1 test262 scenario(s) failed.", result.stderr)
+
+    def test_report_mode_allows_non_regression_failures(self):
+        result = self.run_runner(self.write_engine(1))
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Fail:    1", result.stdout)
+
+    def test_baseline_regressions_exit_non_zero_in_report_mode(self):
+        (self.root / "test262-pass.txt").write_text(
+            "test262/test/sample.js\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_runner(self.write_engine(1))
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("REGRESSED: test262/test/sample.js", result.stdout)
+        self.assertIn("Error: 1 baseline regression(s) detected.", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Re-applies the CI fix originally committed as 09e4320 through a pull request. This is stacked on #133 because current `main` already contains the accidental direct commit until that revert PR lands.

Changes included:

- Add `--fail-on-failures` to `scripts/run-test262.py`
- Make the CI smoke and sample test262 jobs use strict failure behavior
- Add focused Python regression tests for runner exit status
- Document runner report mode vs strict CI mode

## Root cause

The test262 runner reported failing scenarios but did not exit non-zero unless the surrounding shell command failed. The referenced CI run showed `Fail: 2` while the workflow still passed.

## Validation

- `python3 -m unittest discover -s scripts -p 'test_*.py'`\n- `python3 -m py_compile scripts/run-test262.py scripts/test_run_test262.py`\n- `git diff --check`\n\n## Dependency\n\nMerge #133 first, then this PR can be retargeted to `main` or merged after the base branch contains the revert.