### PR TITLE
[perf] Migrate array-iterator get_object callers to get_object_cell (#66)

### DIFF
--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -932,7 +932,7 @@ impl Interpreter {
                                             JsValue::Number(index as f64),
                                             elem,
                                         ]);
-                                        if let Some(obj) = interp.get_object(o.id) {
+                                        if let Some(obj) = interp.get_object_cell(o.id) {
                                             obj.borrow_mut().kind =
                                                 crate::interpreter::types::ObjectKind::Iterator(
                                                     IteratorState::ArrayIterator {
@@ -948,7 +948,7 @@ impl Interpreter {
                                         );
                                     }
                                 };
-                                if let Some(obj) = interp.get_object(o.id) {
+                                if let Some(obj) = interp.get_object_cell(o.id) {
                                     obj.borrow_mut().kind =
                                         crate::interpreter::types::ObjectKind::Iterator(
                                             IteratorState::ArrayIterator {
@@ -970,7 +970,7 @@ impl Interpreter {
                                     && is_typed_array_out_of_bounds(ta)
                                 {
                                     drop(borrowed);
-                                    if let Some(obj) = interp.get_object(o.id) {
+                                    if let Some(obj) = interp.get_object_cell(o.id) {
                                         obj.borrow_mut().kind =
                                             crate::interpreter::types::ObjectKind::Iterator(
                                                 IteratorState::ArrayIterator {


### PR DESCRIPTION
## Summary

Incremental step toward the arena-allocator epic (#66), which is driving `get_object()` (Rc-clone) callers toward the borrow-returning `get_object_cell()` accessor. This converts 3 safe call sites in the array-iterator `next` state machine (`src/interpreter/builtins/iterators.rs`), removing an `Rc` refcount bump on a hot iteration path.

All three are deliberate re-fetches that only do an immediate `borrow_mut()` assignment and drop the borrow before the next re-entrant `interp.*` call — the ideal short-lived shape. The remaining 7 `get_object()` sites in the file (and the bulk in `typedarray.rs`/`collections.rs`/`eval.rs`) are correctly **left as-is** because the object reference legitimately spans a re-entrant `&mut self` call (iterator-result construction, prototype lookup, error allocation) — converting them would be a RefCell aliasing hazard, which the borrow checker rejects.

## Risk
- **Behavior-identical refactor**: only the accessor changed (`get_object` → `get_object_cell`, both `Option`-returning, so `None`-handling is unchanged). Diff is +3/−3.
- Validated: iterator-heavy test262 subset (Array, TypedArray, Map, Set, Iterator, for-of) — **12,630 scenarios, 0 regressions**. `cargo build --release` warning-free; `cargo test` passes.

This is a deliberately small, safe slice; the deeper arena work (dropping the per-slot `Rc`) remains future work. Part of #66 (epic stays open).