### PR TITLE
[error] Implement Error.prototype.stack get/set accessor (error-stack-accessor)

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -239,12 +239,14 @@ pub(crate) fn create_data_property_or_throw(
             };
         }
         if interp.get_object_cell(obj_ref.id).is_some() {
-            // Check extensibility — if object is not extensible and property doesn't exist, fail
-            let not_extensible = !interp
-                .get_object_cell_expect(obj_ref.id)
-                .borrow()
-                .extensible;
-            if not_extensible && !interp.has_property_on_id(obj_ref.id, key) {
+            // Check extensibility — CreateDataProperty fails when the object is
+            // not extensible and lacks an OWN property of this key (an inherited
+            // property must not satisfy the check; cf. OrdinaryDefineOwnProperty).
+            let (not_extensible, has_own) = {
+                let borrow = interp.get_object_cell_expect(obj_ref.id).borrow();
+                (!borrow.extensible, borrow.has_own_property(key))
+            };
+            if not_extensible && !has_own {
                 return Err(interp.create_type_error(&format!(
                     "Cannot add property {key}, object is not extensible"
                 )));

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -1672,7 +1672,6 @@ impl Interpreter {
                 "name".to_string(),
                 JsValue::String(JsString::from_str(name)),
             );
-            o.insert_builtin("stack".to_string(), JsValue::String(JsString::from_str("")));
         }
         let id = obj_id;
         JsValue::Object(crate::types::JsObject { id })

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -562,10 +562,6 @@ impl Interpreter {
                             if let Some(ref cv) = cause_val {
                                 $o.insert_builtin("cause".to_string(), cv.clone());
                             }
-                            $o.insert_builtin(
-                                "stack".to_string(),
-                                JsValue::String(JsString::from_str("")),
-                            );
                         };
                     }
 
@@ -666,6 +662,142 @@ impl Interpreter {
                 "message".to_string(),
                 JsValue::String(JsString::from_str("")),
             );
+
+            // error-stack-accessor: Error.prototype.stack is an own accessor of
+            // %Error.prototype% only; NativeError/AggregateError/SuppressedError
+            // prototypes inherit it. §sec-get/set-error.prototype.stack.
+            let stack_getter = self.create_function(JsFunction::native(
+                "get stack".to_string(),
+                0,
+                |interp, this_val, _args| {
+                    // 2. If E is not an Object, throw a TypeError exception.
+                    let o_id = match this_val {
+                        JsValue::Object(o) => o.id,
+                        _ => {
+                            return Completion::Throw(interp.create_type_error(
+                                "Error.prototype.stack getter called on non-object",
+                            ));
+                        }
+                    };
+                    // 3. If E does not have an [[ErrorData]] internal slot,
+                    //    return undefined. [[ErrorData]] is modeled as
+                    //    class_name.contains("Error") (same as Error.isError);
+                    //    read directly off the receiver so Proxy traps don't fire.
+                    let has_error_data = interp
+                        .get_object(o_id)
+                        .is_some_and(|obj| obj.borrow().class_name.contains("Error"));
+                    if !has_error_data {
+                        return Completion::Normal(JsValue::Undefined);
+                    }
+                    // 4. Return an implementation-defined trace string.
+                    Completion::Normal(JsValue::String(JsString::from_str("")))
+                },
+            ));
+            // Capture %Error.prototype% per-realm for the SameValue check.
+            let stack_home_id = error_prototype_id;
+            let stack_setter = self.create_function(JsFunction::native(
+                "set stack".to_string(),
+                1,
+                move |interp, this_val, args| {
+                    let v = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    // 2. If E is not an Object, throw a TypeError exception.
+                    let o_id = match this_val {
+                        JsValue::Object(o) => o.id,
+                        _ => {
+                            return Completion::Throw(interp.create_type_error(
+                                "Error.prototype.stack setter called on non-object",
+                            ));
+                        }
+                    };
+                    // 3. If v is not a String, throw a TypeError exception.
+                    //    (A String wrapper object is not a String value.)
+                    if !matches!(v, JsValue::String(_)) {
+                        return Completion::Throw(interp.create_type_error(
+                            "Error.prototype.stack setter requires a string value",
+                        ));
+                    }
+                    // SetterThatIgnoresPrototypeProperties:
+                    // 2. If SameValue(this, home) is true, throw a TypeError.
+                    if Some(o_id) == stack_home_id {
+                        return Completion::Throw(interp.create_type_error(
+                            "Error.prototype.stack setter cannot set on %Error.prototype%",
+                        ));
+                    }
+                    // 3. desc = this.[[GetOwnProperty]]("stack") — route through
+                    //    the real internal methods so Proxy traps fire.
+                    let is_proxy = interp
+                        .get_object_cell(o_id)
+                        .is_some_and(|cell| cell.borrow().is_proxy());
+                    if is_proxy {
+                        let desc = match interp.proxy_get_own_property_descriptor(o_id, "stack") {
+                            Ok(d) => d,
+                            Err(e) => return Completion::Throw(e),
+                        };
+                        if matches!(desc, JsValue::Undefined) {
+                            // 4a. CreateDataPropertyOrThrow (fires defineProperty trap).
+                            return match array::create_data_property_or_throw(
+                                interp, this_val, "stack", v,
+                            ) {
+                                Ok(()) => Completion::Normal(JsValue::Undefined),
+                                Err(e) => Completion::Throw(e),
+                            };
+                        }
+                        // 5a. Set(this, "stack", v, true) (fires set trap).
+                        return match interp.proxy_set(o_id, "stack", v, this_val) {
+                            Ok(true) => Completion::Normal(JsValue::Undefined),
+                            Ok(false) => Completion::Throw(
+                                interp.create_type_error("Cannot set property 'stack'"),
+                            ),
+                            Err(e) => Completion::Throw(e),
+                        };
+                    }
+                    let own = interp
+                        .get_object_cell(o_id)
+                        .and_then(|cell| cell.borrow().get_own_property("stack"));
+                    match own {
+                        // 4a. CreateDataPropertyOrThrow.
+                        None => {
+                            match array::create_data_property_or_throw(interp, this_val, "stack", v)
+                            {
+                                Ok(()) => Completion::Normal(JsValue::Undefined),
+                                Err(e) => Completion::Throw(e),
+                            }
+                        }
+                        // 5a. Set(this, "stack", v, true) with receiver == this.
+                        Some(desc) => {
+                            if desc.is_accessor_descriptor() {
+                                match desc.set {
+                                    Some(setter_fn) if !matches!(setter_fn, JsValue::Undefined) => {
+                                        match interp.call_function(&setter_fn, this_val, &[v]) {
+                                            Completion::Normal(_) => {
+                                                Completion::Normal(JsValue::Undefined)
+                                            }
+                                            other => other,
+                                        }
+                                    }
+                                    _ => Completion::Throw(interp.create_type_error(
+                                        "Cannot set property 'stack' which has only a getter",
+                                    )),
+                                }
+                            } else if desc.writable == Some(false) {
+                                Completion::Throw(interp.create_type_error(
+                                    "Cannot assign to read only property 'stack'",
+                                ))
+                            } else {
+                                if let Some(cell) = interp.get_object_cell(o_id) {
+                                    cell.borrow_mut().set_property_value("stack", v);
+                                }
+                                Completion::Normal(JsValue::Undefined)
+                            }
+                        }
+                    }
+                },
+            ));
+            ep.borrow_mut().insert_property(
+                "stack".to_string(),
+                PropertyDescriptor::accessor(Some(stack_getter), Some(stack_setter), false, true),
+            );
+
             // Set constructor on Error.prototype_id
             if let Some(error_ctor) = self.get_global_var("Error") {
                 ep.borrow_mut()
@@ -853,10 +985,6 @@ impl Interpreter {
                             if let Some(ref cv) = cause_val {
                                 $o.insert_builtin("cause".to_string(), cv.clone());
                             }
-                            $o.insert_builtin(
-                                "stack".to_string(),
-                                JsValue::String(JsString::from_str("")),
-                            );
                         };
                     }
 
@@ -965,10 +1093,6 @@ impl Interpreter {
                         }
                         o.insert_builtin("error".to_string(), error_val.clone());
                         o.insert_builtin("suppressed".to_string(), suppressed_val.clone());
-                        o.insert_builtin(
-                            "stack".to_string(),
-                            JsValue::String(JsString::from_str("")),
-                        );
                     }
                     let id = obj_id;
                     Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
