### PR TITLE
[perf] Polymorphic inline caching for property lookups (#71)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: function body, script body, code unit.
 A specific call or property-access location in a Body that can be inline-cached at runtime.
 _Avoid_: cache entry, IC slot (when referring to the location rather than the stored value).
 
+**IC State**:
+Where a property-access IC Site sits on the `Empty → Mono → Poly → Megamorphic` lattice. `Mono` caches one object; `Poly` caches up to `MAX_POLY_PROP` distinct objects (issue #71); `Megamorphic` is the terminal give-up state. Driven by `PropIcSlot::advance`.
+_Avoid_: cache mode, IC level.
+
 **CallSiteId**:
 A dense identifier assigned to a call IC site within a single Body.
 _Avoid_: call IC index, call cache id.

--- a/docs/adr/0002-polymorphic-property-ic.md
+++ b/docs/adr/0002-polymorphic-property-ic.md
@@ -1,0 +1,51 @@
+# Property inline caches are polymorphic; call inline caches stay monomorphic
+
+The property-access inline cache (issue #71) originally had a two-state cache
+lattice: a site cached exactly one object (`Mono`) or gave up entirely
+(`Megamorphic`). A site that saw a second distinct object jumped straight to
+`Megamorphic` and never cached again. Because `shape_id` is a per-object version
+counter (every allocation draws a fresh id) rather than a shared hidden class,
+"the same object at a site" is the unit that hits — so a site that reads a small
+fixed set of long-lived objects (issue #71's motivating case: a handful of
+globals read from one call site) lost its cache the moment the second object
+appeared.
+
+We extended the lattice to `Empty → Mono → Poly(≤ MAX_POLY_PROP) → Megamorphic`.
+`Poly` caches up to `MAX_POLY_PROP` (4) distinct `(obj_id, shape_id, kind)`
+entries; the probe scans them linearly. A fifth distinct object degrades the
+site to `Megamorphic`. Re-seeing a cached object refreshes its entry in place
+(its shape/kind may have advanced). A non-cacheable resolution (proxy /
+module-namespace / typed-array / own-accessor / depth>1) still resets an
+`Empty`/`Mono` site to `Empty`, but pushes a `Poly` site — which has already
+proven it sees several shapes — to `Megamorphic`.
+
+The transition is a pure function, `PropIcSlot::advance(&self, Option<PropIcEntry>)`,
+so the state machine is unit-tested in isolation from the evaluator.
+
+## Storage: out-of-line entries, non-`Copy` slot
+
+`Poly` owns a heap `Vec<PropIcEntry>` rather than an inline fixed array. This
+keeps `PropIcSlot` within its ≤40-byte budget (the `BodyIcStore` holds one slot
+per property-access site, so a bloated slot would multiply across the whole
+body). The trade-off is that `PropIcSlot` is no longer `Copy`. The probe never
+copies the slot: it borrows it, extracts the matching entry's `Copy` fields
+(`obj_shape_id`, `kind`), and releases the borrow before touching any object.
+Only the slow-path record step clones, and only when it grows a `Poly` — an
+allocation that lands on the miss path, never the hit path.
+
+## Scope: property IC only
+
+We made only the property IC polymorphic. The call IC (`CallIcSlot`) keeps its
+`Mono`/`Megamorphic` shape. Call sites in the motivating workloads are
+overwhelmingly monomorphic (one function per site), so polymorphic call caching
+would add scan cost and a second non-`Copy` slot type for little gain. It
+remains a clean follow-up if a polymorphic-call workload shows up.
+
+## Consequences
+
+- Sites that alternate among a small fixed set of objects now hit instead of
+  going megamorphic on the second object.
+- `PropIcSlot` is `Clone` but not `Copy`; the two IC slot types are no longer
+  structurally identical (`CallIcSlot` is still `Copy`).
+- Per-site memory is unchanged in the common case (`Empty`/`Mono` carry no
+  allocation); only genuinely polymorphic sites allocate a small `Vec`.

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -495,10 +495,61 @@ impl Interpreter {
         Completion::Normal(JsValue::Boolean(true))
     }
 
-    /// Classifies the post-lookup state of `(obj_id, key)` into a
-    /// `PropIcSlot::Mono { kind: ... }` ready for caching, or `None` if the
-    /// site is not IC-able under the v1 narrow scope. Caller uses this after
-    /// the slow path returns successfully. Issue #71, plan Step 11.
+    /// Serve a property-access IC hit for a cached `kind`, assuming the
+    /// receiver's `(obj_id, shape_id)` has already matched the cached entry.
+    /// Returns `Some(value)` on a confirmed hit, or `None` to fall through to
+    /// the slow path. Shared by the `Mono` and `Poly` probe paths.
+    ///
+    /// The receiver-shape match alone is not sufficient for the prototype-based
+    /// kinds — reassigning `[[Prototype]]` (`__proto__` / `setPrototypeOf`)
+    /// sets `prototype_id` directly WITHOUT bumping the receiver's shape_id — so
+    /// `ProtoData`/`Missing` re-verify the prototype identity (and, for
+    /// `ProtoData`, the prototype's shape) here. A stale entry self-heals: the
+    /// caller's slow path re-records it.
+    fn ic_probe_prop_kind(
+        &self,
+        obj_rc: &Rc<RefCell<JsObjectData>>,
+        key: &str,
+        kind: crate::interpreter::ic::PropIcKind,
+    ) -> Option<JsValue> {
+        use crate::interpreter::ic::PropIcKind;
+        match kind {
+            PropIcKind::OwnData => obj_rc
+                .borrow()
+                .properties
+                .get(key)
+                .and_then(|d| d.value.clone()),
+            PropIcKind::Missing { proto_id, .. } => {
+                if obj_rc.borrow().prototype_id == proto_id {
+                    Some(JsValue::Undefined)
+                } else {
+                    None
+                }
+            }
+            PropIcKind::ProtoData {
+                proto_id,
+                proto_shape_id,
+            } => {
+                if obj_rc.borrow().prototype_id == Some(proto_id)
+                    && let Some(proto_rc) = self.get_object(proto_id)
+                {
+                    let pb = proto_rc.borrow();
+                    if pb.shape_id == proto_shape_id {
+                        return pb.properties.get(key).and_then(|d| d.value.clone());
+                    }
+                }
+                None
+            }
+            // Reserved kinds are never recorded in this scope, so a probe
+            // should never see them; treat as a miss defensively.
+            PropIcKind::OwnAccessor | PropIcKind::TypedArrayElement => None,
+        }
+    }
+
+    /// Classifies the post-lookup state of `(obj_id, key)` into a `PropIcEntry`
+    /// ready for caching, or `None` if the site is not IC-able under the narrow
+    /// scope. Caller feeds the result into `PropIcSlot::advance` after the slow
+    /// path returns successfully. Issue #71, plan Step 11.
     ///
     /// Scope:
     /// - Object must NOT be a proxy / module-namespace / typed-array.
@@ -511,8 +562,8 @@ impl Interpreter {
         &self,
         obj_id: u64,
         key: &str,
-    ) -> Option<crate::interpreter::ic::PropIcSlot> {
-        use crate::interpreter::ic::{PropIcKind, PropIcSlot};
+    ) -> Option<crate::interpreter::ic::PropIcEntry> {
+        use crate::interpreter::ic::{PropIcEntry, PropIcKind};
         let obj_rc = self.get_object(obj_id)?;
         let obj = obj_rc.borrow();
         // Non-cacheable categories (plan "Excluded from IC in v1").
@@ -525,7 +576,7 @@ impl Interpreter {
         // Own property?
         if let Some(d) = obj.properties.get(key) {
             if d.is_data_descriptor() {
-                return Some(PropIcSlot::Mono {
+                return Some(PropIcEntry {
                     obj_id,
                     obj_shape_id: obj.shape_id,
                     kind: PropIcKind::OwnData,
@@ -540,7 +591,7 @@ impl Interpreter {
         // deeper stays uncached.
         let proto_id = match obj.prototype_id {
             None => {
-                return Some(PropIcSlot::Mono {
+                return Some(PropIcEntry {
                     obj_id,
                     obj_shape_id: obj.shape_id,
                     kind: PropIcKind::Missing {
@@ -571,7 +622,7 @@ impl Interpreter {
             Some(d) if d.is_data_descriptor() => {
                 // Re-read the receiver shape (the borrow was dropped above).
                 let obj_shape_id = obj_rc.borrow().shape_id;
-                Some(PropIcSlot::Mono {
+                Some(PropIcEntry {
                     obj_id,
                     obj_shape_id,
                     kind: PropIcKind::ProtoData {
@@ -792,75 +843,31 @@ impl Interpreter {
                     && self.with_scope_depth == 0
                 {
                     use crate::interpreter::ic::{PropIcKind, PropIcSlot};
-                    let slot = *self.prop_slot(site_id);
-                    if let PropIcSlot::Mono {
-                        obj_id,
-                        obj_shape_id,
-                        kind,
-                    } = slot
-                        && o.id == obj_id
+                    // Probe: find the cached entry whose object identity matches
+                    // the current receiver, without copying the slot (the `Poly`
+                    // variant owns a heap `Vec`). Extract just the Copy fields we
+                    // need for the shape check + dispatch, then release the
+                    // borrow before touching any object.
+                    let cached: Option<(u64, PropIcKind)> = match self.prop_slot(site_id) {
+                        PropIcSlot::Mono {
+                            obj_id,
+                            obj_shape_id,
+                            kind,
+                        } if *obj_id == o.id => Some((*obj_shape_id, *kind)),
+                        PropIcSlot::Poly(entries) => entries
+                            .iter()
+                            .find(|e| e.obj_id == o.id)
+                            .map(|e| (e.obj_shape_id, e.kind)),
+                        _ => None,
+                    };
+                    if let Some((want_shape, kind)) = cached
                         && let Some(obj_rc) = self.get_object(o.id)
-                        && obj_rc.borrow().shape_id == obj_shape_id
+                        && obj_rc.borrow().shape_id == want_shape
+                        && let Some(v) = self.ic_probe_prop_kind(&obj_rc, &key, kind)
                     {
-                        // Shape match — IC hit. Dispatch on kind.
-                        match kind {
-                            PropIcKind::OwnData => {
-                                let val = {
-                                    let b = obj_rc.borrow();
-                                    b.properties.get(&key).and_then(|d| d.value.clone())
-                                };
-                                if let Some(v) = val {
-                                    self.ic_hit_count.set(self.ic_hit_count.get() + 1);
-                                    return Completion::Normal(v);
-                                }
-                                // Slot stale (descriptor flipped to accessor or
-                                // value field cleared) — fall through.
-                            }
-                            PropIcKind::Missing { proto_id, .. } => {
-                                let cur_proto = obj_rc.borrow().prototype_id;
-                                if cur_proto == proto_id {
-                                    self.ic_hit_count.set(self.ic_hit_count.get() + 1);
-                                    return Completion::Normal(JsValue::Undefined);
-                                }
-                            }
-                            PropIcKind::ProtoData {
-                                proto_id,
-                                proto_shape_id,
-                            } => {
-                                // CRITICAL: reassigning `[[Prototype]]`
-                                // (`__proto__` / `Object.setPrototypeOf`) sets
-                                // `prototype_id` directly WITHOUT bumping the
-                                // receiver's shape_id, so the receiver-shape
-                                // match above is NOT sufficient. We must also
-                                // confirm the receiver still points at the same
-                                // prototype, then confirm that prototype's shape
-                                // is unchanged (so the property hasn't been
-                                // added/removed/reordered/flipped on it).
-                                let cur_proto = obj_rc.borrow().prototype_id;
-                                if cur_proto == Some(proto_id)
-                                    && let Some(proto_rc) = self.get_object(proto_id)
-                                {
-                                    let val = {
-                                        let pb = proto_rc.borrow();
-                                        if pb.shape_id == proto_shape_id {
-                                            pb.properties.get(&key).and_then(|d| d.value.clone())
-                                        } else {
-                                            None
-                                        }
-                                    };
-                                    if let Some(v) = val {
-                                        self.ic_hit_count.set(self.ic_hit_count.get() + 1);
-                                        return Completion::Normal(v);
-                                    }
-                                }
-                                // Proto swapped, proto shape advanced, or the
-                                // descriptor lost its value — fall through.
-                            }
-                            // OwnAccessor / TypedArrayElement not recorded in
-                            // this narrow scope; they'd be unreachable here.
-                            // Safe to fall through.
-                            _ => {}
-                        }
+                        // Shape match + confirmed dispatch — IC hit.
+                        self.ic_hit_count.set(self.ic_hit_count.get() + 1);
+                        return Completion::Normal(v);
                     }
                     // Probe miss — fall to the slow path and record afterwards.
                     self.ic_slow_path_count
@@ -868,21 +875,9 @@ impl Interpreter {
                     let result = self.get_object_property(o.id, &key, &obj_val.clone());
                     if let Completion::Normal(_) = &result {
                         // Classify for IC recording. Cheap one-borrow walk.
-                        let new_slot = self.classify_for_prop_ic(o.id, &key);
-                        // Apply the state-machine transition (plan Step 10):
-                        // Empty → Mono(new); Mono(A)→same-obj refresh; Mono(A)→different-obj Megamorphic.
-                        let next = match (slot, new_slot) {
-                            (PropIcSlot::Megamorphic, _) => PropIcSlot::Megamorphic,
-                            (_, None) => PropIcSlot::Empty, // not IC-able; leave Empty
-                            (PropIcSlot::Empty, Some(s)) => s,
-                            (
-                                PropIcSlot::Mono {
-                                    obj_id: prev_id, ..
-                                },
-                                Some(s @ PropIcSlot::Mono { obj_id: new_id, .. }),
-                            ) if prev_id == new_id => s,
-                            (PropIcSlot::Mono { .. }, Some(_)) => PropIcSlot::Megamorphic,
-                        };
+                        let observed = self.classify_for_prop_ic(o.id, &key);
+                        // Drive the Empty → Mono → Poly → Megamorphic machine.
+                        let next = self.prop_slot(site_id).advance(observed);
                         *self.prop_slot(site_id) = next;
                     }
                     return result;

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -869,16 +869,24 @@ impl Interpreter {
                         self.ic_hit_count.set(self.ic_hit_count.get() + 1);
                         return Completion::Normal(v);
                     }
-                    // Probe miss — fall to the slow path and record afterwards.
+                    // Probe miss — snapshot the pre-miss slot BEFORE the slow
+                    // path, then record afterwards. `get_object_property` can
+                    // run user code (an accessor getter or a proxy `get` trap)
+                    // that re-enters this same body + `PropSiteId` and mutates
+                    // the slot; capturing here keeps the state-machine
+                    // transition operating on the slot as it stood before this
+                    // access, honoring `PropIcSlot::advance`'s contract. The
+                    // clone is on the cold miss path only and allocates nothing
+                    // unless the slot was already `Poly`.
                     self.ic_slow_path_count
                         .set(self.ic_slow_path_count.get() + 1);
+                    let prev = self.prop_slot(site_id).clone();
                     let result = self.get_object_property(o.id, &key, &obj_val.clone());
                     if let Completion::Normal(_) = &result {
                         // Classify for IC recording. Cheap one-borrow walk.
                         let observed = self.classify_for_prop_ic(o.id, &key);
                         // Drive the Empty → Mono → Poly → Megamorphic machine.
-                        let next = self.prop_slot(site_id).advance(observed);
-                        *self.prop_slot(site_id) = next;
+                        *self.prop_slot(site_id) = prev.advance(observed);
                     }
                     return result;
                 }

--- a/src/interpreter/ic.rs
+++ b/src/interpreter/ic.rs
@@ -7,7 +7,8 @@
 //! `CallSiteId` / `PropSiteId` identifiers (see `src/interpreter/ic_store.rs`).
 //! The probe at `eval_member` reads the slot via `Interpreter::prop_slot`; on
 //! hit it dispatches directly. On miss it falls through to the slow path which
-//! records a fresh `Mono` entry (or transitions to `Megamorphic`).
+//! feeds the freshly classified resolution into `PropIcSlot::advance`, driving
+//! the `Empty → Mono → Poly(≤MAX_POLY_PROP) → Megamorphic` state machine.
 //!
 //! Shape-id matching is the core invariant: a slot is valid if and only if
 //! `obj.id == slot.obj_id && obj.shape_id == slot.obj_shape_id`. The global
@@ -15,10 +16,35 @@
 //! freed and re-used by GC cannot collide with a stale slot — the new
 //! object's shape_id is freshly drawn from the counter.
 
-/// Property-access IC slot. Stored in a `BodyIcStore` slot and looked up
-/// by `PropSiteId`. `Copy` so reads and writes can be done with short-lived
-/// mutable borrows.
+/// Maximum number of distinct `(obj_id, shape_id)` pairs cached at a single
+/// property-access site before it degrades to `Megamorphic`. Four mirrors the
+/// conventional inline-cache arity: enough to cover a site that genuinely sees
+/// a small fixed set of objects (issue #71's motivating case is a handful of
+/// long-lived globals read from the same site), while keeping the linear probe
+/// scan short.
+pub(crate) const MAX_POLY_PROP: usize = 4;
+
+/// One cached resolution at a property-access site: the object identity and
+/// shape version it was captured against, plus the resolution `kind` the probe
+/// dispatches on. A `Mono` slot holds one of these inline; a `Poly` slot holds
+/// up to `MAX_POLY_PROP` of them out-of-line.
 #[derive(Clone, Copy, Debug)]
+pub(crate) struct PropIcEntry {
+    pub obj_id: u64,
+    pub obj_shape_id: u64,
+    pub kind: PropIcKind,
+}
+
+/// Property-access IC slot. Stored in a `BodyIcStore` slot and looked up by
+/// `PropSiteId`.
+///
+/// Not `Copy`: the `Poly` variant owns a heap `Vec` of entries so the slot
+/// stays small (the `Empty`/`Mono`/`Megamorphic` variants carry no allocation
+/// and the whole slot fits within the size budget below). The probe never
+/// copies the slot — it borrows it, extracts the matching entry's Copy fields,
+/// and releases the borrow before touching the heap. Only the slow-path record
+/// step clones, and only when it grows a `Poly`.
+#[derive(Clone, Debug)]
 pub(crate) enum PropIcSlot {
     /// First execution at this site, or just transitioned out of `Mono` due
     /// to a non-cacheable resolution. Probe falls through to slow path; slow
@@ -32,10 +58,16 @@ pub(crate) enum PropIcSlot {
         obj_shape_id: u64,
         kind: PropIcKind,
     },
+    /// Two-to-`MAX_POLY_PROP` distinct objects have been seen at this site.
+    /// Probe scans the entries for one whose `(obj_id, shape_id)` matches the
+    /// current object and dispatches on that entry's `kind`. Invariants:
+    /// `2 <= entries.len() <= MAX_POLY_PROP` and every entry has a distinct
+    /// `obj_id`.
+    Poly(Vec<PropIcEntry>),
     /// Site has seen a non-cacheable resolution (proxy, module-namespace,
-    /// symbol key, depth>1 prototype) or has shape-thrashed across multiple
-    /// distinct `obj_id`s. Probes always fall through; slow path skips
-    /// the record cost.
+    /// symbol key, depth>1 prototype) or has cached the maximum number of
+    /// distinct `obj_id`s and then seen yet another. Probes always fall
+    /// through; slow path skips the record cost.
     Megamorphic,
 }
 
@@ -86,6 +118,75 @@ impl PropIcSlot {
     #[allow(dead_code)]
     pub(crate) const fn empty() -> Self {
         PropIcSlot::Empty
+    }
+
+    /// Apply the IC state-machine transition after a slow-path resolution.
+    ///
+    /// `observed` is the freshly classified entry for the current access
+    /// (`Some(entry)` if cacheable, `None` if not — proxy / module-namespace /
+    /// typed-array / own-accessor / depth>1). `self` is the slot as it stood
+    /// before this access.
+    ///
+    /// - `Megamorphic` is terminal.
+    /// - A non-cacheable resolution resets `Empty`/`Mono` to `Empty` (giving
+    ///   the site another chance) but pushes a `Poly` site — which has already
+    ///   proven it sees several shapes — to `Megamorphic`.
+    /// - `Empty` records the first `Mono`. A second distinct object promotes
+    ///   `Mono` to a two-entry `Poly`. Further distinct objects extend the
+    ///   `Poly` up to `MAX_POLY_PROP`; one more distinct object degrades it to
+    ///   `Megamorphic`. Re-seeing a cached `obj_id` refreshes that entry in
+    ///   place (its shape/kind may have advanced).
+    pub(crate) fn advance(&self, observed: Option<PropIcEntry>) -> PropIcSlot {
+        match (self, observed) {
+            (PropIcSlot::Megamorphic, _) => PropIcSlot::Megamorphic,
+            // Diverse site meets a non-cacheable shape → give up caching it.
+            (PropIcSlot::Poly(_), None) => PropIcSlot::Megamorphic,
+            // Empty/Mono meet a non-cacheable shape → stay resettable.
+            (_, None) => PropIcSlot::Empty,
+            (PropIcSlot::Empty, Some(e)) => PropIcSlot::Mono {
+                obj_id: e.obj_id,
+                obj_shape_id: e.obj_shape_id,
+                kind: e.kind,
+            },
+            (
+                PropIcSlot::Mono {
+                    obj_id,
+                    obj_shape_id,
+                    kind,
+                },
+                Some(e),
+            ) => {
+                if *obj_id == e.obj_id {
+                    // Same object — refresh (shape/kind may have advanced).
+                    PropIcSlot::Mono {
+                        obj_id: e.obj_id,
+                        obj_shape_id: e.obj_shape_id,
+                        kind: e.kind,
+                    }
+                } else {
+                    PropIcSlot::Poly(vec![
+                        PropIcEntry {
+                            obj_id: *obj_id,
+                            obj_shape_id: *obj_shape_id,
+                            kind: *kind,
+                        },
+                        e,
+                    ])
+                }
+            }
+            (PropIcSlot::Poly(entries), Some(e)) => {
+                let mut entries = entries.clone();
+                if let Some(slot) = entries.iter_mut().find(|x| x.obj_id == e.obj_id) {
+                    *slot = e; // refresh existing entry
+                    PropIcSlot::Poly(entries)
+                } else if entries.len() < MAX_POLY_PROP {
+                    entries.push(e);
+                    PropIcSlot::Poly(entries)
+                } else {
+                    PropIcSlot::Megamorphic
+                }
+            }
+        }
     }
 }
 
@@ -147,11 +248,129 @@ const _ASSERT_CALL_IC_SLOT_SIZE: () = {
     assert!(std::mem::size_of::<CallIcSlot>() <= 32);
 };
 
-// Compile-time invariant: the slot must stay small (<=32 bytes) so that
-// `Expression::Member` doesn't bloat by more than 4 pointer-sized words.
-// The largest variant — `Mono { u64, u64, PropIcKind }` with the largest
-// kind (`ProtoData { u64, u64 }`) — is 32 bytes. If this assertion ever
-// fails, audit `PropIcKind` for accidental growth.
+// Compile-time invariant: the slot must stay small (<=40 bytes). Slots live in
+// the per-body `BodyIcStore` (see `docs/adr/0001-inline-cache-ast-seam.md`),
+// sized one-per-site, so a bloated slot would inflate that `Vec` across every
+// property-access site in a body. The `Poly` variant keeps its entries
+// out-of-line in a `Vec` (a 3-word header) precisely so the slot stays small;
+// the largest inline variant is `Mono { u64, u64, PropIcKind }`. If this
+// assertion ever fails, audit `PropIcKind` for accidental growth.
 const _ASSERT_PROP_IC_SLOT_SIZE: () = {
     assert!(std::mem::size_of::<PropIcSlot>() <= 40);
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(obj_id: u64, shape: u64) -> PropIcEntry {
+        PropIcEntry {
+            obj_id,
+            obj_shape_id: shape,
+            kind: PropIcKind::OwnData,
+        }
+    }
+
+    /// Collect `(obj_id, obj_shape_id)` from a `Poly` slot for assertions.
+    fn poly_ids(slot: &PropIcSlot) -> Vec<(u64, u64)> {
+        match slot {
+            PropIcSlot::Poly(entries) => {
+                entries.iter().map(|e| (e.obj_id, e.obj_shape_id)).collect()
+            }
+            other => panic!("expected Poly, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_records_first_mono() {
+        let next = PropIcSlot::Empty.advance(Some(entry(1, 10)));
+        assert!(matches!(
+            next,
+            PropIcSlot::Mono {
+                obj_id: 1,
+                obj_shape_id: 10,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn mono_same_object_refreshes_shape() {
+        let mono = PropIcSlot::Mono {
+            obj_id: 1,
+            obj_shape_id: 10,
+            kind: PropIcKind::OwnData,
+        };
+        // Same obj_id, advanced shape — must refresh in place, not promote.
+        let next = mono.advance(Some(entry(1, 11)));
+        assert!(matches!(
+            next,
+            PropIcSlot::Mono {
+                obj_id: 1,
+                obj_shape_id: 11,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn mono_second_object_promotes_to_poly() {
+        let mono = PropIcSlot::Mono {
+            obj_id: 1,
+            obj_shape_id: 10,
+            kind: PropIcKind::OwnData,
+        };
+        let next = mono.advance(Some(entry(2, 20)));
+        assert_eq!(poly_ids(&next), vec![(1, 10), (2, 20)]);
+    }
+
+    #[test]
+    fn poly_extends_up_to_max_then_megamorphic() {
+        let mut slot = PropIcSlot::Empty.advance(Some(entry(1, 10)));
+        // Feed distinct objects 2..=MAX_POLY_PROP: each extends the Poly.
+        for id in 2..=MAX_POLY_PROP as u64 {
+            slot = slot.advance(Some(entry(id, id * 10)));
+        }
+        assert_eq!(poly_ids(&slot).len(), MAX_POLY_PROP);
+        // One more distinct object overflows to Megamorphic.
+        let next = slot.advance(Some(entry(MAX_POLY_PROP as u64 + 1, 999)));
+        assert!(matches!(next, PropIcSlot::Megamorphic));
+    }
+
+    #[test]
+    fn poly_refreshes_existing_entry_in_place() {
+        let slot = PropIcSlot::Poly(vec![entry(1, 10), entry(2, 20)]);
+        // Re-see obj 1 with an advanced shape: refresh, do not grow.
+        let next = slot.advance(Some(entry(1, 11)));
+        assert_eq!(poly_ids(&next), vec![(1, 11), (2, 20)]);
+    }
+
+    #[test]
+    fn mono_non_cacheable_resets_to_empty() {
+        let mono = PropIcSlot::Mono {
+            obj_id: 1,
+            obj_shape_id: 10,
+            kind: PropIcKind::OwnData,
+        };
+        assert!(matches!(mono.advance(None), PropIcSlot::Empty));
+        assert!(matches!(PropIcSlot::Empty.advance(None), PropIcSlot::Empty));
+    }
+
+    #[test]
+    fn poly_non_cacheable_goes_megamorphic() {
+        let slot = PropIcSlot::Poly(vec![entry(1, 10), entry(2, 20)]);
+        assert!(matches!(slot.advance(None), PropIcSlot::Megamorphic));
+    }
+
+    #[test]
+    fn megamorphic_is_terminal() {
+        assert!(matches!(
+            PropIcSlot::Megamorphic.advance(Some(entry(1, 10))),
+            PropIcSlot::Megamorphic
+        ));
+        assert!(matches!(
+            PropIcSlot::Megamorphic.advance(None),
+            PropIcSlot::Megamorphic
+        ));
+    }
+}

--- a/src/interpreter/ic_store.rs
+++ b/src/interpreter/ic_store.rs
@@ -179,7 +179,7 @@ mod tests {
             CallIcSlot::Megamorphic
         ));
         assert!(matches!(
-            *interp.ic_store.store_mut(handle).prop_slot(PropSiteId(0)),
+            &*interp.ic_store.store_mut(handle).prop_slot(PropSiteId(0)),
             PropIcSlot::Megamorphic
         ));
     }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1157,29 +1157,117 @@ fn call_ic_invalidates_on_function_replacement() {
 }
 
 #[test]
-fn ic_megamorphic_after_distinct_objects_at_same_site() {
-    // Same call site sees two different objects; the second access shape
-    // mismatches and transitions to Megamorphic. Behavioural correctness
-    // must still hold.
+fn ic_polymorphic_after_two_distinct_objects_at_same_site() {
+    // Same call site sees two different objects. The first miss records Mono(a);
+    // the second promotes the site to a two-entry Poly([a, b]); the third
+    // access re-sees `a` and must HIT the poly entry (not fall to the slow
+    // path). Correctness AND the hit counter are asserted.
     let interp = run_script(
         r#"
         var a = {x: 1};
         var b = {x: 2};
         function read(o) { return o.x; }
-        var v1 = read(a);
-        var v2 = read(b);
-        var v3 = read(a);
+        var v1 = read(a);   // Empty -> Mono(a)      (miss)
+        var v2 = read(b);   // Mono(a) -> Poly([a,b]) (miss)
+        var v3 = read(a);   // Poly hit on `a`
         var result = v1 + "|" + v2 + "|" + v3;
         "#,
     );
     assert_eq!(global_string(&interp, "result"), "1|2|1");
+    assert!(
+        interp.ic_hit_count() > 0,
+        "the third read of `a` must hit the polymorphic slot; got 0 hits \
+         (the probe never recognised the second cached shape)"
+    );
+}
+
+#[test]
+fn ic_polymorphic_two_shapes_hit_in_hot_loop() {
+    // A site alternating between two long-lived objects must cache both and hit
+    // on every steady-state access after the two-iteration warmup.
+    let interp = run_script(
+        r#"
+        var a = {x: 10};
+        var b = {x: 20};
+        function read(o) { return o.x; }
+        var sum = 0;
+        for (var i = 0; i < 50; i++) { sum += read(a); sum += read(b); }
+        "#,
+    );
+    assert_eq!(
+        global_number(&interp, "sum"),
+        1500.0,
+        "behavioral correctness"
+    );
+    assert!(
+        interp.ic_hit_count() > 0,
+        "expected polymorphic IC hits across two alternating shapes; got 0"
+    );
+}
+
+#[test]
+fn ic_polymorphic_four_shapes_hit() {
+    // Four distinct objects fill the polymorphic slot to its arity; each is
+    // re-hit in steady state. Correctness plus a positive hit count prove all
+    // four entries are served from the cache.
+    let interp = run_script(
+        r#"
+        var a = {x: 1}, b = {x: 2}, c = {x: 3}, d = {x: 4};
+        function read(o) { return o.x; }
+        var sum = 0;
+        for (var i = 0; i < 20; i++) {
+            sum += read(a) + read(b) + read(c) + read(d);
+        }
+        "#,
+    );
+    assert_eq!(
+        global_number(&interp, "sum"),
+        200.0,
+        "behavioral correctness"
+    );
+    assert!(
+        interp.ic_hit_count() > 0,
+        "expected polymorphic IC hits across four cached shapes; got 0"
+    );
+}
+
+#[test]
+fn ic_megamorphic_after_fifth_distinct_shape() {
+    // The polymorphic slot caps at four entries. A fifth distinct object
+    // overflows it to Megamorphic, which is terminal: subsequent reads of a
+    // previously-cached object must NOT re-enter the cache and hit. The warmup
+    // itself produces no hits (each object is first-seen), so a zero total hit
+    // count proves the site went — and stayed — megamorphic.
+    let interp = run_script(
+        r#"
+        var a = {x: 1}, b = {x: 2}, c = {x: 3}, d = {x: 4}, e = {x: 5};
+        function read(o) { return o.x; }
+        // Five distinct shapes at one site: a,b,c,d fill the Poly; e overflows.
+        var warm = read(a) + read(b) + read(c) + read(d) + read(e);
+        var sum = 0;
+        for (var i = 0; i < 10; i++) sum += read(a);  // Megamorphic: no hits
+        var result = warm + "|" + sum;
+        "#,
+    );
+    assert_eq!(
+        global_string(&interp, "result"),
+        "15|10",
+        "behavioral correctness"
+    );
+    assert_eq!(
+        interp.ic_hit_count(),
+        0,
+        "a site that overflowed to Megamorphic must not be demoted and start \
+         hitting again"
+    );
 }
 
 #[test]
 fn ic_megamorphic_stays_terminal_after_non_cacheable_miss() {
-    // A site that has already gone Megamorphic must not be demoted back to
-    // Empty when it later sees a non-cacheable proxy lookup. If it were
-    // demoted, the final hot reads of `a.x` would re-enter Mono and hit.
+    // A polymorphic site that then meets a non-cacheable proxy lookup must go
+    // Megamorphic and stay there — never demoted back to Empty. If it were
+    // demoted, the final hot reads of `a.x` would re-enter the cache and hit.
+    // This exercises the `Poly + None -> Megamorphic` transition specifically.
     let interp = run_script(
         r#"
         var a = {x: 1};
@@ -1188,9 +1276,9 @@ fn ic_megamorphic_stays_terminal_after_non_cacheable_miss() {
         function read(o) { return o.x; }
         var sum = 0;
         sum += read(a);  // Empty -> Mono(a)
-        sum += read(b);  // Mono(a) -> Megamorphic
-        sum += read(p);  // non-cacheable; must stay Megamorphic
-        for (var i = 0; i < 10; i++) sum += read(a);
+        sum += read(b);  // Mono(a) -> Poly([a,b])
+        sum += read(p);  // non-cacheable at a Poly site -> Megamorphic
+        for (var i = 0; i < 10; i++) sum += read(a);  // must stay terminal
         var result = sum;
         "#,
     );

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1263,6 +1263,44 @@ fn ic_megamorphic_after_fifth_distinct_shape() {
 }
 
 #[test]
+fn ic_record_uses_pre_slow_path_slot_snapshot() {
+    // The slow path can run user code (here an own-accessor getter) that
+    // re-enters the SAME body + prop site and mutates the slot before recording
+    // resumes. The record step must transition from the slot as it stood BEFORE
+    // this access, not the reentrancy-mutated slot.
+    //
+    // `read(reenter)` misses as a non-cacheable own accessor (classify → None).
+    // Its getter recursively runs `read(a)` and `read(b)` at the same site,
+    // driving the slot Empty → Mono(a) → Poly([a,b]). If the outer record read
+    // the slot AFTER the getter, it would see Poly and apply Poly+None →
+    // Megamorphic, terminalizing the site so the following `read(a)` loop can
+    // never hit. Snapshotting before the slow path yields Empty+None → Empty,
+    // so the loop re-primes Mono(a) and hits. A positive hit count proves the
+    // site was not wrongly terminalized.
+    let interp = run_script(
+        r#"
+        var a = {x: 1};
+        var b = {x: 2};
+        function read(o) { return o.x; }
+        var reenter = { get x() { read(a); read(b); return 0; } };
+        read(reenter);                                // reentrant getter mutates the slot
+        var sum = 0;
+        for (var i = 0; i < 10; i++) sum += read(a);  // must be able to cache + hit
+        "#,
+    );
+    assert_eq!(
+        global_number(&interp, "sum"),
+        10.0,
+        "behavioral correctness"
+    );
+    assert!(
+        interp.ic_hit_count() > 0,
+        "the site must survive the reentrant slow path and re-cache `a`; got 0 \
+         hits (a stale post-slow-path read terminalized it to Megamorphic)"
+    );
+}
+
+#[test]
 fn ic_megamorphic_stays_terminal_after_non_cacheable_miss() {
     // A polymorphic site that then meets a non-cacheable proxy lookup must go
     // Megamorphic and stay there — never demoted back to Empty. If it were


### PR DESCRIPTION
## Summary

Extends the property-access inline cache (issue #71) from a two-state
`Mono → Megamorphic` lattice to `Empty → Mono → Poly(≤4) → Megamorphic`.

Because `shape_id` is a per-object version counter (every allocation draws a
fresh id) rather than a shared hidden class, "the same object at a site" is the
unit that hits. A site that reads a small fixed set of long-lived objects — the
issue's motivating case, a handful of globals read from one call site — used to
lose its cache the moment the second object appeared and drop straight to
`Megamorphic`. It now caches up to four distinct objects and keeps hitting.

- **`ic.rs`** — new `PropIcEntry`, `MAX_POLY_PROP = 4`, `PropIcSlot::Poly(Vec<PropIcEntry>)`, and a pure `PropIcSlot::advance()` state machine (unit-tested in isolation). `Poly` keeps its entries out-of-line in a `Vec` so the slot stays within its ≤40-byte budget; `PropIcSlot` is now `Clone` (not `Copy`).
- **`eval/access.rs`** — the probe borrows the slot and extracts the matching entry's `Copy` fields (no slot copy, no allocation on the hit path), scanning both `Mono` and `Poly`. Per-kind dispatch is factored into `ic_probe_prop_kind`, shared by both paths. `classify_for_prop_ic` now returns a `PropIcEntry`; the record step drives the machine via `advance()`.
- Docs: `docs/adr/0002-polymorphic-property-ic.md` + a `CONTEXT.md` term.

**Scope:** property IC only. The call IC (`CallIcSlot`) stays `Mono`/`Megamorphic` — call sites in the target workloads are overwhelmingly monomorphic, so polymorphic call caching would add scan cost for little gain. Typed-array/computed-element IC and own-accessor recording remain the reserved follow-ups noted in `ic.rs`.

Closes #71.

## Test plan

- [x] `cargo test --release` — 265 unit tests pass, including 8 new IC tests (state-machine `advance()` transitions + behavioral 2/4-shape hits and 5-shape overflow-to-megamorphic).
- [x] `./scripts/lint.sh` — rustfmt + clippy clean.
- [x] `run-test262.py -j 32` — **99,568 / 99,568 (100.00%), 0 fail, 0 regressions** vs the origin/main baseline.
- [x] Acorn — the default-stack overflow on the 2.3MB bundle is pre-existing (reproduces identically on origin/main); under a raised stack the suite runs 13,539/13,541, the 2 failures being parser stack-space-limit tests unrelated to this interpreter-only change.