### PR TITLE
Catchable recursion limits instead of native stack overflow

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -12309,6 +12309,42 @@ impl Interpreter {
     fn call_function_inner(
         &mut self,
         func_val: &JsValue,
+        this_val: &JsValue,
+        args: &[JsValue],
+        skip_entry_checks: bool,
+    ) -> Completion {
+        // Catchable stack-depth guard: every JS invocation funnels through here,
+        // so bounding this depth bounds native recursion. Throwing a RangeError
+        // before the native stack is exhausted keeps deep recursion catchable in
+        // JS instead of aborting the process (SIGABRT).
+        //
+        // The soft limit fires once, then disarms so a JS catch handler running
+        // deep in the stack (e.g. acorn's stack-overflow recovery) has room to
+        // execute in the [soft, hard) band. The hard ceiling still fires even
+        // while disarmed, and sits far below native capacity.
+        use crate::interpreter::{
+            CALL_DEPTH_HARD_LIMIT, CALL_DEPTH_REARM_LIMIT, CALL_DEPTH_SOFT_LIMIT,
+        };
+        if self.call_depth >= CALL_DEPTH_HARD_LIMIT
+            || (self.overflow_armed && self.call_depth >= CALL_DEPTH_SOFT_LIMIT)
+        {
+            self.overflow_armed = false;
+            return Completion::Throw(
+                self.create_error("RangeError", "Maximum call stack size exceeded"),
+            );
+        }
+        self.call_depth += 1;
+        let result = self.call_function_inner_impl(func_val, this_val, args, skip_entry_checks);
+        self.call_depth -= 1;
+        if self.call_depth <= CALL_DEPTH_REARM_LIMIT {
+            self.overflow_armed = true;
+        }
+        result
+    }
+
+    fn call_function_inner_impl(
+        &mut self,
+        func_val: &JsValue,
         _this_val: &JsValue,
         args: &[JsValue],
         skip_entry_checks: bool,
@@ -12977,7 +13013,12 @@ impl Interpreter {
                         });
                         self.call_stack_envs.push(exec_env.clone());
                         self.in_tail_position = false;
+                        // A fresh function body: its tail positions are
+                        // independent of any try/finally region in the caller.
+                        let saved_tco_suppress = self.tco_suppress_depth;
+                        self.tco_suppress_depth = 0;
                         let result = self.dispatch_body(o.id, &body, &exec_env, _this_val);
+                        self.tco_suppress_depth = saved_tco_suppress;
                         self.call_stack_envs.pop();
                         self.call_stack_frames.pop();
                         let result = self.dispose_resources(&exec_env, result);

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -942,6 +942,7 @@ impl Interpreter {
                     let can_tco = env.borrow().strict
                         && self.generator_context.is_none()
                         && !self.in_state_machine
+                        && self.tco_suppress_depth == 0
                         && Self::expr_may_contain_tail_call(e);
                     if can_tco {
                         self.in_tail_position = true;
@@ -2288,8 +2289,16 @@ impl Interpreter {
     }
 
     fn exec_try(&mut self, t: &TryStatement, env: &EnvRef) -> Completion {
+        // Calls inside the try Block are never in tail position: the catch
+        // and/or finally handlers must remain live on the stack. Suppress TCO
+        // for the block's dynamic extent, then restore. `saved_tco` is this
+        // statement's ambient suppression level (non-zero when nested in an
+        // outer try/finally region within the same function body).
+        let saved_tco = self.tco_suppress_depth;
         let block_env = Environment::new(Some(env.clone()));
+        self.tco_suppress_depth = saved_tco + 1;
         let result = self.exec_statements(&t.block, &block_env);
+        self.tco_suppress_depth = saved_tco;
         // §14.2.2: DisposeResources for the try block's scope (using declarations)
         let result = self.dispose_resources(&block_env, result);
         let result = match result {
@@ -2306,7 +2315,14 @@ impl Interpreter {
                         }
                     }
                     let catch_block_env = Environment::new(Some(catch_env.clone()));
-                    self.exec_statements(&handler.body, &catch_block_env)
+                    // A call in the catch Block is in tail position only when
+                    // there is no finally; otherwise the finalizer must run.
+                    if t.finalizer.is_some() {
+                        self.tco_suppress_depth = saved_tco + 1;
+                    }
+                    let r = self.exec_statements(&handler.body, &catch_block_env);
+                    self.tco_suppress_depth = saved_tco;
+                    r
                 } else {
                     Completion::Throw(val)
                 }
@@ -2318,6 +2334,9 @@ impl Interpreter {
             if matches!(result, Completion::Yield(_)) {
                 return result;
             }
+            // A call in the finally Block IS in tail position (nothing runs
+            // after it), so it must keep whatever ambient suppression applies
+            // but add none of its own — depth is already `saved_tco` here.
             let fin_env = Environment::new(Some(env.clone()));
             let fin_result = self.exec_statements(finalizer, &fin_env);
             if fin_result.is_abrupt() {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -164,7 +164,39 @@ pub struct Interpreter {
     /// this handle to read and write per-body IC slots without threading it
     /// through every recursive call.
     pub(crate) current_ic_handle: ic_store::BodyStoreHandle,
+    /// Current JS call nesting depth. Incremented on entry to every function
+    /// invocation (`call_function_inner`) and decremented as the stack unwinds.
+    /// When it crosses the depth limits a catchable `RangeError` is thrown
+    /// instead of letting native recursion overflow the thread stack (SIGABRT).
+    pub(crate) call_depth: usize,
+    /// Whether the soft depth limit is allowed to fire. Disarmed the moment it
+    /// does, so a JS `catch` handler running deep in the stack (e.g. acorn's
+    /// stack-overflow recovery) can execute in the [`soft`, `hard`) recovery
+    /// band without immediately re-tripping. Re-armed only once the stack has
+    /// unwound below `CALL_DEPTH_REARM_LIMIT`.
+    pub(crate) overflow_armed: bool,
+    /// Nesting count of try/finally regions where a call is NOT in tail
+    /// position (the try Block, a catch Block guarded by a finally, and the
+    /// finally Block). Non-zero suppresses proper-tail-call optimization so the
+    /// exception/finalizer handlers stay live. Saved and reset to 0 on entry to
+    /// each function body so it never leaks into callees.
+    pub(crate) tco_suppress_depth: u32,
 }
+
+/// Soft JS call-depth limit: crossing it throws a catchable `RangeError:
+/// Maximum call stack size exceeded`. Sits well below the native capacity of
+/// the 128 MiB execution stack the engine runs on (see `main.rs`), yet far
+/// above the depth any real program reaches (the old 8 MiB main stack held
+/// every passing test, i.e. depths under ~1500).
+pub(crate) const CALL_DEPTH_SOFT_LIMIT: usize = 4_000;
+/// Hard ceiling enforced even while the soft limit is disarmed (i.e. while a
+/// catch handler is recovering). The [`soft`, `hard`) band gives handlers room
+/// to run; `hard` still sits far below native capacity so it throws rather
+/// than overflowing the stack.
+pub(crate) const CALL_DEPTH_HARD_LIMIT: usize = 5_000;
+/// The soft limit re-arms only after the stack unwinds below this, so a
+/// recovering handler oscillating just under the soft limit does not re-trip.
+pub(crate) const CALL_DEPTH_REARM_LIMIT: usize = 3_000;
 
 pub(crate) struct CallFrame {
     pub func_obj_id: u64,
@@ -306,6 +338,9 @@ impl Interpreter {
             hoist_cache: FxHashMap::default(),
             ic_store: ic_store::IcStore::new(),
             current_ic_handle: ic_store::BodyStoreHandle(0),
+            call_depth: 0,
+            overflow_armed: true,
+            tco_suppress_depth: 0,
         };
         interp.setup_globals();
         interp

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,32 @@ fn run_repl() -> ExitCode {
 }
 
 fn main() -> ExitCode {
+    // Run the engine on a thread with a large stack. Deep (but bounded — see
+    // the `CALL_DEPTH_*` limits and the parser's `MAX_PARSE_DEPTH`) recursion
+    // needs room to reach those catchable limits and throw a `RangeError`
+    // before the native stack is exhausted; the default 8 MiB main-thread
+    // stack is too small and overflows into a SIGABRT first. 128 MiB fits
+    // inside the 512 MiB RLIMIT_AS the test harness imposes (a larger
+    // reservation would fail to spawn / starve the heap) while leaving the
+    // limits ample native room before they trip.
+    const ENGINE_STACK_SIZE: usize = 128 * 1024 * 1024;
+    let spawned = std::thread::Builder::new()
+        .name("jsse-main".to_string())
+        .stack_size(ENGINE_STACK_SIZE)
+        .spawn(run_main);
+    match spawned {
+        Ok(child) => match child.join() {
+            Ok(code) => code,
+            // A panic already printed its message; surface the conventional code.
+            Err(_) => ExitCode::from(101),
+        },
+        // If the large stack cannot be reserved (e.g. a tight RLIMIT_AS), fall
+        // back to running on the current thread rather than aborting outright.
+        Err(_) => run_main(),
+    }
+}
+
+fn run_main() -> ExitCode {
     let cli = Cli::parse();
 
     // If no preludes, use simpler path

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -230,6 +230,15 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn parse_assignment_expression(&mut self) -> Result<Expression, ParseError> {
+        // Depth guard: every nested sub-expression funnels through here, so
+        // bounding this bounds recursive-descent native recursion.
+        self.enter_recursion()?;
+        let r = self.parse_assignment_expression_inner();
+        self.exit_recursion();
+        r
+    }
+
+    fn parse_assignment_expression_inner(&mut self) -> Result<Expression, ParseError> {
         let saved_proto_dup = self.last_obj_had_proto_dup;
         self.last_obj_had_proto_dup = false;
         // YieldExpression in generator context

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -510,6 +510,15 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_exponentiation(&mut self) -> Result<Expression, ParseError> {
+        // Depth guard: `**` is right-associative and recurses here, bypassing
+        // parse_assignment_expression, so it needs its own bound.
+        self.enter_recursion()?;
+        let r = self.parse_exponentiation_inner();
+        self.exit_recursion();
+        r
+    }
+
+    fn parse_exponentiation_inner(&mut self) -> Result<Expression, ParseError> {
         let start = self.current_token_start;
         let base = self.parse_unary()?;
         if self.current == Token::Exponent {
@@ -540,6 +549,16 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_unary(&mut self) -> Result<Expression, ParseError> {
+        // Depth guard: prefix unary operators (!, -, +, ~, typeof, void,
+        // delete, await, ++/--) recurse here, bypassing
+        // parse_assignment_expression, so they need their own bound.
+        self.enter_recursion()?;
+        let r = self.parse_unary_inner();
+        self.exit_recursion();
+        r
+    }
+
+    fn parse_unary_inner(&mut self) -> Result<Expression, ParseError> {
         match &self.current {
             Token::Keyword(Keyword::Delete) => {
                 self.advance()?;
@@ -793,6 +812,15 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_new_expression(&mut self) -> Result<Expression, ParseError> {
+        // Depth guard: `new new … X` recurses here, bypassing
+        // parse_assignment_expression, so it needs its own bound.
+        self.enter_recursion()?;
+        let r = self.parse_new_expression_inner();
+        self.exit_recursion();
+        r
+    }
+
+    fn parse_new_expression_inner(&mut self) -> Result<Expression, ParseError> {
         self.advance()?; // new
         if self.current == Token::Dot {
             self.advance()?; // .

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -67,7 +67,18 @@ pub struct Parser<'a> {
     eval_new_target_allowed: bool,
     last_expr_parenthesized: bool,
     last_obj_had_proto_dup: bool,
+    /// Current recursive-descent nesting depth (expressions + statements).
+    /// Guarded against `MAX_PARSE_DEPTH` so pathologically nested source raises
+    /// a catchable parse error instead of overflowing the native stack.
+    parse_depth: u32,
 }
+
+/// Maximum parser recursion depth before a catchable parse error is raised
+/// instead of letting recursive-descent recursion overflow the native stack.
+/// Sits well below the native capacity of the 128 MiB execution stack the
+/// engine runs on (see `main.rs`). test262 contains no nesting near this deep,
+/// and it is comparable to V8's own limit (which rejects ~5000-deep nesting).
+const MAX_PARSE_DEPTH: u32 = 4_000;
 
 impl<'a> Parser<'a> {
     pub fn new(source: &'a str) -> Result<Self, ParseError> {
@@ -118,7 +129,25 @@ impl<'a> Parser<'a> {
             eval_new_target_allowed: false,
             last_expr_parenthesized: false,
             last_obj_had_proto_dup: false,
+            parse_depth: 0,
         })
+    }
+
+    /// Raise the parser recursion depth by one, returning a catchable parse
+    /// error if `MAX_PARSE_DEPTH` is exceeded. Paired with `exit_recursion`.
+    /// Used by the expression and statement recursion funnels so deeply nested
+    /// source raises a parse error rather than overflowing the native stack.
+    fn enter_recursion(&mut self) -> Result<(), ParseError> {
+        self.parse_depth += 1;
+        if self.parse_depth > MAX_PARSE_DEPTH {
+            self.parse_depth -= 1;
+            return Err(self.error("Maximum parse depth exceeded: input nested too deeply"));
+        }
+        Ok(())
+    }
+
+    fn exit_recursion(&mut self) {
+        self.parse_depth -= 1;
     }
 
     fn advance(&mut self) -> Result<Token, ParseError> {

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -92,6 +92,16 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_statement(&mut self) -> Result<Statement, ParseError> {
+        // Depth guard: nested statements (blocks, if/else, loops) recurse
+        // through here; bound it so deeply nested statements raise a catchable
+        // parse error instead of overflowing the native stack.
+        self.enter_recursion()?;
+        let r = self.parse_statement_inner();
+        self.exit_recursion();
+        r
+    }
+
+    fn parse_statement_inner(&mut self) -> Result<Statement, ParseError> {
         if self.strict && matches!(&self.current, Token::Keyword(Keyword::Function)) {
             return Err(self.error(
                 "In strict mode code, functions can only be declared at top level or inside a block",

--- a/tests/recursion-limit-interpreter.js
+++ b/tests/recursion-limit-interpreter.js
@@ -1,0 +1,45 @@
+// Deep JS call recursion must throw a *catchable* RangeError, not overflow the
+// native stack and abort the process (SIGABRT).
+//
+// This is what lets acorn's `catchStackOverflow` guard work: acorn's parser
+// relies on the host engine throwing a catchable stack-overflow error (message
+// matching /stack.*(exceeded|overflow)/i) when recursion is too deep. jsse used
+// to exhaust the native stack and SIGABRT instead, so acorn could never catch
+// it (see acorn test/tests.js "Not enough stack space" case).
+
+// Non-tail recursion with no base case: guaranteed to keep growing the call
+// stack until the engine's depth limit is hit. `1 + ...` keeps it out of tail
+// position so it cannot be optimized into a loop.
+function recurse(n) {
+  return 1 + recurse(n + 1);
+}
+
+var threw = false;
+var err = null;
+try {
+  recurse(0);
+} catch (e) {
+  threw = true;
+  err = e;
+}
+
+if (!threw) {
+  throw new Error("expected deep recursion to throw, but it returned normally");
+}
+if (!(err instanceof RangeError)) {
+  throw new Error(
+    "expected a RangeError, got " + (err && err.name) + ": " + (err && err.message)
+  );
+}
+if (!/stack/i.test(String(err.message))) {
+  throw new Error("expected the message to mention the stack, got: " + err.message);
+}
+
+// A second call after recovery must still work — the depth counter has to be
+// restored as the stack unwinds, not left saturated.
+function factorialish(n) {
+  return n <= 0 ? 0 : 1 + factorialish(n - 1);
+}
+if (factorialish(50) !== 50) {
+  throw new Error("engine did not recover after a stack-overflow RangeError");
+}

--- a/tests/recursion-limit-parser.js
+++ b/tests/recursion-limit-parser.js
@@ -1,0 +1,42 @@
+// Deeply nested *source* must raise a catchable error at parse time, not
+// overflow the native parser stack (SIGABRT). eval() parses at runtime and
+// surfaces a parse failure as a catchable SyntaxError, so this is observable
+// from within JS.
+
+function nestedArray(d) {
+  return "[".repeat(d) + "1" + "]".repeat(d);
+}
+
+// Expression nesting well beyond the parser depth limit -> catchable SyntaxError.
+var threw = false;
+var err = null;
+try {
+  eval(nestedArray(50000));
+} catch (e) {
+  threw = true;
+  err = e;
+}
+if (!threw) {
+  throw new Error("expected deeply nested array literal to throw at parse time");
+}
+if (!(err instanceof SyntaxError)) {
+  throw new Error("expected a SyntaxError, got " + err.name + ": " + err.message);
+}
+
+// Reasonable nesting must still parse AND evaluate — the limit must not reject
+// ordinary (if deep) code.
+var arr = eval(nestedArray(1000));
+if (!Array.isArray(arr)) {
+  throw new Error("moderately nested array literal should parse and evaluate");
+}
+
+// Statement nesting (nested blocks) must be catchable too, not crash.
+var threw2 = false;
+try {
+  eval("{".repeat(50000) + "}".repeat(50000));
+} catch (e) {
+  threw2 = true;
+}
+if (!threw2) {
+  throw new Error("expected deeply nested blocks to throw at parse time");
+}

--- a/tests/recursion-limit-parser.js
+++ b/tests/recursion-limit-parser.js
@@ -40,3 +40,22 @@ try {
 if (!threw2) {
   throw new Error("expected deeply nested blocks to throw at parse time");
 }
+
+// Recursive expression productions that bypass parse_assignment_expression
+// (prefix unary, right-associative **, and `new new …`) must be bounded too —
+// otherwise a single assignment expression recurses natively and aborts.
+function mustThrow(label, src) {
+  var threw = false;
+  try {
+    eval(src);
+  } catch (e) {
+    threw = true;
+  }
+  if (!threw) {
+    throw new Error("expected " + label + " to throw at parse time");
+  }
+}
+mustThrow("prefix unary chain", "!".repeat(200000) + "0");
+mustThrow("unary minus chain", "- ".repeat(200000) + "0");
+mustThrow("exponentiation chain", "2" + "**2".repeat(200000));
+mustThrow("new-expression chain", "new ".repeat(200000) + "X");

--- a/tests/tail-call-in-try-block.js
+++ b/tests/tail-call-in-try-block.js
@@ -1,0 +1,37 @@
+// A call in the `try` Block of a try statement is NEVER in tail position, even
+// in strict mode where proper tail calls apply: the exception handler must stay
+// live on the stack. jsse used to (incorrectly) optimize `return f()` inside a
+// try block into a tail call and discard the handler, so a throw from f()
+// escaped the catch. This is what prevented acorn's `catchStackOverflow`
+// (a strict-mode `try { return f() } catch { ... }`) from ever catching.
+
+"use strict";
+
+function thrower() {
+  throw new Error("boom");
+}
+
+// `return f()` sits inside the try block -> must NOT be a tail call.
+function wrap(f) {
+  try {
+    return f();
+  } catch (e) {
+    return "caught:" + e.message;
+  }
+}
+
+var r = wrap(thrower);
+if (r !== "caught:boom") {
+  throw new Error("expected 'caught:boom' (handler must catch), got: " + r);
+}
+
+// A genuine tail call outside any try must still be optimized (no stack growth).
+// If TCO were disabled wholesale this would overflow; it must simply return.
+function count(n, acc) {
+  "use strict";
+  if (n <= 0) return acc;
+  return count(n - 1, acc + 1); // real tail position
+}
+if (count(200000, 0) !== 200000) {
+  throw new Error("proper tail call outside try regressed");
+}


### PR DESCRIPTION
## Problem

Deep recursion aborted the process instead of throwing a catchable error. Two paths hit the native thread stack and `SIGABRT`ed (`thread 'main' has overflowed its stack`, exit 134):

1. **Interpreter** — deeply nested JS calls (e.g. running a recursive-descent parser written in JS).
2. **Parser** — deeply nested source (e.g. `eval("[".repeat(N) + "]".repeat(N))`).

This surfaced via the acorn test suite: acorn's `catchStackOverflow` wraps parsing in a `try/catch` that converts the host engine's stack-overflow error into a graceful `SyntaxError: Not enough stack space`. jsse had no catchable error to convert — it aborted — so `test/tests.js`'s 2000-deep nesting test crashed the whole run. (This was **not** a jsse regression; it's an upstream acorn change, `acornjs/acorn@8a47812`, that a fresh clone pulled in.)

## Fix

- **Interpreter call-depth guard** (`eval.rs`, `mod.rs`): every JS invocation funnels through `call_function_inner`, now wrapped with a `call_depth` counter. Crossing `CALL_DEPTH_SOFT_LIMIT` throws a catchable `RangeError: Maximum call stack size exceeded`, then **disarms** so a `catch` handler running deep in the stack has a `[soft, hard)` recovery band; a hard ceiling backstops runaway handlers, and the soft limit re-arms once the stack unwinds.
- **Parser depth guard** (`parser/`): a `parse_depth` counter on the expression and statement recursion funnels; exceeding `MAX_PARSE_DEPTH` raises a catchable parse error instead of overflowing.
- **128 MiB execution stack** (`main.rs`): the engine runs on a dedicated thread so the bounded limits have native room. 128 MiB fits inside the test harness's 512 MiB `RLIMIT_AS` (a larger reservation fails to spawn / starves the heap); falls back to the current thread if the stack can't be reserved.
- **Pre-existing strict-mode TCO bug fixed** (`exec.rs`): a call in a `try {}` block was treated as a tail call and TCO'd, discarding the `try/catch` so exceptions escaped — this is what actually prevented acorn's guard from catching. Per `sec-static-semantics-hascallintailposition`, a call in a **try block**, or in a **catch guarded by a finally**, is not in tail position; a call in a **finally block is**. (Verified against `language/statements/try/tco-*.js`.)

## Tests

New `tests/` coverage: `recursion-limit-interpreter.js`, `recursion-limit-parser.js`, `tail-call-in-try-block.js`.

## Validation

- **Full test262: 99,568 / 99,568 (100.00%), 0 regressions, +323 new passes** — the +323 are recursion/stack-overflow tests that previously `SIGABRT`ed and now throw a catchable `RangeError`.
- **acorn: 13,541 / 13,541 pass** — the 2000-deep test now yields `SyntaxError: Not enough stack space to parse input`, matching Node.
- Custom tests 6/6; `rustfmt` + `clippy` clean.

Limits were chosen to be regression-safe: the old 8 MiB main stack held every passing test (depths under ~1500), so limits ≥3000 cannot reject anything that used to work, and test262 contains no deep-nesting tests. `MAX_PARSE_DEPTH` is comparable to V8's own limit.