@@ -1085,10 +1209,6 @@ impl Interpreter {
                                 if let Some(ref cv) = cause_val {
                                     $o.insert_builtin("cause".to_string(), cv.clone());
                                 }
-                                $o.insert_builtin(
-                                    "stack".to_string(),
-                                    JsValue::String(JsString::from_str("")),
-                                );
                             };
                         }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1325,6 +1325,11 @@ impl Interpreter {
 
     /// Iterative prototype-chain walk of `has_property`. TypedArray canonical
     /// numeric indices short-circuit the walk (per §10.4.5.2).
+    // Documented chain-walking HasProperty primitive (sibling of
+    // `own_has_property`); retained as the canonical API even when currently
+    // uncalled — CreateDataProperty's extensibility guard now correctly uses
+    // the own-only variant.
+    #[allow(dead_code)]
     pub(crate) fn has_property_on_id(&self, start_id: u64, key: &str) -> bool {
         let mut current = Some(start_id);
         while let Some(id) = current {


### PR DESCRIPTION
Closes #179.

## Summary

Implements the normative-optional **`error-stack-accessor`** feature: a single get/set **accessor** pair for `stack` on `%Error.prototype%`, replacing the per-instance own empty-string `stack` **data** property that was inserted at every Error-family construction site. NativeError / AggregateError / SuppressedError prototypes inherit the accessor (they do not own a copy).

## What changed

- **`builtins/mod.rs`** — added `get stack` / `set stack` native functions and installed the accessor on `Error.prototype` with attributes `{ enumerable: false, configurable: true }`; removed the 4 own-`stack` data inserts (`init_error!`, `init_native_error!`, `SuppressedError`, `init_agg_error!`).
  - **getter** (`"get stack"`, length 0): TypeError on non-object `this`; returns `undefined` when the receiver lacks `[[ErrorData]]` (modeled as `class_name.contains("Error")`, the same predicate as `Error.isError`, read directly off the receiver so Proxy traps don't fire); otherwise an implementation-defined trace string.
  - **setter** (`"set stack"`, length 1): TypeError on non-object `this` or non-String value; implements `SetterThatIgnoresPrototypeProperties` with the home object `%Error.prototype%` captured **per-realm**, routing through the real `[[GetOwnProperty]]` / `CreateDataPropertyOrThrow` / `[[Set]]` internal methods so Proxy traps, non-writable / non-extensible receivers, own accessors, and cross-realm receivers all behave per spec.
- **`builtins/date.rs`** — removed the 5th own-`stack` insert in the `create_error` helper.
- **`builtins/array.rs`** — fix a latent bug surfaced by the new tests: `create_data_property_or_throw`'s extensibility guard checked `HasProperty` (prototype chain) instead of `HasOwnProperty`, so a non-extensible receiver that *inherits* the key (now the case via the inherited `stack` accessor) wrongly skipped the check. Corrected to own-only, matching `OrdinaryDefineOwnProperty`.
- **`interpreter/mod.rs`** — `has_property_on_id` (a documented chain-walking `HasProperty` primitive) is now uncalled; marked `#[allow(dead_code)]` rather than deleting the documented API.

## Testing

- `built-ins/Error/prototype/stack/`: **70/70 scenarios pass** (was 0/70).
- Full test262: **99,494 / 99,515**, a clean **+70 / −70** vs the de8e621c snapshot — the shared-helper fix caused zero collateral test changes.
- `cargo test --release`: 164 lib tests + smoke oracle, 0 failures. Lint (`rustfmt --check` + `clippy -D warnings`): clean.

## Note on the test262 baseline gate

The on-`main` baseline (`test262-pass.txt`) still reflects the pre-bump `c42f56da` snapshot, so the test262 CI gate will surface **8 pre-existing "regressions"** — the `intl-legacy-constructed-symbol` (DateTimeFormat + NumberFormat) tests tracked by **#180** (`[[FallbackSymbol]]`). These are unrelated to this PR (Intl symbol-chaining domain; they fail on `main` independently because the de8e621c snapshot strengthened them). The baseline is intentionally left untouched here — rolling it forward is a `main`-side `--update-baseline` step.