### PR TITLE
[perf] Intern property keys to Rc<str> at the storage layer (#74)

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -684,7 +684,7 @@ fn obj_delete(interp: &mut Interpreter, o: &JsValue, key: &str) {
     if let Some(cell) = get_obj(interp, o) {
         let mut borrow = cell.borrow_mut();
         borrow.properties.remove(key);
-        borrow.property_order.retain(|k| k != key);
+        borrow.property_order.retain(|k| &**k != key);
         if let Some(elems) = borrow.array_elements_mut()
             && let Ok(idx) = key.parse::<usize>()
             && idx < elems.len()

--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -808,7 +808,7 @@ impl Interpreter {
         // @@toStringTag
         {
             let tag = JsValue::String(JsString::from_str("Atomics"));
-            let sym_key = "Symbol(Symbol.toStringTag)".to_string();
+            let sym_key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor::data(tag, false, false, true);
             self.get_object_cell_expect(atomics_obj_id)
                 .borrow_mut()

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -2765,7 +2765,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .property_order
@@ -3007,7 +3007,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .property_order

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -48,7 +48,7 @@ fn date_to_locale_string(
                             .borrow()
                             .properties
                             .iter()
-                            .map(|(k, pd)| (k.clone(), pd.clone()))
+                            .map(|(k, pd)| (k.to_string(), pd.clone()))
                             .collect();
                         let new_obj_id = interp.create_object_id();
                         for (k, pd) in pds {

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -345,7 +345,7 @@ impl Interpreter {
 
                     if let Some(obj) = interp.get_object_cell(o.id) {
                         obj.borrow_mut().properties.insert(
-                            "[[BoundCompare]]".to_string(),
+                            crate::interpreter::key_intern::intern_key("[[BoundCompare]]"),
                             PropertyDescriptor::data(compare_fn.clone(), false, false, false),
                         );
                     }

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -4874,7 +4874,7 @@ impl Interpreter {
 
                     if let Some(obj) = interp.get_object_cell(o.id) {
                         obj.borrow_mut().properties.insert(
-                            "[[BoundFormat]]".to_string(),
+                            crate::interpreter::key_intern::intern_key("[[BoundFormat]]"),
                             PropertyDescriptor::data(format_fn.clone(), false, false, false),
                         );
                     }

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -20,7 +20,7 @@ impl Interpreter {
 
         // @@toStringTag = "Intl" (per spec 8.1.1)
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Intl"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -3049,7 +3049,7 @@ impl Interpreter {
 
                         if let Some(obj) = interp.get_object_cell(o.id) {
                             obj.borrow_mut().properties.insert(
-                                "[[BoundFormat]]".to_string(),
+                                crate::interpreter::key_intern::intern_key("[[BoundFormat]]"),
                                 PropertyDescriptor::data(format_fn.clone(), false, false, false),
                             );
                         }

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2432,7 +2432,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             self.get_object_cell_expect(math_obj_id)
                 .borrow_mut()
                 .property_order
@@ -3716,8 +3716,9 @@ impl Interpreter {
                         true,
                         false,
                     );
-                    o.property_order.push("rawJSON".to_string());
-                    o.properties.insert("rawJSON".to_string(), desc);
+                    let key = crate::interpreter::key_intern::intern_key("rawJSON");
+                    o.property_order.push(std::rc::Rc::clone(&key));
+                    o.properties.insert(key, desc);
                 }
                 interp
                     .get_object_cell_expect(obj_id)
@@ -3766,7 +3767,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             self.get_object_cell_expect(json_obj_id)
                 .borrow_mut()
                 .property_order
@@ -5176,7 +5177,7 @@ impl Interpreter {
                                 let b = obj.borrow();
                                 b.properties
                                     .iter()
-                                    .map(|(k, d)| (k.clone(), d.clone()))
+                                    .map(|(k, d)| (k.to_string(), d.clone()))
                                     .collect()
                             };
                             for (key, desc) in keys_and_descs {
@@ -5631,25 +5632,25 @@ impl Interpreter {
                                 }
                             }
                             for k in &b.property_order {
-                                if is_string_wrapper && k == "length" {
+                                if is_string_wrapper && &**k == "length" {
                                     continue;
                                 }
                                 if k.starts_with("Symbol(") {
-                                    sym_keys.push(k.clone());
+                                    sym_keys.push(k.to_string());
                                 } else if let Ok(n) = k.parse::<u64>() {
-                                    if n.to_string() == *k {
-                                        int_keys.push((n, k.clone()));
+                                    if n.to_string() == **k {
+                                        int_keys.push((n, k.to_string()));
                                     } else {
-                                        str_keys.push(k.clone());
+                                        str_keys.push(k.to_string());
                                     }
                                 } else {
-                                    str_keys.push(k.clone());
+                                    str_keys.push(k.to_string());
                                 }
                             }
                             // Also pick up symbol keys that may not be in property_order
                             for k in b.properties.keys() {
                                 if k.starts_with("Symbol(") && !b.property_order.contains(k) {
-                                    sym_keys.push(k.clone());
+                                    sym_keys.push(k.to_string());
                                 }
                             }
                             int_keys.sort_by_key(|(n, _)| *n);
@@ -5887,7 +5888,7 @@ impl Interpreter {
                                     }
                                     if let Ok(n) = k.parse::<u64>()
                                         && n < 0xFFFFFFFF
-                                        && n.to_string() == *k
+                                        && n.to_string() == **k
                                     {
                                         continue; // skip numeric indices
                                     }
@@ -5913,7 +5914,7 @@ impl Interpreter {
                             .property_order
                             .iter()
                             .filter(|k| !k.starts_with("Symbol("))
-                            .cloned()
+                            .map(|k| k.to_string())
                             .collect();
                         drop(b);
                         // Sort: integer indices first (already added char indices), then string keys
@@ -6011,11 +6012,13 @@ impl Interpreter {
                                     .property_order
                                     .iter()
                                     .filter(|k| k.starts_with("Symbol("))
-                                    .cloned()
+                                    .map(|k| k.to_string())
                                     .collect();
                                 for k in b.properties.keys() {
-                                    if k.starts_with("Symbol(") && !sym_keys.contains(k) {
-                                        sym_keys.push(k.clone());
+                                    if k.starts_with("Symbol(")
+                                        && !sym_keys.iter().any(|s| s.as_str() == &**k)
+                                    {
+                                        sym_keys.push(k.to_string());
                                     }
                                 }
                                 sym_keys
@@ -6325,8 +6328,12 @@ impl Interpreter {
                                     }
                                 }
                             }
-                            let keys: Vec<String> =
-                                obj.borrow().properties.keys().cloned().collect();
+                            let keys: Vec<String> = obj
+                                .borrow()
+                                .properties
+                                .keys()
+                                .map(|k| k.to_string())
+                                .collect();
                             for key in keys {
                                 let new_desc = PropertyDescriptor {
                                     configurable: Some(false),
@@ -7636,7 +7643,7 @@ impl Interpreter {
                         return Completion::Normal(JsValue::Boolean(false));
                     }
                     obj_mut.properties.remove(&key);
-                    obj_mut.property_order.retain(|k| k != &key);
+                    obj_mut.property_order.retain(|k| &**k != key.as_str());
                     if let Some(map) = obj_mut.parameter_map_mut() {
                         map.remove(&key);
                     }
@@ -7929,14 +7936,14 @@ impl Interpreter {
                             let mut symbols: Vec<(String, usize)> = Vec::new();
                             for (pos, k) in property_order.iter().enumerate() {
                                 if k.starts_with("Symbol(") {
-                                    symbols.push((k.clone(), pos));
+                                    symbols.push((k.to_string(), pos));
                                 } else if let Ok(n) = k.parse::<u64>()
                                     && n < 0xFFFFFFFF
-                                    && n.to_string() == *k
+                                    && n.to_string() == **k
                                 {
                                     // Skip numeric indices, already handled above
                                 } else {
-                                    strings.push((k.clone(), pos));
+                                    strings.push((k.to_string(), pos));
                                 }
                             }
                             for (s, _) in &strings {
@@ -7966,7 +7973,8 @@ impl Interpreter {
                     }
                     let property_order = obj.borrow().property_order.clone();
                     // Collect keys already in property_order into virtual_indices set for dedup
-                    let existing_keys: HashSet<String> = property_order.iter().cloned().collect();
+                    let existing_keys: HashSet<String> =
+                        property_order.iter().map(|k| k.to_string()).collect();
                     // OrdinaryOwnPropertyKeys: indices ascending, then strings, then symbols
                     let mut indices: Vec<(u32, usize)> = Vec::new();
                     let mut strings: Vec<(String, usize)> = Vec::new();
@@ -7980,14 +7988,14 @@ impl Interpreter {
                     }
                     for (pos, k) in property_order.iter().enumerate() {
                         if k.starts_with("Symbol(") {
-                            symbols.push((k.clone(), pos));
+                            symbols.push((k.to_string(), pos));
                         } else if let Ok(n) = k.parse::<u64>()
                             && n < 0xFFFFFFFF
-                            && n.to_string() == *k
+                            && n.to_string() == **k
                         {
                             indices.push((n as u32, pos));
                         } else {
-                            strings.push((k.clone(), pos));
+                            strings.push((k.to_string(), pos));
                         }
                     }
                     indices.sort_by_key(|&(n, _)| n);
@@ -8495,7 +8503,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             self.get_object_cell_expect(reflect_obj_id)
                 .borrow_mut()
                 .property_order
@@ -8874,7 +8882,9 @@ impl Interpreter {
                     }
                     // Per spec, bound functions do not have own .prototype property
                     obj.borrow_mut().properties.remove("prototype");
-                    obj.borrow_mut().property_order.retain(|k| k != "prototype");
+                    obj.borrow_mut()
+                        .property_order
+                        .retain(|k| &**k != "prototype");
                     // Store [[BoundTargetFunction]] / [[BoundThis]] / [[BoundArguments]].
                     let stored_bound_args: Vec<JsValue> = args.iter().skip(1).cloned().collect();
                     obj.borrow_mut().kind = crate::interpreter::types::ObjectKind::BoundFunction(

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -1640,7 +1640,7 @@ impl Interpreter {
 
         // @@toStringTag
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.Duration"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -22,7 +22,7 @@ impl Interpreter {
 
         // @@toStringTag
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.Instant"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -1618,7 +1618,7 @@ impl Interpreter {
 
         // @@toStringTag = "Temporal"
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -9,7 +9,7 @@ impl Interpreter {
 
         // @@toStringTag = "Temporal.Now"
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.Now"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -14,7 +14,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainDate".to_string();
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.PlainDate"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -543,7 +543,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainDateTime".to_string();
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str(
                     "Temporal.PlainDateTime",

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -406,7 +406,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainMonthDay".to_string();
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str(
                     "Temporal.PlainMonthDay",

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -13,7 +13,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainTime".to_string();
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.PlainTime"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -394,7 +394,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainYearMonth".to_string();
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str(
                     "Temporal.PlainYearMonth",

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -1805,7 +1805,7 @@ impl Interpreter {
 
         // @@toStringTag
         {
-            let key = "Symbol(Symbol.toStringTag)".to_string();
+            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str(
                     "Temporal.ZonedDateTime",
@@ -2231,7 +2231,13 @@ impl Interpreter {
                         if let JsValue::Object(ref o) = options_arg {
                             let keys: Vec<String> = interp
                                 .get_object_cell(o.id)
-                                .map(|rc| rc.borrow().properties.keys().cloned().collect())
+                                .map(|rc| {
+                                    rc.borrow()
+                                        .properties
+                                        .keys()
+                                        .map(|k| k.to_string())
+                                        .collect()
+                                })
                                 .unwrap_or_default();
                             for key in keys {
                                 let val = match interp.get_object_property(o.id, &key, &options_arg)

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1536,7 +1536,7 @@ impl Interpreter {
         // @@toStringTag
         {
             let tag = JsValue::String(JsString::from_str("SharedArrayBuffer"));
-            let sym_key = "Symbol(Symbol.toStringTag)".to_string();
+            let sym_key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
             let desc = PropertyDescriptor::data(tag, false, false, true);
             self.get_object_cell_expect(sab_proto_id)
                 .borrow_mut()

--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -215,9 +215,10 @@ impl Interpreter {
             if let Some(go) = self.get_object_cell(gid) {
                 let mut g = go.borrow_mut();
                 if !g.properties.contains_key(name) {
-                    g.property_order.push(name.to_string());
+                    let key = crate::interpreter::key_intern::intern_key(name);
+                    g.property_order.push(Rc::clone(&key));
                     g.properties.insert(
-                        name.to_string(),
+                        key,
                         PropertyDescriptor::data(JsValue::Undefined, true, true, false),
                     );
                 }
@@ -242,9 +243,10 @@ impl Interpreter {
             if let Some(go) = self.get_object_cell(gid) {
                 let mut g = go.borrow_mut();
                 if !g.properties.contains_key(name) {
-                    g.property_order.push(name.to_string());
+                    let key = crate::interpreter::key_intern::intern_key(name);
+                    g.property_order.push(Rc::clone(&key));
                     g.properties.insert(
-                        name.to_string(),
+                        key,
                         PropertyDescriptor::data(JsValue::Undefined, true, true, true),
                     );
                 }
@@ -318,10 +320,11 @@ impl Interpreter {
                 existing.is_none() || existing.is_some_and(|d| d.configurable == Some(true));
             if need_full_desc {
                 let desc = PropertyDescriptor::data(value, true, true, configurable);
+                let key = crate::interpreter::key_intern::intern_key(name);
                 if !g.properties.contains_key(name) {
-                    g.property_order.push(name.to_string());
+                    g.property_order.push(Rc::clone(&key));
                 }
-                g.properties.insert(name.to_string(), desc);
+                g.properties.insert(key, desc);
             } else {
                 g.set_property_value(name, value);
             }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -724,7 +724,7 @@ impl Interpreter {
                             return Completion::Normal(JsValue::Boolean(false));
                         }
                         obj_mut.properties.remove(&key);
-                        obj_mut.property_order.retain(|k| k != &key);
+                        obj_mut.property_order.retain(|k| &**k != key.as_str());
                         if let Some(map) = obj_mut.parameter_map_mut() {
                             map.remove(&key);
                         }
@@ -790,7 +790,7 @@ impl Interpreter {
                             }
                             drop(gb);
                             global.borrow_mut().properties.remove(name);
-                            global.borrow_mut().property_order.retain(|k| k != name);
+                            global.borrow_mut().property_order.retain(|k| &**k != name);
                             self.realm().global_env.borrow_mut().bindings.remove(name);
                             return Completion::Normal(JsValue::Boolean(true));
                         }
@@ -12888,7 +12888,7 @@ impl Interpreter {
                 if let Some(obj) = self.get_object_cell(o.id) {
                     let class = obj.borrow().class_name.clone();
                     let has_callable = obj.borrow().callable.is_some();
-                    let keys: Vec<String> = obj
+                    let keys: Vec<Rc<str>> = obj
                         .borrow()
                         .property_order
                         .iter()
@@ -14637,7 +14637,7 @@ impl Interpreter {
                             .get(k)
                             .is_some_and(|d| d.configurable == Some(false))
                     })
-                    .cloned()
+                    .map(|k| k.to_string())
                     .collect();
                 let c: Vec<String> = b
                     .property_order
@@ -14647,7 +14647,7 @@ impl Interpreter {
                             .get(k)
                             .is_some_and(|d| d.configurable != Some(false))
                     })
-                    .cloned()
+                    .map(|k| k.to_string())
                     .collect();
                 (nc, c)
             };
@@ -15438,7 +15438,7 @@ impl Interpreter {
                 return Ok(false);
             }
             m.properties.remove(key);
-            m.property_order.retain(|k| k != key);
+            m.property_order.retain(|k| &**k != key);
             if let Some(elems) = m.array_elements_mut()
                 && let Ok(idx) = key.parse::<usize>()
                 && idx < elems.len()
@@ -16038,20 +16038,20 @@ impl Interpreter {
 
             for k in &b.property_order {
                 if k.starts_with("Symbol(") {
-                    sym_keys.push(k.clone());
+                    sym_keys.push(k.to_string());
                 } else if let Ok(n) = k.parse::<u64>() {
-                    if n.to_string() == *k {
+                    if n.to_string() == **k {
                         // This is an integer index - add/overwrite (string char indices take precedence, but we let btreemap handle uniqueness)
-                        int_keys_set.insert(n, k.clone());
+                        int_keys_set.insert(n, k.to_string());
                     } else {
-                        str_keys.push(k.clone());
+                        str_keys.push(k.to_string());
                     }
                 } else {
                     // Skip "length" for string wrappers - it's virtual, added separately
-                    if is_string_wrapper && k == "length" {
+                    if is_string_wrapper && &**k == "length" {
                         continue;
                     }
-                    str_keys.push(k.clone());
+                    str_keys.push(k.to_string());
                 }
             }
 

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -482,7 +482,7 @@ impl Interpreter {
                 return Completion::Normal(JsValue::Boolean(false));
             }
             obj_mut.properties.remove(key);
-            obj_mut.property_order.retain(|k| k != key);
+            obj_mut.property_order.retain(|k| &**k != key);
             if let Some(map) = obj_mut.parameter_map_mut() {
                 map.remove(key);
             }

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -392,18 +392,19 @@ pub(crate) fn enumerable_own_keys(
             .property_order
             .iter()
             .filter(|k| {
-                if result.contains(k) {
+                let ks: &str = k;
+                if result.iter().any(|r| r.as_str() == ks) {
                     return false;
                 }
-                if is_string_wrapper && *k == "length" {
+                if is_string_wrapper && ks == "length" {
                     return false;
                 }
-                !k.starts_with("Symbol(")
+                !ks.starts_with("Symbol(")
                     && b.properties
-                        .get(k)
+                        .get(ks)
                         .is_some_and(|d| d.enumerable != Some(false))
             })
-            .cloned()
+            .map(|k| k.to_string())
             .collect();
         if !result.is_empty() {
             result.extend(sort_own_keys(keys));
@@ -996,7 +997,7 @@ fn json_internalize_apply(
                         && let Some(tobj) = interp.get_object_cell(t.id)
                     {
                         tobj.borrow_mut().properties.remove(key);
-                        tobj.borrow_mut().property_order.retain(|k| k != key);
+                        tobj.borrow_mut().property_order.retain(|k| &**k != key);
                     }
                 }
                 Err(e) => return Err(e),
@@ -1061,7 +1062,7 @@ fn json_internalize_apply(
         }
         if let JsValue::Undefined = &new_val {
             cell.borrow_mut().properties.remove(key);
-            cell.borrow_mut().property_order.retain(|k| k != key);
+            cell.borrow_mut().property_order.retain(|k| &**k != key);
             // Also clear dense array storage so get_property doesn't find stale values
             if let Ok(idx) = key.parse::<usize>() {
                 let mut b = cell.borrow_mut();

--- a/src/interpreter/key_intern.rs
+++ b/src/interpreter/key_intern.rs
@@ -1,0 +1,182 @@
+//! Property-key interning (issue #74).
+//!
+//! Property names are stored twice per object: once as the `PropertyMap` key
+//! and once in `JsObjectData.property_order`. Both copies used to be owned
+//! `String`s, so every property cost two heap allocations of the same bytes.
+//!
+//! This module interns ordinary and symbol-encoded keys into a process-thread
+//! cache of `Rc<str>`. The storage layer (`PropertyMap` + `property_order`)
+//! holds `Rc<str>` rather than `String`, so the two stored copies share one
+//! allocation and "cloning" a key is a refcount bump.
+//!
+//! A `thread_local!` cache is used so `JsObjectData` methods — which only have
+//! `&mut self`, not `&mut Interpreter` — can intern without threading any extra
+//! state through the ~1100 property-write call sites.
+//!
+//! ## Integer-index gate
+//! Canonical array-index strings (`"0"`, `"1"`, `"42"`, …) have unbounded
+//! cardinality and would bloat the cache without sharing benefit (each index
+//! appears on at most a handful of objects). They are NOT cached: `intern_key`
+//! returns a fresh `Rc<str>` for them. The gate mirrors `parse_array_index`
+//! in `types.rs` (all-ASCII-digits, no leading zero except "0", value < 2^32-1).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+thread_local! {
+    static KEY_CACHE: RefCell<KeyCache> = RefCell::new(KeyCache::new());
+}
+
+struct KeyCache {
+    map: std::collections::HashMap<Box<str>, Rc<str>>,
+}
+
+// Common property names worth pre-seeding so the very first lookups hit the
+// cache. Symbol-encoded well-known keys are included because they recur on
+// nearly every object that participates in iteration / coercion protocols.
+const SEED_KEYS: &[&str] = &[
+    "length",
+    "prototype",
+    "constructor",
+    "name",
+    "value",
+    "key",
+    "left",
+    "right",
+    "next",
+    "done",
+    "__proto__",
+    "toString",
+    "valueOf",
+    "get",
+    "set",
+    "enumerable",
+    "configurable",
+    "writable",
+    "Symbol(Symbol.iterator)",
+    "Symbol(Symbol.toPrimitive)",
+    "Symbol(Symbol.toStringTag)",
+];
+
+impl KeyCache {
+    fn new() -> Self {
+        let mut map = std::collections::HashMap::with_capacity(SEED_KEYS.len().next_power_of_two());
+        for &s in SEED_KEYS {
+            let rc: Rc<str> = Rc::from(s);
+            map.insert(Box::from(s), rc);
+        }
+        Self { map }
+    }
+
+    fn intern(&mut self, s: &str) -> Rc<str> {
+        if let Some(rc) = self.map.get(s) {
+            return Rc::clone(rc);
+        }
+        let rc: Rc<str> = Rc::from(s);
+        self.map.insert(Box::from(s), Rc::clone(&rc));
+        rc
+    }
+}
+
+/// Returns true if `s` is a canonical array-index string: all ASCII digits,
+/// no leading zero except the single "0", and numeric value < 2^32-1.
+/// Mirrors `parse_array_index` in `types.rs` — keep them in sync.
+#[inline]
+fn is_canonical_array_index(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    // No leading zeros (except "0" itself).
+    if s.len() > 1 && s.as_bytes()[0] == b'0' {
+        return false;
+    }
+    match s.parse::<u32>() {
+        // 0xFFFFFFFF is not a valid array index (spec §6.1.7).
+        Ok(n) => n != u32::MAX,
+        Err(_) => false,
+    }
+}
+
+/// Intern a property key into a shared `Rc<str>`.
+///
+/// Ordinary names and symbol-encoded keys (`"Symbol(...)#id"`) are cached so
+/// repeated uses share one allocation. Canonical array-index strings are NOT
+/// cached (see the integer-index gate in the module docs) — a fresh `Rc<str>`
+/// is returned so the cache never accumulates unbounded numeric keys.
+#[inline]
+pub(crate) fn intern_key(s: &str) -> Rc<str> {
+    if is_canonical_array_index(s) {
+        return Rc::from(s);
+    }
+    KEY_CACHE.with(|c| c.borrow_mut().intern(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interns_ordinary_names_share_allocation() {
+        let a = intern_key("fooBarBaz");
+        let b = intern_key("fooBarBaz");
+        assert!(Rc::ptr_eq(&a, &b), "ordinary names must share one Rc<str>");
+        assert_eq!(a.as_ref(), "fooBarBaz");
+    }
+
+    #[test]
+    fn seed_keys_are_interned() {
+        let a = intern_key("length");
+        let b = intern_key("length");
+        assert!(Rc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn symbol_keys_are_interned_and_preserved() {
+        let key = "Symbol(desc)#42";
+        let a = intern_key(key);
+        let b = intern_key(key);
+        assert!(Rc::ptr_eq(&a, &b), "symbol-encoded keys must intern");
+        // Byte content must be preserved exactly for symbol_key_to_jsvalue.
+        assert_eq!(a.as_ref(), key);
+        assert!(a.starts_with("Symbol("));
+    }
+
+    #[test]
+    fn integer_index_keys_not_cached() {
+        let a = intern_key("42");
+        let b = intern_key("42");
+        assert!(
+            !Rc::ptr_eq(&a, &b),
+            "canonical array-index keys must NOT be cached"
+        );
+        assert_eq!(a.as_ref(), "42");
+    }
+
+    #[test]
+    fn integer_index_gate_matches_array_index_rules() {
+        // Canonical indices: not cached.
+        assert!(is_canonical_array_index("0"));
+        assert!(is_canonical_array_index("1"));
+        assert!(is_canonical_array_index("42"));
+        assert!(is_canonical_array_index("4294967294")); // 2^32-2, max valid index
+        // Not canonical indices: interned.
+        assert!(!is_canonical_array_index("")); // empty
+        assert!(!is_canonical_array_index("00")); // leading zero
+        assert!(!is_canonical_array_index("01")); // leading zero
+        assert!(!is_canonical_array_index("-1")); // negative
+        assert!(!is_canonical_array_index("4294967295")); // 2^32-1, NOT an index
+        assert!(!is_canonical_array_index("4294967296")); // 2^32, overflows u32
+        assert!(!is_canonical_array_index("1.5")); // non-integer
+        assert!(!is_canonical_array_index("length"));
+        assert!(!is_canonical_array_index("Symbol(x)#1"));
+    }
+
+    #[test]
+    fn non_canonical_numeric_names_are_interned() {
+        // "01" is a non-canonical numeric string — it is a real property name,
+        // not an array index, so it should be interned (and shared).
+        let a = intern_key("01");
+        let b = intern_key("01");
+        assert!(Rc::ptr_eq(&a, &b));
+    }
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -27,6 +27,7 @@ mod gc;
 pub(crate) mod generator_analysis;
 pub(crate) mod generator_transform;
 pub(crate) mod ic;
+pub(crate) mod key_intern;
 mod object_arena;
 mod property_map;
 pub(crate) use property_map::PropertyMap;
@@ -4760,10 +4761,10 @@ impl Interpreter {
                 .filter_map(|k| {
                     k.parse::<u64>()
                         .ok()
-                        .filter(|&idx| idx <= 0xFFFF_FFFE && idx.to_string() == *k)
+                        .filter(|&idx| idx <= 0xFFFF_FFFE && idx.to_string() == **k)
                         .map(|idx| idx as u32)
                         .filter(|&idx| idx >= new_len && idx < old_len)
-                        .map(|idx| (idx, k.clone()))
+                        .map(|idx| (idx, k.to_string()))
                 })
                 .collect();
             idx_keys.sort_by_key(|a| std::cmp::Reverse(a.0));
@@ -4779,7 +4780,7 @@ impl Interpreter {
                     break;
                 } else {
                     obj.properties.remove(k.as_str());
-                    obj.property_order.retain(|p| p != k);
+                    obj.property_order.retain(|p| p.as_ref() != k.as_str());
                 }
             }
 

--- a/src/interpreter/property_map.rs
+++ b/src/interpreter/property_map.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use smallvec::SmallVec;
 
@@ -22,10 +23,15 @@ pub struct PropertyMap {
 // The inline variant is intentionally large — eliminating the heap allocation
 // for small objects is the entire point of issue #68. Boxing it would defeat
 // the optimisation.
+// Keys are `Rc<str>` (issue #74): the same interned `Rc<str>` is shared with
+// `JsObjectData.property_order`, so the two stored copies of a property name
+// share one allocation. `Rc<str>` derefs to `&str`, so read-side lookups taking
+// `&str` are unchanged, and `Rc<str>: Borrow<str>` lets the spilled `HashMap`
+// be queried with `&str` keys.
 #[allow(clippy::large_enum_variant)]
 enum PropertyMapInner {
-    Inline(SmallVec<[(String, PropertyDescriptor); INLINE_CAP]>),
-    Spilled(HashMap<String, PropertyDescriptor>),
+    Inline(SmallVec<[(Rc<str>, PropertyDescriptor); INLINE_CAP]>),
+    Spilled(HashMap<Rc<str>, PropertyDescriptor>),
 }
 
 impl PropertyMap {
@@ -37,26 +43,35 @@ impl PropertyMap {
 
     pub fn contains_key(&self, key: &str) -> bool {
         match &self.inner {
-            PropertyMapInner::Inline(v) => v.iter().any(|(k, _)| k == key),
+            PropertyMapInner::Inline(v) => v.iter().any(|(k, _)| k.as_ref() == key),
             PropertyMapInner::Spilled(m) => m.contains_key(key),
         }
     }
 
     pub fn get(&self, key: &str) -> Option<&PropertyDescriptor> {
         match &self.inner {
-            PropertyMapInner::Inline(v) => v.iter().find(|(k, _)| k == key).map(|(_, d)| d),
+            PropertyMapInner::Inline(v) => {
+                v.iter().find(|(k, _)| k.as_ref() == key).map(|(_, d)| d)
+            }
             PropertyMapInner::Spilled(m) => m.get(key),
         }
     }
 
     pub fn get_mut(&mut self, key: &str) -> Option<&mut PropertyDescriptor> {
         match &mut self.inner {
-            PropertyMapInner::Inline(v) => v.iter_mut().find(|(k, _)| k == key).map(|(_, d)| d),
+            PropertyMapInner::Inline(v) => v
+                .iter_mut()
+                .find(|(k, _)| k.as_ref() == key)
+                .map(|(_, d)| d),
             PropertyMapInner::Spilled(m) => m.get_mut(key),
         }
     }
 
-    pub fn insert(&mut self, key: String, value: PropertyDescriptor) -> Option<PropertyDescriptor> {
+    pub fn insert(
+        &mut self,
+        key: Rc<str>,
+        value: PropertyDescriptor,
+    ) -> Option<PropertyDescriptor> {
         match &mut self.inner {
             PropertyMapInner::Inline(v) => {
                 if let Some(slot) = v.iter_mut().find(|(k, _)| *k == key) {
@@ -68,7 +83,7 @@ impl PropertyMap {
                 } else {
                     // Spill: drain inline entries into a fresh randomised HashMap,
                     // then add the new entry.
-                    let mut map: HashMap<String, PropertyDescriptor> =
+                    let mut map: HashMap<Rc<str>, PropertyDescriptor> =
                         HashMap::with_capacity(INLINE_CAP + 1);
                     for (k, d) in v.drain(..) {
                         map.insert(k, d);
@@ -85,7 +100,7 @@ impl PropertyMap {
     pub fn remove(&mut self, key: &str) -> Option<PropertyDescriptor> {
         match &mut self.inner {
             PropertyMapInner::Inline(v) => {
-                let pos = v.iter().position(|(k, _)| k == key)?;
+                let pos = v.iter().position(|(k, _)| k.as_ref() == key)?;
                 Some(v.remove(pos).1)
             }
             PropertyMapInner::Spilled(m) => m.remove(key),
@@ -100,7 +115,7 @@ impl PropertyMap {
         PropertyMapIter { inner }
     }
 
-    pub fn keys(&self) -> impl Iterator<Item = &String> {
+    pub fn keys(&self) -> impl Iterator<Item = &Rc<str>> {
         self.iter().map(|(k, _)| k)
     }
 
@@ -120,12 +135,12 @@ pub struct PropertyMapIter<'a> {
 }
 
 enum PropertyMapIterInner<'a> {
-    Inline(std::slice::Iter<'a, (String, PropertyDescriptor)>),
-    Spilled(std::collections::hash_map::Iter<'a, String, PropertyDescriptor>),
+    Inline(std::slice::Iter<'a, (Rc<str>, PropertyDescriptor)>),
+    Spilled(std::collections::hash_map::Iter<'a, Rc<str>, PropertyDescriptor>),
 }
 
 impl<'a> Iterator for PropertyMapIter<'a> {
-    type Item = (&'a String, &'a PropertyDescriptor);
+    type Item = (&'a Rc<str>, &'a PropertyDescriptor);
 
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.inner {
@@ -140,6 +155,10 @@ mod tests {
     use super::*;
     use crate::interpreter::types::JsObjectData;
     use crate::types::JsValue;
+
+    fn key(s: impl AsRef<str>) -> Rc<str> {
+        Rc::from(s.as_ref())
+    }
 
     fn desc(n: f64) -> PropertyDescriptor {
         PropertyDescriptor::data_default(JsValue::Number(n))
@@ -160,7 +179,7 @@ mod tests {
     fn inline_insert_and_get() {
         let mut m = PropertyMap::new();
         for i in 0..INLINE_CAP {
-            assert!(m.insert(format!("k{i}"), desc(i as f64)).is_none());
+            assert!(m.insert(key(format!("k{i}")), desc(i as f64)).is_none());
         }
         assert!(is_inline(&m));
         for i in 0..INLINE_CAP {
@@ -174,10 +193,10 @@ mod tests {
     fn one_past_capacity_triggers_spill() {
         let mut m = PropertyMap::new();
         for i in 0..INLINE_CAP {
-            m.insert(format!("k{i}"), desc(i as f64));
+            m.insert(key(format!("k{i}")), desc(i as f64));
         }
         assert!(is_inline(&m));
-        m.insert(format!("k{INLINE_CAP}"), desc(INLINE_CAP as f64));
+        m.insert(key(format!("k{INLINE_CAP}")), desc(INLINE_CAP as f64));
         assert!(!is_inline(&m));
         for i in 0..=INLINE_CAP {
             assert!(
@@ -191,11 +210,9 @@ mod tests {
     fn duplicate_insert_returns_previous_and_no_spill() {
         let mut m = PropertyMap::new();
         for i in 0..INLINE_CAP {
-            m.insert(format!("k{i}"), desc(i as f64));
+            m.insert(key(format!("k{i}")), desc(i as f64));
         }
-        let prev = m
-            .insert("k0".to_string(), desc(99.0))
-            .expect("had previous");
+        let prev = m.insert(key("k0"), desc(99.0)).expect("had previous");
         assert_eq!(num(&prev), 0.0);
         assert!(is_inline(&m));
         assert_eq!(num(m.get("k0").expect("present")), 99.0);
@@ -205,7 +222,7 @@ mod tests {
     fn remove_after_spill_keeps_spilled() {
         let mut m = PropertyMap::new();
         for i in 0..=INLINE_CAP {
-            m.insert(format!("k{i}"), desc(i as f64));
+            m.insert(key(format!("k{i}")), desc(i as f64));
         }
         assert!(!is_inline(&m));
         for i in 0..=INLINE_CAP {
@@ -219,7 +236,7 @@ mod tests {
     fn iter_visits_all_entries_in_both_modes() {
         let mut m = PropertyMap::new();
         for i in 0..3 {
-            m.insert(format!("k{i}"), desc(i as f64));
+            m.insert(key(format!("k{i}")), desc(i as f64));
         }
         let mut seen: Vec<(String, f64)> = m
             .iter()
@@ -229,7 +246,7 @@ mod tests {
                 } else {
                     -1.0
                 };
-                (k.clone(), n)
+                (k.to_string(), n)
             })
             .collect();
         seen.sort_by(|a, b| a.0.cmp(&b.0));
@@ -239,7 +256,7 @@ mod tests {
         );
 
         for i in 3..=INLINE_CAP {
-            m.insert(format!("k{i}"), desc(i as f64));
+            m.insert(key(format!("k{i}")), desc(i as f64));
         }
         assert!(!is_inline(&m));
         let mut seen: Vec<(String, f64)> = m
@@ -250,7 +267,7 @@ mod tests {
                 } else {
                     -1.0
                 };
-                (k.clone(), n)
+                (k.to_string(), n)
             })
             .collect();
         seen.sort_by(|a, b| a.0.cmp(&b.0));
@@ -272,14 +289,14 @@ mod tests {
     #[test]
     fn get_mut_in_both_modes() {
         let mut m = PropertyMap::new();
-        m.insert("a".to_string(), desc(1.0));
+        m.insert(key("a"), desc(1.0));
         if let Some(d) = m.get_mut("a") {
             d.value = Some(JsValue::Number(7.0));
         }
         assert_eq!(num(m.get("a").expect("present")), 7.0);
 
         for i in 0..INLINE_CAP {
-            m.insert(format!("k{i}"), desc(i as f64));
+            m.insert(key(format!("k{i}")), desc(i as f64));
         }
         assert!(!is_inline(&m));
         if let Some(d) = m.get_mut("a") {
@@ -291,18 +308,18 @@ mod tests {
     #[test]
     fn keys_includes_symbols_in_both_modes() {
         let mut m = PropertyMap::new();
-        m.insert("Symbol(foo)".to_string(), desc(1.0));
-        m.insert("plain".to_string(), desc(2.0));
-        let keys: Vec<&String> = m.keys().collect();
-        assert!(keys.iter().any(|k| k.as_str() == "Symbol(foo)"));
-        assert!(keys.iter().any(|k| k.as_str() == "plain"));
+        m.insert(key("Symbol(foo)"), desc(1.0));
+        m.insert(key("plain"), desc(2.0));
+        let keys: Vec<&Rc<str>> = m.keys().collect();
+        assert!(keys.iter().any(|k| k.as_ref() == "Symbol(foo)"));
+        assert!(keys.iter().any(|k| k.as_ref() == "plain"));
         for i in 0..INLINE_CAP {
-            m.insert(format!("k{i}"), desc(i as f64));
+            m.insert(key(format!("k{i}")), desc(i as f64));
         }
         assert!(!is_inline(&m));
-        let keys: Vec<&String> = m.keys().collect();
+        let keys: Vec<&Rc<str>> = m.keys().collect();
         assert!(
-            keys.iter().any(|k| k.as_str() == "Symbol(foo)"),
+            keys.iter().any(|k| k.as_ref() == "Symbol(foo)"),
             "Symbol key lost on spill"
         );
     }

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -2,6 +2,7 @@ use crate::ast::*;
 use crate::interpreter::PropertyMap;
 use crate::interpreter::generator_transform::{GeneratorStateMachine, SentValueBinding};
 use crate::interpreter::helpers::same_value;
+use crate::interpreter::key_intern::intern_key;
 use crate::types::{JsString, JsValue};
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
@@ -1544,7 +1545,7 @@ pub struct JsObjectData {
     /// `Interpreter::alloc_object` at allocation time and never reassigned.
     pub id: Option<u64>,
     pub properties: PropertyMap,
-    pub property_order: Vec<String>,
+    pub property_order: Vec<Rc<str>>,
     pub prototype_id: Option<u64>,
     pub callable: Option<JsFunction>,
     pub class_name: String,
@@ -2667,19 +2668,28 @@ impl JsObjectData {
                 }
             };
 
-            if !self.property_order.contains(&key) {
-                self.property_order.push(key.clone());
+            // Intern once; the same Rc<str> is shared between property_order and
+            // the property map so the two stored copies share one allocation.
+            // Compare by value (not pointer): integer-index keys are not interned
+            // and get a fresh Rc each time, so ptr_eq would miss existing entries.
+            let ikey = intern_key(&key);
+            if !self
+                .property_order
+                .iter()
+                .any(|k| k.as_ref() == ikey.as_ref())
+            {
+                self.property_order.push(Rc::clone(&ikey));
             }
             // NOTE: Array length shrinking semantics (ArraySetLength §10.4.2.4) are
             // handled by array_set_length() in mod.rs, which calls this function.
             // Do NOT duplicate that logic here.
             // Save key before it's moved into insert
             let key_for_step7 = if self.parameter_map().is_some() {
-                Some(key.clone())
+                Some(key)
             } else {
                 None
             };
-            self.properties.insert(key, merged);
+            self.properties.insert(ikey, merged);
 
             // §10.4.4.3 step 7: post-define parameter map handling
             if let Some(key_ref) = key_for_step7
@@ -2716,7 +2726,10 @@ impl JsObjectData {
             {
                 let _ = env_ref.borrow_mut().set(param_name, val.clone());
             }
-            self.property_order.push(key.clone());
+            // New property: intern once and share the Rc<str> between
+            // property_order and the property map (one allocation, not two).
+            let ikey = intern_key(&key);
+            self.property_order.push(Rc::clone(&ikey));
             // For new property, fill in defaults per spec
             let is_accessor = desc.is_accessor_descriptor();
             let new_desc = PropertyDescriptor {
@@ -2733,7 +2746,7 @@ impl JsObjectData {
                 enumerable: desc.enumerable.or(Some(false)),
                 configurable: desc.configurable.or(Some(false)),
             };
-            self.properties.insert(key, new_desc);
+            self.properties.insert(ikey, new_desc);
         }
         // Issue #71 (Step 5): reaching this point means either an existing
         // property was redefined (line ~2296 `properties.insert(key, merged)`)
@@ -2793,10 +2806,10 @@ impl JsObjectData {
                         .filter_map(|k| {
                             k.parse::<u64>()
                                 .ok()
-                                .filter(|&idx| idx <= 0xFFFF_FFFE && idx.to_string() == *k)
+                                .filter(|&idx| idx <= 0xFFFF_FFFE && idx.to_string() == **k)
                                 .map(|idx| idx as u32)
                                 .filter(|&idx| idx >= new_len_u32)
-                                .map(|idx| (idx, k.clone()))
+                                .map(|idx| (idx, k.to_string()))
                         })
                         .collect();
                     idx_keys.sort_by_key(|a| std::cmp::Reverse(a.0));
@@ -2812,7 +2825,7 @@ impl JsObjectData {
                             break;
                         } else {
                             self.properties.remove(k.as_str());
-                            self.property_order.retain(|p| p != k);
+                            self.property_order.retain(|p| p.as_ref() != k.as_str());
                             did_remove = true;
                         }
                     }
@@ -2945,9 +2958,10 @@ impl JsObjectData {
             if !self.extensible {
                 return false;
             }
-            self.property_order.push(key.to_string());
+            let ikey = intern_key(key);
+            self.property_order.push(Rc::clone(&ikey));
             self.properties
-                .insert(key.to_string(), PropertyDescriptor::data_default(value));
+                .insert(ikey, PropertyDescriptor::data_default(value));
             // Issue #71 (Step 5): new own property added — structural mutation.
             // The earlier `properties.get_mut(key)` branch (in-place update)
             // does NOT bump; only this insert branch does.
@@ -2957,24 +2971,27 @@ impl JsObjectData {
     }
 
     pub fn insert_value(&mut self, key: String, value: JsValue) {
+        let key = intern_key(&key);
         if !self.properties.contains_key(&key) {
-            self.property_order.push(key.clone());
+            self.property_order.push(Rc::clone(&key));
         }
         self.properties
             .insert(key, PropertyDescriptor::data_default(value));
     }
 
     pub fn insert_builtin(&mut self, key: String, value: JsValue) {
+        let key = intern_key(&key);
         if !self.properties.contains_key(&key) {
-            self.property_order.push(key.clone());
+            self.property_order.push(Rc::clone(&key));
         }
         self.properties
             .insert(key, PropertyDescriptor::data(value, true, false, true));
     }
 
     pub fn insert_property(&mut self, key: String, desc: PropertyDescriptor) {
+        let key = intern_key(&key);
         if !self.properties.contains_key(&key) {
-            self.property_order.push(key.clone());
+            self.property_order.push(Rc::clone(&key));
         }
         self.properties.insert(key, desc);
     }
@@ -3187,11 +3204,11 @@ impl JsObjectData {
             }
             if let Some(desc) = self.properties.get(k) {
                 let is_enumerable = desc.enumerable != Some(false);
-                if seen.insert(k.clone()) && is_enumerable {
+                if seen.insert(k.to_string()) && is_enumerable {
                     if let Some(idx) = parse_array_index(k) {
-                        index_keys.push((idx, k.clone()));
+                        index_keys.push((idx, k.to_string()));
                     } else {
-                        string_keys.push(k.clone());
+                        string_keys.push(k.to_string());
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Implements #74. Property-key strings were allocated/cloned **twice per object** (once as the `PropertyMap` key, once cloned into `property_order`). This changes the storage-layer key type from `String` to `Rc<str>`, fed by a thread-local intern table, so the two stored copies share one allocation and clones become refcount bumps — attacking the `String::clone` cost the issue cites.

- New `src/interpreter/key_intern.rs`: thread-local `HashMap<Box<str>, Rc<str>>` with `intern_key(&str) -> Rc<str>`, pre-seeded with common names (`length`, `prototype`, `constructor`, `value`, `key`, well-known `Symbol(...)` keys, …).
- `PropertyMap` key type and `property_order` element type → `Rc<str>`. The ~6 storage funnels intern once and put the **same** `Rc<str>` into both the map and `property_order` (one allocation per property).
- Scoped to the storage layer: `insert_*`/`define_own_property` **call-site argument types are unchanged** (`String`/`&str`); read-side lookups take `&str` (free, `Rc<str>: Borrow<str>`).

## Spec-correctness (invariants preserved)
- **Enumeration order** unchanged — only the `property_order` element type changed; push order identical.
- **Symbol keys** stay real byte strings (`Rc<str>` derefs to the `"Symbol(...)#id"` bytes); all `starts_with("Symbol(")` checks and `symbol_key_to_jsvalue` behave identically.
- **Integer-index keys are NOT interned** (unbounded cardinality) — gated to a fresh `Rc::from`, still produce correct decimal key strings.

## Validation
- Full local test262 vs `origin/main` baseline: **99,252 pass, 0 regressions, 5 new passes** (with attention to `Object.keys`/`getOwnPropertyNames`/`Reflect.ownKeys`/`for-in` ordering — all clean).
- 6 new `key_intern` unit tests. `cargo build --release` warning-free (0 warnings); `cargo test` (137) + `./scripts/lint.sh` clean.

Diff +368/−131 across 28 files (mostly mechanical byte-equivalent fixups at key consumers). Closes #74. (Follow-up: IC pointer-equality fast path on interned keys.)