### PR TITLE
[ci] harden GitHub Actions; add cargo-deny, CodeQL & workflow linting

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -21,11 +21,11 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
+        uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories bans licenses sources

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,31 @@
+name: cargo-deny
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so newly disclosed RUSTSEC advisories are caught even without a
+    # code change to the crate graph.
+    - cron: "0 3 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
+        with:
+          command: check advisories bans licenses sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,29 @@ env:
   CARGO_TERM_COLOR: always
   TEST262_SAMPLE_SEED: 262023
 
+# Least-privilege default for all jobs; widen per-job only when needed.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (a new push obsoletes in-flight CI).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: recursive
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Check formatting
         run: cargo fmt --check
@@ -36,7 +46,7 @@ jobs:
       - name: Run unit tests
         run: cargo test
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Run Python script tests
         run: uv run python -m unittest discover -s scripts -p 'test_*.py'
@@ -52,4 +62,4 @@ jobs:
             test262/test/language/expressions/dynamic-import/import-attributes/
 
       - name: Run test262 (10% sample, fixed seed ${{ env.TEST262_SAMPLE_SEED }})
-        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1 --seed $TEST262_SAMPLE_SEED
+        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1 --seed "$TEST262_SAMPLE_SEED"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --check
@@ -46,7 +46,7 @@ jobs:
       - name: Run unit tests
         run: cargo test
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run Python script tests
         run: uv run python -m unittest discover -s scripts -p 'test_*.py'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,14 +42,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,6 +16,12 @@ env:
   # Node 20 is removed from runners on 2026-09-16.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+# A new push to the PR (synchronize) supersedes any in-flight review of the
+# prior head, so cancel the stale run rather than post a review of old code.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Skip automated review for bot-authored PRs (e.g. Dependabot).
@@ -36,13 +42,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,13 +46,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,13 +46,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+# CodeQL adds interprocedural dataflow/taint analysis for Rust (GA) beyond
+# Semgrep's `auto` ruleset. Results surface under the repo Security tab.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 4 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Rust)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF results to the Security tab
+      actions: read
+    steps:
+      # No submodules: CodeQL only needs to build the crate, not the (large)
+      # test262/spec test-data submodules.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        with:
+          languages: rust
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        with:
+          category: "/language:rust"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,23 +29,23 @@ jobs:
     steps:
       # No submodules: CodeQL only needs to build the crate, not the (large)
       # test262/spec test-data submodules.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/init@v3
         with:
           languages: rust
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:rust"

--- a/.github/workflows/nightly-test262-coverage.yml
+++ b/.github/workflows/nightly-test262-coverage.yml
@@ -17,21 +17,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@c6d51ded7cde3c421f6cd6046cd601f2248f3710 # cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@v7
 
       - name: Generate coverage from full test262 suite
         run: |
@@ -44,7 +44,7 @@ jobs:
           cargo llvm-cov report --release --lcov --output-path lcov.info
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: pmatos/jsse

--- a/.github/workflows/nightly-test262-coverage.yml
+++ b/.github/workflows/nightly-test262-coverage.yml
@@ -9,28 +9,33 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: recursive
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@c6d51ded7cde3c421f6cd6046cd601f2248f3710 # cargo-llvm-cov
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Generate coverage from full test262 suite
         run: |
+          # shellcheck disable=SC1090 # sourcing dynamic cargo-llvm-cov env export
           source <(cargo llvm-cov show-env --export-prefix)
           cargo llvm-cov clean --workspace
           cargo build --release
@@ -39,7 +44,7 @@ jobs:
           cargo llvm-cov report --release --lcov --output-path lcov.info
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: pmatos/jsse

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,11 +16,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Run Semgrep
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
+        uses: semgrep/semgrep-action@v1
         with:
           config: auto

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -6,15 +6,21 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Run Semgrep
-        uses: semgrep/semgrep-action@v1
+        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
         with:
           config: auto

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,43 @@
+name: Workflow Lint
+
+# These workflows are security-critical (trust gates, id-token: write,
+# CLAUDE_CODE_OAUTH_TOKEN). actionlint catches YAML/expression/shell bugs;
+# zizmor audits for injection, over-broad permissions, and unpinned actions.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.7
+        run: |
+          curl -fsSL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint -color
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: zizmor
+        env:
+          # Enables zizmor's online audits (e.g. stale-action-ref checks).
+          GH_TOKEN: ${{ github.token }}
+        run: uvx zizmor@1.26.1 .github/workflows/

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,7 +21,7 @@ jobs:
   workflow-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -34,7 +34,7 @@ jobs:
           tar -xzf actionlint.tar.gz actionlint
           ./actionlint -color
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@v7
 
       - name: zizmor
         env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,22 @@
