### PR TITLE
[intl] implement ECMA-402 legacy-constructor (FallbackSymbol, Chain/Unwrap)

### DIFF
--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -4169,7 +4169,64 @@ fn format_to_parts_with_options_raw(ms: f64, opts: &DtfOptions) -> Vec<(String, 
     parts
 }
 
+/// ECMA-402 UnwrapDateTimeFormat: resolve the receiver of an Intl.DateTimeFormat
+/// prototype method to the object carrying the [[InitializedDateTimeFormat]]
+/// slot. If `this` lacks the slot but is an instance of %DateTimeFormat%, read
+/// %Intl%.[[FallbackSymbol]] via the ordinary [[Get]] (so Proxy traps fire) and
+/// require the result to carry the slot; otherwise throw a TypeError.
+fn unwrap_dtf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsValue> {
+    if let JsValue::Object(o) = this {
+        let has_slot = interp
+            .get_object_cell(o.id)
+            .map(|c| {
+                matches!(
+                    c.borrow().intl_data(),
+                    Some(IntlData::DateTimeFormat { .. })
+                )
+            })
+            .unwrap_or(false);
+        if has_slot {
+            return Ok(this.clone());
+        }
+        let ctor = interp.realm().intl_date_time_format_ctor.clone();
+        if let Some(ctor) = ctor
+            && matches!(
+                interp.ordinary_has_instance(&ctor, this),
+                Completion::Normal(JsValue::Boolean(true))
+            )
+        {
+            let key = match interp.intl_fallback_symbol() {
+                JsValue::Symbol(s) => s.to_property_key(),
+                _ => unreachable!(),
+            };
+            let fb = match interp.get_object_property(o.id, &key, this) {
+                Completion::Normal(v) => v,
+                Completion::Throw(e) => return Err(e),
+                _ => JsValue::Undefined,
+            };
+            if let JsValue::Object(fo) = &fb {
+                let fb_has_slot = interp
+                    .get_object_cell(fo.id)
+                    .map(|c| {
+                        matches!(
+                            c.borrow().intl_data(),
+                            Some(IntlData::DateTimeFormat { .. })
+                        )
+                    })
+                    .unwrap_or(false);
+                if fb_has_slot {
+                    return Ok(fb);
+                }
+            }
+        }
+    }
+    Err(interp
+        .create_type_error("Intl.DateTimeFormat.prototype method called on incompatible receiver"))
+}
+
 fn extract_dtf_data(interp: &mut Interpreter, this: &JsValue) -> Result<DtfOptions, JsValue> {
+    let recv = unwrap_dtf(interp, this)?;
+    let this = &recv;
     if let JsValue::Object(o) = this
         && let Some(obj) = interp.get_object_cell(o.id)
     {
@@ -4741,6 +4798,11 @@ impl Interpreter {
             "get format".to_string(),
             0,
             |interp, this, _args| {
+                let recv = match unwrap_dtf(interp, this) {
+                    Ok(v) => v,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let this = &recv;
                 if let JsValue::Object(o) = this {
                     enum Probe {
                         NotDtf,
@@ -5747,6 +5809,44 @@ impl Interpreter {
                             has_explicit_components: has_date_time_component || has_style,
                         },
                     ));
+
+                // ECMA-402 ChainDateTimeFormat: when called without `new` on a
+                // receiver that is an instance of %DateTimeFormat%, stash the
+                // freshly-initialized formatter under %Intl%.[[FallbackSymbol]]
+                // and return the receiver instead of a fresh object.
+                if interp.new_target.is_none()
+                    && let JsValue::Object(recv) = _this
+                {
+                    let recv_id = recv.id;
+                    let ctor = interp.realm().intl_date_time_format_ctor.clone();
+                    if let Some(ctor) = ctor
+                        && matches!(
+                            interp.ordinary_has_instance(&ctor, _this),
+                            Completion::Normal(JsValue::Boolean(true))
+                        )
+                    {
+                        let key = match interp.intl_fallback_symbol() {
+                            JsValue::Symbol(s) => s.to_property_key(),
+                            _ => unreachable!(),
+                        };
+                        let desc = crate::interpreter::types::PropertyDescriptor::data(
+                            JsValue::Object(crate::types::JsObject { id: obj_id }),
+                            false,
+                            false,
+                            false,
+                        );
+                        let defined = interp
+                            .get_object_cell_expect(recv_id)
+                            .borrow_mut()
+                            .define_own_property(key, desc);
+                        if !defined {
+                            return Completion::Throw(interp.create_type_error(
+                                "Cannot define [[FallbackSymbol]] property on receiver",
+                            ));
+                        }
+                        return Completion::Normal(_this.clone());
+                    }
+                }
 
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -4189,12 +4189,16 @@ fn unwrap_dtf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsVal
             return Ok(this.clone());
         }
         let ctor = interp.realm().intl_date_time_format_ctor.clone();
-        if let Some(ctor) = ctor
-            && matches!(
-                interp.ordinary_has_instance(&ctor, this),
-                Completion::Normal(JsValue::Boolean(true))
-            )
-        {
+        // ? OrdinaryHasInstance(%DateTimeFormat%, this) — propagate abrupt completions.
+        let is_instance = match &ctor {
+            Some(c) => match interp.ordinary_has_instance(c, this) {
+                Completion::Normal(JsValue::Boolean(b)) => b,
+                Completion::Throw(e) => return Err(e),
+                _ => false,
+            },
+            None => false,
+        };
+        if is_instance {
             let key = match interp.intl_fallback_symbol() {
                 JsValue::Symbol(s) => s.to_property_key(),
                 _ => unreachable!(),
@@ -5818,33 +5822,56 @@ impl Interpreter {
                     && let JsValue::Object(recv) = _this
                 {
                     let recv_id = recv.id;
-                    let ctor = interp.realm().intl_date_time_format_ctor.clone();
-                    if let Some(ctor) = ctor
-                        && matches!(
-                            interp.ordinary_has_instance(&ctor, _this),
-                            Completion::Normal(JsValue::Boolean(true))
-                        )
-                    {
-                        let key = match interp.intl_fallback_symbol() {
-                            JsValue::Symbol(s) => s.to_property_key(),
-                            _ => unreachable!(),
+                    if let Some(ctor) = interp.realm().intl_date_time_format_ctor.clone() {
+                        // ? OrdinaryHasInstance(%DateTimeFormat%, this) — an abrupt
+                        // completion (e.g. revoked Proxy / throwing getPrototypeOf
+                        // trap) must propagate, not fall through to a fresh object.
+                        let is_instance = match interp.ordinary_has_instance(&ctor, _this) {
+                            Completion::Normal(JsValue::Boolean(b)) => b,
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => false,
                         };
-                        let desc = crate::interpreter::types::PropertyDescriptor::data(
-                            JsValue::Object(crate::types::JsObject { id: obj_id }),
-                            false,
-                            false,
-                            false,
-                        );
-                        let defined = interp
-                            .get_object_cell_expect(recv_id)
-                            .borrow_mut()
-                            .define_own_property(key, desc);
-                        if !defined {
-                            return Completion::Throw(interp.create_type_error(
-                                "Cannot define [[FallbackSymbol]] property on receiver",
-                            ));
+                        if is_instance {
+                            let key = match interp.intl_fallback_symbol() {
+                                JsValue::Symbol(s) => s.to_property_key(),
+                                _ => unreachable!(),
+                            };
+                            let desc = crate::interpreter::types::PropertyDescriptor::data(
+                                JsValue::Object(crate::types::JsObject { id: obj_id }),
+                                false,
+                                false,
+                                false,
+                            );
+                            // ? DefinePropertyOrThrow(this, [[FallbackSymbol]], desc):
+                            // route through the receiver's [[DefineOwnProperty]] so a
+                            // Proxy's defineProperty trap fires and a later [[Get]] in
+                            // Unwrap can observe the chained formatter.
+                            let is_proxy = interp
+                                .get_object_cell(recv_id)
+                                .map(|c| {
+                                    let b = c.borrow();
+                                    b.is_proxy() || b.is_proxy_revoked()
+                                })
+                                .unwrap_or(false);
+                            let defined = if is_proxy {
+                                let desc_val = interp.from_property_descriptor(&desc);
+                                match interp.proxy_define_own_property(recv_id, key, &desc_val) {
+                                    Ok(b) => b,
+                                    Err(e) => return Completion::Throw(e),
+                                }
+                            } else {
+                                interp
+                                    .get_object_cell_expect(recv_id)
+                                    .borrow_mut()
+                                    .define_own_property(key, desc)
+                            };
+                            if !defined {
+                                return Completion::Throw(interp.create_type_error(
+                                    "Cannot define [[FallbackSymbol]] property on receiver",
+                                ));
+                            }
+                            return Completion::Normal(_this.clone());
                         }
-                        return Completion::Normal(_this.clone());
                     }
                 }
 

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -782,6 +782,26 @@ impl Interpreter {
         "en".to_string()
     }
 
+    /// ECMA-402 %Intl%.[[FallbackSymbol]] for the current realm.
+    /// Mints a fresh Symbol with description "IntlLegacyConstructedSymbol" on
+    /// first use and caches it on the realm so it is stable within the realm
+    /// and distinct across realms.
+    pub(crate) fn intl_fallback_symbol(&mut self) -> JsValue {
+        if let Some(s) = self.realm().intl_fallback_symbol.clone() {
+            return s;
+        }
+        let id = self.next_symbol_id;
+        self.next_symbol_id += 1;
+        let sym = JsValue::Symbol(crate::types::JsSymbol {
+            id,
+            description: Some(crate::types::JsString::from_str(
+                "IntlLegacyConstructedSymbol",
+            )),
+        });
+        self.realm_mut().intl_fallback_symbol = Some(sym.clone());
+        sym
+    }
+
     pub(crate) fn intl_construct_number_format(
         &mut self,
         locales: &JsValue,

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -6,6 +6,51 @@ use icu::decimal::options::{DecimalFormatterOptions, GroupingStrategy};
 use icu::decimal::{DecimalFormatter, DecimalFormatterPreferences};
 use icu::locale::Locale as IcuLocale;
 
+/// ECMA-402 UnwrapNumberFormat: resolve the receiver of an Intl.NumberFormat
+/// prototype method to the object carrying the [[InitializedNumberFormat]]
+/// slot. If `this` lacks the slot but is an instance of %NumberFormat%, read
+/// %Intl%.[[FallbackSymbol]] via the ordinary [[Get]] (so Proxy traps fire)
+/// and require the result to carry the slot; otherwise throw a TypeError.
+fn unwrap_nf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsValue> {
+    if let JsValue::Object(o) = this {
+        let has_slot = interp
+            .get_object_cell(o.id)
+            .map(|c| matches!(c.borrow().intl_data(), Some(IntlData::NumberFormat { .. })))
+            .unwrap_or(false);
+        if has_slot {
+            return Ok(this.clone());
+        }
+        let ctor = interp.realm().intl_number_format_ctor.clone();
+        if let Some(ctor) = ctor
+            && matches!(
+                interp.ordinary_has_instance(&ctor, this),
+                Completion::Normal(JsValue::Boolean(true))
+            )
+        {
+            let key = match interp.intl_fallback_symbol() {
+                JsValue::Symbol(s) => s.to_property_key(),
+                _ => unreachable!(),
+            };
+            let fb = match interp.get_object_property(o.id, &key, this) {
+                Completion::Normal(v) => v,
+                Completion::Throw(e) => return Err(e),
+                _ => JsValue::Undefined,
+            };
+            if let JsValue::Object(fo) = &fb {
+                let fb_has_slot = interp
+                    .get_object_cell(fo.id)
+                    .map(|c| matches!(c.borrow().intl_data(), Some(IntlData::NumberFormat { .. })))
+                    .unwrap_or(false);
+                if fb_has_slot {
+                    return Ok(fb);
+                }
+            }
+        }
+    }
+    Err(interp
+        .create_type_error("Intl.NumberFormat.prototype method called on incompatible receiver"))
+}
+
 fn locale_nan_string(locale: &str) -> &'static str {
     let lang = locale
         .split('-')
@@ -2934,6 +2979,11 @@ impl Interpreter {
             "get format".to_string(),
             0,
             |interp, this, _args| {
+                let recv = match unwrap_nf(interp, this) {
+                    Ok(v) => v,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let this = &recv;
                 if let JsValue::Object(o) = this {
                     enum Probe {
                         NotNf,
@@ -3074,6 +3124,11 @@ impl Interpreter {
             "formatToParts".to_string(),
             1,
             |interp, this, args| {
+                let recv = match unwrap_nf(interp, this) {
+                    Ok(v) => v,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let this = &recv;
                 if let JsValue::Object(o) = this {
                     let nf_data = {
                         if let Some(obj) = interp.get_object_cell(o.id) {
@@ -3195,6 +3250,11 @@ impl Interpreter {
             "formatRange".to_string(),
             2,
             |interp, this, args| {
+                let recv = match unwrap_nf(interp, this) {
+                    Ok(v) => v,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let this = &recv;
                 if let JsValue::Object(o) = this {
                     let nf_present = interp.get_object_cell(o.id).is_some_and(|cell| {
                         matches!(
@@ -3393,6 +3453,11 @@ impl Interpreter {
             "formatRangeToParts".to_string(),
             2,
             |interp, this, args| {
+                let recv = match unwrap_nf(interp, this) {
+                    Ok(v) => v,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let this = &recv;
                 if let JsValue::Object(o) = this {
                     let nf_present = interp
                         .get_object_cell(o.id)
@@ -3557,6 +3622,11 @@ impl Interpreter {
             "resolvedOptions".to_string(),
             0,
             |interp, this, _args| {
+                let recv = match unwrap_nf(interp, this) {
+                    Ok(v) => v,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let this = &recv;
                 if let JsValue::Object(o) = this
                     && let Some(obj) = interp.get_object_cell(o.id)
                 {
@@ -4448,6 +4518,44 @@ impl Interpreter {
                     rounding_priority,
                     trailing_zero_display,
                 }));
+
+                // ECMA-402 ChainNumberFormat: when called without `new` on a
+                // receiver that is an instance of %NumberFormat%, stash the
+                // freshly-initialized formatter under %Intl%.[[FallbackSymbol]]
+                // and return the receiver instead of a fresh object.
+                if interp.new_target.is_none()
+                    && let JsValue::Object(recv) = _this
+                {
+                    let recv_id = recv.id;
+                    let ctor = interp.realm().intl_number_format_ctor.clone();
+                    if let Some(ctor) = ctor
+                        && matches!(
+                            interp.ordinary_has_instance(&ctor, _this),
+                            Completion::Normal(JsValue::Boolean(true))
+                        )
+                    {
+                        let key = match interp.intl_fallback_symbol() {
+                            JsValue::Symbol(s) => s.to_property_key(),
+                            _ => unreachable!(),
+                        };
+                        let desc = crate::interpreter::types::PropertyDescriptor::data(
+                            JsValue::Object(crate::types::JsObject { id: obj_id }),
+                            false,
+                            false,
+                            false,
+                        );
+                        let defined = interp
+                            .get_object_cell_expect(recv_id)
+                            .borrow_mut()
+                            .define_own_property(key, desc);
+                        if !defined {
+                            return Completion::Throw(interp.create_type_error(
+                                "Cannot define [[FallbackSymbol]] property on receiver",
+                            ));
+                        }
+                        return Completion::Normal(_this.clone());
+                    }
+                }
 
                 Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
             },

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -20,29 +20,33 @@ fn unwrap_nf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsValu
         if has_slot {
             return Ok(this.clone());
         }
-        let ctor = interp.realm().intl_number_format_ctor.clone();
-        if let Some(ctor) = ctor
-            && matches!(
-                interp.ordinary_has_instance(&ctor, this),
-                Completion::Normal(JsValue::Boolean(true))
-            )
-        {
-            let key = match interp.intl_fallback_symbol() {
-                JsValue::Symbol(s) => s.to_property_key(),
-                _ => unreachable!(),
-            };
-            let fb = match interp.get_object_property(o.id, &key, this) {
-                Completion::Normal(v) => v,
+        if let Some(ctor) = interp.realm().intl_number_format_ctor.clone() {
+            // ? OrdinaryHasInstance(%NumberFormat%, this) — propagate abrupt completions.
+            let is_instance = match interp.ordinary_has_instance(&ctor, this) {
+                Completion::Normal(JsValue::Boolean(b)) => b,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => false,
             };
-            if let JsValue::Object(fo) = &fb {
-                let fb_has_slot = interp
-                    .get_object_cell(fo.id)
-                    .map(|c| matches!(c.borrow().intl_data(), Some(IntlData::NumberFormat { .. })))
-                    .unwrap_or(false);
-                if fb_has_slot {
-                    return Ok(fb);
+            if is_instance {
+                let key = match interp.intl_fallback_symbol() {
+                    JsValue::Symbol(s) => s.to_property_key(),
+                    _ => unreachable!(),
+                };
+                let fb = match interp.get_object_property(o.id, &key, this) {
+                    Completion::Normal(v) => v,
+                    Completion::Throw(e) => return Err(e),
+                    _ => JsValue::Undefined,
+                };
+                if let JsValue::Object(fo) = &fb {
+                    let fb_has_slot = interp
+                        .get_object_cell(fo.id)
+                        .map(|c| {
+                            matches!(c.borrow().intl_data(), Some(IntlData::NumberFormat { .. }))
+                        })
+                        .unwrap_or(false);
+                    if fb_has_slot {
+                        return Ok(fb);
+                    }
                 }
             }
         }
@@ -4527,33 +4531,56 @@ impl Interpreter {
                     && let JsValue::Object(recv) = _this
                 {
                     let recv_id = recv.id;
-                    let ctor = interp.realm().intl_number_format_ctor.clone();
-                    if let Some(ctor) = ctor
-                        && matches!(
-                            interp.ordinary_has_instance(&ctor, _this),
-                            Completion::Normal(JsValue::Boolean(true))
-                        )
-                    {
-                        let key = match interp.intl_fallback_symbol() {
-                            JsValue::Symbol(s) => s.to_property_key(),
-                            _ => unreachable!(),
+                    if let Some(ctor) = interp.realm().intl_number_format_ctor.clone() {
+                        // ? OrdinaryHasInstance(%NumberFormat%, this) — an abrupt
+                        // completion (e.g. revoked Proxy / throwing getPrototypeOf
+                        // trap) must propagate, not fall through to a fresh object.
+                        let is_instance = match interp.ordinary_has_instance(&ctor, _this) {
+                            Completion::Normal(JsValue::Boolean(b)) => b,
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => false,
                         };
-                        let desc = crate::interpreter::types::PropertyDescriptor::data(
-                            JsValue::Object(crate::types::JsObject { id: obj_id }),
-                            false,
-                            false,
-                            false,
-                        );
-                        let defined = interp
-                            .get_object_cell_expect(recv_id)
-                            .borrow_mut()
-                            .define_own_property(key, desc);
-                        if !defined {
-                            return Completion::Throw(interp.create_type_error(
-                                "Cannot define [[FallbackSymbol]] property on receiver",
-                            ));
+                        if is_instance {
+                            let key = match interp.intl_fallback_symbol() {
+                                JsValue::Symbol(s) => s.to_property_key(),
+                                _ => unreachable!(),
+                            };
+                            let desc = crate::interpreter::types::PropertyDescriptor::data(
+                                JsValue::Object(crate::types::JsObject { id: obj_id }),
+                                false,
+                                false,
+                                false,
+                            );
+                            // ? DefinePropertyOrThrow(this, [[FallbackSymbol]], desc):
+                            // route through the receiver's [[DefineOwnProperty]] so a
+                            // Proxy's defineProperty trap fires and a later [[Get]] in
+                            // Unwrap can observe the chained formatter.
+                            let is_proxy = interp
+                                .get_object_cell(recv_id)
+                                .map(|c| {
+                                    let b = c.borrow();
+                                    b.is_proxy() || b.is_proxy_revoked()
+                                })
+                                .unwrap_or(false);
+                            let defined = if is_proxy {
+                                let desc_val = interp.from_property_descriptor(&desc);
+                                match interp.proxy_define_own_property(recv_id, key, &desc_val) {
+                                    Ok(b) => b,
+                                    Err(e) => return Completion::Throw(e),
+                                }
+                            } else {
+                                interp
+                                    .get_object_cell_expect(recv_id)
+                                    .borrow_mut()
+                                    .define_own_property(key, desc)
+                            };
+                            if !defined {
+                                return Completion::Throw(interp.create_type_error(
+                                    "Cannot define [[FallbackSymbol]] property on receiver",
+                                ));
+                            }
+                            return Completion::Normal(_this.clone());
                         }
-                        return Completion::Normal(_this.clone());
                     }
                 }
 

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -385,6 +385,9 @@ pub struct Realm {
     pub(crate) intl_number_format_ctor: Option<JsValue>,
     pub(crate) intl_date_time_format_ctor: Option<JsValue>,
     pub(crate) intl_duration_format_ctor: Option<JsValue>,
+    /// ECMA-402 %Intl%.[[FallbackSymbol]]: a fresh per-realm Symbol with
+    /// description "IntlLegacyConstructedSymbol", minted lazily on first use.
+    pub(crate) intl_fallback_symbol: Option<JsValue>,
     pub(crate) error_prototype: Option<u64>,
     pub(crate) type_error_prototype: Option<u64>,
     pub(crate) range_error_prototype: Option<u64>,
@@ -481,6 +484,7 @@ impl Realm {
             intl_number_format_ctor: None,
             intl_date_time_format_ctor: None,
             intl_duration_format_ctor: None,
+            intl_fallback_symbol: None,
             error_prototype: None,
             type_error_prototype: None,
             range_error_prototype: None,

--- a/test262-extra/Intl-legacy-constructor-proxy.js
+++ b/test262-extra/Intl-legacy-constructor-proxy.js
@@ -1,0 +1,82 @@
+// ECMA-402 legacy-constructor: Proxy-receiver behavior of ChainNumberFormat /
+// ChainDateTimeFormat (not covered by test262's intl-normative-optional files).
+// Spec: ChainNumberFormat / ChainDateTimeFormat use
+//   ? OrdinaryHasInstance(%C%, this) and ? DefinePropertyOrThrow(this, ...),
+// so abrupt completions must propagate and the define must honor the
+// receiver's [[DefineOwnProperty]] (firing a Proxy's defineProperty trap).
+
+// --- DefinePropertyOrThrow goes through the receiver's [[DefineOwnProperty]] ---
+// A Proxy chain receiver must see its defineProperty trap fire with the
+// fallback symbol, and the chained formatter must then be observable via Unwrap.
+var defineKeys = [];
+var nfTarget = Object.create(Intl.NumberFormat.prototype);
+var nfProxy = new Proxy(nfTarget, {
+  defineProperty: function (t, key, desc) {
+    defineKeys.push(key);
+    return Reflect.defineProperty(t, key, desc);
+  }
+});
+var nfResult = Intl.NumberFormat.call(nfProxy);
+if (nfResult !== nfProxy) {
+  throw new Test262Error('chain must return the receiver, got a different value');
+}
+if (defineKeys.length !== 1) {
+  throw new Test262Error(
+    'defineProperty trap must fire exactly once, fired ' + defineKeys.length + ' times');
+}
+if (typeof defineKeys[0] !== 'symbol' ||
+    defineKeys[0].description !== 'IntlLegacyConstructedSymbol') {
+  throw new Test262Error('defineProperty trap key must be the fallback symbol');
+}
+// Unwrap reads the fallback symbol via the ordinary [[Get]]; because the define
+// went through the trap, the chained formatter is reachable on the target.
+var nfOpts = Intl.NumberFormat.prototype.resolvedOptions.call(nfProxy);
+if (typeof nfOpts !== 'object' || typeof nfOpts.locale !== 'string') {
+  throw new Test262Error('resolvedOptions via chained Proxy receiver must succeed');
+}
+
+// --- OrdinaryHasInstance abrupt completion propagates (revoked Proxy) ---
+function expectThrows(fn, ctor, msg) {
+  var threw = false;
+  try {
+    fn();
+  } catch (e) {
+    threw = true;
+    if (!(e instanceof ctor)) {
+      throw new Test262Error(msg + ' — wrong error type: ' + e);
+    }
+  }
+  if (!threw) {
+    throw new Test262Error(msg + ' — no error thrown');
+  }
+}
+
+var nfRev = Proxy.revocable(Object.create(Intl.NumberFormat.prototype), {});
+nfRev.revoke();
+expectThrows(
+  function () { Intl.NumberFormat.call(nfRev.proxy); },
+  TypeError,
+  'Intl.NumberFormat.call(revokedProxy) must rethrow, not return a fresh formatter');
+
+var dtfRev = Proxy.revocable(Object.create(Intl.DateTimeFormat.prototype), {});
+dtfRev.revoke();
+expectThrows(
+  function () { Intl.DateTimeFormat.call(dtfRev.proxy); },
+  TypeError,
+  'Intl.DateTimeFormat.call(revokedProxy) must rethrow, not return a fresh formatter');
+
+// --- A throwing getPrototypeOf trap propagates its own exception ---
+var sentinel = new RangeError('from getPrototypeOf');
+var throwingProxy = new Proxy(Object.create(Intl.NumberFormat.prototype), {
+  getPrototypeOf: function () { throw sentinel; }
+});
+var got;
+try {
+  Intl.NumberFormat.call(throwingProxy);
+  throw new Test262Error('throwing getPrototypeOf during has-instance must propagate');
+} catch (e) {
+  got = e;
+}
+if (got !== sentinel) {
+  throw new Test262Error('the getPrototypeOf trap exception must propagate unchanged, got: ' + got);
+}


### PR DESCRIPTION
Fixes #180.

Implements the ECMA-402 normative-optional **legacy-constructor** feature for `Intl.NumberFormat` and `Intl.DateTimeFormat` — jsse previously implemented none of it.

## What changed
- **Per-realm `%Intl%.[[FallbackSymbol]]`** — a fresh `Symbol` with description `"IntlLegacyConstructedSymbol"`, minted lazily and cached on the `Realm` (stable within a realm, distinct across realms). Symbols carry no GC arena id, so no `collect_roots` change is needed.
- **ChainNumberFormat / ChainDateTimeFormat** — when the constructor is called **without `new`** (`new_target` is undefined) on a receiver that is an instance of the prototype, define a `{writable:false, enumerable:false, configurable:false}` own property keyed by the fallback symbol holding the freshly-built formatter, and return the receiver. `new`, `Reflect.construct`, subclass `super()`, and plain `Intl.X()` (non-instance `this`) are unchanged.
- **UnwrapNumberFormat / UnwrapDateTimeFormat** — the prototype methods (`resolvedOptions`, `format` getter, `formatToParts`, `formatRange`, `formatRangeToParts`) accept a receiver that lacks the internal slot but carries the fallback symbol, reading it through the ordinary `[[Get]]` so a wrapping Proxy's `get` trap fires, with a brand re-check on the resolved formatter.

Scope is NumberFormat + DateTimeFormat only (Collator has no legacy-constructor tests).

## Testing
- **8 `intl-normative-optional` test262 files / 16 scenarios: 100% pass** (`FallbackSymbol/{description,per-realm}.js`, and `{NumberFormat,DateTimeFormat}/intl-legacy-constructed-symbol{,-property,-on-unwrap}.js`).
- **Full intl402: 6682/6682, 0 regressions.**
- **Full test262: 99,510/99,515, 0 regressions** (the 5 remaining failures are pre-existing and unrelated — #169 TypedArray slice ×2, #181 source-phase import ×3).
- `rustfmt --check` and `clippy -D warnings` both clean.

4 files changed, +232 lines (additive).