### PR TITLE
[ci] claude-review: make the code-review plugin actually post reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,12 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+env:
+  # Force Node.js 24 for any JS-based actions still pinned to Node 20
+  # (e.g. oven-sh/setup-bun pulled in transitively by anthropics/claude-code-action).
+  # Node 20 is removed from runners on 2026-09-16.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   claude-review:
     # Skip automated review for bot-authored PRs (e.g. Dependabot).
@@ -24,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # required so the review can post PR comments
+      issues: write # required for the `gh pr comment` no-issues summary
       id-token: write
 
     steps:
@@ -41,7 +47,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # The code-review plugin: (1) only posts when invoked with `--comment`
+          # (otherwise it prints a terminal summary and stops); (2) spawns sub-agents
+          # (Task); (3) posts inline findings via the action's github_inline_comment
+          # MCP tool (and the no-issues summary via `gh pr comment`), reading git
+          # history for context. Grant all three or the run ends "success" silently.
+          claude_args: '--allowedTools "Task,Read,Grep,Glob,Bash(gh:*),Bash(git:*),mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Problem

The **Claude Code Review** workflow has reported `success` on every run but has **never posted a review** to any PR — since it was first added (commit `2886f36`). Confirmed against runs on PRs #186, #189, #190: green checks, zero Claude comments.

It was copied from Anthropic's minimal **"Using skills"** docs snippet, which only demonstrates *invoking* a plugin skill — it is not a "post a review" recipe. (Anthropic's docs route the "reviews posted on every PR" use case to a separate managed service, and the skill's own source requires `--comment` to post.)

## Root cause — three missing ingredients

The `code-review` plugin needs **all three** of these to post, and the workflow had none. This mirrors the working setup in [`pmatos/forseti`](https://github.com/pmatos/forseti/blob/main/.github/workflows/claude-code-review.yml).

1. **`--comment` on the prompt.** Without it the skill stops at step 7 and posts nothing (*"If `--comment` was NOT provided, stop here. Do not post any GitHub comments."*), only printing findings to the CI log. Confirmed from the PR #189 run log: no flag, `"is_error": false`, `"No buffered inline comments"`.

2. **Write permissions.** `pull-requests: read` → `write` to post PR comments; `issues: read` → `write` for the `gh pr comment` no-issues summary.

3. **An explicit tool allow-list.** In agent mode `claude-code-action` passes `--allowedTools` to the SDK as a *restrictive* list, so the plugin's sub-agents and file reads must be granted alongside the comment tools — otherwise the run ends "success" silently:
   `Task,Read,Grep,Glob,Bash(gh:*),Bash(git:*),mcp__github_inline_comment__create_inline_comment`

## Fix

- Append `--comment` to the prompt.
- `pull-requests` and `issues` → `write`.
- Add the `claude_args` tool allow-list above.
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` (the action pulls in JS actions still on Node 20, which runners drop on 2026-09-16).
- **Keeps** the `if: github.event.pull_request.user.type != 'Bot'` guard (issue #177).

## Validation

- `yaml.safe_load` parses cleanly.
- Review-critical config now matches the known-working `pmatos/forseti` workflow.
- End-to-end posting is verifiable once merged (this PR's own check uses the base-branch workflow, so it won't self-demonstrate): open/synchronize a human PR and confirm a Claude review comment appears.
