### PR TITLE
[temporal] ZonedDateTime.round day: clamp instant in discontiguous piece

### DIFF
--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -3418,7 +3418,20 @@ impl Interpreter {
                         let start_ns = get_start_of_day(&tz, today_days as i128);
                         let end_ns = get_start_of_day(&tz, tomorrow_days as i128);
                         let day_length_ns = end_ns - start_ns;
-                        let day_progress_ns = total_ns - start_ns;
+                        // Per spec (Temporal.ZonedDateTime.prototype.round, day
+                        // branch): when midnight occurs twice (a backward offset
+                        // shift), an instant whose wall-clock falls late on the
+                        // calendar date can lie in a *discontiguous piece* — by
+                        // instant it sits at/after the next day's earliest
+                        // start-of-day, so total_ns - start_ns would overshoot the
+                        // day. The spec clamps such an instant to endNs - 1 before
+                        // measuring progress, keeping it within its wall-clock day.
+                        let clamped_ns = if total_ns >= end_ns {
+                            end_ns - 1
+                        } else {
+                            total_ns
+                        };
+                        let day_progress_ns = clamped_ns - start_ns;
                         let rounded_day_ns =
                             round_ns_to_increment(day_progress_ns, day_length_ns, &rounding_mode);
                         start_ns + rounded_day_ns


### PR DESCRIPTION
## Summary
`Temporal.ZonedDateTime.prototype.round` with `smallestUnit: "days"` measured day progress as the raw **instant** elapsed since start-of-day (`total_ns - start_ns`). When midnight occurs twice (a backward offset transition), an instant whose wall-clock falls late on the calendar date lies in a **discontiguous piece**: by instant it sits at/after the *next* day's earliest start-of-day, so `total_ns - start_ns` overshoots the day length and `floor`/`trunc` landed on the wrong day.

```js
const zdt3 = Temporal.ZonedDateTime.from('2010-03-04T23:10:00+08:00[Antarctica/Casey]');
zdt3.round({ smallestUnit: "days", roundingMode: "floor" }).toString();
// before: 2010-03-05T00:00:00+11:00[Antarctica/Casey]
// after:  2010-03-04T00:00:00+11:00[Antarctica/Casey]   (start of March 4)
```

## Fix
Mirrors the proposal-temporal reference algorithm for the day branch:
```
startNs = GetStartOfDay(tz, dateStart)         // wall-clock date's start-of-day
endNs   = GetStartOfDay(tz, dateStart + 1)
if (thisNs >= endNs) thisNs = endNs - 1        // clamp into the wall-clock day
dayProgressNs = thisNs - startNs
roundedDayNs  = round(dayProgressNs, dayLengthNs, roundingMode)
```
The clamp keeps an instant in a discontiguous piece within its wall-clock day (consistent with `GetStartOfDay`/`startOfDay`, which already use the wall-clock date). Normal days and spring-forward (gap, 23h/25h) cases are unchanged — they were never clamped.

This is the bug behind proposal-temporal issues [#2938](https://github.com/tc39/proposal-temporal/issues/2938) / [#3312](https://github.com/tc39/proposal-temporal/issues/3312); the sibling `startOfDay`/`hoursInDay` discontiguous-piece tests already passed.

## Tests
Fixes `intl402/Temporal/ZonedDateTime/prototype/round/same-date-starts-twice.js` (+2 scenarios).

Verified against all 36 assertions (4 ZDTs × 9 rounding modes). No regressions in the DST-boundary / spring-forward round tests:
- round suites (built-ins + intl402): **98/98**
- full `Temporal/ZonedDateTime` (built-ins + intl402): **2968/2968, +2 new passes, 0 regressions**

`fmt`/`clippy` clean; 164 unit tests pass.

Closes #170