### PR TITLE
Deepen `? ToIntegerOrInfinity(arg)` into one coercion method

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -1185,8 +1185,8 @@ impl Interpreter {
             }
             let search = args.first().cloned().unwrap_or(JsValue::Undefined);
             let n = if args.len() >= 2 {
-                match interp.to_number_value(&args[1]) {
-                    Ok(v) => to_integer_or_infinity(v),
+                match interp.to_integer_or_infinity_value(&args[1]) {
+                    Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -1235,8 +1235,8 @@ impl Interpreter {
             }
             let search = args.first().cloned().unwrap_or(JsValue::Undefined);
             let n = if args.len() >= 2 {
-                match interp.to_number_value(&args[1]) {
-                    Ok(v) => to_integer_or_infinity(v),
+                match interp.to_integer_or_infinity_value(&args[1]) {
+                    Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -1285,8 +1285,8 @@ impl Interpreter {
             }
             let search = args.first().cloned().unwrap_or(JsValue::Undefined);
             let n = if args.len() >= 2 {
-                match interp.to_number_value(&args[1]) {
-                    Ok(v) => to_integer_or_infinity(v),
+                match interp.to_integer_or_infinity_value(&args[1]) {
+                    Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -1555,8 +1555,8 @@ impl Interpreter {
                 Err(c) => return c,
             } as i64;
             let relative_start = if let Some(v) = args.first() {
-                match interp.to_number_value(v) {
-                    Ok(n) => to_integer_or_infinity(n),
+                match interp.to_integer_or_infinity_value(v) {
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -1567,8 +1567,8 @@ impl Interpreter {
                 if matches!(v, JsValue::Undefined) {
                     len as f64
                 } else {
-                    match interp.to_number_value(v) {
-                        Ok(n) => to_integer_or_infinity(n),
+                    match interp.to_integer_or_infinity_value(v) {
+                        Ok(n) => n,
                         Err(e) => return Completion::Throw(e),
                     }
                 }
@@ -2272,8 +2272,8 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let relative_start = if let Some(v) = args.first() {
-                match interp.to_number_value(v) {
-                    Ok(n) => to_integer_or_infinity(n),
+                match interp.to_integer_or_infinity_value(v) {
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -2286,8 +2286,8 @@ impl Interpreter {
             } else if args.len() == 1 {
                 (len - actual_start as i64) as usize
             } else {
-                let dc = match interp.to_number_value(&args[1]) {
-                    Ok(n) => to_integer_or_infinity(n),
+                let dc = match interp.to_integer_or_infinity_value(&args[1]) {
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 };
                 dc.max(0.0).min((len - actual_start as i64) as f64) as usize
@@ -2432,8 +2432,8 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let relative_start = if let Some(v) = args.first() {
-                match interp.to_number_value(v) {
-                    Ok(n) => to_integer_or_infinity(n),
+                match interp.to_integer_or_infinity_value(v) {
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -2445,8 +2445,8 @@ impl Interpreter {
             } else if args.len() == 1 {
                 (len - actual_start as i64) as usize
             } else {
-                let dc = match interp.to_number_value(&args[1]) {
-                    Ok(n) => to_integer_or_infinity(n),
+                let dc = match interp.to_integer_or_infinity_value(&args[1]) {
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 };
                 dc.max(0.0).min((len - actual_start as i64) as f64) as usize
@@ -2493,8 +2493,8 @@ impl Interpreter {
             };
             let value = args.first().cloned().unwrap_or(JsValue::Undefined);
             let relative_start = if let Some(v) = args.get(1) {
-                match interp.to_number_value(v) {
-                    Ok(n) => to_integer_or_infinity(n),
+                match interp.to_integer_or_infinity_value(v) {
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -2505,8 +2505,8 @@ impl Interpreter {
                 if matches!(v, JsValue::Undefined) {
                     len as f64
                 } else {
-                    match interp.to_number_value(v) {
-                        Ok(n) => to_integer_or_infinity(n),
+                    match interp.to_integer_or_infinity_value(v) {
+                        Ok(n) => n,
                         Err(e) => return Completion::Throw(e),
                     }
                 }
@@ -2746,8 +2746,8 @@ impl Interpreter {
                 if matches!(d, JsValue::Undefined) {
                     1.0
                 } else {
-                    match interp.to_number_value(d) {
-                        Ok(n) => to_integer_or_infinity(n),
+                    match interp.to_integer_or_infinity_value(d) {
+                        Ok(n) => n,
                         Err(e) => return Completion::Throw(e),
                     }
                 }
@@ -2949,8 +2949,8 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let relative_target = if let Some(v) = args.first() {
-                match interp.to_number_value(v) {
-                    Ok(n) => to_integer_or_infinity(n),
+                match interp.to_integer_or_infinity_value(v) {
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -2958,8 +2958,8 @@ impl Interpreter {
             };
             let to_val = resolve_relative_index(relative_target, len as usize) as i64;
             let relative_start = if let Some(v) = args.get(1) {
-                match interp.to_number_value(v) {
-                    Ok(n) => to_integer_or_infinity(n),
+                match interp.to_integer_or_infinity_value(v) {
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -2970,8 +2970,8 @@ impl Interpreter {
                 if matches!(v, JsValue::Undefined) {
                     len as f64
                 } else {
-                    match interp.to_number_value(v) {
-                        Ok(n) => to_integer_or_infinity(n),
+                    match interp.to_integer_or_infinity_value(v) {
+                        Ok(n) => n,
                         Err(e) => return Completion::Throw(e),
                     }
                 }
@@ -3025,8 +3025,8 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let relative_index = if let Some(v) = args.first() {
-                match interp.to_number_value(v) {
-                    Ok(n) => to_integer_or_infinity(n) as i64,
+                match interp.to_integer_or_infinity_value(v) {
+                    Ok(n) => n as i64,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
@@ -3060,8 +3060,8 @@ impl Interpreter {
                 return Completion::Throw(interp.create_range_error("Invalid array length"));
             }
             let relative_index = if let Some(v) = args.first() {
-                match interp.to_number_value(v) {
-                    Ok(n) => to_integer_or_infinity(n) as i64,
+                match interp.to_integer_or_infinity_value(v) {
+                    Ok(n) => n as i64,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -84,6 +84,15 @@ fn to_num(interp: &mut Interpreter, val: &JsValue) -> Result<f64, Completion> {
     }
 }
 
+// §7.1.5 `? ToIntegerOrInfinity(argument)` in the local `to_num`-style shape
+// (Completion errors) used throughout the String prototype builtins.
+fn to_int_or_inf(interp: &mut Interpreter, val: &JsValue) -> Result<f64, Completion> {
+    match interp.to_integer_or_infinity_value(val) {
+        Ok(n) => Ok(n),
+        Err(e) => Err(Completion::Throw(e)),
+    }
+}
+
 fn utf16_units(s: &str) -> Vec<u16> {
     s.encode_utf16().collect()
 }
@@ -156,8 +165,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let pos = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
@@ -181,8 +190,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let pos = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
@@ -204,8 +213,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let pos = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
@@ -244,8 +253,8 @@ impl Interpreter {
                         None => "undefined".to_string(),
                     };
                     let pos = match args.get(1) {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
@@ -337,8 +346,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let pos = match args.get(1) {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n).max(0.0) as usize,
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n.max(0.0) as usize,
                             Err(c) => return c,
                         },
                         None => 0,
@@ -385,10 +394,12 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let pos = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n).max(0.0) as usize,
-                            Err(c) => return c,
-                        },
+                        Some(v) if !matches!(v, JsValue::Undefined) => {
+                            match to_int_or_inf(interp, v) {
+                                Ok(n) => n.max(0.0) as usize,
+                                Err(c) => return c,
+                            }
+                        }
                         _ => 0,
                     };
                     let s_units = utf16_units(&s);
@@ -430,10 +441,12 @@ impl Interpreter {
                     let search_units = utf16_units(&search);
                     let s_len = s_units.len();
                     let end_pos = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n).max(0.0).min(s_len as f64) as usize,
-                            Err(c) => return c,
-                        },
+                        Some(v) if !matches!(v, JsValue::Undefined) => {
+                            match to_int_or_inf(interp, v) {
+                                Ok(n) => n.max(0.0).min(s_len as f64) as usize,
+                                Err(c) => return c,
+                            }
+                        }
                         _ => s_len,
                     };
                     let search_len = search_units.len();
@@ -456,17 +469,19 @@ impl Interpreter {
                     let units = &js_str.code_units;
                     let len = units.len() as f64;
                     let int_start = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
                     };
                     let int_end = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
-                            Err(c) => return c,
-                        },
+                        Some(v) if !matches!(v, JsValue::Undefined) => {
+                            match to_int_or_inf(interp, v) {
+                                Ok(n) => n,
+                                Err(c) => return c,
+                            }
+                        }
                         _ => len,
                     };
                     let from = resolve_relative_index(int_start, len as usize);
@@ -634,8 +649,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let n = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
@@ -656,8 +671,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let max_length = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
@@ -692,8 +707,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let max_length = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n),
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
@@ -1124,8 +1139,8 @@ impl Interpreter {
                     let units = &js_str.code_units;
                     let len = units.len() as i64;
                     let idx = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => to_integer_or_infinity(n) as i64,
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n as i64,
                             Err(c) => return c,
                         },
                         None => 0,

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1863,8 +1863,8 @@ impl Interpreter {
                     // Capture len BEFORE argument coercion (may resize buffer)
                     let len = typed_array_length(&ta) as i64;
                     let idx_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let idx = match interp.to_number_value(&idx_val) {
-                        Ok(n) => to_integer(n) as i64,
+                    let idx = match interp.to_integer_or_infinity_value(&idx_val) {
+                        Ok(n) => n as i64,
                         Err(e) => return Completion::Throw(e),
                     };
                     let actual = if idx < 0 { len + idx } else { idx };
@@ -1907,8 +1907,8 @@ impl Interpreter {
 
                     // Step 2: ToIntegerOrInfinity(offset) BEFORE detach check
                     let offset_f = if args.len() > 1 {
-                        match interp.to_number_value(&args[1]) {
-                            Ok(n) => to_integer(n),
+                        match interp.to_integer_or_infinity_value(&args[1]) {
+                            Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
                         }
                     } else {
@@ -2006,8 +2006,8 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        let src_len = match interp.to_number_value(&len_val) {
-                            Ok(n) => to_integer(n) as usize,
+                        let src_len = match interp.to_integer_or_infinity_value(&len_val) {
+                            Ok(n) => n as usize,
                             Err(e) => return Completion::Throw(e),
                         };
                         if offset + src_len > target_len {
@@ -2071,7 +2071,7 @@ impl Interpreter {
                         typed_array_length(&ta) as i64
                     };
                     let begin = {
-                        let n = to_integer(if let Some(a) = args.first() {
+                        let n = to_integer_or_infinity(if let Some(a) = args.first() {
                             match interp.to_number_value(a) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
@@ -2085,10 +2085,10 @@ impl Interpreter {
                         args.len() <= 1 || matches!(args.get(1), Some(JsValue::Undefined));
                     let end = {
                         let n = if !end_is_undefined {
-                            to_integer(match interp.to_number_value(&args[1]) {
+                            match interp.to_integer_or_infinity_value(&args[1]) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
-                            })
+                            }
                         } else {
                             src_len as f64
                         };
@@ -2137,7 +2137,7 @@ impl Interpreter {
                     };
                     let len = typed_array_length(&ta) as i64;
                     let begin = {
-                        let n = to_integer(if let Some(a) = args.first() {
+                        let n = to_integer_or_infinity(if let Some(a) = args.first() {
                             match interp.to_number_value(a) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
@@ -2149,10 +2149,10 @@ impl Interpreter {
                     };
                     let end = {
                         let n = if args.len() > 1 && !matches!(args[1], JsValue::Undefined) {
-                            to_integer(match interp.to_number_value(&args[1]) {
+                            match interp.to_integer_or_infinity_value(&args[1]) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
-                            })
+                            }
                         } else {
                             len as f64
                         };
@@ -2275,27 +2275,27 @@ impl Interpreter {
                     }
                     let len = typed_array_length(&ta) as i64;
                     let target = {
-                        let n = match interp
-                            .to_number_value(args.first().unwrap_or(&JsValue::Undefined))
-                        {
+                        let n = match interp.to_integer_or_infinity_value(
+                            args.first().unwrap_or(&JsValue::Undefined),
+                        ) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
                         };
-                        resolve_relative_index(to_integer(n), len as usize)
+                        resolve_relative_index(n, len as usize)
                     };
                     let start = {
-                        let n = match interp
-                            .to_number_value(args.get(1).unwrap_or(&JsValue::Undefined))
-                        {
+                        let n = match interp.to_integer_or_infinity_value(
+                            args.get(1).unwrap_or(&JsValue::Undefined),
+                        ) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
                         };
-                        resolve_relative_index(to_integer(n), len as usize)
+                        resolve_relative_index(n, len as usize)
                     };
                     let end = {
                         let n = if args.len() > 2 && !matches!(args[2], JsValue::Undefined) {
-                            match interp.to_number_value(&args[2]) {
-                                Ok(n) => to_integer(n),
+                            match interp.to_integer_or_infinity_value(&args[2]) {
+                                Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
                             }
                         } else {
@@ -2373,7 +2373,7 @@ impl Interpreter {
                     };
                     let len_f = len as f64;
                     let start = {
-                        let v = to_integer(if args.len() > 1 {
+                        let v = to_integer_or_infinity(if args.len() > 1 {
                             match interp.to_number_value(&args[1]) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
@@ -2385,10 +2385,10 @@ impl Interpreter {
                     };
                     let end = {
                         let v = if args.len() > 2 && !matches!(args[2], JsValue::Undefined) {
-                            to_integer(match interp.to_number_value(&args[2]) {
+                            match interp.to_integer_or_infinity_value(&args[2]) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
-                            })
+                            }
                         } else {
                             len_f
                         };
@@ -2444,7 +2444,7 @@ impl Interpreter {
                     }
                     let search = args.first().cloned().unwrap_or(JsValue::Undefined);
                     let from = if args.len() > 1 {
-                        to_integer(match interp.to_number_value(&args[1]) {
+                        (match interp.to_integer_or_infinity_value(&args[1]) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
                         }) as i64
@@ -2500,7 +2500,7 @@ impl Interpreter {
                     }
                     let search = args.first().cloned().unwrap_or(JsValue::Undefined);
                     let from = if args.len() > 1 {
-                        to_integer(match interp.to_number_value(&args[1]) {
+                        (match interp.to_integer_or_infinity_value(&args[1]) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
                         }) as i64
@@ -2557,7 +2557,7 @@ impl Interpreter {
                     }
                     let search = args.first().cloned().unwrap_or(JsValue::Undefined);
                     let from = if args.len() > 1 {
-                        to_integer(match interp.to_number_value(&args[1]) {
+                        (match interp.to_integer_or_infinity_value(&args[1]) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
                         }) as i64
@@ -5326,8 +5326,8 @@ impl Interpreter {
                 Completion::Throw(e) => return Err(Completion::Throw(e)),
                 _ => return Ok(Vec::new()),
             };
-            let len_f = match self.to_number_value(&len_val) {
-                Ok(n) => to_integer(n),
+            let len_f = match self.to_integer_or_infinity_value(&len_val) {
+                Ok(n) => n,
                 Err(e) => return Err(Completion::Throw(e)),
             };
             // §22.2.4.4 step 4+6: AllocateTypedArrayBuffer requires len <= 2^53-1
@@ -6296,16 +6296,6 @@ pub(crate) fn dv_f64_to_f16_bits(val: f64) -> u16 {
         return sign | (1 << 10);
     }
     sign | rounded
-}
-
-fn to_integer(n: f64) -> f64 {
-    if n.is_nan() {
-        return 0.0;
-    }
-    if n == 0.0 || n.is_infinite() {
-        return n;
-    }
-    n.signum() * n.abs().floor()
 }
 
 fn is_bigint_kind(kind: TypedArrayKind) -> bool {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1611,6 +1611,17 @@ impl Interpreter {
         }
     }
 
+    // §7.1.5 ToIntegerOrInfinity — `? ToNumber(argument)` then truncate toward
+    // zero (NaN → +0, ±∞ pass through). The combined coercion that callers used
+    // to open-code as a `to_number_value` match feeding `to_integer_or_infinity`;
+    // this is the spec abstract operation as a single named step, alongside
+    // to_number_value / to_string_value / to_index.
+    #[allow(clippy::wrong_self_convention)]
+    pub(crate) fn to_integer_or_infinity_value(&mut self, val: &JsValue) -> Result<f64, JsValue> {
+        let n = self.to_number_value(val)?;
+        Ok(to_integer_or_infinity(n))
+    }
+
     // §7.1.13 ToBigInt
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_bigint_value(&mut self, val: &JsValue) -> Result<JsValue, JsValue> {

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1473,3 +1473,83 @@ fn collection_prototype_methods_have_correctly_shaped_builtins() {
         "collection prototype methods must keep their observable shape and behavior"
     );
 }
+
+// §7.1.5 ToIntegerOrInfinity — the combined `? ToIntegerOrInfinity(argument)`
+// coercion method that sits alongside to_number_value / to_string_value / to_index.
+// Expected values are the spec's, not recomputed the way the code does it.
+mod to_integer_or_infinity_value_tests {
+    use super::*;
+
+    fn conv(v: JsValue) -> f64 {
+        let mut interp = Interpreter::new();
+        interp
+            .to_integer_or_infinity_value(&v)
+            .expect("expected a normal (non-throwing) coercion")
+    }
+
+    #[test]
+    fn truncates_toward_zero() {
+        assert_eq!(conv(JsValue::Number(3.7)), 3.0);
+        assert_eq!(conv(JsValue::Number(-3.7)), -3.0);
+        assert_eq!(conv(JsValue::Number(5.0)), 5.0);
+        assert_eq!(conv(JsValue::Number(-0.9)), 0.0);
+    }
+
+    #[test]
+    fn nan_becomes_positive_zero() {
+        let r = conv(JsValue::Number(f64::NAN));
+        assert_eq!(r, 0.0);
+        assert!(r.is_sign_positive(), "ToIntegerOrInfinity(NaN) is +0");
+    }
+
+    #[test]
+    fn infinities_pass_through() {
+        assert_eq!(conv(JsValue::Number(f64::INFINITY)), f64::INFINITY);
+        assert_eq!(conv(JsValue::Number(f64::NEG_INFINITY)), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn coerces_booleans_null_and_undefined() {
+        assert_eq!(conv(JsValue::Boolean(true)), 1.0); // ToNumber(true) = 1
+        assert_eq!(conv(JsValue::Boolean(false)), 0.0);
+        assert_eq!(conv(JsValue::Null), 0.0); // ToNumber(null) = 0
+        assert_eq!(conv(JsValue::Undefined), 0.0); // ToNumber(undefined) = NaN -> 0
+    }
+
+    #[test]
+    fn coerces_strings() {
+        assert_eq!(conv(JsValue::String(JsString::from_str("42"))), 42.0);
+        assert_eq!(conv(JsValue::String(JsString::from_str("42.9"))), 42.0);
+        assert_eq!(conv(JsValue::String(JsString::from_str("  -7.5 "))), -7.0);
+        assert_eq!(conv(JsValue::String(JsString::from_str("abc"))), 0.0); // NaN -> 0
+        assert_eq!(
+            conv(JsValue::String(JsString::from_str("Infinity"))),
+            f64::INFINITY
+        );
+    }
+
+    #[test]
+    fn observable_truncation_through_array_prototype_at() {
+        // The builtin routes its index argument through the coercion method,
+        // so truncation is observable at the public JS seam.
+        let interp = run_script(r#"var R = [10, 20, 30].at(1.9);"#);
+        assert_eq!(global_number(&interp, "R"), 20.0);
+    }
+
+    #[test]
+    fn throwing_valueof_propagates_through_the_seam() {
+        // ? ToIntegerOrInfinity must forward a ToNumber abrupt completion.
+        let interp = run_script(
+            r#"
+            var threw = false;
+            try {
+                [1, 2, 3].at({ valueOf() { throw new Error("boom"); } });
+            } catch (e) {
+                threw = (e instanceof Error) && e.message === "boom";
+            }
+            var R = threw ? "threw" : "did-not-throw";
+            "#,
+        );
+        assert_eq!(global_string(&interp, "R"), "threw");
+    }
+}


### PR DESCRIPTION
## Refactoring goal

Surfaced by an architecture audit (mattpocock/skills `improve-codebase-architecture`), implemented test-first with the `tdd` skill.

The spec abstract operation **`? ToIntegerOrInfinity(argument)`** (§7.1.5) was open-coded at ~40 builtin call sites as a `to_number_value` match feeding the free `to_integer_or_infinity` helper. Worse, `typedarray.rs` carried a **second, byte-for-byte-identical implementation** of ToIntegerOrInfinity as a private `to_integer` fn — two copies of one spec operation, free to drift.

This is a *deepening*: give the combined operation a single named step, `Interpreter::to_integer_or_infinity_value`, completing the existing coercion-method family (`to_number_value` / `to_string_value` / `to_index`) rather than leaking its internal ToNumber+truncate structure at every call site.

## What changed

- **New method** `Interpreter::to_integer_or_infinity_value(&val) -> Result<f64, JsValue>` in `eval.rs` — `? ToNumber` then truncate toward zero (NaN → +0, ±∞ passthrough).
- **Adopted** across `Array.prototype` (17 sites), `String.prototype` (13 sites, via a local `to_int_or_inf` wrapper that mirrors the file's existing `to_num` Completion-shaped helper), and `%TypedArray%`/`ArrayBuffer`/`SharedArrayBuffer` prototype builtins (13 sites).
- **Deleted** the duplicate `typedarray::to_integer`. Its only semantic difference — returning `-0.0` for a `-0` input where the canonical helper returns spec-correct `+0` — is unobservable after the `as i64` / `as usize` casts and comparisons every call site applies.

Pure code-motion of an identical block plus removal of a proven-equivalent duplicate. **Behavior preserving** by construction.

## Tests (written red-first)

7 new unit tests in `src/interpreter/tests.rs`, with expected values taken from the ECMAScript spec (not recomputed the way the code does it):

- **Direct seam** — truncation toward zero (`3.7→3`, `-3.7→-3`), `NaN→+0`, `±Infinity` passthrough, boolean/null/undefined coercion, string coercion (`"42.9"→42`, `"  -7.5 "→-7`, `"abc"→0`, `"Infinity"→∞`).
- **Public JS seam** — `[10,20,30].at(1.9) === 20` (observable truncation) and a throwing `valueOf` propagating through `Array.prototype.at` (abrupt-completion forwarding).

## Verification

- `cargo build --release` ✅
- `./scripts/lint.sh` (clippy) ✅
- `cargo test --release` — 215 passing (incl. the 7 new) ✅
- `run-custom-tests.py` — 3/3 ✅
- `run-test262.py` over `Array`, `String`, `TypedArray`, `TypedArrayConstructors`, `ArrayBuffer`, `SharedArrayBuffer` — **13528/13530, 0 regressions, 0 new passes** (the 2 failures are pre-existing, absent from the `origin/main` baseline).

🤖 Generated with Claude Code