### PR TITLE
Consolidate five duplicate Pattern BoundNames walks into Pattern::bound_names

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -296,6 +296,41 @@ pub enum ObjectPatternProperty {
     Rest(Pattern),
 }
 
+impl Pattern {
+    /// Static Semantics: BoundNames — append the identifier names this binding
+    /// pattern introduces, in source order, to `out`.
+    ///
+    /// Property keys and default-value expressions contribute no names; a
+    /// `MemberExpression` target (only reachable in destructuring assignment)
+    /// binds nothing. Holes in an array pattern are skipped.
+    pub(crate) fn bound_names(&self, out: &mut Vec<String>) {
+        match self {
+            Pattern::Identifier(name) => out.push(name.clone()),
+            Pattern::Array(elems) => {
+                for elem in elems.iter().flatten() {
+                    match elem {
+                        ArrayPatternElement::Pattern(p) | ArrayPatternElement::Rest(p) => {
+                            p.bound_names(out);
+                        }
+                    }
+                }
+            }
+            Pattern::Object(props) => {
+                for prop in props {
+                    match prop {
+                        ObjectPatternProperty::KeyValue(_, p) | ObjectPatternProperty::Rest(p) => {
+                            p.bound_names(out);
+                        }
+                        ObjectPatternProperty::Shorthand(name) => out.push(name.clone()),
+                    }
+                }
+            }
+            Pattern::Assign(inner, _) | Pattern::Rest(inner) => inner.bound_names(out),
+            Pattern::MemberExpression(_) => {}
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum Expression {
     Literal(Literal),
@@ -1695,5 +1730,92 @@ mod ic_site_tests {
         assert!(program.body.ic.assigned);
         assert_eq!(program.body.ic.call_site_count, 2);
         assert_eq!(program.body.ic.prop_site_count, 1);
+    }
+}
+
+#[cfg(test)]
+mod bound_names_tests {
+    use super::*;
+
+    fn names_of(pat: &Pattern) -> Vec<String> {
+        let mut out = Vec::new();
+        pat.bound_names(&mut out);
+        out
+    }
+
+    fn ident(name: &str) -> Pattern {
+        Pattern::Identifier(name.to_string())
+    }
+
+    #[test]
+    fn identifier_binds_its_name() {
+        assert_eq!(names_of(&ident("x")), vec!["x"]);
+    }
+
+    #[test]
+    fn member_expression_binds_nothing() {
+        // `[obj.prop] = ...` — an assignment target, not a declaration.
+        let pat = Pattern::MemberExpression(Box::new(Expression::Identifier("obj".to_string())));
+        assert_eq!(names_of(&pat), Vec::<String>::new());
+    }
+
+    #[test]
+    fn assignment_default_binds_only_the_inner_name() {
+        // `a = 5` binds `a`; the default-value expression contributes no names.
+        let pat = Pattern::Assign(
+            Box::new(ident("a")),
+            Box::new(Expression::Identifier("unused".to_string())),
+        );
+        assert_eq!(names_of(&pat), vec!["a"]);
+    }
+
+    #[test]
+    fn rest_binds_inner_name() {
+        let pat = Pattern::Rest(Box::new(ident("r")));
+        assert_eq!(names_of(&pat), vec!["r"]);
+    }
+
+    #[test]
+    fn array_pattern_binds_in_source_order_skipping_holes() {
+        // `[a, , ...b]`
+        let pat = Pattern::Array(vec![
+            Some(ArrayPatternElement::Pattern(ident("a"))),
+            None,
+            Some(ArrayPatternElement::Rest(ident("b"))),
+        ]);
+        assert_eq!(names_of(&pat), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn object_pattern_binds_shorthand_and_value_and_rest_but_not_key() {
+        // `{ s, k: v, ...r }` binds s, v, r — the property key `k` is not bound.
+        let pat = Pattern::Object(vec![
+            ObjectPatternProperty::Shorthand("s".to_string()),
+            ObjectPatternProperty::KeyValue(PropertyKey::Identifier("k".to_string()), ident("v")),
+            ObjectPatternProperty::Rest(ident("r")),
+        ]);
+        assert_eq!(names_of(&pat), vec!["s", "v", "r"]);
+    }
+
+    #[test]
+    fn nested_pattern_flattens_in_source_order() {
+        // `[{ a, k: [b, ...c] }]`
+        let inner_array = Pattern::Array(vec![
+            Some(ArrayPatternElement::Pattern(ident("b"))),
+            Some(ArrayPatternElement::Rest(ident("c"))),
+        ]);
+        let inner_object = Pattern::Object(vec![
+            ObjectPatternProperty::Shorthand("a".to_string()),
+            ObjectPatternProperty::KeyValue(PropertyKey::Identifier("k".to_string()), inner_array),
+        ]);
+        let pat = Pattern::Array(vec![Some(ArrayPatternElement::Pattern(inner_object))]);
+        assert_eq!(names_of(&pat), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn appends_to_existing_vec() {
+        let mut out = vec!["pre".to_string()];
+        ident("x").bound_names(&mut out);
+        assert_eq!(out, vec!["pre", "x"]);
     }
 }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -13437,7 +13437,7 @@ impl Interpreter {
         match stmt {
             Statement::Variable(decl) if decl.kind == VarKind::Var => {
                 for d in &decl.declarations {
-                    Self::collect_pattern_names(&d.pattern, names);
+                    d.pattern.bound_names(names);
                 }
             }
             Statement::Block(stmts) => {
@@ -13458,7 +13458,7 @@ impl Interpreter {
                     && decl.kind == VarKind::Var
                 {
                     for d in &decl.declarations {
-                        Self::collect_pattern_names(&d.pattern, names);
+                        d.pattern.bound_names(names);
                     }
                 }
                 Self::collect_eval_var_names_from_stmt(&f.body, names);
@@ -13468,7 +13468,7 @@ impl Interpreter {
                     && decl.kind == VarKind::Var
                 {
                     for d in &decl.declarations {
-                        Self::collect_pattern_names(&d.pattern, names);
+                        d.pattern.bound_names(names);
                     }
                 }
                 Self::collect_eval_var_names_from_stmt(&fi.body, names);
@@ -13478,7 +13478,7 @@ impl Interpreter {
                     && decl.kind == VarKind::Var
                 {
                     for d in &decl.declarations {
-                        Self::collect_pattern_names(&d.pattern, names);
+                        d.pattern.bound_names(names);
                     }
                 }
                 Self::collect_eval_var_names_from_stmt(&fo.body, names);
@@ -13757,7 +13757,7 @@ impl Interpreter {
                     };
                     for d in &decl.declarations {
                         let mut names = Vec::new();
-                        Self::collect_pattern_names(&d.pattern, &mut names);
+                        d.pattern.bound_names(&mut names);
                         for name in names {
                             lex_env.borrow_mut().bindings.insert(
                                 name,
@@ -13813,7 +13813,7 @@ impl Interpreter {
                             if matches!(decl.kind, VarKind::Let | VarKind::Const) =>
                         {
                             for d in &decl.declarations {
-                                Self::collect_pattern_names(&d.pattern, &mut eval_lexical_names);
+                                d.pattern.bound_names(&mut eval_lexical_names);
                             }
                         }
                         Statement::ClassDeclaration(cls) => {
@@ -16091,45 +16091,7 @@ impl Interpreter {
                         && !matches!(decl.kind, VarKind::Var)
                     {
                         if let Some(d) = decl.declarations.first() {
-                            fn collect_pattern_names(p: &Pattern, out: &mut Vec<String>) {
-                                match p {
-                                    Pattern::Identifier(n) => out.push(n.clone()),
-                                    Pattern::Object(props) => {
-                                        for prop in props {
-                                            match prop {
-                                                crate::ast::ObjectPatternProperty::KeyValue(
-                                                    _,
-                                                    p,
-                                                ) => {
-                                                    collect_pattern_names(p, out);
-                                                }
-                                                crate::ast::ObjectPatternProperty::Shorthand(n) => {
-                                                    out.push(n.clone());
-                                                }
-                                                crate::ast::ObjectPatternProperty::Rest(p) => {
-                                                    collect_pattern_names(p, out);
-                                                }
-                                            }
-                                        }
-                                    }
-                                    Pattern::Array(elems) => {
-                                        for e in elems.iter().flatten() {
-                                            match e {
-                                                crate::ast::ArrayPatternElement::Pattern(p) => {
-                                                    collect_pattern_names(p, out)
-                                                }
-                                                crate::ast::ArrayPatternElement::Rest(p) => {
-                                                    collect_pattern_names(p, out)
-                                                }
-                                            }
-                                        }
-                                    }
-                                    Pattern::Assign(inner, _) => collect_pattern_names(inner, out),
-                                    Pattern::Rest(inner) => collect_pattern_names(inner, out),
-                                    Pattern::MemberExpression(_) => {}
-                                }
-                            }
-                            collect_pattern_names(&d.pattern, &mut tdz_names);
+                            d.pattern.bound_names(&mut tdz_names);
                         }
                         // Save current binding state, then declare as uninitialized
                         for name in &tdz_names {

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -135,14 +135,14 @@ impl Interpreter {
                         }
                         Statement::Variable(decl) if decl.kind == VarKind::Var => {
                             for d in &decl.declarations {
-                                Self::collect_pattern_names(&d.pattern, &mut top_level_var_names);
+                                d.pattern.bound_names(&mut top_level_var_names);
                             }
                         }
                         Statement::Variable(decl)
                             if matches!(decl.kind, VarKind::Let | VarKind::Const) =>
                         {
                             for d in &decl.declarations {
-                                Self::collect_pattern_names(&d.pattern, &mut lexical_names);
+                                d.pattern.bound_names(&mut lexical_names);
                             }
                         }
                         Statement::ClassDeclaration(cls) => {
@@ -270,7 +270,7 @@ impl Interpreter {
             match stmt {
                 Statement::Variable(decl) if matches!(decl.kind, VarKind::Let | VarKind::Const) => {
                     for d in &decl.declarations {
-                        Self::collect_pattern_names(&d.pattern, &mut names);
+                        d.pattern.bound_names(&mut names);
                     }
                 }
                 Statement::ClassDeclaration(c) if !c.name.is_empty() => {
@@ -424,7 +424,7 @@ impl Interpreter {
                     };
                     for d in &decl.declarations {
                         let mut names = Vec::new();
-                        Self::collect_pattern_names(&d.pattern, &mut names);
+                        d.pattern.bound_names(&mut names);
                         for name in names {
                             env.borrow_mut().declare(&name, kind);
                         }
@@ -435,35 +435,6 @@ impl Interpreter {
                 }
                 _ => {}
             }
-        }
-    }
-
-    pub(crate) fn collect_pattern_names(pat: &Pattern, names: &mut Vec<String>) {
-        match pat {
-            Pattern::Identifier(name) => names.push(name.clone()),
-            Pattern::Array(elems) => {
-                for elem in elems.iter().flatten() {
-                    match elem {
-                        ArrayPatternElement::Pattern(p) | ArrayPatternElement::Rest(p) => {
-                            Self::collect_pattern_names(p, names);
-                        }
-                    }
-                }
-            }
-            Pattern::Object(props) => {
-                for prop in props {
-                    match prop {
-                        ObjectPatternProperty::KeyValue(_, p) | ObjectPatternProperty::Rest(p) => {
-                            Self::collect_pattern_names(p, names);
-                        }
-                        ObjectPatternProperty::Shorthand(name) => names.push(name.clone()),
-                    }
-                }
-            }
-            Pattern::Assign(inner, _) | Pattern::Rest(inner) => {
-                Self::collect_pattern_names(inner, names);
-            }
-            Pattern::MemberExpression(_) => {}
         }
     }
 
@@ -724,7 +695,7 @@ impl Interpreter {
                                 if matches!(decl.kind, VarKind::Let | VarKind::Const) =>
                             {
                                 for d in &decl.declarations {
-                                    Self::collect_pattern_names(&d.pattern, &mut block_lexicals);
+                                    d.pattern.bound_names(&mut block_lexicals);
                                 }
                             }
                             Statement::ClassDeclaration(cls) => {
@@ -801,7 +772,7 @@ impl Interpreter {
                         && matches!(decl.kind, VarKind::Let | VarKind::Const)
                     {
                         for d in &decl.declarations {
-                            Self::collect_pattern_names(&d.pattern, blocked);
+                            d.pattern.bound_names(blocked);
                         }
                     }
                     Self::collect_annexb_function_names(
@@ -817,7 +788,7 @@ impl Interpreter {
                         && matches!(decl.kind, VarKind::Let | VarKind::Const)
                     {
                         for d in &decl.declarations {
-                            Self::collect_pattern_names(&d.pattern, blocked);
+                            d.pattern.bound_names(blocked);
                         }
                     }
                     Self::collect_annexb_function_names(
@@ -833,7 +804,7 @@ impl Interpreter {
                         && matches!(decl.kind, VarKind::Let | VarKind::Const)
                     {
                         for d in &decl.declarations {
-                            Self::collect_pattern_names(&d.pattern, blocked);
+                            d.pattern.bound_names(blocked);
                         }
                     }
                     Self::collect_annexb_function_names(
@@ -867,10 +838,7 @@ impl Interpreter {
                                     if matches!(decl.kind, VarKind::Let | VarKind::Const) =>
                                 {
                                     for d in &decl.declarations {
-                                        Self::collect_pattern_names(
-                                            &d.pattern,
-                                            &mut switch_lexicals,
-                                        );
+                                        d.pattern.bound_names(&mut switch_lexicals);
                                     }
                                 }
                                 Statement::ClassDeclaration(cls) => {
@@ -912,7 +880,7 @@ impl Interpreter {
                             // B.3.5: simple BindingIdentifier catch params
                             // do NOT block var redeclaration
                             if !matches!(param, Pattern::Identifier(_)) {
-                                Self::collect_pattern_names(param, blocked);
+                                param.bound_names(blocked);
                             }
                         }
                         Self::collect_annexb_function_names(&h.body, names, blocked);
@@ -1760,7 +1728,7 @@ impl Interpreter {
                 };
                 let mut names = Vec::new();
                 for d in &decl.declarations {
-                    Self::collect_pattern_names(&d.pattern, &mut names);
+                    d.pattern.bound_names(&mut names);
                 }
                 names.into_iter().map(|n| (n, kind)).collect()
             } else {
@@ -1899,7 +1867,7 @@ impl Interpreter {
                 && let Some(d) = decl.declarations.first()
             {
                 let mut names = Vec::new();
-                Self::collect_pattern_names(&d.pattern, &mut names);
+                d.pattern.bound_names(&mut names);
                 for name in &names {
                     tdz_env.borrow_mut().declare(name, BindingKind::Let);
                 }

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -40,7 +40,7 @@ impl<'a> Parser<'a> {
             }
             // "let" cannot be a bound name in let/const declarations (§13.3.1.1)
             let mut names = Vec::new();
-            Self::collect_bound_names(&d.pattern, &mut names);
+            d.pattern.bound_names(&mut names);
             for name in &names {
                 if name == "let" {
                     return Err(self
@@ -1258,7 +1258,7 @@ impl<'a> Parser<'a> {
         let mut names = HashSet::new();
         for p in params {
             let mut bound = Vec::new();
-            Self::collect_bound_names(p, &mut bound);
+            p.bound_names(&mut bound);
             names.extend(bound);
         }
         self.function_param_names = Some(names);
@@ -1341,7 +1341,7 @@ impl<'a> Parser<'a> {
                     {
                         let mut names = Vec::new();
                         for decl in &vd.declarations {
-                            Self::collect_bound_names(&decl.pattern, &mut names);
+                            decl.pattern.bound_names(&mut names);
                         }
                         for name in &names {
                             if param_names.contains(name) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -389,33 +389,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn collect_bound_names(pattern: &Pattern, names: &mut Vec<String>) {
-        match pattern {
-            Pattern::Identifier(n) => names.push(n.clone()),
-            Pattern::Array(elems) => {
-                for elem in elems.iter().flatten() {
-                    match elem {
-                        ArrayPatternElement::Pattern(p) | ArrayPatternElement::Rest(p) => {
-                            Self::collect_bound_names(p, names);
-                        }
-                    }
-                }
-            }
-            Pattern::Object(props) => {
-                for prop in props {
-                    match prop {
-                        ObjectPatternProperty::KeyValue(_, p) | ObjectPatternProperty::Rest(p) => {
-                            Self::collect_bound_names(p, names);
-                        }
-                        ObjectPatternProperty::Shorthand(n) => names.push(n.clone()),
-                    }
-                }
-            }
-            Pattern::Assign(p, _) | Pattern::Rest(p) => Self::collect_bound_names(p, names),
-            Pattern::MemberExpression(_) => {}
-        }
-    }
-
     fn is_simple_parameter_list(params: &[Pattern]) -> bool {
         params.iter().all(|p| matches!(p, Pattern::Identifier(_)))
     }
@@ -424,7 +397,7 @@ impl<'a> Parser<'a> {
         let mut seen = HashSet::new();
         let mut names = Vec::new();
         for p in params {
-            Self::collect_bound_names(p, &mut names);
+            p.bound_names(&mut names);
         }
         for name in &names {
             if !seen.insert(name.as_str()) {
@@ -459,7 +432,7 @@ impl<'a> Parser<'a> {
     fn check_strict_params(&self, params: &[Pattern]) -> Result<(), ParseError> {
         let mut names = Vec::new();
         for p in params {
-            Self::collect_bound_names(p, &mut names);
+            p.bound_names(&mut names);
         }
         for name in &names {
             if name == "eval" || name == "arguments" {
@@ -1202,53 +1175,13 @@ impl<'a> Parser<'a> {
             Statement::Variable(var) => {
                 let mut names = Vec::new();
                 for d in &var.declarations {
-                    self.collect_pattern_names(&d.pattern, &mut names);
+                    d.pattern.bound_names(&mut names);
                 }
                 names
             }
             Statement::FunctionDeclaration(f) => vec![f.name.clone()],
             Statement::ClassDeclaration(c) => vec![c.name.clone()],
             _ => vec![],
-        }
-    }
-
-    fn collect_pattern_names(&self, pattern: &Pattern, names: &mut Vec<String>) {
-        match pattern {
-            Pattern::Identifier(name) => names.push(name.clone()),
-            Pattern::Array(elements) => {
-                for elem in elements.iter().flatten() {
-                    match elem {
-                        ArrayPatternElement::Pattern(p) => {
-                            self.collect_pattern_names(p, names);
-                        }
-                        ArrayPatternElement::Rest(p) => {
-                            self.collect_pattern_names(p, names);
-                        }
-                    }
-                }
-            }
-            Pattern::Object(props) => {
-                for prop in props {
-                    match prop {
-                        ObjectPatternProperty::KeyValue(_, value) => {
-                            self.collect_pattern_names(value, names);
-                        }
-                        ObjectPatternProperty::Shorthand(name) => {
-                            names.push(name.clone());
-                        }
-                        ObjectPatternProperty::Rest(pat) => {
-                            self.collect_pattern_names(pat, names);
-                        }
-                    }
-                }
-            }
-            Pattern::Assign(inner, _) => {
-                self.collect_pattern_names(inner, names);
-            }
-            Pattern::Rest(inner) => {
-                self.collect_pattern_names(inner, names);
-            }
-            Pattern::MemberExpression(_) => {}
         }
     }
 
@@ -1319,7 +1252,7 @@ impl<'a> Parser<'a> {
             Statement::Variable(decl) if decl.kind == VarKind::Var => {
                 for d in &decl.declarations {
                     let mut n = Vec::new();
-                    self.collect_pattern_names(&d.pattern, &mut n);
+                    d.pattern.bound_names(&mut n);
                     names.extend(n);
                 }
             }
@@ -1336,7 +1269,7 @@ impl<'a> Parser<'a> {
             Statement::Variable(decl) if decl.kind != VarKind::Var => {
                 for d in &decl.declarations {
                     let mut n = Vec::new();
-                    self.collect_pattern_names(&d.pattern, &mut n);
+                    d.pattern.bound_names(&mut n);
                     for name in n {
                         if !names.insert(name.clone()) {
                             return Err(self

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -313,52 +313,16 @@ impl<'a> Parser<'a> {
     pub(super) fn bound_names_from_decl(decl: &VariableDeclaration) -> Vec<String> {
         let mut names = Vec::new();
         for d in &decl.declarations {
-            Self::bound_names_from_pattern(&d.pattern, &mut names);
+            d.pattern.bound_names(&mut names);
         }
         names
-    }
-
-    fn bound_names_from_pattern(pat: &Pattern, names: &mut Vec<String>) {
-        match pat {
-            Pattern::Identifier(name) => names.push(name.clone()),
-            Pattern::Array(elems) => {
-                for elem in elems.iter().flatten() {
-                    match elem {
-                        ArrayPatternElement::Pattern(p) => {
-                            Self::bound_names_from_pattern(p, names);
-                        }
-                        ArrayPatternElement::Rest(p) => {
-                            Self::bound_names_from_pattern(p, names);
-                        }
-                    }
-                }
-            }
-            Pattern::Object(props) => {
-                for prop in props {
-                    match prop {
-                        ObjectPatternProperty::KeyValue(_, p) => {
-                            Self::bound_names_from_pattern(p, names);
-                        }
-                        ObjectPatternProperty::Shorthand(name) => {
-                            names.push(name.clone());
-                        }
-                        ObjectPatternProperty::Rest(p) => {
-                            Self::bound_names_from_pattern(p, names);
-                        }
-                    }
-                }
-            }
-            Pattern::Assign(inner, _) => Self::bound_names_from_pattern(inner, names),
-            Pattern::Rest(inner) => Self::bound_names_from_pattern(inner, names),
-            Pattern::MemberExpression(_) => {}
-        }
     }
 
     pub(super) fn collect_var_declared_names(stmt: &Statement, names: &mut Vec<String>) {
         match stmt {
             Statement::Variable(decl) if decl.kind == VarKind::Var => {
                 for d in &decl.declarations {
-                    Self::bound_names_from_pattern(&d.pattern, names);
+                    d.pattern.bound_names(names);
                 }
             }
             Statement::Block(stmts) => {
@@ -379,7 +343,7 @@ impl<'a> Parser<'a> {
                     && decl.kind == VarKind::Var
                 {
                     for d in &decl.declarations {
-                        Self::bound_names_from_pattern(&d.pattern, names);
+                        d.pattern.bound_names(names);
                     }
                 }
                 Self::collect_var_declared_names(&f.body, names);
@@ -389,7 +353,7 @@ impl<'a> Parser<'a> {
                     && decl.kind == VarKind::Var
                 {
                     for d in &decl.declarations {
-                        Self::bound_names_from_pattern(&d.pattern, names);
+                        d.pattern.bound_names(names);
                     }
                 }
                 Self::collect_var_declared_names(&fi.body, names);
@@ -399,7 +363,7 @@ impl<'a> Parser<'a> {
                     && decl.kind == VarKind::Var
                 {
                     for d in &decl.declarations {
-                        Self::bound_names_from_pattern(&d.pattern, names);
+                        d.pattern.bound_names(names);
                     }
                 }
                 Self::collect_var_declared_names(&fo.body, names);
@@ -440,7 +404,7 @@ impl<'a> Parser<'a> {
         // Check duplicate bound names in ForDeclaration
         let mut bound = Vec::new();
         if let Some(d) = decls.first() {
-            Self::bound_names_from_pattern(&d.pattern, &mut bound);
+            d.pattern.bound_names(&mut bound);
         }
         // "let" cannot be a bound name in let/const/using declarations
         if matches!(
@@ -1056,7 +1020,7 @@ impl<'a> Parser<'a> {
                     {
                         let mut names = Vec::new();
                         for d in &decls {
-                            Self::collect_bound_names(&d.pattern, &mut names);
+                            d.pattern.bound_names(&mut names);
                         }
                         let mut seen = HashSet::new();
                         for name in &names {
@@ -1139,7 +1103,7 @@ impl<'a> Parser<'a> {
                 {
                     let mut names = Vec::new();
                     for d in &decls {
-                        Self::collect_bound_names(&d.pattern, &mut names);
+                        d.pattern.bound_names(&mut names);
                     }
                     let mut seen = HashSet::new();
                     for name in &names {
@@ -1243,7 +1207,7 @@ impl<'a> Parser<'a> {
         {
             let mut bound = Vec::new();
             for d in &vd.declarations {
-                Self::bound_names_from_pattern(&d.pattern, &mut bound);
+                d.pattern.bound_names(&mut bound);
             }
             let mut var_names = Vec::new();
             Self::collect_var_declared_names(&body, &mut var_names);
@@ -1349,7 +1313,7 @@ impl<'a> Parser<'a> {
             // §13.15.1: Validate CatchParameter has no duplicate names
             if let Some(ref p) = param {
                 let mut bound = Vec::new();
-                Self::collect_bound_names(p, &mut bound);
+                p.bound_names(&mut bound);
                 let mut seen = HashSet::new();
                 for name in &bound {
                     if !seen.insert(name.as_str()) {
@@ -1375,7 +1339,7 @@ impl<'a> Parser<'a> {
             // LexicallyDeclaredNames of Block
             if let Some(ref p) = param {
                 let mut bound = Vec::new();
-                Self::collect_bound_names(p, &mut bound);
+                p.bound_names(&mut bound);
                 if !bound.is_empty() {
                     let mut lex_names = Vec::new();
                     for stmt in &body {


### PR DESCRIPTION
## Refactoring goal

The ECMAScript Static Semantics operation **BoundNames** for binding patterns
(destructuring targets in `var`/`let`/`const`, function parameters, catch
clauses, etc.) was hand-rolled as **five byte-for-byte-equivalent recursive
walks** over `ast::Pattern`, spread across the parser *and* the interpreter and
under three different names:

| Location | Name |
| --- | --- |
| `src/parser/mod.rs` | `collect_bound_names` (static) |
| `src/parser/mod.rs` | `collect_pattern_names` (`&self`) |
| `src/parser/statements.rs` | `bound_names_from_pattern` (static) |
| `src/interpreter/exec.rs` | `collect_pattern_names` (`pub(crate)`) |
| `src/interpreter/eval.rs` | `collect_pattern_names` (nested local `fn`) |

All five walked the same six `Pattern` variants identically — pushing
`Identifier`/object-`Shorthand` names, recursing into `Array`/`Object`/`Assign`/
`Rest`, ignoring property keys and default-value expressions, and binding nothing
for a `MemberExpression` assignment target. The only differences were the
function name and cosmetic arm grouping — clear evidence the concept had drifted
across independent copies.

This is a **deepening**: the `Pattern` type now owns its BoundNames operation
behind a single, small interface, so adding a future `Pattern` variant means
updating **one** exhaustive `match` (the compiler enforces it) instead of five,
and the operation finally has direct test coverage.

## What changed

- Added `Pattern::bound_names(&self, out: &mut Vec<String>)` in `src/ast.rs`
  (natural home — a pure Static Semantics operation on the syntax type).
- Deleted all five duplicate definitions.
- Repointed every call site (36 across 5 files) to `pattern.bound_names(...)`.
  Purely mechanical — same behaviour, no per-site judgement.

Net **−51 lines**.

## Tests validating it (TDD)

The operation previously had **zero** direct tests. Added `bound_names_tests` in
`src/ast.rs`, written test-first (red → green), pinning the behaviour directly
against the Rust function (no parse/interpret round-trip), with expected values
taken from the spec's BoundNames semantics:

- `identifier_binds_its_name`
- `member_expression_binds_nothing` (assignment target, not a declaration)
- `assignment_default_binds_only_the_inner_name` (default expr contributes no names)
- `rest_binds_inner_name`
- `array_pattern_binds_in_source_order_skipping_holes`
- `object_pattern_binds_shorthand_and_value_and_rest_but_not_key` (property key not bound)
- `nested_pattern_flattens_in_source_order`
- `appends_to_existing_vec`

## Validation

- `cargo test --release --bin jsse` — **254 passed, 0 failed** (incl. the 8 new tests)
- `./scripts/lint.sh` — rustfmt + clippy (`-D warnings`) clean
- Full **test262** suite — no regressions (see PR checks / commit)

🤖 Generated with Claude Code
