### PR TITLE
[interpreter] implement immutable-arraybuffer (Stage-3) proposal

### DIFF
--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -146,7 +146,7 @@ impl Interpreter {
                 let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
                 let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                 let (kind, buffer, byte_offset, element_size, is_bigint) =
-                    match validate_integer_typed_array(interp, &ta_val, false) {
+                    match validate_integer_typed_array(interp, &ta_val, false, false) {
                         Ok(info) => info,
                         Err(e) => return Completion::Throw(e),
                     };
@@ -184,7 +184,7 @@ impl Interpreter {
                 let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                 let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
                 let (kind, buffer, byte_offset, element_size, is_bigint) =
-                    match validate_integer_typed_array(interp, &ta_val, false) {
+                    match validate_integer_typed_array(interp, &ta_val, false, true) {
                         Ok(info) => info,
                         Err(e) => return Completion::Throw(e),
                     };
@@ -245,7 +245,7 @@ impl Interpreter {
                 let expected_val = args.get(2).cloned().unwrap_or(JsValue::Undefined);
                 let replacement_val = args.get(3).cloned().unwrap_or(JsValue::Undefined);
                 let (kind, buffer, byte_offset, element_size, is_bigint) =
-                    match validate_integer_typed_array(interp, &ta_val, false) {
+                    match validate_integer_typed_array(interp, &ta_val, false, true) {
                         Ok(info) => info,
                         Err(e) => return Completion::Throw(e),
                     };
@@ -339,7 +339,7 @@ impl Interpreter {
                 let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                 let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
                 let (_kind, _buffer, byte_offset, element_size, is_bigint) =
-                    match validate_integer_typed_array(interp, &ta_val, true) {
+                    match validate_integer_typed_array(interp, &ta_val, true, false) {
                         Ok(info) => info,
                         Err(e) => return Completion::Throw(e),
                     };
@@ -484,7 +484,7 @@ impl Interpreter {
                 let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
                 let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                 let (kind, _buffer, byte_offset, element_size, _is_bigint) =
-                    match validate_integer_typed_array(interp, &ta_val, true) {
+                    match validate_integer_typed_array(interp, &ta_val, true, false) {
                         Ok(info) => info,
                         Err(e) => return Completion::Throw(e),
                     };
@@ -551,7 +551,7 @@ impl Interpreter {
                 let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
                 let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
                 let (kind, buffer, byte_offset, element_size, is_bigint) =
-                    match validate_integer_typed_array(interp, &ta_val, true) {
+                    match validate_integer_typed_array(interp, &ta_val, true, false) {
                         Ok(info) => info,
                         Err(e) => return Completion::Throw(e),
                     };
@@ -1253,6 +1253,7 @@ fn validate_integer_typed_array(
     interp: &mut Interpreter,
     ta_val: &JsValue,
     waitable: bool,
+    write_access: bool,
 ) -> Result<
     (
         TypedArrayKind,
@@ -1272,13 +1273,14 @@ fn validate_integer_typed_array(
                     info.buffer.clone(),
                     info.byte_offset,
                     info.is_detached.get(),
+                    info.buffer_object_id,
                 )
             })
         })
     } else {
         None
     };
-    if let Some((kind, buffer, byte_offset, is_detached)) = info_snapshot {
+    if let Some((kind, buffer, byte_offset, is_detached, buffer_object_id)) = info_snapshot {
         if waitable {
             if !matches!(kind, TypedArrayKind::Int32 | TypedArrayKind::BigInt64) {
                 return Err(interp.create_type_error(
@@ -1293,6 +1295,16 @@ fn validate_integer_typed_array(
                 | TypedArrayKind::Uint8Clamped
         ) {
             return Err(interp.create_type_error("Atomics operations require integer typed arrays"));
+        }
+        // ValidateTypedArray(..., ~write~): block ops on immutable buffers before
+        // argument coercion so callers observe no side effects on TypeError.
+        if write_access
+            && let Some(buf_id) = buffer_object_id
+            && interp
+                .get_object_cell(buf_id)
+                .is_some_and(|cell| cell.borrow().arraybuffer_is_immutable())
+        {
+            return Err(interp.create_type_error("Cannot modify an immutable ArrayBuffer"));
         }
         if is_detached {
             return Err(interp.create_type_error("typed array is detached"));
@@ -1343,7 +1355,7 @@ fn atomics_rmw(
     let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
     let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
     let (kind, buffer, byte_offset, element_size, is_bigint) =
-        match validate_integer_typed_array(interp, &ta_val, false) {
+        match validate_integer_typed_array(interp, &ta_val, false, true) {
             Ok(info) => info,
             Err(e) => return Completion::Throw(e),
         };

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -766,6 +766,152 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("transferToImmutable".to_string(), transfer_immutable_fn);
 
+        // sliceToImmutable — proposal-immutable-arraybuffer
+        // Spec ordering (deliberate): receiver checks (RequireInternalSlot, SAB) precede
+        // argument coercion. ResolveBounds runs ToNumber on start/end. Detach and
+        // currentLen-vs-final checks happen AFTER coercion to observe its side effects.
+        let slice_immutable_fn = self.create_function(JsFunction::native(
+            "sliceToImmutable".to_string(),
+            2,
+            |interp, this_val, args| {
+                // Step 1-2: RequireInternalSlot(O, [[ArrayBufferData]])
+                let JsValue::Object(o) = this_val else {
+                    return Completion::Throw(interp.create_type_error(
+                        "ArrayBuffer.prototype.sliceToImmutable called on non-object",
+                    ));
+                };
+                let Some(obj) = interp.get_object(o.id) else {
+                    return Completion::Throw(interp.create_type_error(
+                        "ArrayBuffer.prototype.sliceToImmutable called on invalid receiver",
+                    ));
+                };
+                let (is_ab, is_shared, is_detached_pre) = {
+                    let obj_ref = obj.borrow();
+                    (
+                        obj_ref.arraybuffer_data().is_some(),
+                        obj_ref.arraybuffer_is_shared(),
+                        obj_ref
+                            .arraybuffer_detached()
+                            .as_ref()
+                            .is_some_and(|d| d.get()),
+                    )
+                };
+                if !is_ab {
+                    return Completion::Throw(interp.create_type_error(
+                        "ArrayBuffer.prototype.sliceToImmutable called on non-ArrayBuffer",
+                    ));
+                }
+                // Step 3: IsSharedArrayBuffer(O) → TypeError (before argument coercion).
+                if is_shared {
+                    return Completion::Throw(interp.create_type_error(
+                        "ArrayBuffer.prototype.sliceToImmutable called on SharedArrayBuffer",
+                    ));
+                }
+                // Step 4: IsDetachedBuffer(O) → TypeError (before argument coercion).
+                if is_detached_pre {
+                    return Completion::Throw(interp.create_type_error("ArrayBuffer is detached"));
+                }
+                // Step 5: snapshot original len BEFORE coercion.
+                let len = {
+                    let obj_ref = obj.borrow();
+                    buffer_len(obj_ref.arraybuffer_data().unwrap())
+                };
+                let len_f = len as f64;
+
+                // ResolveBounds via ToIntegerOrInfinity semantics.
+                // Truncate is needed: e.g. -0.9 → 0, not (len + -0.9).
+                let resolve = |num: f64| -> usize {
+                    if num.is_nan() || num == 0.0 {
+                        return 0;
+                    }
+                    if num == f64::NEG_INFINITY {
+                        return 0;
+                    }
+                    if num == f64::INFINITY {
+                        return len;
+                    }
+                    let int_val = num.trunc();
+                    if int_val < 0.0 {
+                        ((len_f + int_val) as isize).max(0) as usize
+                    } else if int_val >= len_f {
+                        len
+                    } else {
+                        int_val as usize
+                    }
+                };
+
+                // Step 6: ResolveBounds(len, start, end). Coerce start first, then end.
+                let start_num = if let Some(a) = args.first() {
+                    match interp.to_number_value(a) {
+                        Ok(n) => n,
+                        Err(e) => return Completion::Throw(e),
+                    }
+                } else {
+                    0.0
+                };
+                let first = resolve(start_num);
+
+                let end_undefined = args.len() < 2 || matches!(args[1], JsValue::Undefined);
+                let end_num = if end_undefined {
+                    len_f
+                } else {
+                    match interp.to_number_value(&args[1]) {
+                        Ok(n) => n,
+                        Err(e) => return Completion::Throw(e),
+                    }
+                };
+                let final_to = resolve(end_num);
+
+                // Step 9: newLen = max(final - first, 0)
+                let new_len = final_to.saturating_sub(first);
+
+                // Step 11: re-check detached AFTER coercion.
+                let is_detached = {
+                    let obj_ref = obj.borrow();
+                    obj_ref
+                        .arraybuffer_detached()
+                        .as_ref()
+                        .is_some_and(|d| d.get())
+                };
+                if is_detached {
+                    return Completion::Throw(interp.create_type_error("ArrayBuffer is detached"));
+                }
+                // Step 13-14: re-read currentLen; RangeError if currentLen < final.
+                let current_len = {
+                    let obj_ref = obj.borrow();
+                    buffer_len(obj_ref.arraybuffer_data().unwrap())
+                };
+                if current_len < final_to {
+                    return Completion::Throw(interp.create_range_error(
+                        "ArrayBuffer was resized below the resolved end of the slice",
+                    ));
+                }
+
+                // Step 15: AllocateImmutableArrayBuffer with bytes [first..first+new_len].
+                let new_data = {
+                    let obj_ref = obj.borrow();
+                    let bytes = buffer_bytes(obj_ref.arraybuffer_data().unwrap());
+                    let mut dst = vec![0u8; new_len];
+                    if new_len > 0 {
+                        dst.copy_from_slice(&bytes[first..first + new_len]);
+                    }
+                    dst
+                };
+                let id = interp.create_arraybuffer(new_data);
+                if let Some(ab) = interp
+                    .get_object_cell_expect(id)
+                    .borrow_mut()
+                    .arraybuffer_mut()
+                {
+                    ab.is_immutable = true;
+                }
+                Completion::Normal(JsValue::Object(JsObject { id }))
+            },
+        ));
+        self.get_object_cell_expect(ab_proto_id)
+            .borrow_mut()
+            .insert_builtin("sliceToImmutable".to_string(), slice_immutable_fn);
+
         // resize — spec step ordering: (1) RequireInternalSlot, (2) ToIndex, (3) IsDetachedBuffer
         let resize_fn = self.create_function(JsFunction::native(
             "resize".to_string(),
@@ -1755,6 +1901,9 @@ impl Interpreter {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
                         }
                     };
+                    if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                        return c;
+                    }
 
                     let source = args.first().cloned().unwrap_or(JsValue::Undefined);
 
@@ -2052,6 +2201,20 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
+                    // TypedArrayCreateFromConstructor(..., accessMode=~write~):
+                    // reject result backed by immutable buffer before any writes.
+                    if let JsValue::Object(new_o) = &new_ta_val {
+                        let new_info_opt = interp
+                            .get_object_cell(new_o.id)
+                            .and_then(|cell| cell.borrow().typed_array_info().cloned());
+                        if let Some(info) = new_info_opt
+                            && ta_buffer_is_immutable(interp, &info)
+                        {
+                            return Completion::Throw(
+                                interp.create_type_error("Cannot modify an immutable ArrayBuffer"),
+                            );
+                        }
+                    }
 
                     if count > 0 {
                         // Re-check detach and OOB after species create (user code may resize)
@@ -2143,6 +2306,9 @@ impl Interpreter {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
                         }
                     };
+                    if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                        return c;
+                    }
                     let len = typed_array_length(&ta) as i64;
                     let resolve_index = |v: f64, len: i64| -> usize {
                         let vi = if v == f64::NEG_INFINITY || v < -(len as f64) - 1.0 {
@@ -2246,6 +2412,11 @@ impl Interpreter {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
                         }
                     };
+                    // ValidateTypedArray(..., ~write~): immutability check fires before any
+                    // argument coercion so callers observe no side effects on TypeError.
+                    if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                        return c;
+                    }
                     // Step 3: compute len BEFORE coercion
                     let len = typed_array_length(&ta);
                     // Per spec: coerce value BEFORE start/end
@@ -2507,6 +2678,9 @@ impl Interpreter {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
                         }
                     };
+                    if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                        return c;
+                    }
                     let mut lo = 0usize;
                     let mut hi = typed_array_length(&ta);
                     while lo < hi {
@@ -2547,6 +2721,9 @@ impl Interpreter {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
                         }
                     };
+                    if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                        return c;
+                    }
                     let comparefn = args.first().cloned();
                     if let Some(ref cmp) = comparefn
                         && !matches!(cmp, JsValue::Undefined)
@@ -3564,6 +3741,11 @@ impl Interpreter {
                 } else {
                     return Completion::Throw(interp.create_type_error("not a TypedArray"));
                 };
+                // TypedArrayCreateFromConstructor(..., accessMode=~write~):
+                // result must not be backed by an immutable buffer.
+                if let Err(c) = check_ta_buffer_writable(interp, &new_ta) {
+                    return c;
+                }
 
                 for i in 0..len {
                     let val = typed_array_get_index(&ta, i);
@@ -3626,6 +3808,11 @@ impl Interpreter {
                     && let Some(obj) = interp.get_object_cell(o.id)
                 {
                     let new_ta = obj.borrow().typed_array_info().unwrap().clone();
+                    // TypedArrayCreateFromConstructor(..., accessMode=~write~):
+                    // result must not be backed by an immutable buffer.
+                    if let Err(c) = check_ta_buffer_writable(interp, &new_ta) {
+                        return c;
+                    }
                     for (i, val) in kept.iter().enumerate() {
                         typed_array_set_index(&new_ta, i, val);
                     }
@@ -3909,6 +4096,9 @@ impl Interpreter {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
+                    if let Err(c) = check_target_ta_writable(interp, &target_obj) {
+                        return c;
+                    }
                     let ta_kind = if let JsValue::Object(ref o) = target_obj {
                         interp.get_object_cell(o.id).and_then(|obj| {
                             obj.borrow().typed_array_info().map(|ta| ta.kind)
@@ -3989,6 +4179,9 @@ impl Interpreter {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
+                    if let Err(c) = check_target_ta_writable(interp, &target_obj) {
+                        return c;
+                    }
                     let ta_kind = if let JsValue::Object(ref o) = target_obj {
                         interp.get_object_cell(o.id).and_then(|obj| {
                             obj.borrow().typed_array_info().map(|ta| ta.kind)
@@ -4061,6 +4254,9 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
+                if let Err(c) = check_target_ta_writable(interp, &new_obj) {
+                    return c;
+                }
                 // Get ta_kind for coercion
                 let ta_kind = if let JsValue::Object(ref o) = new_obj {
                     interp
@@ -4650,6 +4846,9 @@ impl Interpreter {
                     Ok(ta) => ta,
                     Err(c) => return c,
                 };
+                if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                    return c;
+                }
 
                 let input = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if !matches!(input, JsValue::String(_)) {
@@ -4689,6 +4888,9 @@ impl Interpreter {
                     Ok(ta) => ta,
                     Err(c) => return c,
                 };
+                if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                    return c;
+                }
 
                 let input = args.first().cloned().unwrap_or(JsValue::Undefined);
                 if !matches!(input, JsValue::String(_)) {
@@ -5080,12 +5282,18 @@ impl Interpreter {
                 "Result of the Symbol.iterator method is not an object",
             )));
         }
-        let mut values = Vec::new();
-        while let JsValue::Object(io) = &iter {
-            let next_fn = match self.get_object_property(io.id, "next", &iter) {
+        // Cache `next` once per IteratorRecord (spec §7.4.5 GetIteratorFromMethod step 3).
+        let next_fn = if let JsValue::Object(io) = &iter {
+            match self.get_object_property(io.id, "next", &iter) {
                 Completion::Normal(v) => v,
-                _ => break,
-            };
+                Completion::Throw(e) => return Err(Completion::Throw(e)),
+                _ => return Err(Completion::Throw(self.create_type_error("bad iterator"))),
+            }
+        } else {
+            return Err(Completion::Throw(self.create_type_error("bad iterator")));
+        };
+        let mut values = Vec::new();
+        while let JsValue::Object(_) = &iter {
             let result = match self.call_function(&next_fn, &iter, &[]) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(Completion::Throw(e)),
@@ -6280,6 +6488,46 @@ fn check_detached(interp: &mut Interpreter, ta: &TypedArrayInfo) -> Result<(), C
     } else {
         Ok(())
     }
+}
+
+/// Returns true iff the TypedArray's backing ArrayBuffer object has `is_immutable=true`.
+fn ta_buffer_is_immutable(interp: &Interpreter, ta: &TypedArrayInfo) -> bool {
+    let Some(buf_id) = ta.buffer_object_id else {
+        return false;
+    };
+    interp
+        .get_object_cell(buf_id)
+        .is_some_and(|cell| cell.borrow().arraybuffer_is_immutable())
+}
+
+/// Spec ValidateTypedArray(..., accessMode=~write~) — throws TypeError if the
+/// TypedArray's backing buffer is immutable.
+fn check_ta_buffer_writable(
+    interp: &mut Interpreter,
+    ta: &TypedArrayInfo,
+) -> Result<(), Completion> {
+    if ta_buffer_is_immutable(interp, ta) {
+        Err(Completion::Throw(interp.create_type_error(
+            "Cannot modify an immutable ArrayBuffer",
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Like check_ta_buffer_writable but accepts a JsValue (the target TA), used after
+/// TypedArrayCreateFromConstructor returns. No-op for non-TypedArray values.
+fn check_target_ta_writable(interp: &mut Interpreter, target: &JsValue) -> Result<(), Completion> {
+    let JsValue::Object(o) = target else {
+        return Ok(());
+    };
+    let info_opt = interp
+        .get_object_cell(o.id)
+        .and_then(|cell| cell.borrow().typed_array_info().cloned());
+    let Some(info) = info_opt else {
+        return Ok(());
+    };
+    check_ta_buffer_writable(interp, &info)
 }
 
 fn parse_base64_options(

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -60,7 +60,9 @@ pub(crate) fn to_number(val: &JsValue) -> f64 {
 // §7.1.4.1.1 StringToNumber (uses §7.1.4.1.2 RoundMVResult via f64::parse)
 fn string_to_number(s: &JsString) -> f64 {
     let rust_str = s.to_rust_string();
-    let trimmed = rust_str.trim();
+    // ECMA-262 §12.2 WhiteSpace includes <ZWNBSP> (U+FEFF), which Rust's
+    // char::is_whitespace omits (Unicode classifies it as Format, not White_Space).
+    let trimmed = rust_str.trim_matches(|c: char| c.is_whitespace() || c == '\u{FEFF}');
     if trimmed.is_empty() {
         return 0.0;
     }


### PR DESCRIPTION
## Summary

Implements the [Stage-3 immutable-arraybuffer proposal](https://tc39.es/proposal-immutable-arraybuffer/) — adds `ArrayBuffer.prototype.sliceToImmutable` and write-blocking for every path that mutates an `ArrayBuffer` through a TypedArray, DataView, or Atomics op. The `is_immutable` slot, `transferToImmutable`, the `immutable` getter, and DataView setter checks were already present; this PR fills the remaining gaps.

Closes #140.

### What changed
- **`ArrayBuffer.prototype.sliceToImmutable`**: receiver / SAB / detach checks before coercion; detach re-check after; `RangeError` if the source shrinks below the resolved end.
- **Three helpers** in `typedarray.rs` (`ta_buffer_is_immutable`, `check_ta_buffer_writable`, `check_target_ta_writable`) — early-rejection used by every write path.
- **TypedArray mutator write-block** for `set`, `copyWithin`, `fill`, `reverse`, `sort`, `setFromHex`, `setFromBase64` — fires before argument coercion so no observable side effects on `TypeError`.
- **Atomics**: `validate_integer_typed_array` gains a `write_access` flag, cascaded to `store`, `compareExchange`, `add`, `sub`, `and`, `or`, `xor`, `exchange` (`load`, `wait`, `waitAsync`, `notify` stay read-only).
- **Species-result rejection** in `TypedArray.prototype.{map, filter, slice}`; **target-TA rejection** in `TypedArray.{from, of}`.

### Drive-by fixes (surfaced by the new test262 cases)
- `string_to_number` now treats `U+FEFF` (ZWNBSP) as whitespace per ECMA-262 §12.2 — Rust's `trim()` omits it because Unicode classifies BOM as Format rather than White_Space.
- `iterate_with_function` caches the iterator's `next` method once per IteratorRecord (spec §7.4.5); re-fetching per iteration produced an infinite loop on the `TA.from` test whose iterator getter re-initialised state on each read.

### Numbers
- **+215 net new test262 passes** (passes the ~58 scenarios listed in #140 plus knock-on wins from the two drive-by fixes).
- 6 reported "regressions" investigated — none caused by this PR:
  - 2 are spec-correct under the proposal: `TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js` predates immutable-arraybuffer and silently relied on writes succeeding through an aliased immutable buffer.
  - 4 are pre-existing `intl402/PluralRules` baseline staleness, verified by rebuilding on `origin/main` (the test already fails there without this PR — `compactDisplay` is missing from the read order).

## Test plan
- [x] `cargo build --release`
- [x] `./scripts/lint.sh` (rustfmt + clippy clean)
- [x] `uv run python scripts/run-test262.py test262/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/` — 22/22
- [x] `uv run python scripts/run-test262.py test262/test/built-ins/Atomics/` — 780/780
- [x] `uv run python scripts/run-test262.py test262/test/built-ins/TypedArray/prototype/{fill,set,copyWithin,reverse,sort,map,filter,slice}/`
- [x] `uv run python scripts/run-test262.py test262/test/built-ins/Uint8Array/prototype/{setFromHex,setFromBase64}/`
- [x] `uv run python scripts/run-test262.py test262/test/built-ins/TypedArrayConstructors/` — 1446/1446
- [x] Full regression: `uv run python scripts/run-test262.py -j 32` → 99,201 / 99,262 (99.94%)