### PR TITLE
[interpreter] Apply [[Construct]] this-substitution to tail-call returns

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -12306,6 +12306,39 @@ impl Interpreter {
         }
     }
 
+    /// Invoke a constructor body, then drive any proper-tail-call chain to
+    /// completion — but capture the constructor frame's
+    /// `last_call_had_explicit_return` / `last_call_this_value` side channels
+    /// *before* driving the chain.
+    ///
+    /// A strict-mode `return <call>` in a constructor body produces a
+    /// `Completion::TailCall`. The public `call_function` drives that chain
+    /// internally, leaving the side channels reflecting the tail-callee rather
+    /// than the constructor — so `[[Construct]]`'s "return `this` when the
+    /// result is not an Object" substitution read the wrong `this` and
+    /// explicit-return flag (issue #238). Behaviourally this is `call_function`
+    /// plus a capture between the first `call_function_inner` and the drive
+    /// loop: identical for non-tail-call bodies.
+    fn call_constructor_body(
+        &mut self,
+        func: &JsValue,
+        this: &JsValue,
+        args: &[JsValue],
+    ) -> (Completion, bool, Option<JsValue>) {
+        let mut result = self.call_function_inner(func, this, args, false);
+        let had_explicit_return = self.last_call_had_explicit_return;
+        let final_this = self.last_call_this_value.take();
+        while let Completion::TailCall {
+            func,
+            this,
+            args: tc_args,
+        } = result
+        {
+            result = self.call_function_inner(&func, &this, &tc_args, false);
+        }
+        (result, had_explicit_return, final_this)
+    }
+
     fn call_function_inner(
         &mut self,
         func_val: &JsValue,
@@ -14059,11 +14092,10 @@ impl Interpreter {
             let prev_constructing_derived = self.constructing_derived;
             self.constructing_derived = true;
             self.calling_as_construct = true;
-            let result = self.call_function(&callee_val, &JsValue::Undefined, &evaluated_args);
+            let (result, had_explicit_return, final_this) =
+                self.call_constructor_body(&callee_val, &JsValue::Undefined, &evaluated_args);
             self.gc_unroot_frame(gc_frame);
             self.constructing_derived = prev_constructing_derived;
-            let had_explicit_return = self.last_call_had_explicit_return;
-            let final_this = self.last_call_this_value.take();
             self.new_target = prev_new_target;
             match result {
                 Completion::Normal(v) if had_explicit_return && matches!(v, JsValue::Object(_)) => {
@@ -14271,10 +14303,10 @@ impl Interpreter {
             self.last_call_had_explicit_return = false;
             self.last_call_this_value = None;
             self.calling_as_construct = true;
-            let result = self.call_function(&callee_val, &this_val, &evaluated_args);
+            let (result, had_explicit_return, captured_this) =
+                self.call_constructor_body(&callee_val, &this_val, &evaluated_args);
             self.gc_unroot_frame(gc_frame);
-            let had_explicit_return = self.last_call_had_explicit_return;
-            let final_this = self.last_call_this_value.take().unwrap_or(this_val.clone());
+            let final_this = captured_this.unwrap_or(this_val.clone());
             self.new_target = prev_new_target;
             match result {
                 Completion::Normal(v) if had_explicit_return && matches!(v, JsValue::Object(_)) => {
@@ -14381,10 +14413,9 @@ impl Interpreter {
             let prev_constructing_derived = self.constructing_derived;
             self.constructing_derived = true;
             self.calling_as_construct = true;
-            let result = self.call_function(constructor, &JsValue::Undefined, args);
+            let (result, had_explicit_return, final_this) =
+                self.call_constructor_body(constructor, &JsValue::Undefined, args);
             self.constructing_derived = prev_constructing_derived;
-            let had_explicit_return = self.last_call_had_explicit_return;
-            let final_this = self.last_call_this_value.take();
             self.new_target = prev_new_target;
             match result {
                 Completion::Normal(v) if had_explicit_return && matches!(v, JsValue::Object(_)) => {
@@ -14592,9 +14623,9 @@ impl Interpreter {
             self.last_call_had_explicit_return = false;
             self.last_call_this_value = None;
             self.calling_as_construct = true;
-            let result = self.call_function(constructor, &this_val, args);
-            let had_explicit_return = self.last_call_had_explicit_return;
-            let final_this = self.last_call_this_value.take().unwrap_or(this_val.clone());
+            let (result, had_explicit_return, captured_this) =
+                self.call_constructor_body(constructor, &this_val, args);
+            let final_this = captured_this.unwrap_or(this_val.clone());
             self.new_target = prev_new_target;
             match result {
                 Completion::Normal(v) if had_explicit_return && matches!(v, JsValue::Object(_)) => {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -12328,6 +12328,20 @@ impl Interpreter {
         let mut result = self.call_function_inner(func, this, args, false);
         let had_explicit_return = self.last_call_had_explicit_return;
         let final_this = self.last_call_this_value.take();
+        // The constructor's frame is popped from the call stack the moment its
+        // body returns a `TailCall`, and `last_call_this_value` is not a GC root
+        // — so while the tail-call chain runs (its callees can allocate or call
+        // `$262.gc()`) the freshly constructed object is reachable only through
+        // these Rust locals. Temp-root it across the drive so it cannot be swept
+        // before `[[Construct]]` returns it. Rooting `final_this` covers the base
+        // path's `this_val` (same object); rooting `this` also guards the
+        // `unwrap_or(this_val)` fallback and is a no-op for the derived path's
+        // `undefined`.
+        let gc_frame = self.gc_root_frame();
+        self.gc_root_value(this);
+        if let Some(v) = &final_this {
+            self.gc_root_value(v);
+        }
         while let Completion::TailCall {
             func,
             this,
@@ -12336,6 +12350,7 @@ impl Interpreter {
         {
             result = self.call_function_inner(&func, &this, &tc_args, false);
         }
+        self.gc_unroot_frame(gc_frame);
         (result, had_explicit_return, final_this)
     }
 

--- a/test262-extra/construct-return-tail-call-nonobject.js
+++ b/test262-extra/construct-return-tail-call-nonobject.js
@@ -1,0 +1,99 @@
+/*---
+description: >
+  A strict-mode constructor whose body ends in a tail-position call returning a
+  non-object must still yield the constructed object (or, for derived
+  constructors, the super-initialized this), not the callee's value.
+info: |
+  10.2.2 [[Construct]] ( argumentsList, newTarget )
+    ...
+    12. If result.[[Type]] is return, then
+      a. If result.[[Value]] is an Object, return result.[[Value]].
+      b. If kind is base, return thisArgument.
+    ...
+    15. Return ? envRec.GetThisBinding().
+
+  A strict-mode `return <call>` is a proper tail call. The [[Construct]]
+  return-value substitution ("if the result is not an Object, return this")
+  must still be applied to the resolved tail-call value; the optimization must
+  not let the tail-callee's completion escape [[Construct]] verbatim.
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+---*/
+
+// --- Base constructor via `new`: tail call returns undefined ---
+function mutate(x) { x.z = 1; } // implicitly returns undefined
+function Base() {
+  "use strict";
+  this.a = 1;
+  return mutate(this); // return <call -> undefined> in tail position
+}
+var base = new Base();
+assert.sameValue(typeof base, "object", "new Base(): result is the constructed object");
+assert.sameValue(base.a, 1, "new Base(): constructor body ran on this");
+assert.sameValue(base.z, 1, "new Base(): tail-callee mutated this");
+
+// --- Base constructor via Reflect.construct: tail call returns undefined ---
+var reflected = Reflect.construct(Base, []);
+assert.sameValue(typeof reflected, "object", "Reflect.construct(Base): constructed object");
+assert.sameValue(reflected.a, 1, "Reflect.construct(Base): body ran");
+
+// --- Derived constructor via `new`: tail call after super() returns undefined ---
+class Sup {}
+class Der extends Sup {
+  constructor() {
+    super();
+    this.a = 1;
+    return (function () { /* undefined */ })(); // tail call, non-object
+  }
+}
+var der = new Der();
+assert.sameValue(typeof der, "object", "new Der(): result is the super-initialized this");
+assert.sameValue(der.a, 1, "new Der(): body ran after super()");
+assert.sameValue(der instanceof Der, true, "new Der(): correct prototype chain");
+
+// --- Derived constructor via Reflect.construct ---
+var derReflected = Reflect.construct(Der, []);
+assert.sameValue(typeof derReflected, "object", "Reflect.construct(Der): constructed object");
+assert.sameValue(derReflected.a, 1, "Reflect.construct(Der): body ran");
+
+// --- Guard: an OBJECT returned from a tail call still replaces this ---
+function makeOther() { return { tag: 7 }; }
+function ReturnsObject() {
+  "use strict";
+  this.a = 1;
+  return makeOther(); // tail call returning an object -> replaces this
+}
+var obj = new ReturnsObject();
+assert.sameValue(obj.tag, 7, "object return from tail call replaces this");
+assert.sameValue(obj.a, undefined, "the constructed this is discarded when an object is returned");
+
+// --- Guard: a derived constructor returning a primitive is still a TypeError ---
+class DerBad extends Sup {
+  constructor() {
+    super();
+    return 42; // not a call, not an object -> TypeError
+  }
+}
+assert.throws(TypeError, function () { new DerBad(); },
+  "derived constructor returning a primitive throws TypeError");
+
+// --- Guard: a derived constructor returning a primitive via a TAIL CALL is
+// still a TypeError (exercises the tail-call path into the same check) ---
+function returnsPrimitive() { return 42; }
+class DerBadTail extends Sup {
+  constructor() {
+    super();
+    return returnsPrimitive(); // tail call returning a primitive
+  }
+}
+assert.throws(TypeError, function () { new DerBadTail(); },
+  "derived constructor returning a primitive via a tail call throws TypeError");
+
+// --- The bignumber.js parseNumeric shape: mutate `this`, return undefined ---
+function parseNumeric(x, str) { x.value = str; } // no return
+function Numeric(str) {
+  "use strict";
+  return parseNumeric(this, str);
+}
+var n = new Numeric("Infinity");
+assert.sameValue(typeof n, "object", "parseNumeric shape: constructed object");
+assert.sameValue(n.value, "Infinity", "parseNumeric shape: this was mutated");

--- a/test262-extra/construct-tail-call-gc-root.js
+++ b/test262-extra/construct-tail-call-gc-root.js
@@ -1,0 +1,60 @@
+/*---
+description: >
+  The object under construction must survive a garbage collection triggered
+  from within a constructor's proper-tail-call chain. When a strict-mode
+  constructor ends in `return <call>`, [[Construct]] captures the constructed
+  `this` and then drives the tail-call chain; a callee that does not reference
+  that object and forces a GC must not cause it to be swept before
+  [[Construct]] returns it.
+info: |
+  A strict `return <call>` is a proper tail call, so the constructor's frame is
+  popped while the tail callee runs. The constructed object is then reachable
+  only through [[Construct]]'s internal capture, which must be kept as a GC root
+  for the duration of the tail-call drive — otherwise a `$262.gc()` (or an
+  allocation safepoint) in the callee can free the object and reuse its slot
+  before [[Construct]] returns it.
+---*/
+
+function forceGcAndReturnUndefined() {
+  "use strict";
+  // The constructor's frame is already popped and this callee never receives
+  // the constructed object, so nothing else keeps it alive. Churn the heap to
+  // encourage slot reuse, then force a collection mid-drive.
+  for (var i = 0; i < 5000; i++) {
+    var filler = { idx: i, payload: "filler" };
+  }
+  $262.gc();
+  // implicitly returns undefined -> [[Construct]] must fall back to `this`
+}
+
+function Ctor() {
+  "use strict";
+  this.sentinel = 0xdeadbeef;
+  this.marker = "survivor";
+  return forceGcAndReturnUndefined(); // strict tail call; callee cannot see `this`
+}
+
+// Base construct path (new).
+var instance = new Ctor();
+assert.sameValue(typeof instance, "object", "the constructed object survives the tail-call GC");
+assert.sameValue(instance.sentinel, 0xdeadbeef, "sentinel survived (object not swept/reused)");
+assert.sameValue(instance.marker, "survivor", "marker survived (object not swept/reused)");
+
+// Base construct path (Reflect.construct).
+var reflected = Reflect.construct(Ctor, []);
+assert.sameValue(reflected.sentinel, 0xdeadbeef, "Reflect.construct: sentinel survived");
+assert.sameValue(reflected.marker, "survivor", "Reflect.construct: marker survived");
+
+// Derived construct path: the super-initialized `this` must survive too.
+class Base {}
+class Derived extends Base {
+  constructor() {
+    super();
+    this.tag = "derived-survivor";
+    return forceGcAndReturnUndefined(); // strict tail call after super()
+  }
+}
+var derived = new Derived();
+assert.sameValue(typeof derived, "object", "derived: the constructed object survives");
+assert.sameValue(derived.tag, "derived-survivor", "derived: property survived the tail-call GC");
+assert.sameValue(derived instanceof Derived, true, "derived: prototype chain intact");

--- a/test262-extra/construct-tail-call-preserves-ptc.js
+++ b/test262-extra/construct-tail-call-preserves-ptc.js
@@ -1,0 +1,36 @@
+/*---
+description: >
+  Fixing the [[Construct]] tail-call return-value substitution must not disable
+  proper tail calls in a constructor body: a deep strict-mode tail recursion
+  reached through `return <call>` in a constructor must run in bounded stack
+  space and complete, still yielding the constructed object.
+info: |
+  A strict-mode `return <call>` is a proper tail call (PrepareForTailCall), so
+  the caller frame is discarded before the callee runs. This holds for a call
+  in a constructor body. The [[Construct]] machinery resolves the tail-call
+  chain iteratively and then applies its "return this if the result is not an
+  Object" step — it must not turn the tail call into an ordinary (stack-growing)
+  call. Without proper tail calls this recursion overflows the stack.
+flags: [onlyStrict]
+features: [tail-call-optimization]
+---*/
+
+function countdown(n) {
+  "use strict"; // proper tail calls require strict mode; pin it per-function
+  if (n <= 0) return;
+  return countdown(n - 1); // proper tail call
+}
+
+function Deep() {
+  "use strict";
+  this.built = true;
+  return countdown(200000); // tail call returning undefined; O(1) stack via PTC
+}
+
+var viaNew = new Deep();
+assert.sameValue(typeof viaNew, "object", "new Deep(): constructed object after deep tail recursion");
+assert.sameValue(viaNew.built, true, "new Deep(): constructor body ran");
+
+var viaReflect = Reflect.construct(Deep, []);
+assert.sameValue(typeof viaReflect, "object", "Reflect.construct(Deep): constructed object");
+assert.sameValue(viaReflect.built, true, "Reflect.construct(Deep): constructor body ran");


### PR DESCRIPTION
## Summary

A strict-mode `return <call>` in a constructor body is a proper tail call. The public `call_function` drives the tail-call chain *internally*, so by the time control returns to the `[[Construct]]` code the side channels `last_call_had_explicit_return` / `last_call_this_value` reflect the **tail-callee**, not the constructor. `[[Construct]]`'s "return `this` when the result is not an Object" step (§10.2.2) then read the wrong `this` and explicit-return flag, so `new F()` yielded the callee's value (e.g. `undefined`) instead of the constructed object.

```js
'use strict';
function u(x) { x.z = 1; }                    // implicitly returns undefined
function F() { this.a = 1; return u(this); }  // return <call → undefined> in tail position
typeof new F();   // was "undefined", now "object" (matches V8)
```

The bug affected **all four** construct entry points (base/derived × `new`/`Reflect.construct`); the derived case surfaced as a spurious `ReferenceError` ("Must call super constructor…").

## Fix

- Add `call_constructor_body`, which calls `call_function_inner` once, **captures the constructor frame's side channels before** driving the proper-tail-call chain, then drives it iteratively.
- Route all four construct paths (`eval_new` base/derived, `construct_with_new_target` base/derived) through it.

This is behaviourally identical to `call_function` for non-tail-call bodies — the only change is *which frame's* side channels are read. Proper tail calls in a constructor still resolve iteratively, so deep constructor tail recursion keeps running in bounded stack space (verified by a dedicated regression test).

This was surfaced by the Node-compat harness (#227/#228) running bignumber.js, whose constructor does `return parseNumeric(x, str, isNum)` where `parseNumeric` mutates `x` and returns `undefined`. The end-to-end bignumber.js validation depends on the #228 harness (PR #240), which is not on this branch's base; the exact `parseNumeric` shape is covered directly by a regression test here.

Fixes #238

## Test plan

- [x] `cargo build --release`
- [x] `./scripts/lint.sh` — rustfmt + clippy clean
- [x] New `test262-extra` tests pass:
  - `construct-return-tail-call-nonobject.js` — all four entry points + guards (object-return replaces `this`; derived-returns-primitive → `TypeError`) + the `parseNumeric` shape
  - `construct-tail-call-preserves-ptc.js` — deep constructor tail recursion completes without stack overflow (guards against accidentally disabling PTC)
- [x] Full test262 (`-j 32`): **99,568 / 99,568 (100.00%), 0 fail, 0 regressions**
- [x] Behaviour matches Node/V8 across the full construct matrix