### PR TITLE
Consolidate ToInt32/ToUint32 into number_ops (fix large-magnitude saturation)

### DIFF
--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -1792,7 +1792,7 @@ impl Interpreter {
                     Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 };
-                let mut radix = crate::interpreter::types::to_int32_modular(radix_num);
+                let mut radix = number_ops::to_int32(radix_num);
                 let s = s.trim_matches(crate::interpreter::builtins::string::is_ecma_whitespace);
                 let (negative, s) = if let Some(rest) = s.strip_prefix('-') {
                     (true, rest)

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -90,21 +90,6 @@ fn utf16_to_byte_offset(s: &str, utf16_offset: usize) -> usize {
     s.len()
 }
 
-fn to_uint32_f64(n: f64) -> u32 {
-    if n.is_nan() || n.is_infinite() || n == 0.0 {
-        return 0;
-    }
-    let int_val = n.signum() * n.abs().floor();
-    // Modulo 2^32
-    let modulo = int_val % 4294967296.0;
-    let modulo = if modulo < 0.0 {
-        modulo + 4294967296.0
-    } else {
-        modulo
-    };
-    modulo as u32
-}
-
 // Surrogate code points (U+D800-U+DFFF) can't be represented as Rust chars.
 // We remap them to Supplementary PUA-A (U+F0000+) so regex matching works
 // on strings containing lone surrogates.
@@ -8185,7 +8170,7 @@ impl Interpreter {
                     0xFFFFFFFF
                 } else {
                     match interp.to_number_value(&limit) {
-                        Ok(n) => to_uint32_f64(n),
+                        Ok(n) => crate::types::number_ops::to_uint32(n),
                         Err(e) => return Completion::Throw(e),
                     }
                 };

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -97,22 +97,6 @@ fn utf16_units(s: &str) -> Vec<u16> {
     s.encode_utf16().collect()
 }
 
-// §7.1.7 ToUint32
-fn to_uint32(n: f64) -> u32 {
-    if n.is_nan() || n.is_infinite() || n == 0.0 {
-        return 0;
-    }
-    let int_val = n.signum() * n.abs().floor();
-    let two32: f64 = 4294967296.0; // 2^32
-    let int32bit = int_val % two32;
-    let int32bit = if int32bit < 0.0 {
-        int32bit + two32
-    } else {
-        int32bit
-    };
-    int32bit as u32
-}
-
 // §7.2.8 IsRegExp(argument) — uses [[Get]] for Symbol.match (invokes getters)
 fn is_regexp(interp: &mut Interpreter, obj_id: u64, obj_val: &JsValue) -> Result<bool, JsValue> {
     if let Some(match_key) = interp.get_symbol_key("match") {
@@ -787,7 +771,7 @@ impl Interpreter {
                         0xFFFF_FFFF // 2^32 - 1
                     } else {
                         match to_num(interp, &limit_arg) {
-                            Ok(n) => to_uint32(n),
+                            Ok(n) => crate::types::number_ops::to_uint32(n),
                             Err(c) => return c,
                         }
                     };

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use crate::interpreter::types::BufferData;
-use crate::types::{JsBigInt, JsObject, JsString, JsValue};
+use crate::types::{JsBigInt, JsObject, JsString, JsValue, number_ops};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -19,20 +19,6 @@ fn with_buffer_read<R>(buf: &Rc<RefCell<BufferData>>, f: impl FnOnce(&[u8]) -> R
 
 fn with_buffer_write<R>(buf: &Rc<RefCell<BufferData>>, f: impl FnOnce(&mut [u8]) -> R) -> R {
     (*buf.borrow_mut()).with_write(f)
-}
-
-fn to_int32_modular(n: f64) -> i32 {
-    if n.is_nan() || n.is_infinite() || n == 0.0 {
-        return 0;
-    }
-    let n = n.trunc();
-    let n = n % 4294967296.0; // 2^32
-    let n = if n < 0.0 { n + 4294967296.0 } else { n };
-    if n >= 2147483648.0 {
-        (n - 4294967296.0) as i32
-    } else {
-        n as i32
-    }
 }
 
 impl Interpreter {
@@ -5852,18 +5838,18 @@ impl Interpreter {
         }
 
         dv_set_method!("setInt8", 1, number, |buf: &mut [u8], n: f64, _le: bool| {
-            buf[0] = to_int32_modular(n) as i8 as u8;
+            buf[0] = number_ops::to_int32(n) as i8 as u8;
         });
         dv_set_method!(
             "setUint8",
             1,
             number,
             |buf: &mut [u8], n: f64, _le: bool| {
-                buf[0] = to_int32_modular(n) as u8;
+                buf[0] = number_ops::to_int32(n) as u8;
             }
         );
         dv_set_method!("setInt16", 2, number, |buf: &mut [u8], n: f64, le: bool| {
-            let v = to_int32_modular(n) as i16;
+            let v = number_ops::to_int32(n) as i16;
             let bytes = if le { v.to_le_bytes() } else { v.to_be_bytes() };
             buf.copy_from_slice(&bytes);
         });
@@ -5872,13 +5858,13 @@ impl Interpreter {
             2,
             number,
             |buf: &mut [u8], n: f64, le: bool| {
-                let v = to_int32_modular(n) as u16;
+                let v = number_ops::to_int32(n) as u16;
                 let bytes = if le { v.to_le_bytes() } else { v.to_be_bytes() };
                 buf.copy_from_slice(&bytes);
             }
         );
         dv_set_method!("setInt32", 4, number, |buf: &mut [u8], n: f64, le: bool| {
-            let v = to_int32_modular(n);
+            let v = number_ops::to_int32(n);
             let bytes = if le { v.to_le_bytes() } else { v.to_be_bytes() };
             buf.copy_from_slice(&bytes);
         });
@@ -5887,7 +5873,7 @@ impl Interpreter {
             4,
             number,
             |buf: &mut [u8], n: f64, le: bool| {
-                let v = to_int32_modular(n) as u32;
+                let v = number_ops::to_int32(n) as u32;
                 let bytes = if le { v.to_le_bytes() } else { v.to_be_bytes() };
                 buf.copy_from_slice(&bytes);
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4650,21 +4650,6 @@ impl Interpreter {
     }
 }
 
-/// §7.1.6 ToUint32 — convert an f64 to u32 per spec.
-fn to_uint32_f64(n: f64) -> u32 {
-    if n.is_nan() || n.is_infinite() || n == 0.0 {
-        return 0;
-    }
-    let int_val = n.signum() * n.abs().floor();
-    let modulo = int_val % 4294967296.0;
-    let modulo = if modulo < 0.0 {
-        modulo + 4294967296.0
-    } else {
-        modulo
-    };
-    modulo as u32
-}
-
 fn setup_agent_side_262(interp: &mut Interpreter) {
     use crate::types::JsObject;
 

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -412,7 +412,7 @@ impl Interpreter {
         // 3. Let newLen be ? ToUint32(Desc.[[Value]]).
         //    ToUint32 internally calls ToNumber — this is valueOf call #1
         let num_for_uint32 = self.to_number_value(&desc_value)?;
-        let new_len = to_uint32_f64(num_for_uint32);
+        let new_len = crate::types::number_ops::to_uint32(num_for_uint32);
 
         // 4. Let numberLen be ? ToNumber(Desc.[[Value]]).
         //    This is a separate ToNumber call — valueOf call #2

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -3,7 +3,7 @@ use crate::interpreter::PropertyMap;
 use crate::interpreter::generator_transform::{GeneratorStateMachine, SentValueBinding};
 use crate::interpreter::helpers::same_value;
 use crate::interpreter::key_intern::intern_key;
-use crate::types::{JsString, JsValue};
+use crate::types::{JsString, JsValue, number_ops};
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
@@ -3555,33 +3555,11 @@ fn to_number(v: &JsValue) -> f64 {
     }
 }
 
-fn to_uint32_modular(n: f64) -> u32 {
-    if n.is_nan() || n.is_infinite() || n == 0.0 {
-        return 0;
-    }
-    let n = n.trunc();
-    let n = n % 4294967296.0; // 2^32
-    let n = if n < 0.0 { n + 4294967296.0 } else { n };
-    n as u32
-}
-pub(crate) fn to_int32_modular(n: f64) -> i32 {
-    if n.is_nan() || n.is_infinite() || n == 0.0 {
-        return 0;
-    }
-    let n = n.trunc();
-    let n = n % 4294967296.0; // 2^32
-    let n = if n < 0.0 { n + 4294967296.0 } else { n };
-    if n >= 2147483648.0 {
-        (n - 4294967296.0) as i32
-    } else {
-        n as i32
-    }
-}
 fn to_int8(v: &JsValue) -> i8 {
-    to_int32_modular(to_number(v)) as i8
+    number_ops::to_int32(to_number(v)) as i8
 }
 fn to_uint8(v: &JsValue) -> u8 {
-    to_uint32_modular(to_number(v)) as u8
+    number_ops::to_uint32(to_number(v)) as u8
 }
 fn to_uint8_clamped(v: &JsValue) -> u8 {
     let n = to_number(v);
@@ -3604,16 +3582,16 @@ fn to_uint8_clamped(v: &JsValue) -> u8 {
     }
 }
 fn to_int16(v: &JsValue) -> i16 {
-    to_int32_modular(to_number(v)) as i16
+    number_ops::to_int32(to_number(v)) as i16
 }
 fn to_uint16(v: &JsValue) -> u16 {
-    to_uint32_modular(to_number(v)) as u16
+    number_ops::to_uint32(to_number(v)) as u16
 }
 fn to_int32(v: &JsValue) -> i32 {
-    to_int32_modular(to_number(v))
+    number_ops::to_int32(to_number(v))
 }
 fn to_uint32(v: &JsValue) -> u32 {
-    to_uint32_modular(to_number(v))
+    number_ops::to_uint32(to_number(v))
 }
 fn to_bigint64(v: &JsValue) -> i64 {
     match v {

--- a/src/types.rs
+++ b/src/types.rs
@@ -416,22 +416,26 @@ pub mod number_ops {
         buf.format(x).to_string()
     }
 
-    // §7.1.6 ToInt32
-    pub fn to_int32(x: f64) -> i32 {
-        if x.is_nan() || x.is_infinite() || x == 0.0 {
+    // §7.1.7 ToUint32 — reduce the truncated real value modulo 2^32. The modular
+    // step is done in f64 (exact for integer-valued doubles) so it stays correct
+    // for magnitudes beyond the i64 range, where an `as i64` cast would saturate.
+    pub fn to_uint32(x: f64) -> u32 {
+        if !x.is_finite() || x == 0.0 {
             return 0;
         }
         let int_val = x.trunc();
-        (int_val as i64 as u32) as i32
+        let modulo = int_val % 4294967296.0; // 2^32
+        let int32bit = if modulo < 0.0 {
+            modulo + 4294967296.0
+        } else {
+            modulo
+        };
+        int32bit as u32
     }
 
-    // §7.1.7 ToUint32
-    pub fn to_uint32(x: f64) -> u32 {
-        if x.is_nan() || x.is_infinite() || x == 0.0 {
-            return 0;
-        }
-        let int_val = x.trunc();
-        int_val as i64 as u32
+    // §7.1.6 ToInt32 — the same int32bit as ToUint32, reinterpreted as signed.
+    pub fn to_int32(x: f64) -> i32 {
+        to_uint32(x) as i32
     }
 }
 
@@ -571,6 +575,64 @@ mod tests {
         assert_eq!(number_ops::to_int32(0.0), 0);
         assert_eq!(number_ops::to_int32(42.9), 42);
         assert_eq!(number_ops::to_int32(-42.9), -42);
+    }
+
+    // §7.1.6 ToInt32 / §7.1.7 ToUint32 — spec-correct modular reduction over the
+    // full f64 range. Expected values cross-checked against Node (`x | 0` and
+    // `x >>> 0`). The large-magnitude cases (>= 2^63) are the ones a saturating
+    // `as i64` cast gets wrong.
+    #[test]
+    fn to_uint32_spec_values() {
+        // NaN / +/-Inf / +/-0 -> +0
+        assert_eq!(number_ops::to_uint32(f64::NAN), 0);
+        assert_eq!(number_ops::to_uint32(f64::INFINITY), 0);
+        assert_eq!(number_ops::to_uint32(f64::NEG_INFINITY), 0);
+        assert_eq!(number_ops::to_uint32(-0.0), 0);
+        // truncation toward zero
+        assert_eq!(number_ops::to_uint32(3.9), 3);
+        assert_eq!(number_ops::to_uint32(-2.5), 4294967294);
+        // around the 2^31 / 2^32 boundaries
+        assert_eq!(number_ops::to_uint32(-1.0), 4294967295);
+        assert_eq!(number_ops::to_uint32(2147483648.0), 2147483648); // 2^31
+        assert_eq!(number_ops::to_uint32(4294967295.0), 4294967295); // 2^32-1
+        assert_eq!(number_ops::to_uint32(4294967296.0), 0); // 2^32
+        assert_eq!(number_ops::to_uint32(4294967301.0), 5); // 2^32+5
+        assert_eq!(number_ops::to_uint32(9007199254740992.0), 0); // 2^53
+        // large magnitudes beyond i64 range (saturating cast gets these wrong)
+        assert_eq!(number_ops::to_uint32(9223372036854775808.0), 0); // 2^63
+        assert_eq!(number_ops::to_uint32(18446744073709551616.0), 0); // 2^64
+        assert_eq!(number_ops::to_uint32(-9223372036854775808.0), 0); // -(2^63)
+        assert_eq!(number_ops::to_uint32(1e21), 3735027712);
+    }
+
+    #[test]
+    fn to_int32_spec_values() {
+        assert_eq!(number_ops::to_int32(-1.0), -1);
+        assert_eq!(number_ops::to_int32(2147483647.0), 2147483647); // 2^31-1
+        assert_eq!(number_ops::to_int32(2147483648.0), -2147483648); // 2^31 wraps
+        assert_eq!(number_ops::to_int32(4294967295.0), -1); // 2^32-1
+        assert_eq!(number_ops::to_int32(4294967296.0), 0); // 2^32
+        assert_eq!(number_ops::to_int32(4294967301.0), 5); // 2^32+5
+        assert_eq!(number_ops::to_int32(9007199254740992.0), 0); // 2^53
+        // large magnitudes beyond i64 range (saturating cast gets these wrong)
+        assert_eq!(number_ops::to_int32(9223372036854775808.0), 0); // 2^63
+        assert_eq!(number_ops::to_int32(18446744073709551616.0), 0); // 2^64
+        assert_eq!(number_ops::to_int32(-9223372036854775808.0), 0); // -(2^63)
+        assert_eq!(number_ops::to_int32(1e21), -559939584);
+    }
+
+    #[test]
+    fn bitwise_and_shift_large_values() {
+        // The bitwise/shift operators feed operands through ToInt32/ToUint32, so
+        // large magnitudes must reduce modulo 2^32 (cross-checked against Node).
+        assert_eq!(number_ops::bitwise_or(18446744073709551616.0, 0.0), 0.0); // (2^64)|0
+        assert_eq!(number_ops::bitwise_or(1e21, 0.0), -559939584.0); // (1e21)|0
+        assert_eq!(number_ops::bitwise_and(4294967301.0, 4294967295.0), 5.0);
+        assert_eq!(
+            number_ops::unsigned_right_shift(18446744073709551616.0, 0.0),
+            0.0
+        );
+        assert_eq!(number_ops::unsigned_right_shift(1e21, 0.0), 3735027712.0);
     }
 
     #[test]

--- a/test262-extra/ToInt32-ToUint32-large-magnitudes.js
+++ b/test262-extra/ToInt32-ToUint32-large-magnitudes.js
@@ -1,0 +1,48 @@
+// ToInt32 (§7.1.6) and ToUint32 (§7.1.7) must reduce the truncated real value
+// modulo 2^32 across the whole Number range. For magnitudes >= 2^63 a naive
+// `truncate as i64` conversion saturates and yields the wrong 32-bit result;
+// the modular reduction must be exact. Expected values cross-checked with Node.
+// Spec: ECMAScript, sec-toint32, sec-touint32.
+
+function assertEq(actual, expected, msg) {
+  // Distinguish +0 from -0 as well as ordinary inequality.
+  if (actual !== expected || 1 / actual !== 1 / expected) {
+    throw new Test262Error(
+      msg + ": expected " + expected + " but got " + actual
+    );
+  }
+}
+
+// Bitwise operators funnel operands through ToInt32.
+assertEq((2 ** 31) | 0, -2147483648, "(2**31)|0");
+assertEq((2 ** 32) | 0, 0, "(2**32)|0");
+assertEq((2 ** 32 + 5) | 0, 5, "(2**32+5)|0");
+assertEq((2 ** 53) | 0, 0, "(2**53)|0");
+assertEq((2 ** 63) | 0, 0, "(2**63)|0");
+assertEq((2 ** 64) | 0, 0, "(2**64)|0");
+assertEq((1e21) | 0, -559939584, "(1e21)|0");
+assertEq(~(2 ** 64), -1, "~(2**64)");
+assertEq((2 ** 32 + 5) & 0xffffffff, 5, "(2**32+5) & 0xffffffff");
+
+// Unsigned right shift funnels operands through ToUint32.
+assertEq((2 ** 32) >>> 0, 0, "(2**32)>>>0");
+assertEq((2 ** 64) >>> 0, 0, "(2**64)>>>0");
+assertEq((1e21) >>> 0, 3735027712, "(1e21)>>>0");
+assertEq(-1 >>> 0, 4294967295, "(-1)>>>0");
+
+// Math.imul / Math.clz32 also use ToInt32 / ToUint32.
+assertEq(Math.imul(2 ** 32 + 3, 2), 6, "Math.imul(2**32+3, 2)");
+assertEq(Math.clz32(2 ** 32 + 1), 31, "Math.clz32(2**32+1)");
+
+// Integer TypedArray element writes coerce via ToInt32 / ToUint32.
+var i32 = new Int32Array(1);
+i32[0] = 2 ** 64;
+assertEq(i32[0], 0, "Int32Array <- 2**64");
+i32[0] = 2 ** 32 + 5;
+assertEq(i32[0], 5, "Int32Array <- 2**32+5");
+
+var u32 = new Uint32Array(1);
+u32[0] = 2 ** 64;
+assertEq(u32[0], 0, "Uint32Array <- 2**64");
+u32[0] = -1;
+assertEq(u32[0], 4294967295, "Uint32Array <- -1");


### PR DESCRIPTION
## Refactoring goal

Surfaced by an architecture audit (`improve-codebase-architecture`): the ECMAScript §7.1.6/§7.1.7 `f64 → int32/uint32` conversions were implemented **seven times** across the codebase — the canonical `number_ops::{to_int32,to_uint32}` plus **six near-identical private copies**:

| copy | file |
|------|------|
| `to_uint32_modular`, `to_int32_modular` | `src/interpreter/types.rs` |
| `to_int32_modular` | `src/interpreter/builtins/typedarray.rs` |
| `to_uint32_f64` | `src/interpreter/mod.rs` |
| `to_uint32_f64` | `src/interpreter/builtins/regexp.rs` |
| `to_uint32` | `src/interpreter/builtins/string.rs` |

Six copies of the same modular reduction is textbook technical debt, and the *deletion test* concentrates: removing them collapses the logic into one deep home (`number_ops`) with a small interface.

## The latent bug this exposed

The duplication had already **diverged**. The canonical `number_ops` versions reduced via `x.trunc() as i64 as u32`, which **saturates** for `|x| ≥ 2⁶³` instead of reducing modulo 2³². Since `number_ops` backs *every* bitwise/shift operator plus `Math.imul`/`Math.clz32`, this was wrong at the core of JS integer semantics:

| expression | before | spec / Node |
|------------|--------|-------------|
| `(2**64) \| 0` | `-1` | `0` |
| `(1e21) \| 0` | `-1` | `-559939584` |
| `(2**64) >>> 0` | `4294967295` | `0` |

The six scattered copies all did the *correct* modular arithmetic — so consolidating onto a corrected `number_ops` is behavior-preserving for them and a strict spec-correctness fix for the operators.

## Change

- `number_ops::to_uint32` now reduces modulo 2³² in `f64` (exact for integer-valued doubles), correct across the whole Number range.
- `number_ops::to_int32` is `to_uint32(x) as i32` — the spec relationship (same `int32bit`, reinterpreted as signed).
- Deleted all six duplicate functions; call sites use `number_ops` directly.

Net **−111 / +91** lines (the `+` is mostly new tests).

## Tests (TDD, red → green)

Written **before** the implementation:

- **Unit** (`src/types.rs`): `to_uint32_spec_values`, `to_int32_spec_values`, `bitwise_and_shift_large_values` pin spec behavior at `NaN`, `±Inf`, `±0`, the `2³¹`/`2³²` boundaries, and `2⁵³`/`2⁶³`/`2⁶⁴`/`1e21`. They **fail on the old saturating impl** and pass on the fix. Expected values are cross-checked against Node (independent source of truth), not recomputed from the code.
- **JS** (`test262-extra/ToInt32-ToUint32-large-magnitudes.js`): drives the fix through `|`, `&`, `~`, `>>>`, `Math.imul`, `Math.clz32`, and `Int32Array`/`Uint32Array` element writes.

## Validation — zero regressions vs `origin/main`

- 227 unit tests ✅ · 28 custom tests ✅ · `rustfmt` + `clippy` clean ✅
- test262: bitwise/shift/`Math`/`parseInt` **600/600**; `TypedArray`/`split`/`Array.length` **4708/4710** (2 pre-existing, unrelated `slice` species-ctor fails); **5% full-suite sample** 7003 scenarios — **0 regressions** across all.