### PR TITLE
[interpreter] Array push/Set: honour Proxy in the prototype chain

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -101,6 +101,27 @@ fn obj_set_throw(
                 Err(e) => return Err(e),
             }
         }
+        // OrdinarySet (§10.1.9.2): when the receiver has no own property for the
+        // key, the parent is consulted. If a Proxy sits in the prototype chain,
+        // its [[Set]] trap must run with the original receiver — a bare Proxy
+        // prototype exposes no own descriptor, so the descriptor walk below would
+        // otherwise skip the trap and wrongly create an own property. proxy_set is
+        // a full proxy-aware OrdinarySet, so delegating the whole [[Set]] here also
+        // honours inherited setters / non-writable data along the way.
+        {
+            let has_own = interp
+                .get_object_cell(obj_ref.id)
+                .is_some_and(|cell| cell.borrow().has_own_property(key));
+            if !has_own && interp.has_proxy_in_prototype_chain(obj_ref.id) {
+                return match interp.proxy_set(obj_ref.id, key, value, o) {
+                    Ok(true) => Ok(()),
+                    Ok(false) => Err(interp.create_type_error(&format!(
+                        "Cannot assign to read only property '{key}'"
+                    ))),
+                    Err(e) => Err(e),
+                };
+            }
+        }
         // Check for setter in prototype chain
         {
             let desc = interp.get_property_descriptor_on_id(obj_ref.id, key);
@@ -980,14 +1001,21 @@ impl Interpreter {
                     // appended index ToString is inherited (setter or data) we
                     // must invoke/honour it via the slow loop rather than write
                     // straight into the Vec — bail to the slow path.
+                    // A bare Proxy prototype exposes no own descriptor, so the
+                    // get_property_descriptor_on_id probe below would miss it and
+                    // the fast path would write straight into the Vec, skipping the
+                    // proxy [[Set]] trap (issue #166). Bail to the slow path (which
+                    // routes through obj_set_throw → proxy_set) whenever a Proxy is
+                    // anywhere in the prototype chain.
                     let inherited = fast_ok
                         && !has_undefined_arg
                         && proto_id.is_some_and(|pid| {
-                            (len..len + args.len()).any(|i| {
-                                interp
-                                    .get_property_descriptor_on_id(pid, &i.to_string())
-                                    .is_some()
-                            })
+                            interp.has_proxy_in_prototype_chain(pid)
+                                || (len..len + args.len()).any(|i| {
+                                    interp
+                                        .get_property_descriptor_on_id(pid, &i.to_string())
+                                        .is_some()
+                                })
                         });
                     if fast_ok && !has_undefined_arg && !inherited {
                         let new_len = len + args.len();

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -15482,7 +15482,7 @@ impl Interpreter {
         }
     }
 
-    fn has_proxy_in_prototype_chain(&self, obj_id: u64) -> bool {
+    pub(crate) fn has_proxy_in_prototype_chain(&self, obj_id: u64) -> bool {
         let mut current = Some(obj_id);
         while let Some(id) = current {
             if self.get_proxy_info(id).is_some() {

--- a/test262-extra/Array-push-proxy-prototype.js
+++ b/test262-extra/Array-push-proxy-prototype.js
@@ -1,0 +1,78 @@
+// Array.prototype.push and the other Array mutators that go through the generic
+// Set(O, P, V, true) helper (obj_set_throw) must not bypass a Proxy in the
+// receiver's prototype chain. Per OrdinarySet (sec-ordinaryset /
+// sec-ordinarysetwithowndescriptor), when the receiver has no own property for
+// the key the engine walks the prototype chain, and a Proxy prototype's [[Set]]
+// trap must run with the original receiver. A bare Proxy exposes no own
+// descriptor, so a helper that only consults an inherited descriptor would skip
+// the trap and wrongly create an own property (issue #166).
+// Spec: ECMAScript 2024, sec-array.prototype.push (step Set(O, ..., E, true)),
+//       sec-ordinaryset,
+//       sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver.
+
+// push into a fresh array whose prototype is a Proxy: the set trap handles the
+// element write, so NO own element is created (only length, which is the
+// array's own property, is bumped).
+var calls = [];
+var a = [];
+Object.setPrototypeOf(
+  a,
+  new Proxy(Array.prototype, { set: function (t, p, v, r) { calls.push(String(p)); return true; } })
+);
+a.push(1);
+if (a.length !== 1) {
+  throw new Test262Error('push proxy-proto: expected length 1, got ' + a.length);
+}
+if (0 in a || a.hasOwnProperty(0)) {
+  throw new Test262Error('push proxy-proto: index 0 must NOT be an own property (trap handled it)');
+}
+if (calls.length !== 1 || calls[0] !== '0') {
+  throw new Test262Error('push proxy-proto: expected set trap once with "0", got ' + JSON.stringify(calls));
+}
+
+// push appends at index === old length; that index has no own property, so the
+// proxy trap must run for it.
+var calls2 = [];
+var b = [0, 0, 0];
+Object.setPrototypeOf(
+  b,
+  new Proxy(Array.prototype, { set: function (t, p, v, r) { calls2.push(String(p)); return true; } })
+);
+b.push(7);
+if (b.length !== 4 || (3 in b) || b.hasOwnProperty(3)) {
+  throw new Test262Error('push proxy-proto append: index 3 must not be own; len=' + b.length);
+}
+if (calls2.length !== 1 || calls2[0] !== '3') {
+  throw new Test262Error('push proxy-proto append: expected set trap once with "3", got ' + JSON.stringify(calls2));
+}
+
+// push whose proxy-prototype trap returns false must throw TypeError, because
+// push performs Set(O, P, V, true) (the Throw flag is set regardless of strict
+// mode).
+var threw = false;
+var c = [];
+Object.setPrototypeOf(c, new Proxy(Array.prototype, { set: function () { return false; } }));
+try {
+  c.push(9);
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+if (!threw) {
+  throw new Test262Error('push proxy-proto set->false: expected TypeError');
+}
+
+// fill writes to indices that already exist as own data properties; OrdinarySet
+// uses the own descriptor directly and must NOT consult the prototype Proxy.
+var fillCalls = [];
+var d = [1, 2, 3];
+Object.setPrototypeOf(d, new Proxy(Array.prototype, { set: function () { fillCalls.push(1); return true; } }));
+d.fill(9);
+if (fillCalls.length !== 0 || d[0] !== 9 || d[1] !== 9 || d[2] !== 9) {
+  throw new Test262Error('fill own indices must not consult proxy: arr=' + JSON.stringify(Array.from(d)) + ' trapCalls=' + fillCalls.length);
+}
+
+// Sanity: with an ordinary (non-Proxy) prototype, push behaves normally.
+var e = [1, 2];
+if (e.push(4) !== 3 || e.length !== 3 || e[2] !== 4) {
+  throw new Test262Error('ordinary-proto push regressed: ret/len/last = ' + e.push + '/' + e.length + '/' + e[2]);
+}


### PR DESCRIPTION
## Summary
`obj_set_throw` — the generic `Set(O, P, V, true)` helper used by `Array.prototype.push` and the other array mutators (`unshift`, `splice`, `fill`, `copyWithin`, `reverse`, `with`, length-sets) — only invoked a `Proxy`'s `[[Set]]` trap when the receiver was **itself** a Proxy. When a Proxy sits in the receiver's **prototype chain** and the receiver has no own property for the key, OrdinarySet (`sec-ordinaryset` / `sec-ordinarysetwithowndescriptor`) requires the parent Proxy's `[[Set]]` trap to run with the original receiver.

A bare Proxy prototype exposes no own descriptor, so the helper's descriptor walk skipped the trap and wrongly created an own property; a strict-mode write whose trap returned `false` also failed to throw.

`push` additionally has a dense-array fast path (#125/#160) whose inherited-property probe uses `get_property_descriptor_on_id`, which **also** misses a bare Proxy prototype — so the fast path wrote straight into the backing `Vec` and bypassed the trap.

```js
var trap = [];
var a = [];
Object.setPrototypeOf(a, new Proxy(Array.prototype, { set(t, p, v) { trap.push(String(p)); return true; } }));
a.push(1);
// before: a.length===1, (0 in a)===true,  trap===[]    (own element created; trap bypassed)
// after:  a.length===1, (0 in a)===false, trap===["0"]  (trap handled the write) — matches Node
```

## Fix (mirrors `eval_assign`'s OrdinarySet)
- **`obj_set_throw`**: when the receiver is not itself a Proxy, has no own property for the key, and has a Proxy in its prototype chain, delegate the whole `[[Set]]` to `proxy_set` with the original receiver (`proxy_set` is a full proxy-aware OrdinarySet, so inherited setters / non-writable data are still honoured). `false` → `TypeError`.
- **`push` fast path**: bail to the slow path whenever a Proxy is in the prototype chain.
- `has_proxy_in_prototype_chain` is now `pub(crate)`.

## Tests
New `test262-extra/Array-push-proxy-prototype.js`:
- `push` into a fresh array with a Proxy prototype → trap fires with `"0"`, no own element, length bumped.
- `push` append index (`[0,0,0].push(7)` → trap `"3"`).
- `push` whose trap returns `false` → `TypeError` (push uses `Set(…, true)` regardless of strict mode).
- `fill` on **own** indices does **not** consult the proxy (own data descriptor used directly).
- ordinary-prototype `push` sanity.

`built-ins/Array` + `built-ins/Proxy`: **6722/6722, 0 regressions**. Unit tests: 164 pass. `fmt`/`clippy` clean.

Closes #166