### PR TITLE
[perf] Cache function-body hoisting analysis keyed by body Rc identity (#72)

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1953,7 +1953,7 @@ impl Interpreter {
         // keyed by the body's Rc pointer identity. The body Rc is stable across
         // function-object clones, so repeated calls reuse the analysis. ASTs are
         // immutable post-parse, so the cache cannot go stale.
-        let key = Rc::as_ptr(body) as *const Vec<Statement>;
+        let key = Rc::as_ptr(body);
         let analysis = match self.hoist_cache.get(&key) {
             Some(a) => a.clone(),
             None => {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1949,7 +1949,29 @@ impl Interpreter {
                 return vm::run_chunk(self, &chunk, exec_env, this_val.clone());
             }
         }
-        self.exec_statements(body, exec_env)
+        // #72: cache the hoisting *name collection* for this function body,
+        // keyed by the body's Rc pointer identity. The body Rc is stable across
+        // function-object clones, so repeated calls reuse the analysis. ASTs are
+        // immutable post-parse, so the cache cannot go stale.
+        let key = Rc::as_ptr(body) as *const Vec<Statement>;
+        let analysis = match self.hoist_cache.get(&key) {
+            Some(a) => a.clone(),
+            None => {
+                let mut var_set = std::collections::HashSet::new();
+                Self::collect_var_names_from_stmts(body, &mut var_set);
+                let mut names = Vec::new();
+                let mut blocked = Vec::new();
+                Self::collect_annexb_function_names(body, &mut names, &mut blocked);
+                let a = Rc::new(HoistAnalysis {
+                    var_names: var_set.into_iter().collect(),
+                    annexb_names: names,
+                    _body: body.clone(),
+                });
+                self.hoist_cache.insert(key, a.clone());
+                a
+            }
+        };
+        self.exec_statements_cached(body, exec_env, Some(&analysis))
     }
 
     pub(super) fn eval_binary(

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -2,6 +2,20 @@ use super::*;
 
 impl Interpreter {
     pub(crate) fn exec_statements(&mut self, stmts: &[Statement], env: &EnvRef) -> Completion {
+        self.exec_statements_cached(stmts, env, None)
+    }
+
+    /// Core statement-sequence executor. `analysis`, when `Some`, supplies the
+    /// pre-computed hoisting *name collection* for this function body (#72),
+    /// letting us skip the per-statement var-hoisting walk and the Annex-B name
+    /// collection. The Annex-B post-processing (which reads live env state) and
+    /// function-declaration hoisting (fresh closures) always run.
+    pub(crate) fn exec_statements_cached(
+        &mut self,
+        stmts: &[Statement],
+        env: &EnvRef,
+        analysis: Option<&Rc<HoistAnalysis>>,
+    ) -> Completion {
         // Hoist var and function declarations
         let var_scope = Environment::find_var_scope(env);
         let is_global = var_scope.borrow().global_object_id.is_some();
@@ -13,10 +27,29 @@ impl Interpreter {
             return err;
         }
 
+        // Hoist var declarations. When a cached analysis is present, declare from
+        // its precomputed name set instead of re-walking the AST — this exactly
+        // replicates the leaf logic of `hoist_pattern` (declare into `var_scope`,
+        // skip if a binding already exists, global vs non-global path).
+        if let Some(analysis) = analysis {
+            for name in &analysis.var_names {
+                if !var_scope.borrow().bindings.contains_key(name) {
+                    if is_global {
+                        self.env_declare_global_var(&var_scope, name);
+                    } else {
+                        var_scope.borrow_mut().declare(name, BindingKind::Var);
+                    }
+                }
+            }
+        } else {
+            for stmt in stmts {
+                // Recursively hoist var declarations from all sub-statements
+                self.hoist_vars_from_stmt(stmt, &var_scope, is_global);
+            }
+        }
         for stmt in stmts {
-            // Recursively hoist var declarations from all sub-statements
-            self.hoist_vars_from_stmt(stmt, &var_scope, is_global);
-            // Check for function declarations (including inside labels)
+            // Check for function declarations (including inside labels). This
+            // builds fresh closures per call and is never cached.
             if let Some(f) = Self::unwrap_labeled_function(stmt) {
                 self.hoist_function_decl(f, env, is_global);
             }
@@ -30,9 +63,20 @@ impl Interpreter {
         // create var bindings for function declarations inside blocks.
         // Skip names that conflict with parameters or lexical bindings.
         if !is_block_scope && !env.borrow().strict {
-            let mut all_annexb = Vec::new();
-            let mut blocked = Vec::new();
-            Self::collect_annexb_function_names(stmts, &mut all_annexb, &mut blocked);
+            // Only the raw name collection is cacheable; the post-processing
+            // below inspects live env/parameter/lexical state and must run per
+            // call. With a cached analysis, reuse its collected names. The
+            // original code discards the `blocked` accumulator after the collect
+            // call; only the `names` (`all_annexb`) feed post-processing.
+            let all_annexb = match analysis {
+                Some(analysis) => analysis.annexb_names.clone(),
+                None => {
+                    let mut names = Vec::new();
+                    let mut blocked = Vec::new();
+                    Self::collect_annexb_function_names(stmts, &mut names, &mut blocked);
+                    names
+                }
+            };
             if !all_annexb.is_empty() {
                 let mut registered = Vec::new();
                 // Collect top-level var/function names from statements

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -53,6 +53,25 @@ fn import_module_type(attrs: &[(String, String)]) -> Option<ImportModuleType> {
     None
 }
 
+/// Cached output of the var/Annex-B hoisting *name collection* for a single
+/// function body, keyed by the body's `Rc` pointer identity (#72).
+///
+/// Only the raw name collection is cached. The Annex-B post-processing that
+/// inspects live env/parameter/lexical state still runs per call, and function
+/// declarations are never cached as values (fresh closures are built per call).
+/// The body `Rc` is pinned to prevent pointer (ABA) reuse from aliasing a
+/// freed body onto a fresh one with the same address.
+pub(crate) struct HoistAnalysis {
+    /// Deduped output of `collect_var_names_from_stmts`.
+    pub(crate) var_names: Vec<String>,
+    /// Raw `names` output of `collect_annexb_function_names`. (The companion
+    /// `blocked` accumulator is internal to the walk and discarded afterwards
+    /// by the original code, so it is intentionally not cached.)
+    pub(crate) annexb_names: Vec<String>,
+    /// Pins the body so its `Rc::as_ptr` key cannot be reused for another body.
+    _body: Rc<Vec<Statement>>,
+}
+
 pub struct Interpreter {
     pub(crate) realms: Vec<Realm>,
     pub(crate) current_realm_id: usize,
@@ -136,6 +155,11 @@ pub struct Interpreter {
     pub(crate) call_ic_fast_dispatch_count: std::cell::Cell<u64>,
     pub(crate) bytecode_enabled: bool,
     pub(crate) bytecode_chunks_executed: usize,
+    /// Per-function-body hoisting-analysis cache keyed by body `Rc` identity
+    /// (#72). The key `*const Vec<Statement>` is used purely as an identity —
+    /// never dereferenced. Cannot go stale: ASTs are immutable post-parse and
+    /// the keyed body is pinned in the value.
+    pub(crate) hoist_cache: FxHashMap<*const Vec<Statement>, Rc<HoistAnalysis>>,
 }
 
 pub(crate) struct CallFrame {
@@ -283,6 +307,7 @@ impl Interpreter {
             call_ic_fast_dispatch_count: std::cell::Cell::new(0),
             bytecode_enabled: false,
             bytecode_chunks_executed: 0,
+            hoist_cache: FxHashMap::default(),
         };
         interp.setup_globals();
         interp


### PR DESCRIPTION
## Summary

Implements #72. The var-hoisting and Annex-B function-name collection re-walked the entire function-body AST on **every** invocation. This memoizes that name collection in a global cache keyed by the body's `Rc` pointer identity (`Rc::as_ptr`), integrated at the `dispatch_body` function-body boundary. Repeated calls of the same function reuse the analysis instead of re-walking.

## Design (low-risk by construction)
- Global `hoist_cache: FxHashMap<*const Vec<Statement>, Rc<HoistAnalysis>>` on `Interpreter` (the issue's recommended alternative — avoids fragile re-borrowing of the function object during call setup, and is automatically shared across all `JsFunction` clones that share the same body `Rc`).
- `HoistAnalysis` pins an `Rc<Vec<Statement>>` of the body, so the keyed pointer can never be freed/reused (no ABA). ASTs are immutable post-parse → the cache can never go stale.
- Caching happens **only** at the function-body boundary (`dispatch_body`, which has the `Rc`). Blocks / `try` / `eval` / top-level keep the original uncached `exec_statements` path unchanged.

## Correctness
- **Var-name equivalence verified**: the cached `collect_var_names_from_stmts` walk was compared construct-by-construct and pattern-by-pattern against the existing side-effecting `hoist_vars_from_stmt`/`hoist_pattern` walk — identical visit set for `var` in nested block/if/while/for/for-in/for-of/switch/try/labeled/with and all destructuring patterns. Only the leaf declare action differs, and it's replicated exactly.
- **Annex-B post-processing stays per-call** — only the *raw* `collect_annexb_function_names` output is cached; the conflict-resolution that inspects live env/param/lexical state runs every call.
- Function-declaration hoisting (fresh closures per call) is untouched.
- `dispatch_body` is only ever called with a function-scope env (`is_global == false`), so the order-insensitive `declare()` branch is used — HashSet iteration order is not observable.

## Validation
- Full local test262 run vs `origin/main` baseline: **99,252 pass, 0 regressions, 5 new passes**.
- `cargo build --release` warning-free; `cargo test` passes (131 tests).

Diff +98/−7 across `eval.rs`, `exec.rs`, `mod.rs`. Closes #72.