### PR TITLE
[modules] Implement source-phase import re-export semantics

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1181,16 +1181,14 @@ impl Interpreter {
                 // empty [[ModuleSource]] (GetModuleSource throws SyntaxError).
                 let referrer = self.current_module_path.clone();
                 match self.resolve_source_phase_target(&source, referrer.as_deref()) {
-                    Ok((_, module)) => match module.borrow().module_source.clone() {
-                        Some(ms) => self.create_resolved_promise(ms),
-                        None => {
-                            let err = self.create_error(
-                                "SyntaxError",
-                                "Source phase imports are not available for this module",
-                            );
-                            self.create_rejected_promise(err)
-                        }
-                    },
+                    Ok((_, Some(ms))) => self.create_resolved_promise(ms),
+                    Ok((_, None)) => {
+                        let err = self.create_error(
+                            "SyntaxError",
+                            "Source phase imports are not available for this module",
+                        );
+                        self.create_rejected_promise(err)
+                    }
                     Err(e) => self.create_rejected_promise(e),
                 }
             }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1176,13 +1176,23 @@ impl Interpreter {
                     Ok(s) => s,
                     Err(e) => return self.create_rejected_promise(e),
                 };
-                // Per spec §16.2.1.7.2: GetModuleSource of SourceTextModule always throws SyntaxError
-                let _ = source;
-                let err = self.create_error(
-                    "SyntaxError",
-                    "Source phase imports are not available for this module",
-                );
-                self.create_rejected_promise(err)
+                // ContinueDynamicImport with source phase: resolve to the
+                // target module's [[ModuleSource]]. A Source Text Module has an
+                // empty [[ModuleSource]] (GetModuleSource throws SyntaxError).
+                let referrer = self.current_module_path.clone();
+                match self.resolve_source_phase_target(&source, referrer.as_deref()) {
+                    Ok((_, module)) => match module.borrow().module_source.clone() {
+                        Some(ms) => self.create_resolved_promise(ms),
+                        None => {
+                            let err = self.create_error(
+                                "SyntaxError",
+                                "Source phase imports are not available for this module",
+                            );
+                            self.create_rejected_promise(err)
+                        }
+                    },
+                    Err(e) => self.create_rejected_promise(e),
+                }
             }
             Expression::Template(tmpl) => {
                 let mut code_units: Vec<u16> = Vec::new();

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -158,6 +158,9 @@ impl Interpreter {
             for val in m.exports.values() {
                 Self::collect_value_roots(val, &mut worklist);
             }
+            if let Some(ms) = &m.module_source {
+                Self::collect_value_roots(ms, &mut worklist);
+            }
             if let Some((promise, resolve, reject)) = &m.top_level_capability {
                 Self::collect_value_roots(promise, &mut worklist);
                 Self::collect_value_roots(resolve, &mut worklist);
@@ -169,6 +172,9 @@ impl Interpreter {
             Self::collect_env_roots(&m.env, &mut worklist);
             for val in m.exports.values() {
                 Self::collect_value_roots(val, &mut worklist);
+            }
+            if let Some(ms) = &m.module_source {
+                Self::collect_value_roots(ms, &mut worklist);
             }
         }
         // Trace active call stack environments

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1755,6 +1755,11 @@ impl Interpreter {
         // For deferred imports, load without evaluation.
         for item in &program.module_items {
             let (specifier, is_deferred, import_type) = match item {
+                // Source-phase imports load only the requested module's source
+                // representation (shallow) — never its dependency graph.
+                ModuleItem::ImportDeclaration(import) if Self::is_source_phase_import(import) => {
+                    (None, false, None)
+                }
                 ModuleItem::ImportDeclaration(import) => {
                     let is_defer = import
                         .specifiers
@@ -1986,6 +1991,19 @@ impl Interpreter {
         }
 
         Ok(())
+    }
+
+    /// Whether an ImportDeclaration is a source-phase import
+    /// (`import source X from '...'`), which has exactly one SourcePhase
+    /// specifier. Such imports must be skipped by the module-graph pre-load
+    /// passes: source-phase loading is shallow and never loads/links the
+    /// target's dependency graph (it is handled by `process_source_phase_import`
+    /// / `resolve_source_phase_target`).
+    fn is_source_phase_import(import: &ImportDeclaration) -> bool {
+        matches!(
+            import.specifiers.as_slice(),
+            [ImportSpecifier::SourcePhase(_)]
+        )
     }
 
     /// `import source X from '<specifier>'` — bind `X` to the target module's
@@ -2507,6 +2525,11 @@ impl Interpreter {
         // For non-deferred, load normally (which includes evaluation).
         for item in &program.module_items {
             let (specifier, is_deferred, itype) = match item {
+                // Source-phase imports load only the requested module's source
+                // representation (shallow) — never its dependency graph.
+                ModuleItem::ImportDeclaration(import) if Self::is_source_phase_import(import) => {
+                    (None, false, None)
+                }
                 ModuleItem::ImportDeclaration(import) => {
                     let is_defer = import
                         .specifiers
@@ -2738,6 +2761,11 @@ impl Interpreter {
         // Pre-load pass: load sub-dependencies
         for item in &program.module_items {
             let (specifier, itype) = match item {
+                // Source-phase imports load only the requested module's source
+                // representation (shallow) — never its dependency graph.
+                ModuleItem::ImportDeclaration(import) if Self::is_source_phase_import(import) => {
+                    (None, None)
+                }
                 ModuleItem::ImportDeclaration(import) => (
                     Some(import.source.as_str()),
                     import_module_type(&import.attributes),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -198,7 +198,9 @@ pub struct LoadedModule {
     pub cached_import_meta: Option<JsValue>,        // cached import.meta object per §16.2.1.5.2
     pub error: Option<JsValue>,                     // if module evaluation threw, the error
     pub namespace_imports: HashMap<String, PathBuf>, // local_name -> source module path (for `import * as ns`)
-    pub star_export_sources: Vec<String>,            // source specifiers from `export * from '...'`
+    pub source_imports: HashMap<String, PathBuf>, // local_name -> source-phase target path (for `import source X`)
+    pub module_source: Option<JsValue>, // [[ModuleSource]]: source-phase representation (empty for Source Text Modules)
+    pub star_export_sources: Vec<String>, // source specifiers from `export * from '...'`
     pub evaluated: bool,
     pub is_evaluating: bool,
     pub has_tla: bool,
@@ -675,7 +677,23 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("agent".to_string(), agent_val);
 
-        // $262.AbstractModuleSource — §28.1.1.1
+        // $262.AbstractModuleSource — §28.1.1.1 (source-phase imports proposal)
+        let ams_fn = self.abstract_module_source_constructor(realm_id);
+        self.get_object_cell_expect(dollar_262_id)
+            .borrow_mut()
+            .insert_builtin("AbstractModuleSource".to_string(), ams_fn);
+
+        JsValue::Object(crate::types::JsObject { id: dollar_262_id })
+    }
+
+    /// Get (or lazily mint) the per-realm %AbstractModuleSource% constructor.
+    /// The constructor throws on `[[Construct]]`; its `prototype` is the
+    /// [[Prototype]] shared by every host-provided Module Source object.
+    pub(crate) fn abstract_module_source_constructor(&mut self, realm_id: usize) -> JsValue {
+        if let Some(ctor) = self.realms[realm_id].abstract_module_source_ctor.clone() {
+            return ctor;
+        }
+
         let ams_fn = self.create_function(JsFunction::native(
             "AbstractModuleSource".to_string(),
             0,
@@ -691,7 +709,7 @@ impl Interpreter {
             unreachable!()
         };
 
-        // AbstractModuleSource.prototype_id
+        // %AbstractModuleSource.prototype%
         let ams_proto_id = self.create_object_id();
         // constructor property
         self.get_object_cell_expect(ams_proto_id)
@@ -731,11 +749,91 @@ impl Interpreter {
             );
         }
 
-        self.get_object_cell_expect(dollar_262_id)
-            .borrow_mut()
-            .insert_builtin("AbstractModuleSource".to_string(), ams_fn);
+        self.realms[realm_id].abstract_module_source_ctor = Some(ams_fn.clone());
+        ams_fn
+    }
 
-        JsValue::Object(crate::types::JsObject { id: dollar_262_id })
+    /// Return the [[Prototype]] object id for host-provided Module Source
+    /// objects — i.e. `%AbstractModuleSource.prototype%` in the current realm.
+    fn abstract_module_source_prototype_id(&mut self) -> Option<u64> {
+        let ctor = self.abstract_module_source_constructor(self.current_realm_id);
+        if let JsValue::Object(o) = ctor
+            && let JsValue::Object(p) = self.get_property_on_id(o.id, "prototype")
+        {
+            return Some(p.id);
+        }
+        None
+    }
+
+    /// Get (or lazily create) the host module that the `<module source>`
+    /// test262 specifier resolves to. Its `[[ModuleSource]]` is a fresh
+    /// %AbstractModuleSource% instance; it exposes no bindings.
+    fn get_or_create_module_source_module(&mut self) -> Rc<RefCell<LoadedModule>> {
+        let sentinel = PathBuf::from("<module source>");
+        if let Some(existing) = self.module_registry_get(&sentinel) {
+            return existing;
+        }
+
+        // The Module Source object: an ordinary object whose [[Prototype]] is
+        // %AbstractModuleSource.prototype% so `x instanceof AbstractModuleSource`.
+        let source_id = self.create_object_id();
+        let proto_id = self.abstract_module_source_prototype_id();
+        {
+            let mut obj = self.get_object_cell_expect(source_id).borrow_mut();
+            obj.prototype_id = proto_id;
+            obj.class_name = "AbstractModuleSource".to_string();
+        }
+        let source_val = JsValue::Object(crate::types::JsObject { id: source_id });
+
+        let module_env = Environment::new_function_scope(Some(self.realm().global_env.clone()));
+        module_env.borrow_mut().strict = true;
+        let module = Rc::new(RefCell::new(LoadedModule {
+            path: sentinel.clone(),
+            env: module_env,
+            exports: HashMap::new(),
+            export_bindings: HashMap::new(),
+            cached_namespace: None,
+            cached_deferred_namespace: None,
+            cached_import_meta: None,
+            error: None,
+            namespace_imports: HashMap::new(),
+            source_imports: HashMap::new(),
+            module_source: Some(source_val),
+            star_export_sources: Vec::new(),
+            evaluated: true,
+            is_evaluating: false,
+            deferred_only: false,
+            has_tla: false,
+            program_ast: None,
+            async_evaluation_order: None,
+            pending_async_dependencies: 0,
+            async_parent_modules: Vec::new(),
+            cycle_root: None,
+            top_level_capability: None,
+            dfs_index: None,
+            dfs_ancestor_index: None,
+        }));
+        self.module_registry_insert(sentinel, module.clone());
+        module
+    }
+
+    /// Resolve the target module for a source-phase import (`import source X
+    /// from '<specifier>'` / `import.source('<specifier>')`). The test262
+    /// `<module source>` host specifier maps to a synthetic host module whose
+    /// `[[ModuleSource]]` is populated; any other specifier resolves as a
+    /// normal Source Text Module (whose `[[ModuleSource]]` is empty).
+    fn resolve_source_phase_target(
+        &mut self,
+        specifier: &str,
+        referrer: Option<&Path>,
+    ) -> Result<(PathBuf, Rc<RefCell<LoadedModule>>), JsValue> {
+        if specifier == "<module source>" {
+            let module = self.get_or_create_module_source_module();
+            return Ok((PathBuf::from("<module source>"), module));
+        }
+        let resolved = self.resolve_module_specifier(specifier, referrer)?;
+        let module = self.load_module(&resolved)?;
+        Ok((resolved, module))
     }
 
     pub(crate) fn gc_root_value(&mut self, val: &JsValue) {
@@ -1580,6 +1678,8 @@ impl Interpreter {
             cached_import_meta: None,
             error: None,
             namespace_imports: HashMap::new(),
+            source_imports: HashMap::new(),
+            module_source: None,
             star_export_sources: Vec::new(),
             evaluated: false,
             is_evaluating: false,
@@ -1776,6 +1876,15 @@ impl Interpreter {
 
     fn process_import(&mut self, import: &ImportDeclaration, env: &EnvRef) -> Result<(), JsValue> {
         let module_path = self.current_module_path.clone();
+
+        // Source-phase import (`import source X from '...'`) — a source-phase
+        // ImportDeclaration has exactly one SourcePhase specifier. Handle it
+        // before the generic specifier resolution, which cannot resolve the
+        // host `<module source>` specifier.
+        if let [ImportSpecifier::SourcePhase(local)] = import.specifiers.as_slice() {
+            return self.process_source_phase_import(local, &import.source, env);
+        }
+
         let resolved = self.resolve_module_specifier(&import.source, module_path.as_deref())?;
 
         let itype = import_module_type(&import.attributes);
@@ -1868,6 +1977,45 @@ impl Interpreter {
         Ok(())
     }
 
+    /// `import source X from '<specifier>'` — bind `X` to the target module's
+    /// `[[ModuleSource]]` (source-phase imports proposal, InitializeEnvironment
+    /// step 7.d.v / 7.e). A Source Text Module has an empty `[[ModuleSource]]`,
+    /// which is a SyntaxError.
+    fn process_source_phase_import(
+        &mut self,
+        local: &str,
+        specifier: &str,
+        env: &EnvRef,
+    ) -> Result<(), JsValue> {
+        let referrer = self.current_module_path.clone();
+        let (target_path, target) =
+            self.resolve_source_phase_target(specifier, referrer.as_deref())?;
+
+        let module_source = target.borrow().module_source.clone();
+        let Some(module_source) = module_source else {
+            return Err(self.create_error(
+                "SyntaxError",
+                &format!("Module '{specifier}' has no source phase representation"),
+            ));
+        };
+
+        env.borrow_mut().declare(local, BindingKind::Const);
+        env.borrow_mut().initialize_binding(local, module_source);
+
+        // Record the source-phase target so `export { X }` re-exports resolve
+        // to the same ResolvedBinding { [[Module]], [[BindingName]]: ~source~ }.
+        if let Some(ref mp) = referrer {
+            let canon = mp.canonicalize().unwrap_or_else(|_| mp.clone());
+            if let Some(current_mod) = self.module_registry_get(&canon) {
+                current_mod
+                    .borrow_mut()
+                    .source_imports
+                    .insert(local.to_string(), target_path);
+            }
+        }
+        Ok(())
+    }
+
     fn create_import_binding_for(
         &mut self,
         local: &str,
@@ -1897,6 +2045,24 @@ impl Interpreter {
                         let ns = self.create_namespace_for_env(&source_env);
                         env.borrow_mut().declare(local, BindingKind::Const);
                         env.borrow_mut().initialize_binding(local, ns);
+                    } else if binding_name == "*source*" {
+                        // Resolved to a source-phase binding — bind to the
+                        // target module's [[ModuleSource]] (InitializeEnvironment
+                        // step 7.d.v). Empty [[ModuleSource]] is a SyntaxError.
+                        match self.module_source_for_env(&source_env) {
+                            Some(ms) => {
+                                env.borrow_mut().declare(local, BindingKind::Const);
+                                env.borrow_mut().initialize_binding(local, ms);
+                            }
+                            None => {
+                                return Err(self.create_error(
+                                    "SyntaxError",
+                                    &format!(
+                                        "Module '{imported}' has no source phase representation"
+                                    ),
+                                ));
+                            }
+                        }
                     } else {
                         env.borrow_mut()
                             .create_import_binding(local, source_env, binding_name);
@@ -2158,6 +2324,8 @@ impl Interpreter {
                 cached_import_meta: None,
                 error: None,
                 namespace_imports: HashMap::new(),
+                source_imports: HashMap::new(),
+                module_source: None,
                 star_export_sources: Vec::new(),
                 evaluated: true,
                 is_evaluating: false,
@@ -2228,6 +2396,8 @@ impl Interpreter {
             cached_import_meta: None,
             error: None,
             namespace_imports: HashMap::new(),
+            source_imports: HashMap::new(),
+            module_source: None,
             star_export_sources: Vec::new(),
             evaluated: false,
             is_evaluating: false,
@@ -2308,7 +2478,12 @@ impl Interpreter {
                 }) => Some(s.as_str()),
                 _ => None,
             };
+            // The test262 `<module source>` host specifier is resolved by the
+            // host (source-phase imports), not as a file path; every other
+            // specifier — including source-phase targets like `<do not resolve>`
+            // — must still surface unresolvable-specifier errors here.
             if let Some(spec) = specifier
+                && spec != "<module source>"
                 && let Err(e) = self.resolve_module_specifier(spec, Some(&canon_path))
             {
                 Self::cache_module_error(&loaded_module, &e);
@@ -2485,6 +2660,8 @@ impl Interpreter {
             cached_import_meta: None,
             error: None,
             namespace_imports: HashMap::new(),
+            source_imports: HashMap::new(),
+            module_source: None,
             star_export_sources: Vec::new(),
             evaluated: false,
             is_evaluating: false,
@@ -2664,6 +2841,8 @@ impl Interpreter {
             cached_import_meta: None,
             error: None,
             namespace_imports: HashMap::new(),
+            source_imports: HashMap::new(),
+            module_source: None,
             star_export_sources: Vec::new(),
             evaluated: true,
             is_evaluating: false,
@@ -3628,12 +3807,23 @@ impl Interpreter {
                     let binding_name = binding.clone();
                     let env = module_ref.env.clone();
                     let ns_path = module_ref.namespace_imports.get(&binding_name).cloned();
+                    let source_path = module_ref.source_imports.get(&binding_name).cloned();
                     drop(module_ref);
                     // Namespace import (import * as foo) resolves to the source module
                     if let Some(ns_path) = ns_path
                         && let Ok(ns_mod) = self.load_module(&ns_path)
                     {
                         return Ok((ns_mod.borrow().env.clone(), "*namespace*".to_string()));
+                    }
+                    // Source-phase import (import source foo) re-exported via
+                    // `export { foo }` resolves to ResolvedBinding { [[Module]]:
+                    // source-phase target, [[BindingName]]: ~source~ }. Two
+                    // re-exports of the same `<module source>` therefore compare
+                    // equal (same target env + "*source*"), so are unambiguous.
+                    if let Some(source_path) = source_path
+                        && let Ok(source_mod) = self.load_module(&source_path)
+                    {
+                        return Ok((source_mod.borrow().env.clone(), "*source*".to_string()));
                     }
                     // Check if it's an indirect (imported) binding
                     if let Some(ref indirect_map) = env.borrow().indirect_bindings
@@ -4141,6 +4331,18 @@ impl Interpreter {
             return self.create_module_namespace(&module);
         }
         JsValue::Undefined
+    }
+
+    /// Find the [[ModuleSource]] of the module whose environment is `target_env`.
+    /// Used to resolve `~source~` re-export bindings to the source object.
+    fn module_source_for_env(&self, target_env: &EnvRef) -> Option<JsValue> {
+        let realm_id = self.current_realm_id;
+        self.module_registry
+            .iter()
+            .filter(|((rid, _), _)| *rid == realm_id)
+            .map(|(_, module)| module)
+            .find(|m| Rc::ptr_eq(&m.borrow().env, target_env))
+            .and_then(|m| m.borrow().module_source.clone())
     }
 
     fn hoist_module_statement(&mut self, stmt: &Statement, env: &EnvRef) {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -817,30 +817,34 @@ impl Interpreter {
         module
     }
 
-    /// Resolve the target module for a source-phase import (`import source X
-    /// from '<specifier>'` / `import.source('<specifier>')`). The test262
-    /// `<module source>` host specifier maps to a synthetic host module whose
-    /// `[[ModuleSource]]` is populated; any other specifier resolves as a
-    /// normal Source Text Module (whose `[[ModuleSource]]` is empty).
+    /// Resolve the `[[ModuleSource]]` for a source-phase import (`import source
+    /// X from '<specifier>'` / `import.source('<specifier>')`), returning the
+    /// resolved path and the source object (`None` when the target has no
+    /// source-phase representation, which the caller turns into a SyntaxError).
     ///
-    /// Loads via `load_module_no_eval`: the source phase never evaluates the
-    /// target and `GetModuleSource` does not consult `[[EvaluationError]]`, so a
-    /// module that previously evaluated-and-threw (e.g. via an earlier plain
-    /// `import()`) must still surface its `[[ModuleSource]]` result — here, the
-    /// source-phase SyntaxError — rather than replaying the cached eval error.
-    /// Parse/link errors are still surfaced (they precede evaluation).
+    /// The test262 `<module source>` host specifier maps to a synthetic host
+    /// module whose `[[ModuleSource]]` is populated. For any other specifier,
+    /// source-phase loading is *shallow*: it resolves the requested specifier
+    /// (a genuine host-resolution failure of that specifier surfaces here as a
+    /// non-SyntaxError) but must NOT load, link, or evaluate the target — the
+    /// source phase never triggers host loads for the target's transitive
+    /// dependencies, nor consults `[[EvaluationError]]`. jsse has no concrete
+    /// Module Source kind, so every resolvable file is an ordinary Source Text
+    /// Module with an empty `[[ModuleSource]]`; returning `None` here lets the
+    /// caller reject with the source-phase SyntaxError without exposing the
+    /// target's dependency-resolution, link, or cached evaluation errors.
     fn resolve_source_phase_target(
         &mut self,
         specifier: &str,
         referrer: Option<&Path>,
-    ) -> Result<(PathBuf, Rc<RefCell<LoadedModule>>), JsValue> {
+    ) -> Result<(PathBuf, Option<JsValue>), JsValue> {
         if specifier == "<module source>" {
             let module = self.get_or_create_module_source_module();
-            return Ok((PathBuf::from("<module source>"), module));
+            let module_source = module.borrow().module_source.clone();
+            return Ok((PathBuf::from("<module source>"), module_source));
         }
         let resolved = self.resolve_module_specifier(specifier, referrer)?;
-        let module = self.load_module_no_eval(&resolved)?;
-        Ok((resolved, module))
+        Ok((resolved, None))
     }
 
     pub(crate) fn gc_root_value(&mut self, val: &JsValue) {
@@ -1995,10 +1999,9 @@ impl Interpreter {
         env: &EnvRef,
     ) -> Result<(), JsValue> {
         let referrer = self.current_module_path.clone();
-        let (target_path, target) =
+        let (target_path, module_source) =
             self.resolve_source_phase_target(specifier, referrer.as_deref())?;
 
-        let module_source = target.borrow().module_source.clone();
         let Some(module_source) = module_source else {
             return Err(self.create_error(
                 "SyntaxError",

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -822,6 +822,13 @@ impl Interpreter {
     /// `<module source>` host specifier maps to a synthetic host module whose
     /// `[[ModuleSource]]` is populated; any other specifier resolves as a
     /// normal Source Text Module (whose `[[ModuleSource]]` is empty).
+    ///
+    /// Loads via `load_module_no_eval`: the source phase never evaluates the
+    /// target and `GetModuleSource` does not consult `[[EvaluationError]]`, so a
+    /// module that previously evaluated-and-threw (e.g. via an earlier plain
+    /// `import()`) must still surface its `[[ModuleSource]]` result — here, the
+    /// source-phase SyntaxError — rather than replaying the cached eval error.
+    /// Parse/link errors are still surfaced (they precede evaluation).
     fn resolve_source_phase_target(
         &mut self,
         specifier: &str,
@@ -832,7 +839,7 @@ impl Interpreter {
             return Ok((PathBuf::from("<module source>"), module));
         }
         let resolved = self.resolve_module_specifier(specifier, referrer)?;
-        let module = self.load_module(&resolved)?;
+        let module = self.load_module_no_eval(&resolved)?;
         Ok((resolved, module))
     }
 

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -388,6 +388,10 @@ pub struct Realm {
     /// ECMA-402 %Intl%.[[FallbackSymbol]]: a fresh per-realm Symbol with
     /// description "IntlLegacyConstructedSymbol", minted lazily on first use.
     pub(crate) intl_fallback_symbol: Option<JsValue>,
+    /// %AbstractModuleSource% constructor (source-phase imports proposal),
+    /// minted lazily on first use. Its `prototype` is the [[Prototype]] of
+    /// every host-provided Module Source object.
+    pub(crate) abstract_module_source_ctor: Option<JsValue>,
     pub(crate) error_prototype: Option<u64>,
     pub(crate) type_error_prototype: Option<u64>,
     pub(crate) range_error_prototype: Option<u64>,
@@ -485,6 +489,7 @@ impl Realm {
             intl_date_time_format_ctor: None,
             intl_duration_format_ctor: None,
             intl_fallback_symbol: None,
+            abstract_module_source_ctor: None,
             error_prototype: None,
             type_error_prototype: None,
             range_error_prototype: None,
@@ -598,6 +603,7 @@ impl Realm {
             &self.intl_date_time_format_ctor,
             &self.intl_duration_format_ctor,
             &self.typed_array_constructor,
+            &self.abstract_module_source_ctor,
         ] {
             if let Some(JsValue::Object(o)) = ctor {
                 worklist.push(o.id);

--- a/test262-extra/source-phase-import-eval-error-dep.mjs
+++ b/test262-extra/source-phase-import-eval-error-dep.mjs
@@ -1,0 +1,4 @@
+// Fixture for ./source-phase-import-eval-error.mjs — an ordinary Source Text
+// Module that throws during evaluation. Imported normally first (to cache the
+// evaluation error), then via `import.source()` which must NOT replay it.
+throw new Error("boom during evaluation");

--- a/test262-extra/source-phase-import-eval-error.mjs
+++ b/test262-extra/source-phase-import-eval-error.mjs
@@ -1,0 +1,37 @@
+// Source-phase imports: `import.source()` of an ordinary Source Text Module
+// must reject with the source-phase SyntaxError (GetModuleSource, §16.2.1.7.2)
+// even after a prior plain dynamic import of the same module evaluated it and
+// rejected. ContinueDynamicImport for the source phase never evaluates the
+// module or consults [[EvaluationError]]
+// (https://tc39.es/proposal-source-phase-imports/#sec-continuedynamicimport),
+// so the cached evaluation failure must not leak into the source-phase result.
+//
+// Regression guard for the review feedback on PR #220 (pmatos/jsse#181).
+// flags: [module]
+
+// A plain dynamic import evaluates the module and rejects, caching the
+// thrown value as the module's [[EvaluationError]].
+let evalErr = null;
+try {
+  await import('./source-phase-import-eval-error-dep.mjs');
+} catch (e) {
+  evalErr = e;
+}
+if (evalErr === null) {
+  throw new Error('plain import of a throwing module should reject');
+}
+if (evalErr instanceof SyntaxError) {
+  throw new Error('plain import should reject with the thrown error, not a SyntaxError');
+}
+
+// import.source() of the same module must reject with the source-phase
+// SyntaxError, NOT replay the cached evaluation error.
+let srcErr = null;
+try {
+  await import.source('./source-phase-import-eval-error-dep.mjs');
+} catch (e) {
+  srcErr = e;
+}
+if (!(srcErr instanceof SyntaxError)) {
+  throw new Error('import.source() after a cached evaluation error should reject with a SyntaxError, got: ' + srcErr);
+}

--- a/test262-extra/source-phase-import-module-source-plain-dep.mjs
+++ b/test262-extra/source-phase-import-module-source-plain-dep.mjs
@@ -1,0 +1,4 @@
+// Fixture for ./source-phase-import-module-source.mjs — an ordinary Source
+// Text Module. Its [[ModuleSource]] is empty, so `import.source()` of it must
+// reject with a SyntaxError (GetModuleSource, §16.2.1.7.2).
+export const plain = 1;

--- a/test262-extra/source-phase-import-module-source.mjs
+++ b/test262-extra/source-phase-import-module-source.mjs
@@ -1,0 +1,49 @@
+// Source-phase imports (https://github.com/tc39/proposal-source-phase-imports):
+// the `<module source>` host specifier resolves to a module whose
+// [[ModuleSource]] is an %AbstractModuleSource% instance, and both the static
+// (`import source X from`) and dynamic (`import.source()`) forms expose it.
+//
+// Not covered by test262: the dynamic `import.source()` *success* path
+// (test262's import.source cases are syntax-only or resolution failures) and
+// the SyntaxError result of `import.source()` on an ordinary Source Text
+// Module (GetModuleSource, §16.2.1.7.2).
+//
+// Spec:
+//   - InitializeEnvironment step 7.d.v / 7.e (import source X binding)
+//   - GetModuleSource: a Source Text Module has an empty [[ModuleSource]]
+//   - %AbstractModuleSource% (§28.1.1)
+// flags: [module]
+
+// --- static `import source X from '<module source>'` ---
+import source staticSource from '<module source>';
+
+if (typeof staticSource !== 'object' || staticSource === null) {
+  throw new Error('import source binding should be a Module Source object');
+}
+if (!(staticSource instanceof $262.AbstractModuleSource)) {
+  throw new Error('import source binding should be a %AbstractModuleSource% instance');
+}
+
+// --- dynamic `import.source('<module source>')` resolves to a Module Source ---
+const dynamicSource = await import.source('<module source>');
+
+if (!(dynamicSource instanceof $262.AbstractModuleSource)) {
+  throw new Error('import.source() should resolve to a %AbstractModuleSource% instance');
+}
+// The host resolves `<module source>` to the same Module Record every time,
+// so both forms observe the same [[ModuleSource]] object.
+if (dynamicSource !== staticSource) {
+  throw new Error('import.source() and import source should yield the same [[ModuleSource]]');
+}
+
+// --- import.source() of an ordinary module rejects with SyntaxError ---
+// A Source Text Module has an empty [[ModuleSource]]; GetModuleSource throws.
+let rejection = null;
+try {
+  await import.source('./source-phase-import-module-source-plain-dep.mjs');
+} catch (e) {
+  rejection = e;
+}
+if (!(rejection instanceof SyntaxError)) {
+  throw new Error('import.source() of a Source Text Module should reject with a SyntaxError, got: ' + rejection);
+}

--- a/test262-extra/source-phase-reexport-a-dep.mjs
+++ b/test262-extra/source-phase-reexport-a-dep.mjs
@@ -1,0 +1,5 @@
+// Fixture for ./source-phase-reexport.mjs — one of two modules re-exporting
+// the same `<module source>` binding as `mod`, star-combined in
+// ./source-phase-reexport-star-dep.mjs.
+import source mod from '<module source>';
+export { mod };

--- a/test262-extra/source-phase-reexport-b-dep.mjs
+++ b/test262-extra/source-phase-reexport-b-dep.mjs
@@ -1,0 +1,5 @@
+// Fixture for ./source-phase-reexport.mjs — the second module re-exporting the
+// same `<module source>` binding as `mod` (see ...-a-dep.mjs). Because both
+// resolve to the same [[Module]] + ~source~, the star combination is unambiguous.
+import source mod from '<module source>';
+export { mod };

--- a/test262-extra/source-phase-reexport-dep.mjs
+++ b/test262-extra/source-phase-reexport-dep.mjs
@@ -1,0 +1,5 @@
+// Fixture for ./source-phase-reexport.mjs — re-exports a source-phase binding.
+// `export { x }` where `x` is bound by `import source` is reclassified to an
+// indirect ExportEntry with [[ImportName]] ~source~.
+import source x from '<module source>';
+export { x };

--- a/test262-extra/source-phase-reexport-star-dep.mjs
+++ b/test262-extra/source-phase-reexport-star-dep.mjs
@@ -1,0 +1,5 @@
+// Fixture for ./source-phase-reexport.mjs — star-re-exports `mod` from two
+// modules that both `import source mod from '<module source>'`. ResolveExport
+// finds the same [[Module]] + ~source~ from both, so `mod` is unambiguous.
+export * from './source-phase-reexport-a-dep.mjs';
+export * from './source-phase-reexport-b-dep.mjs';

--- a/test262-extra/source-phase-reexport.mjs
+++ b/test262-extra/source-phase-reexport.mjs
@@ -1,0 +1,41 @@
+// Source-phase imports: re-exporting a source-phase binding
+// (`import source x from '...'; export { x };`) reclassifies the export to an
+// indirect ExportEntry whose [[ImportName]] is ~source~. Resolving it yields a
+// ResolvedBinding { [[Module]]: source-phase target, [[BindingName]]: ~source~ }
+// which binds to the target's [[ModuleSource]].
+//
+// This is a local regression guard for the fix tracked by pmatos/jsse#181,
+// mirroring the three test262 cases:
+//   language/module-code/source-phase-import/reexport-source-binding-named-import.js
+//   language/module-code/source-phase-import/reexport-source-binding-namespace-get.js
+//   language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js
+//
+// Spec:
+//   - ResolveExport ~source~ (sec-resolveexport)
+//   - Module Namespace [[Get]] ~source~ (sec-module-namespace-...-get)
+// flags: [module]
+
+// A named import of a re-exported source-phase binding binds to the
+// underlying [[ModuleSource]].
+import { x } from './source-phase-reexport-dep.mjs';
+// A namespace import observes the same [[ModuleSource]] via [[Get]].
+import * as ns from './source-phase-reexport-dep.mjs';
+// Re-exporting the same `<module source>` binding from two modules through
+// `export *` is unambiguous: both resolve to the same [[Module]] + ~source~.
+import { mod } from './source-phase-reexport-star-dep.mjs';
+
+if (!(x instanceof $262.AbstractModuleSource)) {
+  throw new Error('named re-exported source binding should be a %AbstractModuleSource% instance');
+}
+if (!(ns.x instanceof $262.AbstractModuleSource)) {
+  throw new Error('namespace [[Get]] of a re-exported source binding should be a %AbstractModuleSource% instance');
+}
+if (ns.x !== x) {
+  throw new Error('the named and namespace views should observe the same [[ModuleSource]]');
+}
+if (!(mod instanceof $262.AbstractModuleSource)) {
+  throw new Error('unambiguous double star re-export should resolve to a %AbstractModuleSource% instance');
+}
+if (mod !== x) {
+  throw new Error('all re-exports of the same `<module source>` should observe the same [[ModuleSource]]');
+}

--- a/test262-extra/source-phase-shallow-load.mjs
+++ b/test262-extra/source-phase-shallow-load.mjs
@@ -1,0 +1,20 @@
+// Source-phase imports: source-phase loading is *shallow* — it loads only the
+// requested module's source representation and never resolves, links, or
+// evaluates the target's dependency graph
+// (https://tc39.es/proposal-source-phase-imports/#sec-continuedynamicimport).
+// `import.source()` of an ordinary Source Text Module must reject with the
+// source-phase SyntaxError even when that module imports a missing/invalid
+// dependency — the transitive dependency error must not leak out.
+//
+// Regression guard for the review feedback on PR #220 (pmatos/jsse#181).
+// flags: [module]
+
+let err = null;
+try {
+  await import.source('./source-phase-shallow-target-dep.mjs');
+} catch (e) {
+  err = e;
+}
+if (!(err instanceof SyntaxError)) {
+  throw new Error('import.source() of a module with a missing transitive dependency should reject with a SyntaxError (shallow source-phase load), got: ' + err);
+}

--- a/test262-extra/source-phase-shallow-target-dep.mjs
+++ b/test262-extra/source-phase-shallow-target-dep.mjs
@@ -1,0 +1,6 @@
+// Fixture for ./source-phase-shallow-load.mjs — an ordinary Source Text Module
+// whose own (transitive) dependency does not exist. Source-phase loading must
+// NOT resolve/link this dependency: it should surface the source-phase
+// SyntaxError for the requested module, not the missing-dependency error.
+import { missing } from './source-phase-shallow-nonexistent.mjs';
+export const y = missing;

--- a/test262-extra/source-phase-static-importer-dep.mjs
+++ b/test262-extra/source-phase-static-importer-dep.mjs
@@ -1,0 +1,7 @@
+// Fixture for ./source-phase-static-shallow.mjs — statically source-phase
+// imports a Source Text Module whose own dependency is missing. Static
+// source-phase loading must be shallow (not load the target's dependency
+// graph), so linking this module fails with the source-phase SyntaxError,
+// NOT the target's missing-dependency error.
+import source x from './source-phase-shallow-target-dep.mjs';
+export const value = x;

--- a/test262-extra/source-phase-static-shallow.mjs
+++ b/test262-extra/source-phase-static-shallow.mjs
@@ -1,0 +1,22 @@
+// Source-phase imports: the STATIC form (`import source x from '...'`) is
+// shallow too — the module-graph pre-load passes must not load/link the
+// source-phase target's dependency graph. A static `import source` of an
+// ordinary Source Text Module whose transitive dependency is missing must
+// fail to link with the source-phase SyntaxError, not the missing-dependency
+// error.
+//
+// Companion to ./source-phase-shallow-load.mjs (which covers the dynamic
+// `import.source()` form). Regression guard for PR #220 (pmatos/jsse#181).
+// flags: [module]
+
+// Dynamically import a module that statically source-phase-imports a target
+// with a missing dependency; its link must fail with a SyntaxError.
+let err = null;
+try {
+  await import('./source-phase-static-importer-dep.mjs');
+} catch (e) {
+  err = e;
+}
+if (!(err instanceof SyntaxError)) {
+  throw new Error('a static `import source` of a module with a missing transitive dependency should fail to link with a SyntaxError (shallow source-phase load), got: ' + err);
+}


### PR DESCRIPTION
## Summary

Implements the runtime half of the [source-phase imports proposal](https://github.com/tc39/proposal-source-phase-imports) that the existing `import source X from '...'` parser stub left unimplemented. The three tracked test262 re-export cases all failed with `Cannot resolve bare module specifier '<module source>'`; this wires up the missing pieces:

- **Host source resolution** — the test262 `<module source>` host specifier resolves to a synthetic module whose `[[ModuleSource]]` is a lazily-minted per-realm `%AbstractModuleSource%` instance (`LoadedModule.module_source`, `Realm.abstract_module_source_ctor`, both GC-rooted).
- **Static `import source X`** — binds `X` to the target's `[[ModuleSource]]` (`InitializeEnvironment` 7.d.v); an ordinary Source Text Module has an empty `[[ModuleSource]]`, which is a `SyntaxError`.
- **`~source~` re-export** — `export { X }` of a source-phase binding resolves to `ResolvedBinding { [[Module]]: target, [[BindingName]]: ~source~ }`, so two `export *` re-exports of the same `<module source>` compare equal and are **unambiguous**; the named import and namespace `[[Get]]` both observe the underlying source object.
- **Dynamic `import.source()`** — resolves to the target's `[[ModuleSource]]` (previously always rejected).

The `%AbstractModuleSource%` constructor build was extracted from `create_dollar_262` into a lazily-minted, cached per-realm helper so `$262.AbstractModuleSource.prototype` and every Module Source object share one prototype identity.

Fixes #181

## Test plan

- [x] `cargo build --release` — clean
- [x] `./scripts/lint.sh` (clippy + rustfmt) — clean
- [x] Full test262 suite — **99,568 / 99,568 (100.00%), 0 failures, 0 regressions, +323 new passes** vs `origin/main:test262-pass.txt`
- [x] The 3 tracked tests now pass (`reexport-source-binding-named-import`, `reexport-source-binding-namespace-get`, `namespace-unambiguous-if-import-source-and-export`)
- [x] Guard dirs unchanged: `built-ins/AbstractModuleSource/` (8/8), `language/expressions/dynamic-import/` (1900/1900), full `language/module-code/`
- [x] New `test262-extra/` regression tests (static + dynamic `import.source`, named/namespace re-export, unambiguous double-star re-export) — custom suite 28/28