### PR TITLE
Add local cargo-mutants integration

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,23 @@
+# cargo-mutants configuration. Defaults documented at https://mutants.rs/.
+#
+# `unicode_tables.rs` and `emoji_strings.rs` are generated data tables; mutating
+# bytes inside lookup tables only produces noise.
+#
+# `temporal/duration.rs` and `temporal/plain_date_time.rs` each contain several
+# helpers that return a 10-tuple of `f64`. cargo-mutants enumerates 3^10 =
+# 59,049 mutants per such function (every combination of 0.0 / 1.0 / -1.0 per
+# tuple slot), and these two files alone account for ~90% of all mutants in the
+# crate. Excluded until cargo-mutants supports a per-function mutant cap or
+# those helpers are refactored to return a struct.
+
+exclude_globs = [
+    "src/unicode_tables.rs",
+    "src/emoji_strings.rs",
+    "src/interpreter/builtins/temporal/duration.rs",
+    "src/interpreter/builtins/temporal/plain_date_time.rs",
+]
+
+# The default per-mutant timeout multiplier (5x baseline) is tight when the
+# baseline is dominated by a fixed-cost test262 sample. Floor it so a quick
+# baseline doesn't squeeze the budget below what the oracle actually needs.
+minimum_test_timeout = 60.0

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ jetstream-baseline.json
 jetstream-results.json
 scripts/.unicode_cache/
 __pycache__/
+mutants.out/
+mutants.out.old/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,17 @@ A from-scratch JavaScript engine implemented in Rust. No JS parser/engine librar
 - Run test262 on a specific directory: `uv run python scripts/run-test262.py test262/test/built-ins/Symbol/`
 - Run custom tests: `uv run python scripts/run-custom-tests.py`
 
+## Mutation Testing
+- Local-only (not in CI). Driver: `./scripts/run-mutants.sh` (forwards args to `cargo mutants`).
+- Requires `cargo install cargo-mutants --locked` and `uv` on PATH (or at `~/.local/bin/uv`).
+- Examples:
+  - `./scripts/run-mutants.sh --list` — enumerate mutants without running.
+  - `./scripts/run-mutants.sh --shard 0/8` — single shard of the corpus.
+  - `./scripts/run-mutants.sh --file src/lexer.rs` — restrict to one file.
+- Oracle is `cargo test --release` plus `tests/test262_smoke_oracle.rs`, which runs a 0.5% random test262 sample (~3,500 scenarios, ~20 s on a fast machine). The sample is unseeded, so kill verdicts are non-deterministic across mutants — the trade-off is broader cross-section coverage over many runs.
+- Configuration in `.cargo/mutants.toml`. Generated tables (`unicode_tables.rs`, `emoji_strings.rs`) and two combinatorially-explosive Temporal helpers (`duration.rs`, `plain_date_time.rs`) are excluded.
+- Output in `mutants.out/` (gitignored): `caught.txt`, `missed.txt`, `unviable.txt`, `outcomes.json`, plus per-mutant diffs/logs.
+
 ## Acorn Tests
 - Run acorn tests: `./scripts/run-acorn-tests.sh`
 - Compare with Node baseline: `./scripts/run-acorn-tests.sh --node`

