### PR TITLE
[gc] Reuse mark bitmap across collections (#126)

### DIFF
--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -40,7 +40,12 @@ impl Interpreter {
         self.gc_requested = false;
         self.gc_alloc_count = 0;
         let obj_count = self.objects.capacity() as usize;
-        let mut marks = vec![false; obj_count];
+        // Reuse the mark bitmap buffer across collections to avoid per-GC
+        // allocation churn. clear()+resize(_, false) yields an all-false buffer
+        // (invariant required by mark/sweep) while keeping the backing capacity.
+        let mut marks = std::mem::take(&mut self.gc_marks);
+        marks.clear();
+        marks.resize(obj_count, false);
 
         // Collect roots from all realms
         let mut worklist: Vec<u64> = Vec::new();
@@ -249,6 +254,8 @@ impl Interpreter {
                 }
             }
         }
+        // Return the buffer to the interpreter so its capacity is reused next GC.
+        self.gc_marks = marks;
     }
 
     fn collect_value_roots(val: &JsValue, worklist: &mut Vec<u64>) {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -66,6 +66,8 @@ pub struct Interpreter {
     gc_bytes_since_gc: usize,
     gc_external_bytes: usize,
     gc_threshold_bytes: usize,
+    // Reusable mark bitmap scratch buffer, cleared+resized each GC collection.
+    gc_marks: Vec<bool>,
     generator_context: Option<GeneratorContext>,
     pub(crate) destructuring_yield: bool,
     pub(crate) pending_iter_close: Vec<JsValue>,
@@ -223,6 +225,7 @@ impl Interpreter {
             gc_bytes_since_gc: 0,
             gc_external_bytes: 0,
             gc_threshold_bytes: GC_INITIAL_THRESHOLD_BYTES,
+            gc_marks: Vec::new(),
             generator_context: None,
             destructuring_yield: false,
             pending_iter_close: Vec::new(),


### PR DESCRIPTION
## Summary

First incremental step toward the generational-GC epic (#126). The mark-and-sweep collector allocated a fresh `vec![false; obj_count]` on **every** collection. This promotes the mark bitmap to a reusable `Interpreter.gc_marks` buffer that is `mem::take`-n at the start of each collection, `clear()`+`resize(obj_count, false)`-d (reusing capacity), and restored at the single function exit — eliminating the per-collection allocation churn the issue's "cheaper interim" experiment calls for.

## Correctness
- **Pure allocation optimization** — marks, sweep, and the freed-object set are byte-for-byte identical to before.
- The all-`false` invariant holds at the start of every collection (`clear()` then `resize(.., false)`).
- The buffer is restored on every exit path (the only early `return` precedes the `mem::take`).
- The buffer holds only `bool`s → not traced, not a GC root.

## Validation
- Full local test262 run against the `origin/main` baseline: **99,252 pass, 0 regressions, 5 new passes**.
- `cargo build --release` warning-free; `cargo test` passes (131 tests).

Diff is +11/−1 across `src/interpreter/mod.rs` (field + init) and `src/interpreter/gc.rs` (`gc_safepoint`). Part of #126 (epic stays open; full nursery/write-barrier work is future).