### PR TITLE
[test] Fix gc.rs unit test to use Rc<str> property keys (unbreak CI)

### DIFF
--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -564,11 +564,11 @@ mod tests {
         let mut data = JsObjectData::new();
         data.prototype_id = Some(7);
         data.properties.insert(
-            "x".to_string(),
+            "x".into(),
             PropertyDescriptor::data(obj(8), true, true, true),
         );
         data.properties.insert(
-            "n".to_string(),
+            "n".into(),
             PropertyDescriptor::data(JsValue::Number(1.0), true, true, true),
         );
 
@@ -581,7 +581,7 @@ mod tests {
     fn trace_object_fields_roots_accessor_get_and_set() {
         let mut data = JsObjectData::new();
         data.properties.insert(
-            "acc".to_string(),
+            "acc".into(),
             PropertyDescriptor::accessor(Some(obj(10)), Some(obj(11)), true, true),
         );
 


### PR DESCRIPTION
## Problem

CI on `main` has been red for ~18h — the **Run unit tests** step (`cargo test`) fails to compile:

```
error[E0308]: mismatched types
   --> src/interpreter/gc.rs:567
    | "x".to_string(),
    | ^^^^^^^^^^^^^^^ expected `Rc<str>`, found `String`
```

(3 occurrences.)

## Root cause — silent semantic merge conflict

- **PR #74** (`205745a`, "Intern property keys to Rc<str>") changed `PropertyMap::insert` to take `Rc<str>` keys.
- **PR #25** (`b68adfc`, "Add GC root-tracing unit tests") added tests that call `insert` with `String` keys.

Each passed CI against its own base. Git merged both cleanly (no textual conflict), but the combination breaks `cargo test`. The `cargo build --release` step stayed green because it doesn't compile test code — so only the unit-test step caught it.

## Fix

Convert the three test `insert` call sites to `Rc<str>` via `.into()`.

## Verification

- `cargo test` — 164 + 1 passed, 0 failed
- `cargo fmt --check` — clean
- Clippy unaffected (test-only change; CI clippy doesn't use `--all-targets`)