### PR TITLE
[ci] claude-review: skip bot-authored PRs (fix Dependabot CI failures)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip automated review for bot-authored PRs (e.g. Dependabot).
+    # anthropics/claude-code-action@v1 refuses non-human actors and aborts the
+    # run with a failing check ("Workflow initiated by non-human actor: ...
+    # Add bot to allowed_bots list"); an AI review of a dependency-bump lockfile
+    # adds little value, and this job holds `id-token: write` plus the
+    # CLAUDE_CODE_OAUTH_TOKEN secret, so it is better not to run it on
+    # bot-authored PRs at all than to allow-list them in. See issue #177.
+    if: github.event.pull_request.user.type != 'Bot'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

The **Claude Code Review** workflow (`.github/workflows/claude-code-review.yml`) fails on every Dependabot/bot-authored PR. `anthropics/claude-code-action@v1` refuses non-human actors and aborts the `claude-review` check in ~10s:

```
##[error]Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

This shows a red `claude-review` check on every Dependabot PR (e.g. #175) even though the change is fine and all other checks pass.

## Fix

Gate the job on `github.event.pull_request.user.type != 'Bot'`, so it is **skipped** (neutral, not failed) for bot-authored PRs.

Chose skipping over allow-listing the bot (`allowed_bots`) because:
- An AI review of a dependency-bump lockfile adds little value and consumes a Claude review session.
- The job holds `id-token: write` and consumes `secrets.CLAUDE_CODE_OAUTH_TOKEN`; not running a privileged, secret-consuming workflow on bot-authored PRs at all is the more conservative posture, consistent with the trust gating already in `claude.yml`.

Human-authored PRs are unaffected — they continue to get automated review.

`claude.yml` needs no change: it is already gated `if: github.actor == 'pmatos' && (... @claude ...)`, so a bot can never trigger it.

Closes #177
