### PR TITLE
[ci] Add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ name: Release
 # Linux `jsse` binary, and publishes a GitHub Release with the packaged
 # tarball + checksums. Adapted for this Rust crate from the pewpew release
 # workflow (which targets a Node/Electron app).
+#
+# Retrying a partial failure: the commit/tag/publish steps are rerunnable, but
+# only when you re-dispatch with the SAME target version. To complete a release
+# that pushed the bump commit/tag but failed before/during publish, re-run with
+# the `version` input set to that exact version (e.g. `1.2.3`). A `bump`
+# dispatch (no `version`) always mints the NEXT version from `main` by design,
+# so it starts a new release rather than completing the stuck one.
 
 on:
   workflow_dispatch:
@@ -185,8 +192,11 @@ jobs:
           # Idempotent publish: if a release for this tag already exists (e.g. a
           # prior run created it but failed during asset upload), re-upload the
           # assets with --clobber instead of failing on `gh release create`.
-          # This makes a same-version re-dispatch complete a partially-published
-          # release rather than leaving it stuck.
+          # This completes a partially-published release ONLY when the run
+          # re-dispatched with the same explicit `version` (so $TAG matches the
+          # stuck release). A `bump` dispatch computes the next version from
+          # `main` and mints a new tag/release by design — see the retry note in
+          # the workflow header.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; re-uploading assets."
             gh release upload "$TAG" ./release-upload/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,8 +121,28 @@ jobs:
         run: |
           set -euo pipefail
           git add Cargo.toml Cargo.lock
-          git commit -m "chore(release): $TAG"
-          git tag -a "$TAG" -m "Release $TAG"
+          # Idempotent: a retry that re-targets the already-bumped version stages
+          # nothing, so only commit when the bump actually changed the manifest.
+          if git diff --cached --quiet; then
+            echo "No version change to commit (already at ${TAG#v}); reusing existing commit."
+          else
+            git commit -m "chore(release): $TAG"
+          fi
+          # Create the tag only if it does not already exist. If it does (a prior
+          # run got this far), it must point at the commit we are about to
+          # release; otherwise abort rather than silently move or reuse it.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            existing="$(git rev-parse "refs/tags/${TAG}^{commit}")"
+            head="$(git rev-parse "HEAD^{commit}")"
+            if [ "$existing" != "$head" ]; then
+              echo "Tag ${TAG} already exists at ${existing}, not HEAD ${head}." >&2
+              echo "Delete the tag (and any release) and re-run to recover." >&2
+              exit 1
+            fi
+            echo "Tag ${TAG} already exists at HEAD; reusing it."
+          else
+            git tag -a "$TAG" -m "Release $TAG"
+          fi
 
       - name: Build release binary
         run: cargo build --release --locked
@@ -149,10 +169,12 @@ jobs:
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
           set -euo pipefail
+          # Both pushes are no-ops ("Everything up-to-date") when a prior run
+          # already advanced main / published the tag, so reruns are safe.
           git push origin "HEAD:${GITHUB_REF_NAME}"
           git push origin "$TAG"
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.bump.outputs.tag }}
@@ -160,12 +182,22 @@ jobs:
           PRERELEASE: ${{ inputs.prerelease }}
         run: |
           set -euo pipefail
