### PR TITLE
[perf] Inline-cache depth-1 prototype data property reads (#71)

### DIFF
--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -501,12 +501,13 @@ impl Interpreter {
     /// site is not IC-able under the v1 narrow scope. Caller uses this after
     /// the slow path returns successfully. Issue #71, plan Step 11.
     ///
-    /// v1 scope:
+    /// Scope:
     /// - Object must NOT be a proxy / module-namespace / typed-array.
-    /// - Property must resolve as own data (→ `OwnData`) or be absent up to
-    ///   the immediate prototype (→ `Missing`).
-    /// - Own accessors, proto-chain hits, and depth>1 misses return `None`
-    ///   (caller leaves the slot Empty rather than caching).
+    /// - Property must resolve as own data (→ `OwnData`), as a depth-1
+    ///   prototype data descriptor (→ `ProtoData`), or be absent when the
+    ///   immediate prototype is null (→ `Missing`).
+    /// - Own accessors, depth-1 prototype *accessors*, and depth>1 hits/misses
+    ///   return `None` (caller leaves the slot Empty rather than caching).
     fn classify_for_prop_ic(
         &self,
         obj_id: u64,
@@ -535,18 +536,57 @@ impl Interpreter {
             return None;
         }
         // Absent on receiver — only cacheable if the immediate prototype is
-        // null (depth-1 Missing). Anything deeper stays uncached for v1.
-        if obj.prototype_id.is_none() {
-            return Some(PropIcSlot::Mono {
-                obj_id,
-                obj_shape_id: obj.shape_id,
-                kind: PropIcKind::Missing {
-                    proto_id: None,
-                    proto_shape_id: 0,
-                },
-            });
+        // null (depth-1 Missing) or the immediate prototype carries the
+        // property as a plain data descriptor (depth-1 ProtoData). Anything
+        // deeper stays uncached.
+        let proto_id = match obj.prototype_id {
+            None => {
+                return Some(PropIcSlot::Mono {
+                    obj_id,
+                    obj_shape_id: obj.shape_id,
+                    kind: PropIcKind::Missing {
+                        proto_id: None,
+                        proto_shape_id: 0,
+                    },
+                });
+            }
+            Some(pid) => pid,
+        };
+        // Depth-1 prototype lookup. Drop the receiver borrow first so the
+        // prototype borrow below can never alias it (proto could be the same
+        // slot in pathological setups, though that would be a self-cycle).
+        drop(obj);
+        let proto_rc = self.get_object(proto_id)?;
+        let proto = proto_rc.borrow();
+        // The prototype must be an ordinary object whose own data property can
+        // be fetched directly. A proxy/module-namespace/typed-array prototype
+        // would require trap/index logic the probe doesn't perform.
+        if proto.proxy().is_some()
+            || proto.module_namespace().is_some()
+            || proto.typed_array_info().is_some()
+        {
+            return None;
         }
-        None
+        match proto.properties.get(key) {
+            // Depth-1 data descriptor on the immediate prototype.
+            Some(d) if d.is_data_descriptor() => {
+                // Re-read the receiver shape (the borrow was dropped above).
+                let obj_shape_id = obj_rc.borrow().shape_id;
+                Some(PropIcSlot::Mono {
+                    obj_id,
+                    obj_shape_id,
+                    kind: PropIcKind::ProtoData {
+                        proto_id,
+                        proto_shape_id: proto.shape_id,
+                    },
+                })
+            }
+            // Depth-1 accessor — excluded (no getter invocation in the probe).
+            Some(_) => None,
+            // Absent on the immediate prototype → resolves deeper than depth-1
+            // (or is missing). Not cacheable in this narrow scope.
+            None => None,
+        }
     }
 
     pub(super) fn eval_member(
@@ -784,9 +824,42 @@ impl Interpreter {
                                     return Completion::Normal(JsValue::Undefined);
                                 }
                             }
-                            // OwnAccessor / ProtoData / TypedArrayElement not
-                            // recorded in the v1 narrow scope; they'd be
-                            // unreachable here. Safe to fall through.
+                            PropIcKind::ProtoData {
+                                proto_id,
+                                proto_shape_id,
+                            } => {
+                                // CRITICAL: reassigning `[[Prototype]]`
+                                // (`__proto__` / `Object.setPrototypeOf`) sets
+                                // `prototype_id` directly WITHOUT bumping the
+                                // receiver's shape_id, so the receiver-shape
+                                // match above is NOT sufficient. We must also
+                                // confirm the receiver still points at the same
+                                // prototype, then confirm that prototype's shape
+                                // is unchanged (so the property hasn't been
+                                // added/removed/reordered/flipped on it).
+                                let cur_proto = obj_rc.borrow().prototype_id;
+                                if cur_proto == Some(proto_id)
+                                    && let Some(proto_rc) = self.get_object(proto_id)
+                                {
+                                    let val = {
+                                        let pb = proto_rc.borrow();
+                                        if pb.shape_id == proto_shape_id {
+                                            pb.properties.get(&key).and_then(|d| d.value.clone())
+                                        } else {
+                                            None
+                                        }
+                                    };
+                                    if let Some(v) = val {
+                                        self.ic_hit_count.set(self.ic_hit_count.get() + 1);
+                                        return Completion::Normal(v);
+                                    }
+                                }
+                                // Proto swapped, proto shape advanced, or the
+                                // descriptor lost its value — fall through.
+                            }
+                            // OwnAccessor / TypedArrayElement not recorded in
+                            // this narrow scope; they'd be unreachable here.
+                            // Safe to fall through.
                             _ => {}
                         }
                     }

--- a/src/interpreter/ic.rs
+++ b/src/interpreter/ic.rs
@@ -41,10 +41,10 @@ pub(crate) enum PropIcSlot {
 /// for the probe to dispatch without re-walking proxy/module-ns/typed-array
 /// detection or the prototype chain.
 ///
-/// Phase-2 v1 only constructs `OwnData` and `Missing`. `OwnAccessor`,
-/// `ProtoData`, and `TypedArrayElement` are reserved for follow-up cycles
-/// (the probe path already handles them defensively, so adding the recording
-/// hook later is a small change).
+/// Constructs `OwnData`, `Missing`, and depth-1 `ProtoData`. `OwnAccessor`
+/// and `TypedArrayElement` are reserved for follow-up cycles (the probe path
+/// already handles them defensively, so adding the recording hook later is a
+/// small change).
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum PropIcKind {
@@ -57,8 +57,10 @@ pub(crate) enum PropIcKind {
     /// Probe re-fetches the descriptor and invokes the getter.
     OwnAccessor,
     /// Property resolved on the immediate prototype (depth 1) as a data
-    /// descriptor. Probe verifies BOTH the receiver shape AND the prototype
-    /// shape before re-fetching.
+    /// descriptor. Probe verifies the receiver shape, the receiver's current
+    /// `prototype_id` (a proto swap does NOT bump the receiver shape), AND the
+    /// prototype's shape before re-fetching the value from the prototype's own
+    /// data property.
     ProtoData { proto_id: u64, proto_shape_id: u64 },
     /// Property is absent up to and including the immediate prototype.
     /// Probe verifies the prototype shape (or `proto_id == None`) and

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -842,6 +842,126 @@ fn ic_invalidates_on_delete_property() {
 }
 
 #[test]
+fn ic_records_proto_data_after_repeated_dot_access() {
+    // Hot loop reads `o.x` where `x` lives on the immediate prototype as a
+    // data property, not on `o` itself. After warmup the depth-1 ProtoData IC
+    // must be hitting (proves the probe serves the value directly from the
+    // prototype without re-walking the chain on every read).
+    let interp = run_script(
+        r#"
+        var proto = {x: 42};
+        var o = Object.create(proto);
+        var sum = 0;
+        for (var i = 0; i < 100; i++) {
+            sum += o.x;
+        }
+        "#,
+    );
+    assert_eq!(
+        global_number(&interp, "sum"),
+        4200.0,
+        "behavioral correctness"
+    );
+    assert!(
+        interp.ic_hit_count() > 0,
+        "expected depth-1 ProtoData IC hits after 100-iteration hot loop on \
+         o.x (x on the immediate prototype); got 0"
+    );
+}
+
+#[test]
+fn ic_proto_data_invalidates_on_prototype_swap() {
+    // CRITICAL: reassigning `[[Prototype]]` does NOT bump the receiver's
+    // shape_id. If the ProtoData hit arm validated only the receiver shape, it
+    // would serve the OLD prototype's value after the swap. The explicit
+    // `prototype_id == proto_id` guard must force a miss and re-resolution.
+    let interp = run_script(
+        r#"
+        var a = {x: 1};
+        var b = {x: 2};
+        var o = Object.create(a);
+        var first = 0;
+        for (var i = 0; i < 20; i++) first += o.x;   // populate ProtoData on `a`
+        Object.setPrototypeOf(o, b);
+        var post = o.x;                              // must now see b.x === 2
+        var result = first + "|" + post;
+        "#,
+    );
+    assert_eq!(
+        global_string(&interp, "result"),
+        "20|2",
+        "after Object.setPrototypeOf the read must reflect the new prototype, \
+         not the stale cached one"
+    );
+}
+
+#[test]
+fn ic_proto_data_invalidates_on_proto_property_change() {
+    // Mutating the prototype's property structure (delete) bumps the
+    // prototype's shape_id → the cached proto_shape_id no longer matches → the
+    // probe must miss and observe the new (absent) state.
+    let interp = run_script(
+        r#"
+        var proto = {x: 5};
+        var o = Object.create(proto);
+        var sum = 0;
+        for (var i = 0; i < 20; i++) sum += o.x;     // populate ProtoData
+        delete proto.x;
+        var post = (typeof o.x === "undefined") ? "gone" : "still:" + o.x;
+        var result = sum + "|" + post;
+        "#,
+    );
+    assert_eq!(global_string(&interp, "result"), "100|gone");
+}
+
+#[test]
+fn ic_proto_data_shadowed_by_own_property() {
+    // Adding an own property to the receiver bumps the receiver's shape_id →
+    // the cached (proto-resolved) slot misses → the closer own value wins.
+    let interp = run_script(
+        r#"
+        var proto = {x: 1};
+        var o = Object.create(proto);
+        var first = 0;
+        for (var i = 0; i < 20; i++) first += o.x;   // populate ProtoData (=1)
+        o.x = 99;                                    // shadow on the receiver
+        var post = o.x;
+        var result = first + "|" + post;
+        "#,
+    );
+    assert_eq!(
+        global_string(&interp, "result"),
+        "20|99",
+        "an own property added to the receiver must shadow the cached \
+         prototype data value"
+    );
+}
+
+#[test]
+fn ic_proto_accessor_not_served_as_data() {
+    // The property resolves on the immediate prototype as an ACCESSOR, not a
+    // data descriptor. classify_for_prop_ic must NOT record it as ProtoData,
+    // so every read invokes the getter (observed via the side-effect counter).
+    let interp = run_script(
+        r#"
+        var calls = 0;
+        var proto = {};
+        Object.defineProperty(proto, 'x', { get: function() { calls++; return 7; }, configurable: true });
+        var o = Object.create(proto);
+        var sum = 0;
+        for (var i = 0; i < 10; i++) sum += o.x;
+        var result = sum + "|" + calls;
+        "#,
+    );
+    assert_eq!(
+        global_string(&interp, "result"),
+        "70|10",
+        "a prototype accessor must be invoked on every read (10 getter calls), \
+         never cached as ProtoData"
+    );
+}
+
+#[test]
 fn call_ic_records_after_repeated_call() {
     // Phase 3 tracer: the call site `f()` repeatedly invokes the same plain
     // user function. After the first call, the IC slot must be Mono and


### PR DESCRIPTION
## Summary

Incremental step toward the inline-caching epic (#71). The property-IC previously deferred `ProtoData` (the `PropIcKind::ProtoData` variant existed but `classify_for_prop_ic` returned `None`). This wires it up: when a property is absent on the receiver's own properties but present as a **data** descriptor on its **immediate** prototype, the access site caches `ProtoData { proto_id, proto_shape_id }` and serves subsequent hits directly, skipping the chain walk.

## Correctness
The probe hit arm validates **all three** before serving:
1. receiver `shape_id` == cached receiver shape,
2. receiver's **current** `prototype_id` == cached `proto_id`,
3. the prototype's current `shape_id` == cached `proto_shape_id`.

Guard (2) is load-bearing: prototype reassignment (`Object.setPrototypeOf` / `__proto__=`) does **not** bump the receiver's `shape_id` in this engine, so a proto swap is caught by the explicit `prototype_id` comparison. Property add/remove/reorder on the prototype bumps its `shape_id` → miss. Delete is also handled (the probe re-fetches and falls through if gone). **Accessors and depth > 1 are excluded** (left uncached) — getters on a prototype always re-invoke.

## Validation
- Full local test262 vs `origin/main` baseline: **99,252 pass, 0 regressions, 5 new passes**.
- 5 new IC integration tests (hot-loop hit, proto-swap invalidation, proto-property-delete invalidation, own-shadow, accessor-exclusion). `cargo build --release` warning-free; `cargo test` + `./scripts/lint.sh` clean.

Diff +220/−25. Part of #71 (epic stays open; `OwnAccessor`/`TypedArrayElement`/deeper proto caching remain future work).