### PR TITLE
Fix asyncDispose to call return() with no arguments

### DIFF
--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -3963,10 +3963,9 @@ impl Interpreter {
 
                 // 6. Else,
                 let return_method = return_method.unwrap();
-                //   a. Let result be Call(return, O, « undefined »).
+                //   a. Let result be Call(return, O, « »).
                 //   b. IfAbruptRejectPromise(result, promiseCapability).
-                let result = match interp.call_function(&return_method, this, &[JsValue::Undefined])
-                {
+                let result = match interp.call_function(&return_method, this, &[]) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => {
                         interp.reject_promise(cap_promise_id, e);


### PR DESCRIPTION
## Summary

Fixes a test262 regression introduced by the bump to `d1d583db`.

The explicit-resource-management proposal spec updated `%AsyncIteratorPrototype%[Symbol.asyncDispose]` step 6.a from `Call(return, O, « undefined »)` to `Call(return, O, « »)` — the `return` method must be invoked with an **empty** argument list.

jsse was passing a single `undefined` argument, so the callee observed `arguments.length === 1` instead of `0`.

## Test impact

- **Fixes** `built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/invokes-return.js` (both default and strict scenarios), which asserts `argumentCount === 0`.
- All 18 scenarios under `Symbol.asyncDispose/` pass.
- Full suite: **99,563 / 99,568 passing, 0 regressions** (+2 vs. baseline).

## Remaining known failures (not addressed here, not regressions)

- `Promise/allSettledKeyed/result-property-descriptors.js` (×2) — upstream test bug (reproduces identically on V8), already fixed upstream in test262 `f2d1435644`; resolves on next submodule bump. jsse's `allSettledKeyed` is spec-correct.
- `source-phase-import` re-export (×3) — tracked in #181 (unimplemented `source-phase-imports` proposal).