### PR TITLE
[intl] PluralRules: read and surface compactDisplay option

### DIFF
--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -341,6 +341,7 @@ impl Interpreter {
                         locale,
                         plural_type,
                         notation,
+                        compact_display,
                         minimum_integer_digits,
                         minimum_fraction_digits,
                         maximum_fraction_digits,
@@ -401,6 +402,21 @@ impl Interpreter {
                                     true,
                                 ),
                             );
+                        // compactDisplay is surfaced only when notation is "compact" (§17.4).
+                        if let Some(cd) = &compact_display {
+                            interp
+                                .get_object_cell_expect(result_id)
+                                .borrow_mut()
+                                .insert_property(
+                                    "compactDisplay".to_string(),
+                                    PropertyDescriptor::data(
+                                        JsValue::String(JsString::from_str(cd)),
+                                        true,
+                                        true,
+                                        true,
+                                    ),
+                                );
+                        }
                         interp
                             .get_object_cell_expect(result_id)
                             .borrow_mut()
@@ -637,6 +653,25 @@ impl Interpreter {
                     Ok(Some(v)) => v,
                     Ok(None) => "standard".to_string(),
                     Err(e) => return Completion::Throw(e),
+                };
+
+                // compactDisplay — must be read immediately after notation per spec
+                // (its getter always runs); [[CompactDisplay]] is only retained when
+                // notation is "compact".
+                let compact_display_opt = match interp.intl_get_option(
+                    &options,
+                    "compactDisplay",
+                    &["short", "long"],
+                    Some("short"),
+                ) {
+                    Ok(Some(v)) => Some(v),
+                    Ok(None) => Some("short".to_string()),
+                    Err(e) => return Completion::Throw(e),
+                };
+                let compact_display = if notation == "compact" {
+                    compact_display_opt
+                } else {
+                    None
                 };
 
                 let minimum_integer_digits = match interp.intl_get_number_option(
@@ -1008,6 +1043,7 @@ impl Interpreter {
                     locale,
                     plural_type,
                     notation,
+                    compact_display,
                     minimum_integer_digits,
                     minimum_fraction_digits,
                     maximum_fraction_digits,

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1402,6 +1402,8 @@ pub(crate) enum IntlData {
         locale: String,
         plural_type: String,
         notation: String,
+        /// [[CompactDisplay]] — Some only when notation is "compact" (§17.4).
+        compact_display: Option<String>,
         minimum_integer_digits: u32,
         minimum_fraction_digits: u32,
         maximum_fraction_digits: u32,


### PR DESCRIPTION
## Summary
`Intl.PluralRules` never read the `compactDisplay` option (an Intl.NumberFormat-v3 addition to PluralRules) during construction, and `resolvedOptions()` never reported it.

Per `sec-intl.pluralrules` / §17.4:
1. `compactDisplay` is read (string option, `"short"`/`"long"`, default `"short"`) **immediately after `notation`**, so its getter always runs — making the option read order and throwing-getter propagation spec-correct.
2. `[[CompactDisplay]]` is retained **only** when `notation === "compact"`; otherwise it is undefined.
3. `resolvedOptions()` includes `compactDisplay` **only** when `[[Notation]]` is `"compact"`, placed immediately after `notation`.

## Implementation
- `IntlData::PluralRules` gains a `compact_display: Option<String>` field (`Some` only when notation is `"compact"`).
- Constructor reads `compactDisplay` right after `notation` (always invokes the getter), then keeps it only for compact notation.
- `resolvedOptions()` conditionally inserts `compactDisplay`.

## Tests
Fixes the 3 failing test262 tests (6 scenarios):
- `intl402/PluralRules/constructor-option-read-order.js`
- `intl402/PluralRules/constructor-options-throwing-getters.js`
- `intl402/PluralRules/compactDisplay-undefined-unless-notation-compact.js`

Local `intl402/PluralRules` suite: **106/106, +6 new passes, 0 regressions**.

Closes #168