### PR TITLE
Extract shared resolve_relative_index helper for slice/copyWithin/fill clamping

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -1649,11 +1649,7 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                let k = if relative_start < 0.0 {
-                    (len as f64 + relative_start).max(0.0) as usize
-                } else {
-                    (relative_start as i64).min(len) as usize
-                };
+                let k = resolve_relative_index(relative_start, len as usize);
                 let relative_end = if let Some(v) = args.get(1) {
                     if matches!(v, JsValue::Undefined) {
                         len as f64
@@ -1666,11 +1662,7 @@ impl Interpreter {
                 } else {
                     len as f64
                 };
-                let fin = if relative_end < 0.0 {
-                    (len as f64 + relative_end).max(0.0) as usize
-                } else {
-                    (relative_end as i64).min(len) as usize
-                };
+                let fin = resolve_relative_index(relative_end, len as usize);
                 let count = fin.saturating_sub(k);
                 let a = match array_species_create(interp, &o, count) {
                     Ok(v) => v,
@@ -2484,11 +2476,7 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                let actual_start = if relative_start < 0.0 {
-                    (len as f64 + relative_start).max(0.0) as usize
-                } else {
-                    (relative_start as i64).min(len) as usize
-                };
+                let actual_start = resolve_relative_index(relative_start, len as usize);
                 let insert_count = if args.len() > 2 { args.len() - 2 } else { 0 };
                 let actual_delete_count = if args.is_empty() {
                     0usize
@@ -2657,11 +2645,7 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                let actual_start = if relative_start < 0.0 {
-                    (len as f64 + relative_start).max(0.0) as usize
-                } else {
-                    (relative_start as i64).min(len) as usize
-                };
+                let actual_start = resolve_relative_index(relative_start, len as usize);
                 let actual_delete_count = if args.is_empty() {
                     0usize
                 } else if args.len() == 1 {
@@ -2729,11 +2713,7 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                let k = if relative_start < 0.0 {
-                    (len as f64 + relative_start).max(0.0) as usize
-                } else {
-                    (relative_start as i64).min(len) as usize
-                };
+                let k = resolve_relative_index(relative_start, len as usize);
                 let relative_end = if let Some(v) = args.get(2) {
                     if matches!(v, JsValue::Undefined) {
                         len as f64
@@ -2746,11 +2726,7 @@ impl Interpreter {
                 } else {
                     len as f64
                 };
-                let fin = if relative_end < 0.0 {
-                    (len as f64 + relative_end).max(0.0) as usize
-                } else {
-                    (relative_end as i64).min(len) as usize
-                };
+                let fin = resolve_relative_index(relative_end, len as usize);
                 for i in k..fin {
                     if let Err(e) = obj_set_throw(interp, &o, &i.to_string(), value.clone()) {
                         return Completion::Throw(e);
@@ -3240,11 +3216,7 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                let to_val = if relative_target < 0.0 {
-                    (len as f64 + relative_target).max(0.0) as i64
-                } else {
-                    (relative_target as i64).min(len)
-                };
+                let to_val = resolve_relative_index(relative_target, len as usize) as i64;
                 let relative_start = if let Some(v) = args.get(1) {
                     match interp.to_number_value(v) {
                         Ok(n) => to_integer_or_infinity(n),
@@ -3253,11 +3225,7 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                let from = if relative_start < 0.0 {
-                    (len as f64 + relative_start).max(0.0) as i64
-                } else {
-                    (relative_start as i64).min(len)
-                };
+                let from = resolve_relative_index(relative_start, len as usize) as i64;
                 let relative_end = if let Some(v) = args.get(2) {
                     if matches!(v, JsValue::Undefined) {
                         len as f64
@@ -3270,11 +3238,7 @@ impl Interpreter {
                 } else {
                     len as f64
                 };
-                let fin = if relative_end < 0.0 {
-                    (len as f64 + relative_end).max(0.0) as i64
-                } else {
-                    (relative_end as i64).min(len)
-                };
+                let fin = resolve_relative_index(relative_end, len as usize) as i64;
                 let count = (fin - from).min(len - to_val);
                 if count <= 0 {
                     return Completion::Normal(o);

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -469,16 +469,8 @@ impl Interpreter {
                         },
                         _ => len,
                     };
-                    let from = if int_start < 0.0 {
-                        (len + int_start).max(0.0) as usize
-                    } else {
-                        int_start.min(len) as usize
-                    };
-                    let to = if int_end < 0.0 {
-                        (len + int_end).max(0.0) as usize
-                    } else {
-                        int_end.min(len) as usize
-                    };
+                    let from = resolve_relative_index(int_start, len as usize);
+                    let to = resolve_relative_index(int_end, len as usize);
                     let from = from.min(units.len());
                     let to = to.min(units.len());
                     if from >= to {

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -2074,20 +2074,6 @@ impl Interpreter {
                     } else {
                         typed_array_length(&ta) as i64
                     };
-                    let resolve_idx = |v: f64, len: i64| -> usize {
-                        let vi = if v == f64::NEG_INFINITY || v <= -(len as f64) - 1.0 {
-                            i64::MIN / 2
-                        } else if v == f64::INFINITY || v > len as f64 {
-                            i64::MAX / 2
-                        } else {
-                            v as i64
-                        };
-                        (if vi < 0 {
-                            (len + vi).max(0)
-                        } else {
-                            vi.min(len)
-                        }) as usize
-                    };
                     let begin = {
                         let n = to_integer(if let Some(a) = args.first() {
                             match interp.to_number_value(a) {
@@ -2097,7 +2083,7 @@ impl Interpreter {
                         } else {
                             0.0
                         });
-                        resolve_idx(n, src_len)
+                        resolve_relative_index(n, src_len as usize)
                     };
                     let end_is_undefined =
                         args.len() <= 1 || matches!(args.get(1), Some(JsValue::Undefined));
@@ -2110,7 +2096,7 @@ impl Interpreter {
                         } else {
                             src_len as f64
                         };
-                        resolve_idx(n, src_len)
+                        resolve_relative_index(n, src_len as usize)
                     };
                     let new_len = end.saturating_sub(begin);
                     let bpe = ta.kind.bytes_per_element();
@@ -2156,20 +2142,6 @@ impl Interpreter {
                         }
                     };
                     let len = typed_array_length(&ta) as i64;
-                    let resolve_idx = |v: f64, len: i64| -> usize {
-                        let vi = if v == f64::NEG_INFINITY || v <= -(len as f64) - 1.0 {
-                            i64::MIN / 2
-                        } else if v == f64::INFINITY || v > len as f64 {
-                            i64::MAX / 2
-                        } else {
-                            v as i64
-                        };
-                        (if vi < 0 {
-                            (len + vi).max(0)
-                        } else {
-                            vi.min(len)
-                        }) as usize
-                    };
                     let begin = {
                         let n = to_integer(if let Some(a) = args.first() {
                             match interp.to_number_value(a) {
@@ -2179,7 +2151,7 @@ impl Interpreter {
                         } else {
                             0.0
                         });
-                        resolve_idx(n, len)
+                        resolve_relative_index(n, len as usize)
                     };
                     let end = {
                         let n = if args.len() > 1 && !matches!(args[1], JsValue::Undefined) {
@@ -2190,7 +2162,7 @@ impl Interpreter {
                         } else {
                             len as f64
                         };
-                        resolve_idx(n, len)
+                        resolve_relative_index(n, len as usize)
                     };
                     let count = end.saturating_sub(begin);
 
@@ -2310,20 +2282,6 @@ impl Interpreter {
                         return c;
                     }
                     let len = typed_array_length(&ta) as i64;
-                    let resolve_index = |v: f64, len: i64| -> usize {
-                        let vi = if v == f64::NEG_INFINITY || v < -(len as f64) - 1.0 {
-                            i64::MIN / 2
-                        } else if v == f64::INFINITY || v > len as f64 {
-                            i64::MAX / 2
-                        } else {
-                            v as i64
-                        };
-                        (if vi < 0 {
-                            (len + vi).max(0)
-                        } else {
-                            vi.min(len)
-                        }) as usize
-                    };
                     let target = {
                         let n = match interp
                             .to_number_value(args.first().unwrap_or(&JsValue::Undefined))
@@ -2331,7 +2289,7 @@ impl Interpreter {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
                         };
-                        resolve_index(to_integer(n), len)
+                        resolve_relative_index(to_integer(n), len as usize)
                     };
                     let start = {
                         let n = match interp
@@ -2340,7 +2298,7 @@ impl Interpreter {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
                         };
-                        resolve_index(to_integer(n), len)
+                        resolve_relative_index(to_integer(n), len as usize)
                     };
                     let end = {
                         let n = if args.len() > 2 && !matches!(args[2], JsValue::Undefined) {
@@ -2351,7 +2309,7 @@ impl Interpreter {
                         } else {
                             len as f64
                         };
-                        resolve_index(n, len)
+                        resolve_relative_index(n, len as usize)
                     };
                     // Re-check detach and OOB after coercion
                     if ta.is_detached.get() || is_typed_array_out_of_bounds(&ta) {
@@ -2435,11 +2393,7 @@ impl Interpreter {
                         } else {
                             0.0
                         });
-                        if v < 0.0 {
-                            ((len_f + v) as isize).max(0) as usize
-                        } else {
-                            (v as usize).min(len)
-                        }
+                        resolve_relative_index(v, len)
                     };
                     let end = {
                         let v = if args.len() > 2 && !matches!(args[2], JsValue::Undefined) {
@@ -2450,11 +2404,7 @@ impl Interpreter {
                         } else {
                             len_f
                         };
-                        if v < 0.0 {
-                            ((len_f + v) as isize).max(0) as usize
-                        } else {
-                            (v as usize).min(len)
-                        }
+                        resolve_relative_index(v, len)
                     };
                     // Re-check detach and OOB after coercion (buffer may have been resized)
                     if ta.is_detached.get() {

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+// Resolves a spec "relative index" argument (already passed through ToIntegerOrInfinity)
+// against a length, per the clamp used by e.g. Array.prototype.slice, String.prototype.slice,
+// and the %TypedArray%.prototype equivalents:
+//   if n < 0, max(len + n, 0); else min(n, len)
+pub(crate) fn resolve_relative_index(n: f64, len: usize) -> usize {
+    let len = len as f64;
+    if n < 0.0 {
+        (len + n).max(0.0) as usize
+    } else {
+        n.min(len) as usize
+    }
+}
+
 pub(crate) fn to_integer_or_infinity(n: f64) -> f64 {
     if n.is_nan() || n == 0.0 {
         0.0
@@ -2288,5 +2301,53 @@ fn hex_val(b: u8) -> Result<u8, String> {
         b'a'..=b'f' => Ok(b - b'a' + 10),
         b'A'..=b'F' => Ok(b - b'A' + 10),
         _ => Err("URI malformed".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod resolve_relative_index_tests {
+    use super::resolve_relative_index;
+
+    #[test]
+    fn in_range_positive_index_is_unchanged() {
+        assert_eq!(resolve_relative_index(3.0, 10), 3);
+    }
+
+    #[test]
+    fn negative_index_counts_back_from_length() {
+        assert_eq!(resolve_relative_index(-3.0, 10), 7);
+    }
+
+    #[test]
+    fn positive_index_beyond_length_clamps_to_length() {
+        assert_eq!(resolve_relative_index(100.0, 10), 10);
+    }
+
+    #[test]
+    fn negative_index_beyond_length_clamps_to_zero() {
+        assert_eq!(resolve_relative_index(-100.0, 10), 0);
+    }
+
+    #[test]
+    fn negative_index_exactly_at_length_boundary_clamps_to_zero() {
+        // n == -(len) - 1 is the boundary where two previously-duplicated
+        // implementations of this clamp disagreed on `<` vs `<=`; both landed on 0.
+        assert_eq!(resolve_relative_index(-11.0, 10), 0);
+    }
+
+    #[test]
+    fn positive_infinity_clamps_to_length() {
+        assert_eq!(resolve_relative_index(f64::INFINITY, 10), 10);
+    }
+
+    #[test]
+    fn negative_infinity_clamps_to_zero() {
+        assert_eq!(resolve_relative_index(f64::NEG_INFINITY, 10), 0);
+    }
+
+    #[test]
+    fn zero_length_clamps_everything_to_zero() {
+        assert_eq!(resolve_relative_index(-1.0, 0), 0);
+        assert_eq!(resolve_relative_index(5.0, 0), 0);
     }
 }


### PR DESCRIPTION
## Summary

This is a targeted architecture refactor from a codebase audit (using the `codebase-design`/`improve-codebase-architecture` deep-module vocabulary), aimed at eliminating duplicated, drift-prone logic rather than adding new features.

The audit surfaced several duplication hotspots (receiver-validation boilerplate in `collections.rs`, repeated Date getter wrappers, RegExp Symbol.match/replace/split loop duplication, a fragmented property-access interface in `eval.rs`/`mod.rs`). This PR tackles the highest-payoff, lowest-risk candidate: the **relative-index clamping algorithm** — "if `n < 0`, clamp to `max(0, len+n)`, else `min(len, n)`" — used by the spec algorithms behind `Array.prototype.slice/splice/toSpliced/fill/copyWithin`, `String.prototype.slice`, and the `%TypedArray%.prototype` equivalents.

This algorithm was hand-rolled independently at **9 call sites** across `array.rs`, `string.rs`, and `typedarray.rs`. `typedarray.rs` alone reimplemented it **4 different ways**, including one genuine inconsistency between `<` and `<=` at the lower boundary (`copyWithin` vs. `slice`/`subarray`) that happened to still produce the same clamped result — a latent correctness risk that would only need one future edit to diverge for real.

Deletion test: deleting all 9 inline implementations and factoring them into one helper makes 9 call sites shrink to one-liners; the arithmetic (a real correctness risk given NaN/Infinity/overflow edge cases) collapses into one place instead of drifting independently in 3 files.

## Changes

- Added `resolve_relative_index(n: f64, len: usize) -> usize` to `src/interpreter/helpers.rs`, a pure function with no interpreter/JS dependency, directly unit-testable in Rust.
- Swept all 9 duplicated inline implementations in `array.rs` (`slice`, `splice`, `toSpliced`, `fill`, `copyWithin`), `string.rs` (`slice`), and `typedarray.rs` (`subarray`, `slice`, `copyWithin`, `fill`) over to the shared helper.
- Net diff: +81/-114 lines, despite adding 8 new unit tests — pure duplication removal.

## Tests

Built test-first (TDD): 8 unit tests in `src/interpreter/helpers.rs` pin the helper's boundary behavior directly against the Rust function — no JS parsing or interpreter execution involved — added one vertical slice at a time before the call-site sweep:

- in-range positive index unchanged
- negative index counts back from length
- positive index beyond length clamps to length
- negative index beyond length clamps to zero
- negative index exactly at the `<` vs `<=` boundary that previously diverged between implementations (both landed on 0; now pinned to prevent regression)
- `+Infinity`/`-Infinity` clamp correctly
- zero-length array clamps everything to zero

## Test plan

- [x] `cargo build --release` — clean, no warnings
- [x] `cargo test --bin jsse --release` — 172/172 passing (including the 8 new unit tests)
- [x] `./scripts/lint.sh` — clippy clean
- [x] `uv run python scripts/run-custom-tests.py` — 3/3 passing
- [ ] `uv run python scripts/run-test262.py` — **not run**: this sandboxed environment's network access is scoped to the `pmatos/jsse` repo only, so the `test262`/`spec` git submodules (hosted at `tc39/*`) could not be fetched (`git submodule update` returns 403). Since this is a pure refactor preserving the exact clamping semantics (verified by the unit tests above, including the boundary case where prior implementations disagreed), a full test262 run on this branch is recommended before merge to confirm no regressions in `built-ins/Array`, `built-ins/String`, and `built-ins/TypedArray*`.

https://claude.ai/code/session_019oiTHXtesxw6uvcF31MU1p

---
_Generated by [Claude Code](https://claude.ai/code/session_019oiTHXtesxw6uvcF31MU1p)_