+# zizmor audit configuration.
+#
+# Every other finding is fixed in the workflows themselves (SHA-pinned actions,
+# least-privilege permissions, persist-credentials: false on read-only
+# checkouts). The two ignores below are deliberate, documented exceptions.
+
+rules:
+  # claude.yml's @claude responder can be asked to implement changes and push a
+  # branch; claude-code-action manages its own git credentials, and this job
+  # uploads no artifacts, so persisted checkout credentials cannot leak. Leaving
+  # checkout auth at its default here avoids breaking the push path. Revisit if
+  # the action's auth model changes.
+  artipacked:
+    ignore:
+      - claude.yml
+
+  # semgrep/semgrep-action is archived. Migrating off it (to the semgrep CLI /
+  # container) changes an existing, green scan job, so it is tracked as a
+  # separate follow-up rather than bundled into this hardening change.
+  archived-uses:
+    ignore:
+      - semgrep.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,10 +1,20 @@
 # zizmor audit configuration.
 #
-# Every other finding is fixed in the workflows themselves (SHA-pinned actions,
-# least-privilege permissions, persist-credentials: false on read-only
-# checkouts). The two ignores below are deliberate, documented exceptions.
+# Most hardening is in the workflows themselves (least-privilege permissions,
+# persist-credentials: false on read-only checkouts). The settings below are
+# deliberate, documented policy choices.
 
 rules:
+  # Actions are pinned to version tags (e.g. @v7), not commit SHAs, for
+  # readability and easy review; Dependabot's github-actions updater keeps the
+  # tags current. Relax zizmor's default hash-pin requirement to ref-pin so tag
+  # pins pass, while still failing on the genuinely dangerous cases: an action
+  # pinned to a mutable branch or to no ref at all.
+  unpinned-uses:
+    config:
+      policies:
+        "*": ref-pin
+
   # claude.yml's @claude responder can be asked to implement changes and push a
   # branch; claude-code-action manages its own git credentials, and this job
   # uploads no artifacts, so persisted checkout credentials cannot leak. Leaving

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,46 @@
+# cargo-deny configuration — supply-chain gate that Dependabot alone does not
+# provide: it scans the RUSTSEC advisory DB, enforces an allow-list of licenses,
+# and rejects crates pulled from unexpected registries/git sources.
+#
+# Run locally with:  cargo deny check advisories bans licenses sources
+# See https://embarkstudios.github.io/cargo-deny/ for the full schema.
+
+[graph]
+# Evaluate the crate graph with all features enabled so no dependency escapes
+# the checks by hiding behind an off-by-default feature.
+all-features = true
+
+[advisories]
+version = 2
+# Add RUSTSEC IDs here with a justification only when an advisory is triaged as
+# not applicable; keep the list empty so new advisories fail loudly by default.
+ignore = []
+
+[licenses]
+version = 2
+# The allow-list is exactly the permissive licenses currently in the crate
+# graph. A dependency bump that introduces any other license (notably anything
+# copyleft) will fail this check by design, surfacing it for a manual decision
+# instead of silently shipping — add the new license here once reviewed.
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Unicode-3.0",
+  "BSL-1.0",
+  "Unlicense",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+[bans]
+# Duplicate versions and wildcard requirements are worth surfacing but should
+# not hard-fail CI on transitive noise outside our control.
+multiple-versions = "warn"
+wildcards = "warn"
+allow = []
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Addresses the **GitHub Actions hardening + static-analysis** portion of the SOTA DevX audit in #192. Config/CI-only and additive — no engine source is touched.

**Hardening of existing workflows**
- Least-privilege `permissions: contents: read` on `ci.yml` + `nightly-test262-coverage.yml` (they previously inherited the repo default).
- `concurrency: cancel-in-progress` on `ci`, `semgrep`, and `claude-code-review` so superseded pushes stop burning runners.
- **Pin every third-party action to a version tag** (`@v7`, `@stable`, …); Dependabot's existing `github-actions` updater keeps them current on major bumps. zizmor's `unpinned-uses` audit is set to `ref-pin` in `.github/zizmor.yml`, so tag pins pass while a mutable-branch or unpinned ref still fails.
- `persist-credentials: false` on read-only checkouts.

**New static-analysis / supply-chain jobs**
- **cargo-deny** — `deny.toml` (advisories / bans / licenses / sources) + a job that also runs weekly to catch newly disclosed RUSTSEC advisories. The license allow-list is exactly the permissive set currently in the crate graph; anything new fails by design for a manual decision.
- **CodeQL (Rust)** — interprocedural dataflow/taint on push/PR + weekly.
- **actionlint + zizmor** workflow-lint job; `.github/zizmor.yml` documents the accepted findings and the tag-pin policy.

## Validated locally

- `actionlint` — clean.
- `zizmor` (online **and** offline) — no findings.
- `cargo deny check advisories bans licenses sources` — all `ok`.
- No `.rs` changed, so fmt/clippy/build/tests are unaffected.

## Deferred to follow-ups

These were intentionally kept out — they need a structural change or alter an existing green step and shouldn't be shipped without validation:

- #193 — cargo-fuzz (needs a `[lib]` target + differential-vs-node harness + fuzzing skill)
- #194 — Miri over the unsafe-adjacent modules (ready recipe included)
- #195 — cargo-nextest swap + clippy PostToolUse hook
- #196 — migrate semgrep off its archived action

Part of #192 (kept open until the follow-ups land).

## Test plan

- [ ] `workflow-lint` job green (actionlint + zizmor)
- [ ] `cargo-deny` job green
- [ ] `CodeQL` job green (autobuild + analyze)
- [ ] existing `CI` + `Semgrep` jobs still green
