### PR TITLE
Deepen TypedArray detached/out-of-bounds check into one helper

### DIFF
--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1852,10 +1852,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -1924,10 +1922,8 @@ impl Interpreter {
                     let offset = offset_f as usize;
 
                     // Step 3: Check detach after offset coercion
-                    if ta.is_detached.get() || is_typed_array_out_of_bounds(&ta) {
-                        return Completion::Throw(
-                            interp.create_type_error("typed array is detached"),
-                        );
+                    if let Err(c) = check_detached_or_out_of_bounds(interp, &ta) {
+                        return c;
                     }
 
                     // Check if source is a TypedArray
@@ -2131,10 +2127,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2268,10 +2262,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2312,10 +2304,8 @@ impl Interpreter {
                         resolve_relative_index(n, len as usize)
                     };
                     // Re-check detach and OOB after coercion
-                    if ta.is_detached.get() || is_typed_array_out_of_bounds(&ta) {
-                        return Completion::Throw(
-                            interp.create_type_error("typed array is detached"),
-                        );
+                    if let Err(c) = check_detached_or_out_of_bounds(interp, &ta) {
+                        return c;
                     }
                     // Use original len for count (per spec), but bound copy by actual buffer
                     let _cur_len = typed_array_length(&ta);
@@ -2360,10 +2350,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2442,10 +2430,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2500,10 +2486,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2559,10 +2543,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2618,10 +2600,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2661,10 +2641,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2784,10 +2762,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2850,10 +2826,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -2930,10 +2904,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -3001,10 +2973,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -3271,10 +3241,8 @@ impl Interpreter {
                     let ta = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                             ta.clone()
                         } else {
@@ -3414,10 +3382,8 @@ impl Interpreter {
                     {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                         } else {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
@@ -3448,10 +3414,8 @@ impl Interpreter {
                     {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                         } else {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
@@ -3477,10 +3441,8 @@ impl Interpreter {
                     {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
-                            if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                                return Completion::Throw(
-                                    interp.create_type_error("typed array is detached"),
-                                );
+                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
+                                return c;
                             }
                         } else {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
@@ -6182,11 +6144,7 @@ fn extract_ta_and_callback(
         let ta = {
             let obj_ref = obj.borrow();
             if let Some(ta) = obj_ref.typed_array_info() {
-                if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                    return Err(Completion::Throw(
-                        interp.create_type_error("typed array is detached"),
-                    ));
-                }
+                check_detached_or_out_of_bounds(interp, ta)?;
                 ta.clone()
             } else {
                 return Err(Completion::Throw(
@@ -6432,6 +6390,21 @@ fn validate_uint8array_no_detach_check(
 
 fn check_detached(interp: &mut Interpreter, ta: &TypedArrayInfo) -> Result<(), Completion> {
     if ta.is_detached.get() {
+        Err(Completion::Throw(
+            interp.create_type_error("typed array is detached"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Combines the detached check with the out-of-bounds check that applies to
+/// typed arrays tracking a resizable ArrayBuffer that has since shrunk.
+fn check_detached_or_out_of_bounds(
+    interp: &mut Interpreter,
+    ta: &TypedArrayInfo,
+) -> Result<(), Completion> {
+    if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
         Err(Completion::Throw(
             interp.create_type_error("typed array is detached"),
         ))

--- a/test262-extra/TypedArray-detached-out-of-bounds-consistency.js
+++ b/test262-extra/TypedArray-detached-out-of-bounds-consistency.js
@@ -1,0 +1,84 @@
+// Every %TypedArray%.prototype method that reads through its receiver's
+// backing buffer must reject a detached buffer and a buffer that has been
+// resized out from under a length-tracking view identically: throw a
+// TypeError before doing any further work. Each method independently
+// re-derives this same "is_detached || is_typed_array_out_of_bounds" guard
+// (see e.g. ValidateTypedArray, 23.2.4.1 IsTypedArrayOutOfBounds), so a
+// method that forgets one half of the check would silently operate on
+// invalid backing memory instead of throwing.
+// Spec: ECMAScript 2024, sec-validatetypedarray,
+//       sec-istypedarrayoutofbounds.
+
+function Test262Error(message) {
+  this.message = message || "";
+}
+Test262Error.prototype.toString = function () {
+  return "Test262Error: " + this.message;
+};
+
+var METHODS = [
+  "at", "set", "slice", "copyWithin", "fill", "indexOf", "lastIndexOf",
+  "includes", "reverse", "sort", "join", "toLocaleString", "toReversed",
+  "toSorted", "with", "values", "entries", "keys", "forEach", "map",
+  "filter", "every", "some", "find", "findIndex", "findLast",
+  "findLastIndex", "reduce", "reduceRight"
+];
+
+function invoke(view, name) {
+  switch (name) {
+    case "set": return view.set([1]);
+    case "with": return view.with(0, 1);
+    case "fill": return view.fill(1);
+    case "copyWithin": return view.copyWithin(0, 0);
+    case "indexOf": case "lastIndexOf": case "includes": return view[name](1);
+    case "forEach": case "map": case "filter": case "every": case "some":
+    case "find": case "findIndex": case "findLast": case "findLastIndex":
+      return view[name](function () { return true; });
+    case "reduce": case "reduceRight":
+      return view[name](function (acc) { return acc; }, 0);
+    default: return view[name]();
+  }
+}
+
+function assertThrowsTypeError(view, name, label) {
+  var threw = null;
+  try {
+    invoke(view, name);
+  } catch (e) {
+    threw = e;
+  }
+  if (threw === null) {
+    throw new Test262Error(label + ": " + name + " did not throw");
+  }
+  if (!(threw instanceof TypeError)) {
+    throw new Test262Error(label + ": " + name + " threw " + threw.constructor.name + ", expected TypeError");
+  }
+}
+
+// Detached buffer: every method must throw TypeError, not read stale memory.
+METHODS.forEach(function (name) {
+  var buf = new ArrayBuffer(8);
+  var view = new Uint8Array(buf);
+  buf.transfer();
+  assertThrowsTypeError(view, name, "detached");
+});
+
+// Length-tracking view over a resizable buffer that has shrunk below the
+// view's byteOffset: the view is "out of bounds" without being detached.
+METHODS.forEach(function (name) {
+  var rab = new ArrayBuffer(16, { maxByteLength: 16 });
+  var view = new Uint8Array(rab, 8);
+  rab.resize(4);
+  assertThrowsTypeError(view, name, "out-of-bounds");
+});
+
+// Sanity: a live, in-bounds view must not be rejected by the same guard.
+(function () {
+  var buf = new ArrayBuffer(4);
+  var view = new Uint8Array(buf);
+  view.fill(7);
+  if (view[0] !== 7) {
+    throw new Test262Error("sanity: fill on a valid view should not throw / should apply");
+  }
+  view.at(0);
+})();


### PR DESCRIPTION
## Summary

Ran an architecture audit (mattpocock/skills `improve-codebase-architecture` process) over `src/`, focused on `src/interpreter/`, `src/interpreter/builtins/`, and `src/parser/`. The audit surfaced several deepening opportunities (duplicated `define_method`/`insert_builtin` boilerplate, three near-identical `ArrayBuffer` transfer methods, repeated Map/Set branding checks, parallel generator/async state-machine loops, etc.) — full findings are in the session transcript. This PR implements the top "Strong" recommendation that was self-contained and low-risk enough for one focused change.

**Problem:** Every `%TypedArray%.prototype` method that reads through its receiver's backing buffer re-derived the same `ta.is_detached.get() || is_typed_array_out_of_bounds(ta)` guard and hand-rolled the identical `TypeError("typed array is detached")`, copy-pasted across ~20 call sites in `src/interpreter/builtins/typedarray.rs` (`at`, `set`, `slice`, `copyWithin`, `fill`, `indexOf`, `lastIndexOf`, `includes`, `reverse`, `sort`, `join`, `toLocaleString`, `toReversed`, `toSorted`, `with`, `values`, `entries`, `keys`, and the shared `extract_ta_and_callback` helper backing `forEach`/`map`/`filter`/`every`/`some`/`find*`/`reduce*`). A `check_detached` helper already existed for the detached-only case but nothing covered the combined detached-or-out-of-bounds case, so call sites bypassed it.

Deletion test: real — deleting the would-be helper means the check (and its exact error string) has to be kept in lockstep across ~20 sites by hand, which is the actual friction today.

**Solution:** Added `check_detached_or_out_of_bounds`, mirroring `check_detached`'s shape, and replaced all ~20 matching call sites with it (mechanical, behavior-preserving — verified via a scripted regex pass plus a manual diff review). Left untouched, since they're semantically different:
- the `byteOffset`/`byteLength`/`length` getters, which return `0` rather than throw,
- the `set()` source-argument check, whose message is `"source typed array is detached"` (a different receiver), and
- the `subarray` OOB-clamps-to-zero-length path (`"Per spec: if OOB, srcArrayLength = 0 (no throw for subarray)"`).

## Tests

Added `test262-extra/TypedArray-detached-out-of-bounds-consistency.js`, which pins the invariant across every affected method: each one throws `TypeError` (not silently misbehaving, not a different error type) for both
1. a detached `ArrayBuffer` (via `ArrayBuffer.prototype.transfer()`), and
2. a length-tracking view that has gone out of bounds because its backing resizable `ArrayBuffer` shrank underneath it (via `.resize()`).

This is a pure refactor (no observable behavior change), so per the TDD "Refactor" step the safety net is: confirm full coverage passes before refactoring, refactor, confirm it still passes after. Verified:
- `cargo build --release` — clean.
- `./scripts/lint.sh` — clean (clippy + fmt).
- `uv run python scripts/run-test262.py test262/test/built-ins/TypedArray test262/test/built-ins/TypedArrayConstructors test262/test/built-ins/ArrayBuffer test262/test/built-ins/SharedArrayBuffer test262/test/built-ins/Uint8Array` — 5110/5112 passing (the 2 failures are a pre-existing, unrelated `slice` species-constructor test not in the passing baseline — confirmed zero regressions).
- `uv run python scripts/run-custom-tests.py` — 3/3 passing.
- New `test262-extra` test passes directly under `jsse`.
- Full `test262` suite run in progress; will report/update if it surfaces anything unexpected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5R1Ana4wJuPgKQTPqFfWi)_