### PR TITLE
docs: record that external PRs are not a triage surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ A from-scratch JavaScript engine implemented in Rust. No JS parser/engine librar
 
 ### Issue tracker
 
-Issues live on GitHub at `pmatos/jsse` and are managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+Issues live on GitHub at `pmatos/jsse` and are managed via the `gh` CLI; external PRs are not a triage surface (issues only). See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,10 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
+## Pull requests as a request surface
+
+External pull requests are **not** a triage surface for this repo. `/triage` processes GitHub issues only; it does not pull outside contributors' PRs into the queue. (Collaborators' in-flight PRs are left alone in either case.)
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.


### PR DESCRIPTION
## Summary

Follow-up to the `setup-matt-pocock-skills` configuration. The GitHub issue-tracker setup never recorded whether **external pull requests** feed the `/triage` queue. This records the decision explicitly.

**Decision: issues only.** `/triage` processes GitHub issues; it does not pull outside contributors' PRs into the queue. (Collaborators' in-flight PRs are left alone regardless.)

## Changes

- `docs/agents/issue-tracker.md` — new "Pull requests as a request surface" section.
- `CLAUDE.md` — Agent skills → Issue tracker one-liner now notes "issues only".

Docs only; no behavior change.

🤖 Generated with Claude Code