### PR TITLE
[runtime] Make __host_exit uncatchable via Completion::Exit

### DIFF
--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -498,16 +498,13 @@ impl Interpreter {
 
             let mut current_error: Option<JsValue> = None;
             for resource in stack.iter().rev() {
-                // A pending `__host_exit` (issue #229) makes the exit immediate:
-                // stop before running further disposers or `wrap_suppressed_error`
-                // (a user-replaceable `SuppressedError`). Abrupt so callers
-                // unwind. Inert unless the node host floor is enabled.
-                if self.pending_exit.is_some() {
-                    return Completion::Throw(JsValue::Undefined);
-                }
                 let result = self.call_function(&resource.dispose_method, &resource.value, &[]);
-                if self.pending_exit.is_some() {
-                    return Completion::Throw(JsValue::Undefined);
+                // A disposer that called `__host_exit` (issue #242) makes the
+                // exit immediate: propagate the `Completion::Exit` before
+                // running further disposers or `wrap_suppressed_error` (a
+                // user-replaceable `SuppressedError`). Inert off-path.
+                if let Completion::Exit(code) = result {
+                    return Completion::Exit(code);
                 }
                 match result {
                     Completion::Normal(_) => {}
@@ -559,13 +556,11 @@ impl Interpreter {
             0,
             |interp, this, _args| {
                 let result = interp.async_disposable_stack_dispose(this);
-                // A pending `__host_exit` (issue #229) must propagate abruptly,
-                // not be wrapped into a (resolved/rejected) promise returned as
-                // `Normal(promise)` — that would let the caller keep evaluating
-                // in expression position. Inert unless the node host floor is on.
-                if interp.pending_exit.is_some() {
-                    return Completion::Throw(JsValue::Undefined);
-                }
+                // A disposer that called `__host_exit` (issue #242) surfaces as
+                // `Completion::Exit`; it must propagate abruptly (via the `other`
+                // arm) rather than being wrapped into a resolved/rejected promise
+                // returned as `Normal`, which would let the caller keep
+                // evaluating in expression position.
                 match result {
                     Completion::Normal(_) => interp.create_resolved_promise(JsValue::Undefined),
                     Completion::Throw(e) => interp.create_rejected_promise(e),
@@ -1050,11 +1045,6 @@ impl Interpreter {
             let mut needs_await = false;
             let mut has_awaited = false;
             for resource in stack.iter().rev() {
-                // A pending `__host_exit` (issue #229) stops async disposal
-                // immediately; abrupt so callers unwind. Inert off-path.
-                if self.pending_exit.is_some() {
-                    return Completion::Throw(JsValue::Undefined);
-                }
                 if resource.hint == DisposeHint::Async
                     && matches!(resource.dispose_method, JsValue::Undefined)
                 {
@@ -1062,16 +1052,18 @@ impl Interpreter {
                     continue;
                 }
                 let result = self.call_function(&resource.dispose_method, &resource.value, &[]);
-                if self.pending_exit.is_some() {
-                    return Completion::Throw(JsValue::Undefined);
+                // A disposer that called `__host_exit` (issue #242) stops async
+                // disposal immediately; propagate the exit. Inert off-path.
+                if let Completion::Exit(code) = result {
+                    return Completion::Exit(code);
                 }
                 match result {
                     Completion::Normal(v) if resource.hint == DisposeHint::Async => {
                         needs_await = true;
                         has_awaited = true;
                         let awaited = self.await_value(&v);
-                        if self.pending_exit.is_some() {
-                            return Completion::Throw(JsValue::Undefined);
+                        if let Completion::Exit(code) = awaited {
+                            return Completion::Exit(code);
                         }
                         if let Completion::Throw(e) = awaited {
                             current_error = Some(self.wrap_suppressed_error(e, current_error));
@@ -1084,10 +1076,10 @@ impl Interpreter {
                 }
             }
             if needs_await && !has_awaited {
-                let _ = self.await_value(&JsValue::Undefined);
-                // The final await may have run a job requesting `__host_exit`.
-                if self.pending_exit.is_some() {
-                    return Completion::Throw(JsValue::Undefined);
+                // The final await may have run a job that called `__host_exit`
+                // (issue #242): propagate the `Completion::Exit` abruptly.
+                if let Completion::Exit(code) = self.await_value(&JsValue::Undefined) {
+                    return Completion::Exit(code);
                 }
             }
 

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -4735,13 +4735,13 @@ impl Interpreter {
     /// IteratorClose per §7.4.6 - called during abrupt completion (e.g., break/throw in for-of).
     /// The original completion takes priority over errors from return().
     pub(crate) fn iterator_close(&mut self, iterator: &JsValue, _completion: JsValue) -> JsValue {
-        // A pending `__host_exit` (issue #229) makes the exit immediate: skip
-        // the iterator's user-defined `return()` (arbitrary side effects / a
-        // possible re-entrant `__host_exit`), matching Node's `process.exit`.
-        // Inert unless the node host floor is enabled.
-        if self.pending_exit.is_some() {
-            return _completion;
-        }
+        // Note (issue #242): when a for-of *body* calls `__host_exit`, its
+        // `Completion::Exit` takes the loop's `other` arm and never reaches
+        // here, so the iterator's `return()` is not run. This path only runs
+        // when the loop is unwinding a genuine throw/break; if `return()` then
+        // itself calls `__host_exit`, that boundary returns a `JsValue` and so
+        // cannot carry the exit — record it in the terminal `pending_exit`
+        // sink instead. Inert unless the node host floor is enabled.
         if let JsValue::Object(io) = iterator {
             // GetMethod(iterator, "return"): undefined/null → no-op, non-callable → TypeError
             let return_val = match self.get_object_property(io.id, "return", iterator) {
@@ -4757,18 +4757,19 @@ impl Interpreter {
                 return _completion;
             }
             // Call return(), but original completion takes priority over errors
-            let _ = self.call_function(&return_val, iterator, &[]);
+            if let Completion::Exit(code) = self.call_function(&return_val, iterator, &[]) {
+                self.pending_exit = Some(code);
+            }
         }
         _completion
     }
 
     /// IteratorClose for normal completion paths (no abrupt completion to prioritize).
     pub(crate) fn iterator_close_result(&mut self, iterator: &JsValue) -> Result<(), JsValue> {
-        // See `iterator_close`: a pending `__host_exit` (issue #229) skips the
-        // iterator's `return()` so the exit is immediate. Inert off-path.
-        if self.pending_exit.is_some() {
-            return Ok(());
-        }
+        // See `iterator_close` (issue #242): only reached when the loop is not
+        // unwinding a body `Completion::Exit`. If `return()` itself calls
+        // `__host_exit`, record it in the terminal sink — this `Result`-typed
+        // boundary cannot carry a `Completion::Exit`. Inert off-path.
         if let JsValue::Object(io) = iterator {
             // GetMethod(iterator, "return"): undefined/null → no-op, non-callable → TypeError
             let return_val = match self.get_object_property(io.id, "return", iterator) {
@@ -4787,6 +4788,7 @@ impl Interpreter {
                     return Err(self.create_type_error("Iterator result is not an object"));
                 }
                 Completion::Throw(e) => return Err(e),
+                Completion::Exit(code) => self.pending_exit = Some(code),
                 _ => {}
             }
         }

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -80,11 +80,15 @@ impl Interpreter {
 
         // __host_exit(code)
         //
-        // Records the process exit code and unwinds uncatchably. The returned
-        // sentinel Throw stops execution; `pending_exit` — not the thrown value
-        // — is the signal that try/catch, the microtask drain loop, and `main`
-        // all honor, so the exit is not swallowed by user `catch`/`finally` or
-        // by a Promise reaction. Backs process.exit.
+        // Unwinds the stack uncatchably by returning `Completion::Exit(code)`
+        // (issue #242). That completion kind propagates like `Throw` but is
+        // structurally uncatchable — no user `catch`/`finally`, disposer,
+        // iterator `return()`, or Promise reaction ever consumes it — so the
+        // exit is immediate at every site without a per-site flag re-check.
+        // The exit code is carried in the completion; the interpreter's
+        // `pending_exit` sink is written only where `Exit` crosses a boundary
+        // that cannot carry a completion (the event-loop drain, `run`). Backs
+        // process.exit.
         let exit_fn = self.create_function(JsFunction::native(
             "__host_exit".to_string(),
             1,
@@ -97,8 +101,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     },
                 };
-                interp.pending_exit = Some(code);
-                Completion::Throw(JsValue::Undefined)
+                Completion::Exit(code)
             },
         ));
         self.install_host_global("__host_exit", exit_fn);

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -944,6 +944,11 @@ impl Interpreter {
                             ) {
                                 Completion::Throw(e) => Err(e),
                                 Completion::Normal(v) => Ok(v),
+                                // A `__host_exit` inside the reaction handler
+                                // (issue #242) propagates out of the job as
+                                // `Completion::Exit` — the Promise reaction must
+                                // not consume it into a fulfillment/rejection.
+                                Completion::Exit(code) => return Completion::Exit(code),
                                 _ => Ok(JsValue::Undefined),
                             }
                         } else {
@@ -1006,6 +1011,12 @@ impl Interpreter {
             Box::new(move |interp| {
                 let result =
                     interp.call_function(&then_fn, &thenable, &[resolve_fn, reject_fn.clone()]);
+                // A `__host_exit` inside the user `then` (issue #242) propagates
+                // out of the job as `Completion::Exit` rather than being turned
+                // into a rejection.
+                if let Completion::Exit(code) = result {
+                    return Completion::Exit(code);
+                }
                 if let Completion::Throw(e) = result
                     && let Completion::Throw(e2) =
                         interp.call_function(&reject_fn, &JsValue::Undefined, &[e])

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -6298,14 +6298,32 @@ impl Interpreter {
                 );
                 return Completion::Normal(self.create_iter_result_object(yield_val, false));
             }
+            if let Completion::Exit(code) = stmt_result {
+                // `__host_exit` (issue #242) is uncatchable and immediate:
+                // complete the generator without routing through its
+                // catch/finally states or disposing, and propagate the exit.
+                obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                    IteratorState::StateMachineGenerator {
+                        state_machine,
+                        func_env,
+                        is_strict,
+                        execution_state: StateMachineExecutionState::Completed,
+                        _sent_value: JsValue::Undefined,
+                        try_stack: vec![],
+                        pending_binding: None,
+                        delegated_iterator: None,
+                        pending_exception: None,
+                        pending_return: None,
+                    },
+                );
+                self.generator_inline_iters.remove(&o.id);
+                return Completion::Exit(code);
+            }
             if let Completion::Throw(e) = stmt_result {
-                // A pending `__host_exit` (issue #229) is uncatchable: don't
-                // route the sentinel throw into the generator/async body's
-                // catch/finally states — let it complete the machine and
-                // propagate. Inert unless the node host floor is enabled.
-                if self.pending_exit.is_none()
-                    && let Some(try_info) = current_try_stack.pop()
-                {
+                // Route genuine throws through the generator body's
+                // catch/finally states (a `Completion::Exit` was handled
+                // above and never reaches here).
+                if let Some(try_info) = current_try_stack.pop() {
                     if let Some(catch_state) = try_info.catch_state {
                         pending_exception = Some(e);
                         current_id = catch_state;
@@ -6409,12 +6427,11 @@ impl Interpreter {
                         match _result {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
-                                // Route through try-stack for proper catch/finally handling
-                                // — unless `__host_exit` is pending (issue #229), which is
-                                // uncatchable and must complete the machine instead.
-                                if self.pending_exit.is_none()
-                                    && let Some(try_info) = current_try_stack.pop()
-                                {
+                                // Route genuine throws through the try-stack for
+                                // catch/finally handling (a `Completion::Exit`
+                                // takes the `other` arm below and never reaches
+                                // here — issue #242).
+                                if let Some(try_info) = current_try_stack.pop() {
                                     if let Some(catch_state) = try_info.catch_state {
                                         pending_exception = Some(e);
                                         current_id = catch_state;
@@ -9828,14 +9845,33 @@ impl Interpreter {
                 None
             };
 
+            if let Completion::Exit(code) = stmt_result {
+                // `__host_exit` (issue #242) is uncatchable and immediate:
+                // complete the async generator without routing to its
+                // catch/finally states, disposing, or settling the result
+                // promise, and propagate the exit.
+                self.generator_inline_iters.remove(&o.id);
+                obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                    IteratorState::StateMachineAsyncGenerator {
+                        state_machine,
+                        func_env,
+                        is_strict,
+                        execution_state: StateMachineExecutionState::Completed,
+                        _sent_value: JsValue::Undefined,
+                        try_stack: vec![],
+                        pending_binding: None,
+                        delegated_iterator: None,
+                        pending_exception: None,
+                        pending_return: None,
+                    },
+                );
+                return Completion::Exit(code);
+            }
             if let Completion::Throw(e) = stmt_result {
-                // A pending `__host_exit` (issue #229) is uncatchable: don't
-                // route the sentinel throw into the generator/async body's
-                // catch/finally states — let it complete the machine and
-                // propagate. Inert unless the node host floor is enabled.
-                if self.pending_exit.is_none()
-                    && let Some(try_info) = current_try_stack.pop()
-                {
+                // Route genuine throws through the async generator body's
+                // catch/finally states (a `Completion::Exit` was handled above
+                // and never reaches here).
+                if let Some(try_info) = current_try_stack.pop() {
                     if let Some(catch_state) = try_info.catch_state {
                         pending_exception = Some(e);
                         current_id = catch_state;
@@ -10022,12 +10058,11 @@ impl Interpreter {
                         match self.eval_expr(expr, &func_env) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
-                                // Route through try-stack for proper catch/finally handling
-                                // — unless `__host_exit` is pending (issue #229), which is
-                                // uncatchable and must complete the machine instead.
-                                if self.pending_exit.is_none()
-                                    && let Some(try_info) = current_try_stack.pop()
-                                {
+                                // Route genuine throws through the try-stack for
+                                // catch/finally handling (a `Completion::Exit`
+                                // takes the `other` arm below and never reaches
+                                // here — issue #242).
+                                if let Some(try_info) = current_try_stack.pop() {
                                     if let Some(catch_state) = try_info.catch_state {
                                         pending_exception = Some(e);
                                         current_id = catch_state;
@@ -15581,30 +15616,34 @@ impl Interpreter {
             },
         );
 
-        self.async_function_resume(async_id, JsValue::Undefined, false);
+        let resume = self.async_function_resume(async_id, JsValue::Undefined, false);
 
         self.gc_unroot_frame(gc_frame);
-        // The synchronous drive above may have requested `__host_exit`
-        // (issue #229). Returning `Normal(promise)` here would let the CALLER
-        // keep evaluating — including in expression position (`f(), g()`;
-        // `h(f())`), which the statement-level chokepoint can't reach. Return
-        // the abrupt sentinel instead. Inert unless the node host floor is on.
-        if self.pending_exit.is_some() {
-            return Completion::Throw(JsValue::Undefined);
+        // If the body ran `__host_exit` synchronously (before any await, issue
+        // #242), propagate the exit as this call's completion — in expression
+        // position too (`f(), g()`; `h(f())`), which a statement-level check
+        // cannot reach — instead of returning the never-to-settle promise.
+        if let Completion::Exit(code) = resume {
+            return Completion::Exit(code);
         }
         Completion::Normal(promise)
     }
 
+    /// Drives an async function's state machine. Returns `Completion::Exit`
+    /// (issue #242) if the body called `__host_exit` — the caller must
+    /// propagate it rather than settling the result promise — and
+    /// `Completion::Normal(undefined)` otherwise (the promise was settled or
+    /// the machine suspended at an await).
     pub(crate) fn async_function_resume(
         &mut self,
         async_id: u64,
         sent_value: JsValue,
         is_error: bool,
-    ) {
+    ) -> Completion {
         use crate::interpreter::generator_transform::{SentValueBindingKind, StateTerminator};
 
         let Some(state) = self.scheduler.remove_async_function_state(async_id) else {
-            return;
+            return Completion::Normal(JsValue::Undefined);
         };
 
         let AsyncFunctionState {
@@ -15703,10 +15742,16 @@ impl Interpreter {
                         Completion::Return(v) => {
                             self.scheduler.remove_async_function_state(async_id);
                             let _ = self.call_function(&resolve_fn, &JsValue::Undefined, &[v]);
-                            return;
+                            return Completion::Normal(JsValue::Undefined);
                         }
                         Completion::Throw(e) => {
                             pending_exception = Some(e);
+                        }
+                        // A disposer that called `__host_exit` (issue #242)
+                        // propagates out uncatchably rather than settling.
+                        Completion::Exit(code) => {
+                            self.scheduler.remove_async_function_state(async_id);
+                            return Completion::Exit(code);
                         }
                         _ => {}
                     }
@@ -15737,12 +15782,11 @@ impl Interpreter {
                     &for_of_stack,
                     for_of_iter_env.clone(),
                 );
-                return;
+                return Completion::Normal(JsValue::Undefined);
             }
 
             if current_id >= state_machine.states.len() {
-                self.async_fn_complete(async_id, &func_env, &resolve_fn, &reject_fn);
-                return;
+                return self.async_fn_complete(async_id, &func_env, &resolve_fn, &reject_fn);
             }
             let terminator = state_machine.states[current_id].terminator.clone();
 
@@ -15755,16 +15799,10 @@ impl Interpreter {
                 )
                 && let Some(exc) = pending_exception.take()
             {
-                // A pending `__host_exit` (issue #229) is uncatchable: reject
-                // the promise without routing the sentinel through the async
-                // body's catch/finally handlers, and stop driving the machine.
-                // Inert unless the node host floor is enabled. Mirrors the
-                // unhandled-throw path below.
-                if self.pending_exit.is_some() {
-                    self.scheduler.remove_async_function_state(async_id);
-                    let _ = self.call_function(&reject_fn, &JsValue::Undefined, &[exc]);
-                    return;
-                }
+                // Genuine throws route through the async body's catch/finally
+                // handlers here. A `Completion::Exit` (issue #242) never becomes
+                // a `pending_exception`, so it is not routed and cannot be
+                // caught — it is handled at the body-execution site below.
                 let mut handled = false;
                 for i in (0..try_stack.len()).rev() {
                     if !try_stack[i].entered_catch
@@ -15790,19 +15828,32 @@ impl Interpreter {
                     continue;
                 }
                 let disp = self.dispose_resources(&func_env, Completion::Throw(exc));
+                // A disposer that called `__host_exit` (issue #242) propagates
+                // out uncatchably instead of rejecting the promise.
+                if let Completion::Exit(code) = disp {
+                    self.scheduler.remove_async_function_state(async_id);
+                    return Completion::Exit(code);
+                }
                 let exc = match disp {
                     Completion::Throw(e) => e,
                     _ => JsValue::Undefined,
                 };
                 self.scheduler.remove_async_function_state(async_id);
                 let _ = self.call_function(&reject_fn, &JsValue::Undefined, &[exc]);
-                return;
+                return Completion::Normal(JsValue::Undefined);
             }
 
             self.in_state_machine = true;
             let exec_env = for_of_iter_env.as_ref().unwrap_or(&func_env);
             let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, exec_env);
             self.in_state_machine = saved_in_state_machine;
+            // `__host_exit` in the async body (issue #242) propagates out as
+            // `Completion::Exit` instead of settling the result promise; the
+            // caller re-raises it uncatchably.
+            if let Completion::Exit(code) = stmt_result {
+                self.scheduler.remove_async_function_state(async_id);
+                return Completion::Exit(code);
+            }
 
             // Execute tail calls inline — async functions don't use PTC, but
             // strict mode return statements produce TailCall completions.
@@ -15920,7 +15971,7 @@ impl Interpreter {
                     &for_of_stack,
                     for_of_iter_env.clone(),
                 );
-                return;
+                return Completion::Normal(JsValue::Undefined);
             }
 
             let term_env = for_of_iter_env.as_ref().unwrap_or(&func_env).clone();
@@ -15953,7 +16004,7 @@ impl Interpreter {
                                 &for_of_stack,
                                 for_of_iter_env.clone(),
                             );
-                            return;
+                            return Completion::Normal(JsValue::Undefined);
                         }
                         _ => JsValue::Undefined,
                     };
@@ -15974,7 +16025,7 @@ impl Interpreter {
                         &for_of_stack,
                         for_of_iter_env.clone(),
                     );
-                    return;
+                    return Completion::Normal(JsValue::Undefined);
                 }
 
                 StateTerminator::Return(ref expr) => {
@@ -16221,6 +16272,12 @@ impl Interpreter {
                     // Dispose resources from previous iteration (for using/await using)
                     let disp_env = for_of_iter_env.take().unwrap_or_else(|| func_env.clone());
                     let disp = self.dispose_resources(&disp_env, Completion::Empty);
+                    if let Completion::Exit(code) = disp {
+                        // A disposer that called `__host_exit` (issue #242)
+                        // propagates out uncatchably.
+                        self.scheduler.remove_async_function_state(async_id);
+                        return Completion::Exit(code);
+                    }
                     if let Completion::Throw(e) = disp {
                         pending_exception = Some(e);
                         continue;
@@ -16280,7 +16337,7 @@ impl Interpreter {
                                 for_of_iter_env.clone(),
                             );
                             self.in_state_machine = saved_in_state_machine;
-                            return;
+                            return Completion::Normal(JsValue::Undefined);
                         }
                     } else {
                         let iterator = func_env
@@ -16388,8 +16445,7 @@ impl Interpreter {
                 }
 
                 StateTerminator::Completed => {
-                    self.async_fn_complete(async_id, &func_env, &resolve_fn, &reject_fn);
-                    return;
+                    return self.async_fn_complete(async_id, &func_env, &resolve_fn, &reject_fn);
                 }
 
                 StateTerminator::Yield { .. } => {
@@ -16405,15 +16461,20 @@ impl Interpreter {
         func_env: &EnvRef,
         resolve_fn: &JsValue,
         reject_fn: &JsValue,
-    ) {
+    ) -> Completion {
         let disp = self.dispose_resources(func_env, Completion::Normal(JsValue::Undefined));
         self.scheduler.remove_async_function_state(async_id);
         match disp {
+            // A disposer that called `__host_exit` (issue #242) propagates out
+            // uncatchably instead of settling the result promise.
+            Completion::Exit(code) => Completion::Exit(code),
             Completion::Throw(e) => {
                 let _ = self.call_function(reject_fn, &JsValue::Undefined, &[e]);
+                Completion::Normal(JsValue::Undefined)
             }
             _ => {
                 let _ = self.call_function(resolve_fn, &JsValue::Undefined, &[JsValue::Undefined]);
+                Completion::Normal(JsValue::Undefined)
             }
         }
     }
@@ -16469,20 +16530,17 @@ impl Interpreter {
                 let value = v.clone();
                 self.scheduler.enqueue_microtask((
                     vec![resolve_fn.clone(), reject_fn.clone(), value.clone()],
-                    Box::new(move |interp| {
-                        interp.async_function_resume(async_id, value, false);
-                        Completion::Normal(JsValue::Undefined)
-                    }),
+                    // Return the resume completion so a `__host_exit` in the
+                    // resumed body (issue #242) reaches the drain loop as
+                    // `Completion::Exit` instead of being discarded.
+                    Box::new(move |interp| interp.async_function_resume(async_id, value, false)),
                 ));
             }
             Some(PromiseState::Rejected(e)) => {
                 let err = e.clone();
                 self.scheduler.enqueue_microtask((
                     vec![resolve_fn.clone(), reject_fn.clone(), err.clone()],
-                    Box::new(move |interp| {
-                        interp.async_function_resume(async_id, err, true);
-                        Completion::Normal(JsValue::Undefined)
-                    }),
+                    Box::new(move |interp| interp.async_function_resume(async_id, err, true)),
                 ));
             }
             _ => {
@@ -16492,10 +16550,12 @@ impl Interpreter {
                 let fulfill_handler = self.create_function(JsFunction::native(
                     "asyncFnFulfill".to_string(),
                     1,
+                    // Return the resume completion so a `__host_exit` in the
+                    // resumed body (issue #242) propagates as `Completion::Exit`
+                    // through the Promise reaction to the drain loop.
                     move |interp, _this, args| {
                         let v = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        interp.async_function_resume(async_id, v, false);
-                        Completion::Normal(JsValue::Undefined)
+                        interp.async_function_resume(async_id, v, false)
                     },
                 ));
 
@@ -16504,8 +16564,7 @@ impl Interpreter {
                     1,
                     move |interp, _this, args| {
                         let e = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        interp.async_function_resume(async_id, e, true);
-                        Completion::Normal(JsValue::Undefined)
+                        interp.async_function_resume(async_id, e, true)
                     },
                 ));
 
@@ -16677,9 +16736,9 @@ impl Interpreter {
             if done.get() {
                 break;
             }
-            // A job/completion run below may have requested `__host_exit`
-            // (issue #229): stop draining immediately so no further queued user
-            // job runs after the exit. Inert unless the node host floor is on.
+            // Terminal-sink read for `__host_exit` (issue #242): stop draining
+            // immediately so no further queued user job runs after the exit.
+            // Inert unless the node host floor is on.
             if self.pending_exit.is_some() {
                 break;
             }
@@ -16688,8 +16747,15 @@ impl Interpreter {
                 for val in &roots {
                     self.gc_root_value(val);
                 }
-                let _ = job(self);
+                let job_result = job(self);
                 self.gc_unroot_frame(mt_frame);
+                // A `__host_exit` inside the job (issue #242) latches the
+                // terminal sink; the post-loop check turns it into a
+                // `Completion::Exit` returned from this `await`.
+                if let Completion::Exit(code) = job_result {
+                    self.pending_exit = Some(code);
+                    break;
+                }
                 continue;
             }
             // Check agent async completions
@@ -16729,15 +16795,12 @@ impl Interpreter {
 
         self.gc_unroot_frame(gc_frame);
 
-        // A job drained above may have requested `__host_exit` (issue #229) with
-        // no await result recorded. Return the abrupt sentinel so EVERY caller
-        // propagates the exit uniformly, rather than falling through as
-        // `Normal(undefined)` and relying on each caller to re-poll. Inert
-        // unless the node host floor is enabled.
-        if self.pending_exit.is_some() {
-            return Completion::Throw(JsValue::Undefined);
+        // If a drained job requested `__host_exit` (issue #242), propagate the
+        // exit out of this `await` uncatchably instead of yielding the awaited
+        // value; the terminal sink stays set for `main`.
+        if let Some(code) = self.pending_exit {
+            return Completion::Exit(code);
         }
-
         match result.borrow_mut().take() {
             Some(Ok(v)) => Completion::Normal(v),
             Some(Err(e)) => Completion::Throw(e),

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -45,12 +45,6 @@ impl Interpreter {
                     break;
                 }
             }
-            // See exec_statements_cached: stop on a pending `__host_exit`
-            // (issue #229) even when the statement completed non-abruptly.
-            if self.pending_exit.is_some() {
-                last = Completion::Throw(JsValue::Undefined);
-                break;
-            }
         }
         self.current_ic_handle = prev;
         last
@@ -231,15 +225,6 @@ impl Interpreter {
                     self.call_stack_envs.pop();
                     return other;
                 }
-            }
-            // Chokepoint for `__host_exit` (issue #229): a statement may set
-            // `pending_exit` while returning a non-abrupt completion — an async
-            // call that rejected its promise, or `using` disposal. Stop the
-            // sequence so trailing statements don't run, regardless of which
-            // path requested the exit. Inert unless the node host floor is on.
-            if self.pending_exit.is_some() {
-                self.call_stack_envs.pop();
-                return Completion::Throw(JsValue::Undefined);
             }
         }
         self.call_stack_envs.pop();
@@ -2308,10 +2293,18 @@ impl Interpreter {
         // §14.2.2: DisposeResources for the try block's scope (using declarations)
         let result = self.dispose_resources(&block_env, result);
         let result = match result {
-            // An in-flight `__host_exit` (issue #229) is uncatchable: skip the
-            // catch handler and let the sentinel throw propagate. `pending_exit`
-            // is always `None` unless the node host floor is enabled.
-            c @ Completion::Throw(_) if self.pending_exit.is_some() => c,
+            // A buried `__host_exit` (issue #242) — one that ran during the try
+            // block through a boundary that cannot carry a `Completion::Exit`,
+            // i.e. an iterator `return()` — latches the terminal sink while
+            // returning some other completion. Honor it here (the universal
+            // catch/finally chokepoint) so the exit stays uncatchable: convert
+            // to `Exit` so neither `catch` nor `finally` runs. A direct
+            // `Completion::Exit` never sets the sink, so it falls through to the
+            // `other` arm below instead.
+            _ if self.pending_exit.is_some() => Completion::Exit(self.pending_exit.unwrap()),
+            // A `Completion::Exit` (issue #242) is structurally uncatchable: it
+            // does not match this `Throw` arm, so the catch handler is skipped
+            // and the exit propagates out via the `other` arm below.
             Completion::Throw(val) => {
                 if let Some(handler) = &t.handler {
                     let catch_env = Environment::new(Some(env.clone()));
@@ -2333,9 +2326,9 @@ impl Interpreter {
             other => other,
         };
         if let Some(finalizer) = &t.finalizer {
-            // A pending `__host_exit` (issue #229) skips `finally`, matching
-            // Node's `process.exit` (immediate teardown, no finally).
-            if self.pending_exit.is_some() {
+            // A `Completion::Exit` (issue #242) skips `finally`, matching Node's
+            // `process.exit` (immediate teardown, no finally).
+            if matches!(result, Completion::Exit(_)) {
                 return result;
             }
             // If we're yielding, don't run finally - generator will handle it on return/throw
@@ -2567,14 +2560,12 @@ impl Interpreter {
     }
 
     pub(crate) fn dispose_resources(&mut self, env: &EnvRef, completion: Completion) -> Completion {
-        // A pending `__host_exit` (issue #229) makes the exit immediate: skip
+        // A `Completion::Exit` (issue #242) makes the exit immediate: skip
         // running `Symbol.dispose`/`Symbol.asyncDispose` (user code that could
         // re-enter `__host_exit` or overwrite the code), matching Node's
-        // `process.exit`. Return an ABRUPT sentinel (not the possibly-Normal
-        // input completion) so the caller's `exec_statements` unwinds instead
-        // of running trailing statements. Inert unless the floor is enabled.
-        if self.pending_exit.is_some() {
-            return Completion::Throw(JsValue::Undefined);
+        // `process.exit`, and propagate the exit unchanged.
+        if matches!(completion, Completion::Exit(_)) {
+            return completion;
         }
         let stack = env.borrow_mut().dispose_stack.take();
         let Some(mut stack) = stack else {
@@ -2592,34 +2583,25 @@ impl Interpreter {
         let _had_error = current_error.is_some();
 
         for resource in &stack {
-            // A prior disposer may have requested `__host_exit` (issue #229):
-            // stop before running the remaining disposers so the exit is
-            // immediate. Return an ABRUPT sentinel (the block may have been
-            // completing normally) so trailing statements don't run. Inert
-            // unless the node host floor is enabled.
-            if self.pending_exit.is_some() {
-                return Completion::Throw(JsValue::Undefined);
-            }
             // §10.4.4.3 Dispose: If method is undefined, result is undefined; else Call(method, V)
             let result = if matches!(resource.dispose_method, JsValue::Undefined) {
                 Completion::Normal(JsValue::Undefined)
             } else {
                 self.call_function(&resource.dispose_method, &resource.value, &[])
             };
-            // The disposer itself may have requested `__host_exit` (issue #229):
-            // stop before `wrap_suppressed_error`, which would call the
-            // user-replaceable `SuppressedError` constructor (arbitrary JS
-            // after the supposedly-immediate exit). Abrupt sentinel so trailing
-            // statements don't run. Inert off-path.
-            if self.pending_exit.is_some() {
-                return Completion::Throw(JsValue::Undefined);
+            // A disposer that called `__host_exit` (issue #242) makes the exit
+            // immediate: propagate the `Completion::Exit` before running the
+            // remaining disposers or `wrap_suppressed_error` (a user-replaceable
+            // `SuppressedError` constructor — arbitrary JS after the exit).
+            if let Completion::Exit(code) = result {
+                return Completion::Exit(code);
             }
             match result {
                 Completion::Normal(v) if resource.hint == DisposeHint::Async => {
                     let awaited = self.await_value(&v);
-                    // Awaiting an async disposer may likewise have requested exit.
-                    if self.pending_exit.is_some() {
-                        return Completion::Throw(JsValue::Undefined);
+                    // Awaiting an async disposer may likewise have exited.
+                    if let Completion::Exit(code) = awaited {
+                        return Completion::Exit(code);
                     }
                     if let Completion::Throw(e) = awaited {
                         current_error = Some(self.wrap_suppressed_error(e, current_error));

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -155,10 +155,13 @@ pub struct Interpreter {
     /// installed and every host-floor check below is inert — the global
     /// environment is byte-identical to a build without this feature.
     pub(crate) node_host_enabled: bool,
-    /// Set by `__host_exit(code)` to signal an uncatchable process exit. When
-    /// `Some`, the try/catch handler propagates instead of catching, the
-    /// microtask drain loop stops, and `main` uses the code as the process
-    /// exit status. Always `None` when `node_host_enabled` is false.
+    /// Terminal exit-code sink for `__host_exit` (issue #242). The exit itself
+    /// propagates structurally as `Completion::Exit(code)`, which is
+    /// uncatchable by construction; this field is written only where that
+    /// completion crosses a boundary that cannot carry one — the event-loop
+    /// drain (microtask jobs), an inline `await` drain, an iterator `return()`,
+    /// or module top-level await — and is read by `main`/`run` to set the
+    /// process exit status. Always `None` when `node_host_enabled` is false.
     pub(crate) pending_exit: Option<i32>,
     /// Monotonic clock anchor for `__host_hrtime`. Set when the host floor is
     /// enabled so elapsed nanoseconds are measured from a stable origin.
@@ -1635,6 +1638,12 @@ impl Interpreter {
             }
             SourceType::Module => self.run_module(program, None),
         };
+        // A top-level `__host_exit` (issue #242) latches its code into the
+        // terminal `pending_exit` sink (read by `main`) and skips draining —
+        // `drain_microtasks_until_idle` early-returns while the sink is set.
+        if let Completion::Exit(code) = &result {
+            self.pending_exit = Some(*code);
+        }
         self.drain_microtasks_until_idle();
         result
     }
@@ -1650,6 +1659,11 @@ impl Interpreter {
                     global.borrow_mut().strict = true;
                 }
                 let r = self.exec_body(&program.body, &global);
+                // A top-level `__host_exit` (issue #242) latches its code (read
+                // by `main`) so draining is skipped.
+                if let Completion::Exit(code) = &r {
+                    self.pending_exit = Some(*code);
+                }
                 // Drain microtasks before restoring path so async callbacks can use relative imports
                 self.drain_microtasks_until_idle();
                 self.current_module_path = prev;
@@ -1657,6 +1671,9 @@ impl Interpreter {
             }
             SourceType::Module => {
                 let r = self.run_module(program, Some(path.to_path_buf()));
+                if let Completion::Exit(code) = &r {
+                    self.pending_exit = Some(*code);
+                }
                 // Keep path set during microtask draining so async callbacks can use relative imports
                 let prev = self.current_module_path.take();
                 self.current_module_path = Some(path.to_path_buf());
@@ -3173,7 +3190,14 @@ impl Interpreter {
         let prev_path = self.current_module_path.take();
         self.current_module_path = Some(module_path.to_path_buf());
         self.static_module_load_depth += 1;
-        self.async_function_resume(async_id, JsValue::Undefined, false);
+        // Module top-level `await` (issue #242): this driver returns `()`, so a
+        // `__host_exit` from top-level module code is recorded in the terminal
+        // `pending_exit` sink rather than carried as a completion.
+        if let Completion::Exit(code) =
+            self.async_function_resume(async_id, JsValue::Undefined, false)
+        {
+            self.pending_exit = Some(code);
+        }
         self.static_module_load_depth -= 1;
         self.current_module_path = prev_path;
     }
@@ -4717,11 +4741,11 @@ impl Interpreter {
     pub(crate) fn drain_microtasks(&mut self) {
         let mut iterations = 0u64;
         loop {
-            // Backstop for `__host_exit` (issue #229): a throw raised from an
-            // async body / Promise reaction is swallowed into a rejection rather
-            // than propagating, so the try/catch guard alone cannot stop the
-            // loop. Bail here the moment an exit is pending. Inert (always
-            // `None`) unless the node host floor is enabled.
+            // Terminal-sink read for `__host_exit` (issue #242): a job below may
+            // have run user code that latched the sink through a boundary that
+            // cannot carry a completion (e.g. an iterator `return()`). Bail the
+            // moment the sink is set. `pending_exit` is always `None` unless the
+            // node host floor is enabled.
             if self.pending_exit.is_some() {
                 return;
             }
@@ -4730,8 +4754,16 @@ impl Interpreter {
                 for val in &roots {
                     self.gc_root_value(val);
                 }
-                let _ = job(self);
+                let job_result = job(self);
                 self.gc_unroot_frame(mt_frame);
+                // A `__host_exit` inside the job (issue #242) surfaces as
+                // `Completion::Exit`; the drain loop is a `()`-returning
+                // event-loop boundary, so latch the code into the terminal sink
+                // and stop — no further queued job runs after the exit.
+                if let Completion::Exit(code) = job_result {
+                    self.pending_exit = Some(code);
+                    return;
+                }
                 iterations += 1;
                 // Periodically check agent async completions (e.g. waitAsync timeouts)
                 // so they get processed even when the microtask queue stays busy
@@ -4797,8 +4829,9 @@ impl Interpreter {
     /// with no `.then` / `await`) does not block process exit.
     pub(crate) fn drain_microtasks_until_idle(&mut self) {
         self.drain_microtasks();
-        // A pending `__host_exit` (issue #229) stops the loop immediately;
-        // don't block up to 120s waiting on timers/host-async work.
+        // Terminal-sink read for `__host_exit` (issue #242): the drain above
+        // latches `pending_exit` when a job exits. Stop immediately; don't block
+        // up to 120s waiting on timers/host-async work.
         if self.pending_exit.is_some() {
             return;
         }
@@ -4809,9 +4842,9 @@ impl Interpreter {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
         loop {
             self.drain_microtasks();
-            // A host callback drained above may have requested `__host_exit`
-            // (issue #229): stop immediately instead of waiting up to 120s on
-            // any still-pending timer/async job. Inert unless the floor is on.
+            // See above (issue #242): a job drained above may have latched the
+            // exit sink — stop immediately instead of waiting up to 120s on any
+            // still-pending timer/async job. Inert unless the floor is on.
             if self.pending_exit.is_some() {
                 return;
             }
@@ -4871,8 +4904,17 @@ impl Interpreter {
                 for val in &roots {
                     self.gc_root_value(val);
                 }
-                let _ = job(self);
+                let job_result = job(self);
                 self.gc_unroot_frame(mt_frame);
+                // A `__host_exit` inside the job (issue #242) latches the
+                // terminal sink and stops draining.
+                if let Completion::Exit(code) = job_result {
+                    self.pending_exit = Some(code);
+                    return;
+                }
+            }
+            if self.pending_exit.is_some() {
+                return;
             }
             let completions: Vec<_> = {
                 let mut lock = self.agent_async_completions.0.lock().unwrap();

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1912,7 +1912,9 @@ mod node_host_tests {
         // Execution stopped at __host_exit: catch, finally, and the trailing
         // statement never ran.
         assert_eq!(global_string(&interp, "reached"), "before");
-        assert!(matches!(c, Completion::Throw(_)));
+        // The exit propagates structurally as `Completion::Exit` (issue #242) —
+        // not a `Throw` — so no `catch`/`finally` can consume it.
+        assert!(matches!(c, Completion::Exit(42)));
     }
 
     #[test]
@@ -1972,7 +1974,7 @@ mod node_host_tests {
         // The generator/async state machine routes a Throw through its own
         // catch/finally states; a pending exit must bypass that. (PR #237
         // review round 2, Codex P2.)
-        let (interp, _c) = run_node_script(
+        let (interp, c) = run_node_script(
             r#"
             globalThis.ran = "no";
             function* g() { try { yield 0; __host_exit(7); } catch { globalThis.ran = "caught"; } }
@@ -1983,6 +1985,9 @@ mod node_host_tests {
         );
         assert_eq!(interp.pending_exit, Some(7));
         assert_eq!(global_string(&interp, "ran"), "no");
+        // The generator state machine surfaces the exit as `Completion::Exit`
+        // rather than routing it into the body's catch state (issue #242).
+        assert!(matches!(c, Completion::Exit(7)));
     }
 
     #[test]
@@ -2002,7 +2007,7 @@ mod node_host_tests {
     fn host_exit_from_disposer_stops_remaining_disposers() {
         // Disposal runs in reverse order: `b` disposes first and calls exit,
         // so `a`'s disposer must not run. (PR #237 review round 2, Codex P2.)
-        let (interp, _c) = run_node_script(
+        let (interp, c) = run_node_script(
             r#"
             globalThis.d = "";
             {
@@ -2013,6 +2018,8 @@ mod node_host_tests {
         );
         assert_eq!(interp.pending_exit, Some(4));
         assert_eq!(global_string(&interp, "d"), "b");
+        // dispose_resources returns `Completion::Exit` structurally (issue #242).
+        assert!(matches!(c, Completion::Exit(4)));
     }
 
     #[test]
@@ -2104,7 +2111,7 @@ mod node_host_tests {
         // The last-deferred disposer (exit) runs first; the earlier one must
         // not run, and the statement after dispose() must not run.
         // (PR #237 review round 5, Codex P2.)
-        let (interp, _c) = run_node_script(
+        let (interp, c) = run_node_script(
             r#"
             globalThis.side = "no";
             globalThis.afterStack = "no";
@@ -2118,6 +2125,92 @@ mod node_host_tests {
         assert_eq!(interp.pending_exit, Some(4));
         assert_eq!(global_string(&interp, "side"), "no");
         assert_eq!(global_string(&interp, "afterStack"), "no");
+        // DisposableStack.prototype.dispose returns `Completion::Exit` (issue #242).
+        assert!(matches!(c, Completion::Exit(4)));
+    }
+
+    #[test]
+    fn host_exit_from_chained_reaction_stops_chain() {
+        // A `__host_exit` in a Promise reaction handler (issue #242) must
+        // propagate out of the reaction job as `Completion::Exit` — not be
+        // swallowed into a fulfillment — so the drain loop stops and the
+        // chained `.then` never runs. This is load-bearing: if the reaction
+        // job's completion match dropped `Exit`, `chained` would become "yes".
+        let (interp, _c) = run_node_script(
+            r#"
+            globalThis.chained = "no";
+            Promise.resolve()
+              .then(() => { __host_exit(3); })
+              .then(() => { globalThis.chained = "yes"; });
+            "#,
+        );
+        assert_eq!(interp.pending_exit, Some(3));
+        assert_eq!(global_string(&interp, "chained"), "no");
+    }
+
+    #[test]
+    fn host_exit_from_reject_reaction_stops_drain() {
+        // The reject-reaction path must also propagate `Completion::Exit`
+        // (issue #242): a `.catch` handler that calls `__host_exit` stops the
+        // drain, and a following queued microtask does not run.
+        let (interp, _c) = run_node_script(
+            r#"
+            globalThis.after = "no";
+            Promise.reject(0).catch(() => { __host_exit(1); });
+            Promise.resolve().then(() => { globalThis.after = "yes"; });
+            "#,
+        );
+        assert_eq!(interp.pending_exit, Some(1));
+        assert_eq!(global_string(&interp, "after"), "no");
+    }
+
+    #[test]
+    fn host_exit_from_thenable_resolve() {
+        // Resolving a promise with a thenable runs a job that calls the user
+        // `then`; a `__host_exit` there (issue #242) must propagate out of that
+        // job rather than being turned into a rejection.
+        let (interp, _c) = run_node_script(
+            r#"
+            globalThis.after = "no";
+            Promise.resolve({ then(_res, _rej) { __host_exit(2); } });
+            Promise.resolve().then(() => { globalThis.after = "yes"; });
+            "#,
+        );
+        assert_eq!(interp.pending_exit, Some(2));
+        assert_eq!(global_string(&interp, "after"), "no");
+    }
+
+    #[test]
+    fn host_exit_from_iterator_return_during_throw_is_uncatchable() {
+        // When a for-of unwinds a *genuine* throw, the iterator's `return()`
+        // runs — and if it calls `__host_exit` (issue #242), the exit must stay
+        // uncatchable even though `return()` returns a `JsValue` and so cannot
+        // carry a `Completion::Exit`. The sink is latched in `iterator_close`
+        // and honored at the `try` boundary, so the surrounding `catch` and
+        // `finally` do not run.
+        let (interp, c) = run_node_script(
+            r#"
+            globalThis.caught = "no";
+            globalThis.cleanup = "no";
+            globalThis.fin = "no";
+            const iter = {
+              [Symbol.iterator]() { return this; },
+              next() { return { value: 1, done: false }; },
+              return() { globalThis.cleanup = "ran"; __host_exit(5); return { done: true }; },
+            };
+            try {
+              for (const x of iter) { throw new Error("boom"); }
+            } catch (e) { globalThis.caught = "yes"; }
+            finally { globalThis.fin = "ran"; }
+            "#,
+        );
+        assert_eq!(interp.pending_exit, Some(5));
+        // `return()` ran (genuine throw unwind) and requested the exit...
+        assert_eq!(global_string(&interp, "cleanup"), "ran");
+        // ...but the exit is uncatchable: neither catch nor finally ran.
+        assert_eq!(global_string(&interp, "caught"), "no");
+        assert_eq!(global_string(&interp, "fin"), "no");
+        assert!(matches!(c, Completion::Exit(5)));
     }
 
     #[test]

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -212,6 +212,13 @@ pub enum Completion {
         this: JsValue,
         args: Vec<JsValue>,
     },
+    /// A host-requested process exit (`__host_exit`, issue #242). Propagates
+    /// like `Throw` — it is abrupt and unwinds the stack — but is structurally
+    /// uncatchable: it does not match the `Throw` arm any `catch`, `finally`,
+    /// disposer, iterator `return()`, or Promise reaction inspects, so no user
+    /// code can ever consume it. Only the node host floor produces it (behind
+    /// `--node`), so it never arises with the floor off.
+    Exit(i32),
     Empty,
 }
 


### PR DESCRIPTION
## Summary

Replaces the leaky `pending_exit` sentinel-`Throw` mechanism for `__host_exit`
(the `--node` host floor) with a structurally-uncatchable `Completion::Exit(i32)`
completion kind, as proposed in #242.

Previously the exit was a sentinel `Completion::Throw(undefined)` plus a
`pending_exit` flag that every unwinding site had to remember to re-check —
"every new code path that runs user callbacks during unwinding must remember to
re-check `pending_exit`". Now the exit propagates like `Throw` but never matches
the `Throw` arm any `catch`, `finally`, disposer, iterator `return()`, or Promise
reaction inspects, so no user code can consume it.

### Design

- `__host_exit(code)` returns `Completion::Exit(code)` and sets no flag.
- **Synchronous unwinding is fully structural** — `try/catch/finally`, `using`
  disposal, `DisposableStack`, iterator close, and the generator/async
  state-machine throw-routing all propagate `Completion::Exit` without a flag
  re-check. The scattered `pending_exit.is_some()` guards are removed.
- The async-function driver (`async_function_resume`) now returns the body's
  `Completion::Exit` instead of settling the result promise; Promise
  reaction/thenable jobs propagate it instead of swallowing it into a
  fulfillment/rejection (fixing the exact `_ => Ok(undefined)` swallow the issue
  warned about).
- `pending_exit` survives only as a **write-once terminal sink**, written where
  `Exit` crosses a boundary that cannot carry a completion — the event-loop
  drain (type-erased microtask jobs), an inline `await` drain, an iterator
  `return()` (`JsValue`-returning), and module top-level await — and read by
  `main`/`run` to set the process exit status.

The compiler does not enforce this (every `Completion` match already has a
wildcard arm), so the audit — not the variant addition — is the substance, and
the regression tests are the net: because `__host_exit` no longer writes the
field, every `pending_exit` assertion now only holds if structural propagation
actually reached `run`/drain.

### Out of scope

`__host_exit` is `--node`-only, so these paths are behaviorally unreachable in
normal use and left uncovered:

- **`Array.fromAsync` async-mapper** calling `process.exit` — the `fromAsync`
  continuation job discards its helper's completion. Not one of the sites the
  issue enumerates (catch/finally/disposer/iterator `return()`/Promise
  reaction); the exit code would still be captured once it reaches a normal
  boundary.
- **Bytecode VM** (`bytecode/vm.rs`, off by default) — `--node` uses the
  tree-walker, so `--node --bytecode` is not audited for `Completion::Exit`.

Fixes #242

## Test plan

- [ ] `cargo test --release` — 287 unit tests + smoke oracle, all passing
      (13 ported + 3 new `host_exit_*` tests directly assert `Completion::Exit`)
- [ ] `./scripts/lint.sh` — rustfmt + clippy clean
- [ ] `uv run python scripts/run-test262.py -j 32` — 0 regressions
      (all `__host_exit` paths are `--node`-only, so test262 is unaffected)