-          args=(--generate-notes --title "$TAG")
-          if [ "$DRAFT" = "true" ]; then args+=(--draft); fi
-          if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi
-          gh release create "$TAG" \
-            "${args[@]}" \
-            ./release-upload/*
+          # Idempotent publish: if a release for this tag already exists (e.g. a
+          # prior run created it but failed during asset upload), re-upload the
+          # assets with --clobber instead of failing on `gh release create`.
+          # This makes a same-version re-dispatch complete a partially-published
+          # release rather than leaving it stuck.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; re-uploading assets."
+            gh release upload "$TAG" ./release-upload/* --clobber
+          else
+            args=(--generate-notes --title "$TAG")
+            if [ "$DRAFT" = "true" ]; then args+=(--draft); fi
+            if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi
+            gh release create "$TAG" \
+              "${args[@]}" \
+              ./release-upload/*
+          fi
 
       - name: Upload build artifacts (for debugging / reruns)
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+name: Release
+
+# Manually-triggered release. Bumps the crate version, tags it, builds the
+# Linux `jsse` binary, and publishes a GitHub Release with the packaged
+# tarball + checksums. Adapted for this Rust crate from the pewpew release
+# workflow (which targets a Node/Electron app).
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver bump (ignored if explicit `version` is set)'
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      version:
+        description: 'Explicit version (e.g. 1.2.3). Overrides `bump` if set.'
+        type: string
+        required: false
+        default: ''
+      draft:
+        description: 'Publish release as draft'
+        type: boolean
+        required: false
+        default: false
+      prerelease:
+        description: 'Mark release as pre-release'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+# Least-privilege default; the release job widens to contents: write below.
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Bump version and build Linux artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Needed to push the version-bump commit + tag and to create the Release.
+    permissions:
+      contents: write
+    steps:
+      # Full history so the tag lands on the right commit. Checkout credentials
+      # are persisted (the default) so the bump commit + tag can be pushed back
+      # to main; uploaded artifacts contain only the packaged binary (no .git),
+      # so the token cannot leak. No submodules: the release build does not need
+      # the (large) test262/spec test-data submodules.
+      - name: Checkout (full history for tagging)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate branch
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Release must be run from 'main' (got ${GITHUB_REF_NAME})." >&2
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Configure git author
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Verify tree (fmt + clippy + tests)
+        run: |
+          cargo fmt --check
+          cargo clippy --release -- -D warnings
+          cargo test --release
+
+      - name: Bump version
+        id: bump
+        env:
+          VERSION: ${{ inputs.version }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          CURRENT="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          if [ -n "$VERSION" ]; then
+            NEW_VERSION="$VERSION"
+          else
+            IFS='.' read -r major minor patch <<< "$CURRENT"
+            case "$BUMP" in
+              major) major=$((major + 1)); minor=0; patch=0 ;;
+              minor) minor=$((minor + 1)); patch=0 ;;
+              patch) patch=$((patch + 1)) ;;
+              *) echo "Unknown bump: $BUMP" >&2; exit 1 ;;
+            esac
+            NEW_VERSION="${major}.${minor}.${patch}"
+          fi
+          # Rewrite the [package] version, then re-lock just this crate so
+          # Cargo.lock stays in sync (only the jsse entry changes).
+          sed -i "0,/^version = \"${CURRENT}\"/s//version = \"${NEW_VERSION}\"/" Cargo.toml
+          cargo update -p jsse
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Bumped ${CURRENT} -> ${NEW_VERSION}"
+
+      - name: Commit + tag
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): $TAG"
+          git tag -a "$TAG" -m "Release $TAG"
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Collect release artifacts
+        id: artifacts
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          set -euo pipefail
+          TARGET=x86_64-unknown-linux-gnu
+          STAGE="jsse-${TAG}-${TARGET}"
+          mkdir -p "./release-upload/${STAGE}"
+          strip target/release/jsse
+          cp target/release/jsse "./release-upload/${STAGE}/"
+          cp README.md LICENSE "./release-upload/${STAGE}/"
+          tar -czf "./release-upload/${STAGE}.tar.gz" -C ./release-upload "${STAGE}"
+          rm -rf "./release-upload/${STAGE:?}"
+          (cd ./release-upload && sha256sum -- * > SHA256SUMS.txt)
+          ls -la ./release-upload
+
+      - name: Push version bump + tag
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.bump.outputs.tag }}
+          DRAFT: ${{ inputs.draft }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          set -euo pipefail
+          args=(--generate-notes --title "$TAG")
+          if [ "$DRAFT" = "true" ]; then args+=(--draft); fi
+          if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi
+          gh release create "$TAG" \
+            "${args[@]}" \
+            ./release-upload/*
+
+      - name: Upload build artifacts (for debugging / reruns)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-artifacts-${{ steps.bump.outputs.tag }}
+          path: release-upload/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -23,6 +23,10 @@ rules:
   artipacked:
     ignore:
       - claude.yml
+      # release.yml persists checkout credentials so the version-bump commit and
+      # tag can be pushed back to main. It uploads only the packaged binary and
+      # checksums (no .git), so the token cannot leak via artifacts.
+      - release.yml
 
   # semgrep/semgrep-action is archived. Migrating off it (to the semgrep CLI /
   # container) changes an existing, green scan job, so it is tracked as a


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`, a manually-triggered (`workflow_dispatch`) release pipeline adapted from [`pmatos/pewpew`'s `release.yml`](https://github.com/pmatos/pewpew/blob/main/.github/workflows/release.yml). The upstream workflow targets a Node/Electron app; this version is reworked for the Rust `jsse` crate.

## What the workflow does

1. **Inputs** — semver `bump` (`patch`/`minor`/`major`) or an explicit `version`, plus `draft` / `prerelease` toggles.
2. **Branch guard** — refuses to run unless triggered from `main`.
3. **Verify tree** — `cargo fmt --check`, `cargo clippy --release -- -D warnings`, `cargo test --release` before mutating anything.
4. **Bump** — rewrites the `[package]` version in `Cargo.toml`, then `cargo update -p jsse` re-locks just the crate's own entry in `Cargo.lock` (leaves all 62 deps untouched — verified locally).
5. **Commit + tag** — `chore(release): vX.Y.Z` commit and an annotated `vX.Y.Z` tag.
6. **Build + package** — `cargo build --release --locked`, strip the binary, tar it up with `README.md` + `LICENSE` as `jsse-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz`, and emit `SHA256SUMS.txt`.
7. **Publish** — push the bump commit + tag, then `gh release create` with auto-generated notes (honouring the draft/prerelease flags). Also uploads the artifacts via `actions/upload-artifact` for reruns.

## Adaptation notes (pewpew → jsse)

- **Node → Rust toolchain**: `dtolnay/rust-toolchain@stable` + `Swatinem/rust-cache@v2`, matching `ci.yml`/`codeql.yml`.
- **`npm version` → Cargo bump**: pure-shell semver arithmetic + `sed` on `Cargo.toml` + `cargo update -p jsse` to sync the lockfile.
- **electron-builder AppImage/deb → tarball**: packages the compiled `jsse` binary (the shippable artifact for a CLI) plus checksums.
- **Repo conventions**: tag-pinned actions (per `zizmor.yml`'s `ref-pin` policy + Dependabot), top-level `permissions: contents: read` widened to `contents: write` only on the release job, `concurrency` group, `CARGO_TERM_COLOR`.
- **Dropped** pewpew's "open next dev cycle" step — that `-pre` prerelease bump is an npm idiom; Rust projects conventionally keep a plain version on `main` between releases.
- **No submodules** on checkout — the release build doesn't need the large `test262`/`spec` test-data submodules (`cargo test` early-returns without `JSSE_MUTANTS_ORACLE`).

`zizmor.yml`: adds `release.yml` to the `artipacked` ignore list — the release job legitimately persists checkout credentials to push the bump commit/tag, and its uploaded artifacts contain no `.git`, so the token can't leak. This mirrors the existing `claude.yml` handling.

## Validation

- `actionlint` 1.7.7 and `zizmor` 1.26.1 (the exact versions `workflow-lint.yml` runs) both pass with **no findings**.
- Bump arithmetic (patch/minor/major/explicit) and the `Cargo.lock` re-lock verified locally.