### PR TITLE
[ci] Document trust-gate threat model in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   claude:
+    # SECURITY: the `if:` below is the trust gate that prevents untrusted users
+    # from triggering this workflow. This job holds `id-token: write` and
+    # consumes `secrets.CLAUDE_CODE_OAUTH_TOKEN`, so a stray trigger from a fork
+    # commenter is a direct prompt-injection / secret-exfil surface. Do not relax
+    # the author_association allowlist or drop a clause without re-walking the
+    # threat model — see PR #113 / issue #139.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||


### PR DESCRIPTION
## Summary

Adds a `SECURITY` threat-model comment block immediately above the `jobs.claude.if` trust gate in `.github/workflows/claude.yml`, as requested in #139.

The four-line `if:` expression is the entire load-bearing security boundary: the job holds `id-token: write` and consumes `secrets.CLAUDE_CODE_OAUTH_TOKEN`, so a stray trigger from an untrusted commenter is a direct prompt-injection / secret-exfil surface. A future "simplifying" edit could silently drop the `author_association` check. The comment makes the threat explicit so the boundary survives future edits.

## Notes
- Documentation-only change to a workflow file — no engine code touched, so no test262 impact.
- YAML validated with `yaml.safe_load`.
- This is the documented exception to CLAUDE.md's "comment sparingly" rule (a load-bearing security boundary).

Closes #139.