### PR TITLE
[interp] Bound eval-time expression recursion to a catchable RangeError

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -5,6 +5,21 @@ mod access;
 mod literals;
 mod modules;
 
+/// RAII guard that decrements the interpreter's expression-evaluation depth
+/// counter on every exit path of `eval_expr` — the tail return, each of its
+/// ~100 early `return`s, and any unwind. It holds an `Rc<Cell<usize>>` rather
+/// than a borrow of `Interpreter` so `eval_expr` can keep using `&mut self`
+/// across the whole match without a borrow conflict; because the counter lives
+/// in its own allocation, nested `&mut self` reborrows never invalidate the
+/// handle (a raw pointer into `self` would be unsound here).
+struct EvalDepthGuard(std::rc::Rc<std::cell::Cell<usize>>);
+
+impl Drop for EvalDepthGuard {
+    fn drop(&mut self) {
+        self.0.set(self.0.get() - 1);
+    }
+}
+
 /// StringToBigInt per spec §7.1.14 — handles empty string, hex, octal, binary.
 fn string_to_bigint_for_comparison(s: &str) -> Option<num_bigint::BigInt> {
     let trimmed = s.trim();
@@ -292,6 +307,31 @@ impl Interpreter {
     }
 
     pub(crate) fn eval_expr(&mut self, expr: &Expression, env: &EnvRef) -> Completion {
+        // Catchable stack-depth guard for expression evaluation. Every
+        // expression node — and each recursive descent into an operand —
+        // funnels through here, so bounding this depth bounds the native
+        // recursion a deeply left-nested AST (`1+1+1+…`, `1&&1&&1…`, parsed in
+        // a loop so it never trips the parser's `MAX_PARSE_DEPTH`) would
+        // otherwise use to overflow the stack (SIGABRT).
+        //
+        // Kept a single function on purpose. Splitting the depth accounting
+        // into a thin wrapper around an inner `_impl` added a call frame per
+        // operand, which roughly *tripled* the native stack each level consumes
+        // — lowering the overflow ceiling and eroding the headroom the
+        // `call_depth` guard depends on. Instead, `EvalDepthGuard` decrements on
+        // every one of this match's exit paths (its many early `return`s and
+        // any unwind included), so the counter reflects real native depth
+        // without splitting the hot function.
+        use crate::interpreter::EVAL_DEPTH_LIMIT;
+        let depth = self.eval_depth.get();
+        if depth >= EVAL_DEPTH_LIMIT {
+            // Check before incrementing: the throw path never touches the counter.
+            return Completion::Throw(
+                self.create_error("RangeError", "Maximum call stack size exceeded"),
+            );
+        }
+        self.eval_depth.set(depth + 1);
+        let _depth_guard = EvalDepthGuard(std::rc::Rc::clone(&self.eval_depth));
         match expr {
             Expression::Literal(lit) => Completion::Normal(self.eval_literal(lit)),
             Expression::Identifier(name) => {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -181,6 +181,16 @@ pub struct Interpreter {
     /// exception/finalizer handlers stay live. Saved and reset to 0 on entry to
     /// each function body so it never leaks into callees.
     pub(crate) tco_suppress_depth: u32,
+    /// Current expression-evaluation nesting depth. Incremented on entry to
+    /// every `eval_expr` and decremented (via `EvalDepthGuard`) as it unwinds.
+    /// A deeply *left-nested* binary/logical AST (e.g. `1+1+1+…`, parsed in a
+    /// loop so it never trips the parser's `MAX_PARSE_DEPTH`) recurses once per
+    /// operand through `eval_expr`; bounding this depth throws a catchable
+    /// `RangeError` before the native stack overflows (SIGABRT). Separate from
+    /// `call_depth`: a flat expression drives this without any JS call. Held in
+    /// an `Rc<Cell<>>` so the drop guard can own an independent handle without
+    /// borrowing `self` (see `EvalDepthGuard` in `eval.rs`).
+    pub(crate) eval_depth: std::rc::Rc<std::cell::Cell<usize>>,
 }
 
 /// Soft JS call-depth limit: crossing it throws a catchable `RangeError:
@@ -197,6 +207,22 @@ pub(crate) const CALL_DEPTH_HARD_LIMIT: usize = 5_000;
 /// The soft limit re-arms only after the stack unwinds below this, so a
 /// recovering handler oscillating just under the soft limit does not re-trip.
 pub(crate) const CALL_DEPTH_REARM_LIMIT: usize = 3_000;
+
+/// Expression-evaluation nesting limit: crossing it throws a catchable
+/// `RangeError: Maximum call stack size exceeded` instead of overflowing the
+/// native stack on a deeply left-nested expression tree.
+///
+/// No soft/hard recovery band is needed here (unlike `call_depth`): the only
+/// input that reaches this depth is a single flat expression, which has no
+/// intermediate `catch` points, so the throw fully unwinds every `eval_expr`
+/// frame before any handler runs. Expression nesting reachable *through* JS
+/// calls is bounded first by the `CALL_DEPTH_*` guards (hard 5000 × a few eval
+/// frames per level ≈ well under 20k), so this limit never interferes with
+/// normal recursion. It sits far above that (50k) yet at roughly a third of the
+/// measured native overflow point on the 128 MiB execution stack (a flat
+/// expression SIGABRTs between 140k and 150k operands with the guard removed),
+/// leaving ample headroom for the error object's own construction.
+pub(crate) const EVAL_DEPTH_LIMIT: usize = 50_000;
 
 pub(crate) struct CallFrame {
     pub func_obj_id: u64,
@@ -341,6 +367,7 @@ impl Interpreter {
             call_depth: 0,
             overflow_armed: true,
             tco_suppress_depth: 0,
+            eval_depth: std::rc::Rc::new(std::cell::Cell::new(0)),
         };
         interp.setup_globals();
         interp

--- a/tests/recursion-limit-interpreter.js
+++ b/tests/recursion-limit-interpreter.js
@@ -43,3 +43,58 @@ function factorialish(n) {
 if (factorialish(50) !== 50) {
   throw new Error("engine did not recover after a stack-overflow RangeError");
 }
+
+// ---------------------------------------------------------------------------
+// Deep eval-time expression recursion (jsse#241).
+//
+// Binary/logical operators parse in a left-associative *loop*, so a flat
+// expression like "1+1+1+…" never trips the parser depth limit — the tree is
+// only walked recursively later, by eval_expr, once per operand. That walk
+// used to exhaust the native stack (SIGABRT) instead of throwing. It must now
+// throw a *catchable* RangeError, just like deep call recursion above.
+
+function evalMustRangeError(label, src) {
+  var threw = false;
+  var err = null;
+  try {
+    eval(src);
+  } catch (e) {
+    threw = true;
+    err = e;
+  }
+  if (!threw) {
+    throw new Error("expected " + label + " to throw at eval time");
+  }
+  if (!(err instanceof RangeError)) {
+    throw new Error(
+      "expected " + label + " to throw a RangeError, got " +
+        (err && err.name) + ": " + (err && err.message)
+    );
+  }
+  if (!/stack/i.test(String(err.message))) {
+    throw new Error(
+      "expected " + label + " message to mention the stack, got: " + err.message
+    );
+  }
+}
+
+// Additive (left-nested Binary) and logical (left-nested Logical) arms both
+// descend through eval_expr and must both be bounded.
+evalMustRangeError("deep additive expression", "1" + "+1".repeat(500000));
+evalMustRangeError("deep logical expression", "1" + "&&1".repeat(500000));
+
+// The eval-depth counter must unwind on the throw path, not leak. If it did,
+// repeated deep-eval failures would accumulate phantom depth until an
+// expression well *below* the limit spuriously threw. Trip the limit many
+// times, then require a moderately deep (but legal) expression to still
+// evaluate to the right value in the same process.
+for (var i = 0; i < 20; i++) {
+  try {
+    eval("1" + "+1".repeat(60000));
+  } catch (e) {
+    // expected RangeError, swallow
+  }
+}
+if (eval("1" + "+1".repeat(10000)) !== 10001) {
+  throw new Error("eval-depth counter leaked: a below-limit expression failed after recovery");
+}


### PR DESCRIPTION
## Summary

- A deeply *left-nested* binary/logical AST (`eval("1" + "+1".repeat(500000))`, `"&&1"`, …) parses fine — binary operators parse in a left-associative **loop**, so they never trip the parser's `MAX_PARSE_DEPTH` — but overflowed the native stack (SIGABRT) later, when `eval_expr` recursed once per operand. This is the eval-time gap left open after #239 bounded **call** depth and **parse** depth.
- Bound `eval_expr` nesting with a new `EVAL_DEPTH_LIMIT` (50k) so a deep tree now throws a catchable `RangeError: Maximum call stack size exceeded`, consistent with #239's goal.
- The depth counter is decremented on every one of `eval_expr`'s ~100 exit paths via a `Drop` guard, keeping `eval_expr` a **single function**. Splitting it into a wrapper + inner `_impl` (the obvious approach) added a call frame per operand that *tripled* the per-level native stack — lowering the overflow ceiling and eroding the headroom the `call_depth` guard relies on. The guard holds an `Rc<Cell<usize>>` rather than a borrow of `self`, so it stays sound under the nested `&mut self` reborrows (a raw pointer into `self` would be Stacked-Borrows UB here).

## Calibration

The limit sits ~3× above the deepest eval nesting real recursion reaches (itself already capped by the `call_depth` hard limit of 5000) and at roughly a third of the measured native overflow point — with the guard removed, a flat expression SIGABRTs between **140k and 150k** operands on the 128 MiB execution stack — leaving ample headroom for constructing the error object at the limit.

**Known pre-existing hole (not addressed, unchanged from #239's frame-accounting assumption):** a program combining deep call recursion *and* a large flat expression at the deepest leaf could in theory overflow before either individual limit fires. This is not reachable by real code and is out of scope here.

Fixes #241

## Test plan

- [x] `uv run python scripts/run-test262.py -j 32` — **99,568 / 99,568, 0 regressions**
- [x] `./scripts/run-acorn-tests.sh` — **13,507 pass on jsse, cross-checked vs Node** (same stack-overflow-recovery domain as #239)
- [x] `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual repro: both `eval("1"+"+1".repeat(500000))` and the `&&` variant now throw a catchable `RangeError` (were SIGABRT)
- [x] New regression tests in `tests/recursion-limit-interpreter.js`: additive + logical deep exprs throw a catchable `RangeError`, and a below-limit expression still evaluates after 20 deep-throw iterations (counter-leak detector)
- [x] Perf: tight arithmetic loop (`for … s += i`, 1e7) within run-to-run noise before/after