### PR TITLE
[ci] Pin claude.yml trust gate to maintainer actor

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,13 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    # Only `opened`: on `opened`, github.actor IS the issue author, so the
+    # `github.actor == 'pmatos'` gate below means pmatos authored the text.
+    # `assigned` is deliberately excluded — on that activity type github.actor is
+    # the *assigner*, so a maintainer triaging an untrusted user's @claude issue
+    # would run the privileged job on attacker-authored body/title (a confused
+    # deputy). See issue #138.
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
@@ -18,8 +24,10 @@ jobs:
     # commenter is a direct prompt-injection / secret-exfil surface. The gate is
     # pinned to the single maintainer (`github.actor == 'pmatos'`) rather than an
     # `author_association` allowlist, because `COLLABORATOR` also covers Read /
-    # Triage roles that cannot push code. Do not widen the actor check or drop a
-    # clause without re-walking the threat model — see PR #113 / issues #138, #139.
+    # Triage roles that cannot push code. Do not widen the actor check, drop a
+    # clause, or re-add the `issues: assigned` trigger without re-walking the
+    # threat model (on `assigned`, github.actor is the assigner, not the issue
+    # author) — see PR #113 / issues #138, #139.
     # When external collaborators are added, replace the literal with a curated
     # actor allowlist (or layer claude-code-action's own allowlist on top).
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,14 +15,20 @@ jobs:
     # SECURITY: the `if:` below is the trust gate that prevents untrusted users
     # from triggering this workflow. This job holds `id-token: write` and
     # consumes `secrets.CLAUDE_CODE_OAUTH_TOKEN`, so a stray trigger from a fork
-    # commenter is a direct prompt-injection / secret-exfil surface. Do not relax
-    # the author_association allowlist or drop a clause without re-walking the
-    # threat model — see PR #113 / issue #139.
+    # commenter is a direct prompt-injection / secret-exfil surface. The gate is
+    # pinned to the single maintainer (`github.actor == 'pmatos'`) rather than an
+    # `author_association` allowlist, because `COLLABORATOR` also covers Read /
+    # Triage roles that cannot push code. Do not widen the actor check or drop a
+    # clause without re-walking the threat model — see PR #113 / issues #138, #139.
+    # When external collaborators are added, replace the literal with a curated
+    # actor allowlist (or layer claude-code-action's own allowlist on top).
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      github.actor == 'pmatos' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Implements **Option B** from #138: tightens the `.github/workflows/claude.yml` trust gate from the `["OWNER","MEMBER","COLLABORATOR"]` `author_association` allowlist to a literal `github.actor == 'pmatos'` check.

### Why
`author_association` returns `COLLABORATOR` for **any** collaborator access level — including Read and Triage roles, which cannot push code. Such a user would still pass the old gate and trigger this privileged workflow (`id-token: write` + `secrets.CLAUDE_CODE_OAUTH_TOKEN`). Pinning to the single maintainer closes that breadth.

The threat-model comment (from the base PR) is updated to document the actor-pin rationale and the migration path (curated actor allowlist) for when external collaborators are added.

## Stacking
- **Depends on #152** (`[ci] Document trust-gate threat model in claude.yml`, closes #139). This PR is based on that branch; merge #152 first, or merge them together. GitHub will retarget this to `main` once the base merges.

## Notes
- Workflow-only change, no engine code — no test262 impact.
- YAML validated with `yaml.safe_load`.

Closes #138.