--- a/scripts/run-mutants.sh
+++ b/scripts/run-mutants.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run cargo-mutants locally with the jsse-specific oracle wired up.
+#
+# Usage:
+#   ./scripts/run-mutants.sh                          # all mutants, in-place
+#   ./scripts/run-mutants.sh --shard 0/8              # single shard
+#   ./scripts/run-mutants.sh --file src/lexer.rs      # single file
+#   ./scripts/run-mutants.sh --list                   # enumerate, don't run
+#
+# All arguments are forwarded to `cargo mutants`. The oracle is `cargo test
+# --release`, which includes `tests/test262_smoke_oracle.rs` (gated on
+# JSSE_MUTANTS_ORACLE — set automatically here).
+#
+# Exclusions and per-mutant timeout floor live in `.cargo/mutants.toml`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v cargo-mutants >/dev/null 2>&1; then
+    echo "error: cargo-mutants is not installed." >&2
+    echo "       run: cargo install cargo-mutants --locked" >&2
+    exit 1
+fi
+
+# `tests/test262_smoke_oracle.rs` shells out to `uv run python …`; the GitHub
+# Actions runner sets uv up via setup-uv@v7, but locally uv typically lives in
+# ~/.local/bin which isn't on every shell's PATH.
+if ! command -v uv >/dev/null 2>&1 && [[ -x "$HOME/.local/bin/uv" ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+if ! command -v uv >/dev/null 2>&1; then
+    echo "error: uv is not on PATH and not at ~/.local/bin/uv." >&2
+    echo "       see https://docs.astral.sh/uv/ for install instructions." >&2
+    exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+export JSSE_MUTANTS_ORACLE=1
+
+# If the user passed their own `--` separator, trust the rest of their args.
+# Otherwise append `-- --release` so cargo test runs with the release profile
+# (debug builds of the JS engine are too slow for the test262 oracle).
+has_separator=false
+for arg in "$@"; do
+    if [[ "$arg" == "--" ]]; then
+        has_separator=true
+        break
+    fi
+done
+
+if $has_separator; then
+    exec cargo mutants --in-place --baseline=skip --timeout 600 "$@"
+else
+    exec cargo mutants --in-place --baseline=skip --timeout 600 "$@" -- --release
+fi

--- a/tests/test262_smoke_oracle.rs
+++ b/tests/test262_smoke_oracle.rs
@@ -1,0 +1,41 @@
+//! test262 random-sample oracle for cargo-mutants. Gated on the
+//! `JSSE_MUTANTS_ORACLE` env var so a normal `cargo test` stays fast.
+//!
+//! Each invocation samples a fresh random subset of test262 (no `--seed`),
+//! so mutation verdicts are intentionally non-deterministic across mutants
+//! and shards. Over many runs this exercises a broader cross-section of
+//! the suite than a fixed smoke set would.
+
+use std::process::Command;
+
+#[test]
+fn test262_smoke_oracle() {
+    if std::env::var_os("JSSE_MUTANTS_ORACLE").is_none() {
+        return;
+    }
+
+    let jsse = env!("CARGO_BIN_EXE_jsse");
+    let workspace = env!("CARGO_MANIFEST_DIR");
+    let runner = format!("{workspace}/scripts/run-test262.py");
+    let test262 = format!("{workspace}/test262");
+
+    let status = Command::new("uv")
+        .args([
+            "run",
+            "python",
+            &runner,
+            "--fail-on-failures",
+            "--jsse",
+            jsse,
+            "--test262",
+            &test262,
+            "--sample",
+            "0.005",
+            "-j",
+            "8",
+        ])
+        .current_dir(workspace)
+        .status()
+        .expect("failed to invoke run-test262.py via uv");
+    assert!(status.success(), "test262 random sample failed");
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/run-mutants.sh`, a thin wrapper around `cargo mutants` that wires up the test262 oracle and sane defaults (`--in-place --baseline=skip --timeout 600 -- --release`).
- Adds `tests/test262_smoke_oracle.rs`, an env-gated integration test that shells out to `run-test262.py --sample 0.005 -j 8` (~3,500 scenarios per run, ~20 s on a fast machine). The sample is unseeded — verdicts are intentionally non-deterministic so mutants are exercised against varied test slices across runs.
- Adds `.cargo/mutants.toml` excluding generated tables (`unicode_tables.rs`, `emoji_strings.rs`) and two Temporal helpers (`duration.rs`, `plain_date_time.rs`) whose 10-tuple-of-`f64` returns blow up to 3^10 mutants apiece and alone account for ~90% of the corpus.

After exclusions, `cargo mutants --list` reports **33,982** mutants (down from 357,845).

The integration is local-only by design — running this in CI would burn far too many GitHub Actions minutes for the coverage delivered.

## Test plan
- [x] `cargo test --test test262_smoke_oracle` (no env var) returns immediately — oracle stays a no-op for normal `cargo test`.
- [x] `JSSE_MUTANTS_ORACLE=1 cargo test --release --test test262_smoke_oracle` runs 3,457 scenarios, 100% pass on baseline (~18 s).
- [x] `./scripts/run-mutants.sh --list` enumerates 33,982 mutants; 0 from any excluded file.
- [x] Wrapper handles a user-supplied `--` separator without producing a double `-- --`.
- [x] `cargo fmt --check` clean; `cargo clippy --tests -- -D warnings` clean.
- [ ] Run `./scripts/run-mutants.sh --shard 0/8` end-to-end on a beefy machine to confirm caught/missed/unviable bookkeeping populates `mutants.out/`.