### PR TITLE
[test] Node-compat: process + full console + util.format/inspect shim

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,17 @@ The Node/host surface ships **only** as a prepended JS shim
 test262 is unaffected. Everything here lives under `scripts/`; no `src/` change
 is required to add a library.
 
+The shim's readable-output layer (`process`, the full `console` method set, and
+the `util.format` / `util.inspect` core they share) is built on top of the
+flag-gated Rust "syscall floor" (issue #229): `__host_write` (byte-accurate fd
+I/O), `__host_hrtime` (monotonic clock), and `__host_exit` (real process exit).
+The runner therefore invokes **jsse with `--node`** so those primitives exist
+(never Node — it has no such flag and doesn't need one). The shim is guarded to
+be a complete no-op on real Node, where `process`, the full `console`, and
+`require('util')` already exist; that inertness is what lets the identical bundle
+run on Node as the reference oracle. When the floor is absent (jsse without
+`--node`) each surface degrades to a pure-JS fallback.
+
 ## Running
 
 ```sh
@@ -68,6 +79,24 @@ These share a self-contained runner that loads each module with a **dynamic**
 reads the original entry, extracts the module list / require prefix / harness
 global, and emits an equivalent entry using literal `require()` calls. Each
 config's `lib_prepare` invokes it (see `scripts/libs/decimal.js.sh`).
+
+## Shim self-test
+
+`scripts/run-node-shim-selftest.sh` exercises the readable-output layer directly,
+independent of any library:
+
+```sh
+./scripts/run-node-shim-selftest.sh [--no-build]
+```
+
+It concatenates `node-shim.js` in front of `node-shim.selftest.js` (exactly as
+the runner prepends the shim to a bundle), runs the result on **jsse `--node`**
+and on **Node**, and requires both to exit 0 and emit byte-identical stdout.
+Node is the oracle for the deterministic surfaces — the `util.format` specifiers
+(`%s %d %i %f %j %c %%`), byte-accurate `process.stdout.write`, and the
+`console.count`/`group`/`assert` output shapes are asserted exactly.
+`util.inspect` is intentionally best-effort (depth, cycles, common types) and is
+only smoke-tested structurally, never byte-compared against Node.
 
 ## Current status
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -94,9 +94,13 @@ the runner prepends the shim to a bundle), runs the result on **jsse `--node`**
 and on **Node**, and requires both to exit 0 and emit byte-identical stdout.
 Node is the oracle for the deterministic surfaces — the `util.format` specifiers
 (`%s %d %i %f %j %c %%`), byte-accurate `process.stdout.write`, and the
-`console.count`/`group`/`assert` output shapes are asserted exactly.
-`util.inspect` is intentionally best-effort (depth, cycles, common types) and is
-only smoke-tested structurally, never byte-compared against Node.
+`console.count`/`group`/`assert` output shapes are asserted exactly. The
+byte-exact `%s` guarantee covers primitives and objects with a user-defined
+`toString`; `%s`/`%o`/`%O` of plain objects and arrays route through
+`util.inspect`, which is intentionally best-effort (depth, cycles, common types)
+— it does not invoke getters, but it is only smoke-tested structurally and never
+byte-compared against Node. (Fully Node-accurate `%s` object dispatch is tracked
+separately.)
 
 ## Current status
 

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -102,10 +102,7 @@
             var label = isIdentifierKey(k) ? k : quoteString(k);
             parts.push(label + ": " + renderMember(v, k, depth));
           }
-          var ctorName =
-            v.constructor && v.constructor.name && v.constructor.name !== "Object"
-              ? v.constructor.name + " "
-              : "";
+          var ctorName = constructorName(v);
           out = parts.length
             ? ctorName + "{ " + parts.join(", ") + " }"
             : ctorName + "{}";
@@ -127,6 +124,29 @@
         return desc.get ? (desc.set ? "[Getter/Setter]" : "[Getter]") : "[Setter]";
       }
       return render(desc ? desc.value : container[key], depth - 1);
+    }
+
+    // Derive the "ClassName " prefix without a plain `v.constructor` get, which
+    // would invoke an accessor `constructor` or a Proxy get-trap — Node reads
+    // constructor metadata via the prototype chain, not by calling a getter. Use
+    // data descriptors only, and treat any exotic-trap throw as "no prefix".
+    function constructorName(v) {
+      try {
+        var ctor;
+        var own = Object.getOwnPropertyDescriptor(v, "constructor");
+        if (own) {
+          if (!own.get && !own.set) ctor = own.value;
+        } else {
+          var proto = Object.getPrototypeOf(v);
+          var pd = proto
+            ? Object.getOwnPropertyDescriptor(proto, "constructor")
+            : null;
+          if (pd && !pd.get && !pd.set) ctor = pd.value;
+        }
+        return ctor && ctor.name && ctor.name !== "Object" ? ctor.name + " " : "";
+      } catch (e) {
+        return "";
+      }
     }
 
     return render(value, maxDepth);

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -30,6 +30,7 @@
   var hostWrite = typeof __host_write !== "undefined" ? __host_write : null;
   var hostHrtime = typeof __host_hrtime !== "undefined" ? __host_hrtime : null;
   var hostExit = typeof __host_exit !== "undefined" ? __host_exit : null;
+  var fallbackConsoleLog = console.log;
 
   var NS_PER_SEC = 1000000000;
 
@@ -254,6 +255,7 @@
     }
     // Fallback: jsse without the syscall floor only exposes newline-appending
     // console.log, so accumulate partial writes and emit one line at a time.
+    // Use the original native log because this shim replaces console.log below.
     var buf = "";
     return {
       fd: fd,
@@ -262,7 +264,7 @@
         buf += String(chunk);
         var idx;
         while ((idx = buf.indexOf("\n")) !== -1) {
-          console.log(buf.slice(0, idx));
+          fallbackConsoleLog.call(console, buf.slice(0, idx));
           buf = buf.slice(idx + 1);
         }
         var callback = typeof encodingOrCb === "function" ? encodingOrCb : cb;
@@ -271,7 +273,7 @@
       },
       _flush: function () {
         if (buf.length) {
-          console.log(buf);
+          fallbackConsoleLog.call(console, buf);
           buf = "";
         }
       },

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -5,27 +5,259 @@
 // Node globals — can execute on jsse. It is a pure-JS shim: nothing here is
 // baked into jsse's default global object, so test262 is unaffected.
 //
-// Every stub is guarded so that on Node (where these globals already exist)
-// the shim is an inert no-op. That lets `run-library-tests.sh --node` run the
-// exact same bundle against Node as a reference oracle.
+// The readable-output layer (process, the full console method set, and the
+// util.format / util.inspect core they share) is built on top of the flag-gated
+// Rust "syscall floor" (issue #229): __host_write (byte-accurate fd I/O),
+// __host_hrtime (monotonic clock), and __host_exit (real process exit). The
+// harness runs jsse with `--node` so those primitives exist; when they are
+// absent (jsse without --node) each surface degrades to a pure-JS fallback.
+//
+// Everything below is skipped on real Node, where `process`, the full
+// `console`, and `require('util')` already exist. That inertness is what lets
+// `run-library-tests.sh --node` run the exact same bundle against Node as a
+// reference oracle.
 
-if (typeof console.group === "undefined") {
-  console.group = function (name) {
-    console.log("--- " + name + " ---");
+(function () {
+  "use strict";
+
+  // On Node, `process.versions.node` is set; the whole shim is a no-op there.
+  var onNode =
+    typeof process !== "undefined" &&
+    !!(process.versions && process.versions.node);
+  if (onNode) return;
+
+  // The syscall floor (issue #229), present only under jsse `--node`.
+  var hostWrite = typeof __host_write !== "undefined" ? __host_write : null;
+  var hostHrtime = typeof __host_hrtime !== "undefined" ? __host_hrtime : null;
+  var hostExit = typeof __host_exit !== "undefined" ? __host_exit : null;
+
+  var NS_PER_SEC = 1000000000;
+
+  // ---- util.inspect (best-effort) ------------------------------------------
+  //
+  // A readable, Node-flavoured rendering of arbitrary values for console.dir,
+  // the %o/%O format specifiers, and console.log of non-strings. It is
+  // deliberately NOT byte-compatible with Node's util.inspect (colour
+  // heuristics, `<ref *N>` back-references, hidden keys, getters, Map/Set
+  // internals — a bottomless pit); it only needs to be correct on depth,
+  // cycles, and the common types.
+  function quoteString(s) {
+    return (
+      "'" +
+      String(s)
+        .replace(/\\/g, "\\\\")
+        .replace(/'/g, "\\'")
+        .replace(/\n/g, "\\n") +
+      "'"
+    );
+  }
+
+  function isIdentifierKey(k) {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k);
+  }
+
+  function inspect(value, opts) {
+    opts = opts || {};
+    var maxDepth = typeof opts.depth === "number" ? opts.depth : 2;
+    var seen = [];
+
+    function render(v, depth) {
+      var t = typeof v;
+      if (v === null) return "null";
+      if (t === "undefined") return "undefined";
+      if (t === "string") return quoteString(v);
+      if (t === "number") return Object.is(v, -0) ? "-0" : String(v);
+      if (t === "bigint") return String(v) + "n";
+      if (t === "boolean") return String(v);
+      if (t === "symbol") return v.toString();
+      if (t === "function") {
+        return "[Function" + (v.name ? ": " + v.name : " (anonymous)") + "]";
+      }
+
+      // Objects.
+      if (seen.indexOf(v) !== -1) return "[Circular *1]";
+      if (v instanceof Error) {
+        return v.stack ? String(v.stack) : String(v.name) + ": " + String(v.message);
+      }
+      if (v instanceof RegExp) return String(v);
+      if (v instanceof Date) {
+        return isNaN(v.getTime()) ? "Invalid Date" : v.toISOString();
+      }
+
+      if (depth < 0) return Array.isArray(v) ? "[Array]" : "[Object]";
+
+      seen.push(v);
+      var out;
+      try {
+        if (Array.isArray(v)) {
+          var items = [];
+          for (var i = 0; i < v.length; i++) items.push(render(v[i], depth - 1));
+          out = items.length ? "[ " + items.join(", ") + " ]" : "[]";
+        } else {
+          var keys = Object.keys(v);
+          var parts = [];
+          for (var j = 0; j < keys.length; j++) {
+            var k = keys[j];
+            var label = isIdentifierKey(k) ? k : quoteString(k);
+            parts.push(label + ": " + render(v[k], depth - 1));
+          }
+          var ctorName =
+            v.constructor && v.constructor.name && v.constructor.name !== "Object"
+              ? v.constructor.name + " "
+              : "";
+          out = parts.length
+            ? ctorName + "{ " + parts.join(", ") + " }"
+            : ctorName + "{}";
+        }
+      } finally {
+        seen.pop();
+      }
+      return out;
+    }
+
+    return render(value, maxDepth);
+  }
+
+  // ---- util.format ----------------------------------------------------------
+  //
+  // Node's printf-style formatter. The %s %d %i %f %j %c %% specifiers are
+  // deterministic and matched exactly; %o/%O defer to the best-effort inspect.
+  function convS(v) {
+    var t = typeof v;
+    if (t === "string") return v;
+    if (t === "bigint") return String(v) + "n";
+    if (t === "number") return Object.is(v, -0) ? "-0" : String(v);
+    if (v === null) return "null";
+    if (t === "undefined") return "undefined";
+    if (t === "boolean") return String(v);
+    if (t === "symbol") return v.toString();
+    if (t === "function") return inspect(v, { depth: 0 });
+    // Object: String() when it defines its own toString, else inspect (Node
+    // uses inspect with depth 0 here).
+    if (typeof v.toString === "function" && v.toString !== Object.prototype.toString) {
+      return String(v);
+    }
+    return inspect(v, { depth: 0 });
+  }
+
+  function convD(v) {
+    var t = typeof v;
+    if (t === "bigint") return String(v) + "n";
+    if (t === "symbol") return "NaN";
+    return String(Number(v));
+  }
+
+  function convI(v) {
+    var t = typeof v;
+    if (t === "bigint") return String(v) + "n";
+    if (t === "symbol") return "NaN";
+    return String(parseInt(v, 10));
+  }
+
+  function convF(v) {
+    if (typeof v === "symbol") return "NaN";
+    return String(parseFloat(v));
+  }
+
+  function convJ(v) {
+    try {
+      var s = JSON.stringify(v);
+      return s === undefined ? "undefined" : s;
+    } catch (e) {
+      return "[Circular]";
+    }
+  }
+
+  function format() {
+    var args = arguments;
+    var first = args[0];
+    if (typeof first !== "string") {
+      // No format string: inspect every argument, join with a space.
+      var pieces = [];
+      for (var i = 0; i < args.length; i++) {
+        pieces.push(typeof args[i] === "string" ? args[i] : inspect(args[i]));
+      }
+      return pieces.join(" ");
+    }
+    // A lone string argument is returned verbatim — Node performs no specifier
+    // substitution unless there is at least one argument to format, so e.g.
+    // format("%%") is "%%" and format("%s") is "%s", but format("%%", x)
+    // substitutes.
+    if (args.length === 1) return first;
+
+    var out = "";
+    var lastPos = 0;
+    var argIndex = 1;
+    var f = first;
+    var n = f.length;
+    for (var p = 0; p < n - 1; p++) {
+      if (f.charCodeAt(p) !== 37 /* % */) continue;
+      var next = f.charCodeAt(p + 1);
+      if (next === 37 /* %% */) {
+        out += f.slice(lastPos, p) + "%";
+        lastPos = p + 2;
+        p++;
+        continue;
+      }
+      // Specifiers that consume an argument only fire while one remains.
+      var repl = null;
+      if (argIndex < args.length) {
+        switch (next) {
+          case 115: repl = convS(args[argIndex++]); break; // s
+          case 100: repl = convD(args[argIndex++]); break; // d
+          case 105: repl = convI(args[argIndex++]); break; // i
+          case 102: repl = convF(args[argIndex++]); break; // f
+          case 106: repl = convJ(args[argIndex++]); break; // j
+          case 111: repl = inspect(args[argIndex++], { depth: 4 }); break; // o
+          case 79: repl = inspect(args[argIndex++], {}); break; // O
+          case 99: argIndex++; repl = ""; break; // c (CSS ignored)
+        }
+      }
+      if (repl !== null) {
+        out += f.slice(lastPos, p) + repl;
+        lastPos = p + 2;
+        p++;
+      }
+    }
+    out += f.slice(lastPos);
+
+    // Trailing arguments beyond the specifiers are appended, space-separated.
+    for (; argIndex < args.length; argIndex++) {
+      var extra = args[argIndex];
+      out += " " + (typeof extra === "string" ? extra : inspect(extra));
+    }
+    return out;
+  }
+
+  globalThis.util = {
+    format: format,
+    formatWithOptions: function (opts, first) {
+      return format.apply(null, Array.prototype.slice.call(arguments, 1));
+    },
+    inspect: inspect,
   };
-}
-if (typeof console.groupEnd === "undefined") {
-  console.groupEnd = function () {};
-}
 
-if (typeof process === "undefined") {
-  // Line-buffered writer: jsse only exposes newline-appending console.log, so
-  // accumulate partial writes and emit one console.log per completed line.
-  // This reconstructs Node's byte-stream stdout/stderr closely enough for
-  // test runners that print progress with process.stdout.write(str) (no "\n").
-  var makeStream = function () {
+  // ---- process --------------------------------------------------------------
+  function makeStream(fd) {
+    if (hostWrite) {
+      return {
+        fd: fd,
+        isTTY: false,
+        write: function (chunk, encodingOrCb, cb) {
+          hostWrite(fd, String(chunk));
+          var callback = typeof encodingOrCb === "function" ? encodingOrCb : cb;
+          if (typeof callback === "function") callback();
+          return true;
+        },
+        _flush: function () {},
+      };
+    }
+    // Fallback: jsse without the syscall floor only exposes newline-appending
+    // console.log, so accumulate partial writes and emit one line at a time.
     var buf = "";
     return {
+      fd: fd,
+      isTTY: false,
       write: function (chunk, encodingOrCb, cb) {
         buf += String(chunk);
         var idx;
@@ -37,7 +269,6 @@ if (typeof process === "undefined") {
         if (typeof callback === "function") callback();
         return true;
       },
-      // Flush any trailing partial line (no terminating newline).
       _flush: function () {
         if (buf.length) {
           console.log(buf);
@@ -45,43 +276,216 @@ if (typeof process === "undefined") {
         }
       },
     };
-  };
+  }
 
-  var stdout = makeStream();
-  var stderr = makeStream();
+  var stdout = makeStream(1);
+  var stderr = makeStream(2);
+  var hrtimeFn;
+
+  function makeHrtime() {
+    var hr;
+    if (hostHrtime) {
+      hr = function (prev) {
+        var now = hostHrtime(); // BigInt nanoseconds, monotonic
+        if (prev) {
+          var prevNs =
+            BigInt(prev[0]) * BigInt(NS_PER_SEC) + BigInt(prev[1]);
+          var delta = now - prevNs;
+          return [
+            Number(delta / BigInt(NS_PER_SEC)),
+            Number(delta % BigInt(NS_PER_SEC)),
+          ];
+        }
+        return [
+          Number(now / BigInt(NS_PER_SEC)),
+          Number(now % BigInt(NS_PER_SEC)),
+        ];
+      };
+      hr.bigint = function () {
+        return hostHrtime();
+      };
+    } else {
+      hr = function (prev) {
+        var ms = Date.now();
+        var s = Math.floor(ms / 1000);
+        var ns = (ms % 1000) * 1e6;
+        if (prev) {
+          var ds = s - prev[0];
+          var dns = ns - prev[1];
+          if (dns < 0) {
+            ds -= 1;
+            dns += NS_PER_SEC;
+          }
+          return [ds, dns];
+        }
+        return [s, ns];
+      };
+      hr.bigint = function () {
+        return BigInt(Math.floor(Date.now() * 1e6));
+      };
+    }
+    return hr;
+  }
+
+  hrtimeFn = makeHrtime();
 
   globalThis.process = {
-    argv: ["node", "bundle.js"],
+    argv: ["node", "/bundle.js"],
+    argv0: "node",
+    execPath: "/usr/bin/node",
     env: {},
+    pid: 1,
+    ppid: 0,
     platform: "linux",
+    arch: "x64",
+    version: "v20.0.0",
+    versions: { node: "20.0.0" },
+    cwd: function () {
+      return "/";
+    },
+    // Node's nextTick runs before Promise microtasks, but jsse has no separate
+    // tick queue; a microtask is close enough for library test runners.
+    nextTick: function (cb) {
+      var extra = Array.prototype.slice.call(arguments, 1);
+      Promise.resolve().then(function () {
+        cb.apply(undefined, extra);
+      });
+    },
     stdout: stdout,
     stderr: stderr,
+    hrtime: hrtimeFn,
     exit: function (code) {
-      // Flush buffered output before exiting so a final partial line is not
-      // lost. exit(0) falls through (a library's runner often calls it at the
-      // end); a non-zero code throws so the harness sees the failure.
+      code = code ? code | 0 : 0;
+      if (hostExit) {
+        hostExit(code); // real, uncatchable exit (issue #242)
+        return;
+      }
+      // Fallback: flush buffered output, then let a non-zero code surface as a
+      // throw the harness can see.
       stdout._flush();
       stderr._flush();
       if (code) throw new Error("process.exit(" + code + ")");
     },
-    // Node's high-resolution timer, [seconds, nanoseconds]. jsse has no
-    // monotonic clock (that arrives with the flag-gated Rust floor), so derive
-    // it from Date.now(). Only used by test runners to report elapsed time, so
-    // millisecond resolution is sufficient; correctness never depends on it.
-    hrtime: function (prev) {
-      var ms = Date.now();
-      var s = Math.floor(ms / 1000);
-      var ns = (ms % 1000) * 1e6;
-      if (prev) {
-        var ds = s - prev[0];
-        var dns = ns - prev[1];
-        if (dns < 0) {
-          ds -= 1;
-          dns += 1e9;
-        }
-        return [ds, dns];
-      }
-      return [s, ns];
+    on: function () {
+      return globalThis.process;
+    },
+    once: function () {
+      return globalThis.process;
+    },
+    emit: function () {
+      return false;
     },
   };
-}
+
+  // ---- console --------------------------------------------------------------
+  var groupIndent = "";
+
+  function writeLine(stream, args) {
+    var line = format.apply(null, args);
+    if (groupIndent) {
+      line = groupIndent + line.replace(/\n/g, "\n" + groupIndent);
+    }
+    stream.write(line + "\n");
+  }
+
+  var counts = {};
+  var timers = {};
+
+  function timerNow() {
+    return hrtimeFn.bigint();
+  }
+
+  var jsseConsole = {
+    log: function () {
+      writeLine(stdout, arguments);
+    },
+    info: function () {
+      writeLine(stdout, arguments);
+    },
+    debug: function () {
+      writeLine(stdout, arguments);
+    },
+    error: function () {
+      writeLine(stderr, arguments);
+    },
+    warn: function () {
+      writeLine(stderr, arguments);
+    },
+    dir: function (obj, opts) {
+      stdout.write((groupIndent || "") + inspect(obj, opts || {}) + "\n");
+    },
+    trace: function () {
+      var msg = format.apply(null, arguments);
+      var stack = new Error().stack || "";
+      stderr.write("Trace" + (msg ? ": " + msg : "") + "\n" + stack + "\n");
+    },
+    assert: function (cond) {
+      if (cond) return;
+      var rest = Array.prototype.slice.call(arguments, 1);
+      var msg = rest.length ? ": " + format.apply(null, rest) : "";
+      stderr.write("Assertion failed" + msg + "\n");
+    },
+    group: function () {
+      if (arguments.length) writeLine(stdout, arguments);
+      groupIndent += "  ";
+    },
+    groupCollapsed: function () {
+      if (arguments.length) writeLine(stdout, arguments);
+      groupIndent += "  ";
+    },
+    groupEnd: function () {
+      groupIndent = groupIndent.slice(0, groupIndent.length - 2);
+    },
+    count: function (label) {
+      label = label === undefined ? "default" : String(label);
+      counts[label] = (counts[label] || 0) + 1;
+      jsseConsole.log(label + ": " + counts[label]);
+    },
+    countReset: function (label) {
+      label = label === undefined ? "default" : String(label);
+      counts[label] = 0;
+    },
+    time: function (label) {
+      label = label === undefined ? "default" : String(label);
+      timers[label] = timerNow();
+    },
+    timeEnd: function (label) {
+      label = label === undefined ? "default" : String(label);
+      if (!(label in timers)) {
+        jsseConsole.warn("Warning: No such label '" + label + "'");
+        return;
+      }
+      var ms = Number(timerNow() - timers[label]) / 1e6;
+      delete timers[label];
+      jsseConsole.log(label + ": " + ms + "ms");
+    },
+    timeLog: function (label) {
+      label = label === undefined ? "default" : String(label);
+      if (!(label in timers)) {
+        jsseConsole.warn("Warning: No such label '" + label + "'");
+        return;
+      }
+      var ms = Number(timerNow() - timers[label]) / 1e6;
+      var rest = Array.prototype.slice.call(arguments, 1);
+      var extra = rest.length ? " " + format.apply(null, rest) : "";
+      jsseConsole.log(label + ": " + ms + "ms" + extra);
+    },
+    // Best-effort: Node renders an ASCII table; a readable inspect dump is
+    // close enough for the test runners that call it.
+    table: function (data) {
+      jsseConsole.dir(data, { depth: null });
+    },
+  };
+
+  // jsse binds `console` as a lexical const (not a plain global-object
+  // property), so a `globalThis.console = …` reassignment would be shadowed by
+  // bare `console` references in the bundle. Mutate the existing object instead:
+  // its native `log` is writable/configurable and the object is extensible, so
+  // overriding `log` and adding the rest of the method set takes effect for
+  // both `console.x` and bare `console` uses.
+  for (var method in jsseConsole) {
+    if (Object.prototype.hasOwnProperty.call(jsseConsole, method)) {
+      console[method] = jsseConsole[method];
+    }
+  }
+})();

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -100,7 +100,22 @@
           for (var j = 0; j < keys.length; j++) {
             var k = keys[j];
             var label = isIdentifierKey(k) ? k : quoteString(k);
-            parts.push(label + ": " + render(v[k], depth - 1));
+            // Render accessors without invoking them — Node's util.inspect shows
+            // [Getter]/[Setter] rather than calling the getter, so a throwing or
+            // side-effecting getter cannot make a diagnostic print throw/mutate
+            // under jsse where it would not under Node.
+            var desc = Object.getOwnPropertyDescriptor(v, k);
+            var valueStr;
+            if (desc && (desc.get || desc.set)) {
+              valueStr = desc.get
+                ? desc.set
+                  ? "[Getter/Setter]"
+                  : "[Getter]"
+                : "[Setter]";
+            } else {
+              valueStr = render(desc ? desc.value : v[k], depth - 1);
+            }
+            parts.push(label + ": " + valueStr);
           }
           var ctorName =
             v.constructor && v.constructor.name && v.constructor.name !== "Object"

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -92,7 +92,7 @@
       try {
         if (Array.isArray(v)) {
           var items = [];
-          for (var i = 0; i < v.length; i++) items.push(render(v[i], depth - 1));
+          for (var i = 0; i < v.length; i++) items.push(renderMember(v, i, depth));
           out = items.length ? "[ " + items.join(", ") + " ]" : "[]";
         } else {
           var keys = Object.keys(v);
@@ -100,22 +100,7 @@
           for (var j = 0; j < keys.length; j++) {
             var k = keys[j];
             var label = isIdentifierKey(k) ? k : quoteString(k);
-            // Render accessors without invoking them — Node's util.inspect shows
-            // [Getter]/[Setter] rather than calling the getter, so a throwing or
-            // side-effecting getter cannot make a diagnostic print throw/mutate
-            // under jsse where it would not under Node.
-            var desc = Object.getOwnPropertyDescriptor(v, k);
-            var valueStr;
-            if (desc && (desc.get || desc.set)) {
-              valueStr = desc.get
-                ? desc.set
-                  ? "[Getter/Setter]"
-                  : "[Getter]"
-                : "[Setter]";
-            } else {
-              valueStr = render(desc ? desc.value : v[k], depth - 1);
-            }
-            parts.push(label + ": " + valueStr);
+            parts.push(label + ": " + renderMember(v, k, depth));
           }
           var ctorName =
             v.constructor && v.constructor.name && v.constructor.name !== "Object"
@@ -129,6 +114,19 @@
         seen.pop();
       }
       return out;
+    }
+
+    // Render one own property/element WITHOUT invoking accessors — Node's
+    // util.inspect shows [Getter]/[Setter] rather than calling the getter, so a
+    // throwing or side-effecting accessor (object property or array element)
+    // cannot make a diagnostic print throw/mutate under jsse where it would not
+    // under Node.
+    function renderMember(container, key, depth) {
+      var desc = Object.getOwnPropertyDescriptor(container, key);
+      if (desc && (desc.get || desc.set)) {
+        return desc.get ? (desc.set ? "[Getter/Setter]" : "[Getter]") : "[Setter]";
+      }
+      return render(desc ? desc.value : container[key], depth - 1);
     }
 
     return render(value, maxDepth);
@@ -180,7 +178,14 @@
       var s = JSON.stringify(v);
       return s === undefined ? "undefined" : s;
     } catch (e) {
-      return "[Circular]";
+      // Node's %j suppresses ONLY circular-structure failures (returning
+      // "[Circular]") and re-throws everything else — BigInt, and user
+      // toJSON/getter exceptions. jsse's circular error is
+      // "Converting circular structure to JSON"; its BigInt/toJSON errors do not
+      // mention "circular", so matching the message is safe here (the shim is
+      // inert on Node, so this only ever sees jsse's error text).
+      if (e && /circular/i.test(String(e.message))) return "[Circular]";
+      throw e;
     }
   }
 

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -101,6 +101,20 @@ eq(util.format("%f", 2), "2", "%f integer");
 // ---- util.format: %j %c %% ------------------------------------------------
 eq(util.format("%j", { a: 1, b: [2, 3] }), '{"a":1,"b":[2,3]}', "%j json");
 eq(util.format("%j", undefined), "undefined", "%j undefined");
+(function () {
+  var circular = {};
+  circular.self = circular;
+  eq(util.format("%j", circular), "[Circular]", "%j circular structure -> [Circular]");
+  // Node's %j re-throws non-circular serialization errors (BigInt etc.) rather
+  // than masking them as [Circular].
+  var threw = false;
+  try {
+    util.format("%j", 1n);
+  } catch (e) {
+    threw = true;
+  }
+  truthy(threw, "%j of a BigInt re-throws instead of masking");
+})();
 eq(util.format("%c", "color:red"), "", "%c ignored (consumes arg)");
 
 // %% only substitutes when at least one argument is present: a lone string is
@@ -144,6 +158,15 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     configurable: true,
   });
   eq(util.inspect(throwingGetter), "{ x: [Getter] }", "inspect does not invoke getters");
+  var arrGetter = [1];
+  Object.defineProperty(arrGetter, "1", {
+    get: function () {
+      throw new Error("boom");
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  eq(util.inspect(arrGetter), "[ 1, [Getter] ]", "inspect does not invoke array getters");
 })();
 
 // ---- process fields -------------------------------------------------------

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -134,6 +134,16 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   truthy(typeof ci === "string" && ci.length > 0, "inspect handles cycles without hanging");
   var nested = util.inspect({ a: { b: { c: 1 } } }, { depth: 1 });
   truthy(typeof nested === "string" && nested.length > 0, "inspect respects depth option");
+  // Accessors must not be invoked (Node shows [Getter]); a throwing getter must
+  // not make inspect throw. This IS deterministic across engines, so assert it.
+  var throwingGetter = Object.defineProperty({}, "x", {
+    get: function () {
+      throw new Error("boom");
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  eq(util.inspect(throwingGetter), "{ x: [Getter] }", "inspect does not invoke getters");
 })();
 
 // ---- process fields -------------------------------------------------------

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1,0 +1,221 @@
+// Self-test for the Node host-compat readable-output layer (scripts/node-shim.js,
+// issue #230). It runs on BOTH jsse (`--node`, with the shim prepended) and Node
+// (where the shim is inert) and must produce byte-identical output and exit 0 on
+// both. Node is the oracle: the expected literals below are whatever Node emits,
+// so a jsse divergence fails the run.
+//
+// Deterministic surfaces (util.format specifiers, byte-accurate stdout, the
+// count/group/assert output shapes) are asserted exactly. util.inspect is
+// best-effort (issue #230), so it is only smoke-tested structurally — never
+// byte-compared against Node.
+//
+// This file is not esbuild-bundled: scripts/run-node-shim-selftest.sh simply
+// concatenates the shim in front of it. On jsse the shim installs globalThis.util;
+// on Node `util` is require-only, so fall back to require().
+
+"use strict";
+
+var util =
+  typeof globalThis.util !== "undefined" ? globalThis.util : require("util");
+
+var testNo = 0;
+
+function ok(name) {
+  testNo++;
+  console.log("ok " + testNo + " - " + name);
+}
+
+function eq(actual, expected, name) {
+  if (actual !== expected) {
+    throw new Error(
+      "FAIL " + name + ": expected " + JSON.stringify(expected) +
+        " got " + JSON.stringify(actual)
+    );
+  }
+  ok(name);
+}
+
+function truthy(cond, name) {
+  if (!cond) throw new Error("FAIL " + name + ": condition not met");
+  ok(name);
+}
+
+// Capture output written during fn() so non-deterministic renderings never
+// reach the diffed stream. process.stdout/stderr are the objects the shim's
+// console writes through (and Node's console is bound to the same objects), so
+// swapping their write method captures both.
+function capture(fn) {
+  var out = [];
+  var err = [];
+  var ow = process.stdout.write;
+  var ew = process.stderr.write;
+  process.stdout.write = function (s) {
+    out.push(String(s));
+    return true;
+  };
+  process.stderr.write = function (s) {
+    err.push(String(s));
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stdout.write = ow;
+    process.stderr.write = ew;
+  }
+  return { out: out.join(""), err: err.join("") };
+}
+
+console.log("# node-shim self-test");
+
+// ---- util.format: %s ------------------------------------------------------
+eq(util.format("%s", "hi"), "hi", "%s string");
+eq(util.format("%s", 42), "42", "%s number");
+eq(util.format("%s", -0), "-0", "%s negative zero");
+eq(util.format("%s", 10n), "10n", "%s bigint");
+eq(util.format("%s", true), "true", "%s boolean");
+eq(util.format("%s", null), "null", "%s null");
+eq(util.format("%s", undefined), "undefined", "%s undefined");
+eq(
+  util.format("%s", {
+    toString: function () {
+      return "OBJ";
+    },
+  }),
+  "OBJ",
+  "%s object with toString"
+);
+
+// ---- util.format: %d %i %f ------------------------------------------------
+eq(util.format("%d", 42), "42", "%d integer");
+eq(util.format("%d", 3.5), "3.5", "%d float");
+eq(util.format("%d", "7"), "7", "%d numeric string");
+eq(util.format("%d", "nope"), "NaN", "%d non-numeric string");
+eq(util.format("%d", 10n), "10n", "%d bigint");
+eq(util.format("%i", 3.9), "3", "%i truncates");
+eq(util.format("%i", "42px"), "42", "%i leading integer");
+eq(util.format("%i", 10n), "10n", "%i bigint");
+eq(util.format("%f", "3.14xyz"), "3.14", "%f leading float");
+eq(util.format("%f", 2), "2", "%f integer");
+
+// ---- util.format: %j %c %% ------------------------------------------------
+eq(util.format("%j", { a: 1, b: [2, 3] }), '{"a":1,"b":[2,3]}', "%j json");
+eq(util.format("%j", undefined), "undefined", "%j undefined");
+eq(util.format("%c", "color:red"), "", "%c ignored (consumes arg)");
+
+// %% only substitutes when at least one argument is present: a lone string is
+// returned verbatim (so "%%" stays "%%"), but "%%" with an extra arg becomes "%".
+eq(util.format("%%"), "%%", "%% verbatim (single arg)");
+eq(util.format("100%% done"), "100%% done", "%% verbatim mid-string (single arg)");
+eq(util.format("%%", "x"), "% x", "%% substitutes with extra arg");
+eq(util.format("a %% b %s", "c"), "a % b c", "%% substitutes alongside %s");
+
+// ---- util.format: structure -----------------------------------------------
+eq(util.format("%s%s", "a", "b"), "ab", "consecutive specifiers");
+eq(util.format("%s", "a", "b"), "a b", "extra args appended");
+eq(util.format("%s"), "%s", "single-arg string returned verbatim");
+eq(util.format("%d and %s"), "%d and %s", "single-arg string with specifiers verbatim");
+eq(util.format("plain text"), "plain text", "plain string");
+eq(util.format("x=%d y=%s", 1, "two"), "x=1 y=two", "mixed specifiers");
+eq(util.format("just %z here", 1), "just %z here 1", "unknown specifier + extra arg");
+eq(util.format(), "", "no arguments");
+eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
+
+// ---- util.inspect: best-effort (structural only) --------------------------
+(function () {
+  var arr = util.inspect([1, 2, 3]);
+  truthy(
+    arr.indexOf("1") !== -1 && arr.indexOf("2") !== -1 && arr.indexOf("3") !== -1,
+    "inspect renders array elements"
+  );
+  var cyc = {};
+  cyc.self = cyc;
+  var ci = util.inspect(cyc);
+  truthy(typeof ci === "string" && ci.length > 0, "inspect handles cycles without hanging");
+  var nested = util.inspect({ a: { b: { c: 1 } } }, { depth: 1 });
+  truthy(typeof nested === "string" && nested.length > 0, "inspect respects depth option");
+})();
+
+// ---- process fields -------------------------------------------------------
+truthy(typeof process.platform === "string" && process.platform.length > 0, "process.platform");
+truthy(typeof process.arch === "string" && process.arch.length > 0, "process.arch");
+truthy(process.versions && typeof process.versions.node === "string", "process.versions.node");
+truthy(typeof process.version === "string" && process.version[0] === "v", "process.version");
+truthy(Array.isArray(process.argv) && process.argv.length >= 2, "process.argv");
+truthy(typeof process.env === "object" && process.env !== null, "process.env");
+truthy(typeof process.cwd === "function" && typeof process.cwd() === "string", "process.cwd()");
+truthy(typeof process.pid === "number", "process.pid");
+
+// ---- process.hrtime -------------------------------------------------------
+(function () {
+  var h = process.hrtime();
+  truthy(
+    Array.isArray(h) && h.length === 2 && typeof h[0] === "number" && typeof h[1] === "number",
+    "process.hrtime() returns [seconds, nanoseconds]"
+  );
+  truthy(typeof process.hrtime.bigint() === "bigint", "process.hrtime.bigint() returns a BigInt");
+})();
+
+// ---- process.nextTick -----------------------------------------------------
+var tickRan = false;
+process.nextTick(function () {
+  tickRan = true;
+});
+
+// ---- console: count / group / assert / time (captured) --------------------
+(function () {
+  var c = capture(function () {
+    console.count("widget");
+    console.count("widget");
+    console.countReset("widget");
+    console.count("widget");
+  });
+  eq(c.out, "widget: 1\nwidget: 2\nwidget: 1\n", "console.count / countReset");
+
+  var g = capture(function () {
+    console.group("Section");
+    console.log("nested");
+    console.groupEnd();
+    console.log("flush");
+  });
+  eq(g.out, "Section\n  nested\nflush\n", "console.group indentation");
+
+  var a = capture(function () {
+    console.assert(false, "boom");
+    console.assert(true, "quiet");
+  });
+  eq(a.err, "Assertion failed: boom\n", "console.assert on failure");
+
+  var t = capture(function () {
+    console.time("phase");
+    console.timeEnd("phase");
+  });
+  truthy(/^phase: [\d.]+(ms|s|m|h|min)\n$/.test(t.out), "console.timeEnd format");
+
+  var d = capture(function () {
+    console.dir({ hello: 1 });
+  });
+  truthy(d.out.indexOf("hello") !== -1 && d.out.indexOf("1") !== -1, "console.dir renders object");
+
+  var e = capture(function () {
+    console.error("err %s", "msg");
+    console.warn("warn %d", 5);
+  });
+  eq(e.err, "err msg\nwarn 5\n", "console.error / warn format to stderr");
+})();
+
+// ---- console.log formatting reaches real stdout (diffed) ------------------
+console.log("formatted: %s=%d", "count", 3);
+console.log("multi", "args", 7);
+
+// ---- byte-accurate process.stdout.write (no implicit newline) -------------
+process.stdout.write("A");
+process.stdout.write("B");
+process.stdout.write("C\n");
+
+// nextTick must have run by end of the synchronous phase's microtask drain.
+Promise.resolve().then(function () {
+  truthy(tickRan, "process.nextTick scheduled a callback");
+  console.log("1.." + testNo);
+  console.log("# all passed");
+});

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -167,6 +167,32 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     configurable: true,
   });
   eq(util.inspect(arrGetter), "[ 1, [Getter] ]", "inspect does not invoke array getters");
+  // The constructor-name prefix must not invoke an accessor `constructor` or a
+  // Proxy get-trap (Node derives it from prototype metadata).
+  var ctorGetter = { a: 1 };
+  Object.defineProperty(ctorGetter, "constructor", {
+    get: function () {
+      throw new Error("boom");
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  eq(util.inspect(ctorGetter), "{ a: 1 }", "inspect does not invoke a constructor getter");
+  var ctorProxy = new Proxy(
+    { a: 1 },
+    {
+      get: function (t, k) {
+        if (k === "constructor") throw new Error("trap");
+        return t[k];
+      },
+    }
+  );
+  eq(util.inspect(ctorProxy), "{ a: 1 }", "inspect does not trip a Proxy constructor trap");
+  // A normal named class still gets its "ClassName " prefix.
+  function Widget() {
+    this.a = 1;
+  }
+  eq(util.inspect(new Widget()), "Widget { a: 1 }", "inspect keeps the class-name prefix");
 })();
 
 // ---- process fields -------------------------------------------------------

--- a/scripts/run-library-tests.sh
+++ b/scripts/run-library-tests.sh
@@ -192,15 +192,21 @@ VERDICT=""; COUNT=""
 evaluate() {   # <engine> <label>  → sets VERDICT/COUNT, returns 0 on PASS
     local engine="$1" label="$2"
     local out="$LIB_CACHE/out-$label.txt" rc=0 result
+    # jsse needs --node to install the #229 __host_* syscall floor (byte I/O,
+    # monotonic clock, process exit) that node-shim.js builds process/console/
+    # util on. Node has no such flag, and the shim is guarded so it stays inert
+    # there — that is what keeps `--node` a valid same-bundle reference oracle.
+    local engine_args=()
+    [ "$label" = "jsse" ] && engine_args=(--node)
     echo ""
     echo "========================================"
     echo "  Running $LIB test suite on $label"
     echo "========================================"
     if [ -n "$LIB_TIMEOUT" ]; then
-        timeout "$LIB_TIMEOUT" "$engine" "$FINAL" > "$out" 2>&1 || rc=$?
+        timeout "$LIB_TIMEOUT" "$engine" "${engine_args[@]}" "$FINAL" > "$out" 2>&1 || rc=$?
         [ "$rc" -eq 124 ] && echo "(timed out after ${LIB_TIMEOUT}s)" >> "$out"
     else
-        "$engine" "$FINAL" > "$out" 2>&1 || rc=$?
+        "$engine" "${engine_args[@]}" "$FINAL" > "$out" 2>&1 || rc=$?
     fi
     cat "$out"
     result="$(lib_verdict "$out" "$rc" || true)"

--- a/scripts/run-node-shim-selftest.sh
+++ b/scripts/run-node-shim-selftest.sh
@@ -106,6 +106,48 @@ check_exit() {  # <label> <cmd...>
 check_exit jsse "$JSSE" --node
 command -v node >/dev/null 2>&1 && check_exit node node
 
+# ---- no-host fallback probe -----------------------------------------------
+# The library harness always passes --node, but node-shim.js documents a
+# degraded pure-JS fallback for plain jsse runs. Cover that path directly so the
+# fallback stream never recurses through the shimmed console methods.
+echo ""
+echo "== jsse fallback without --node =="
+FALLBACK_PROBE="$TMP/fallback-probe.js"
+cat "$SCRIPT_DIR/node-shim.js" > "$FALLBACK_PROBE"
+cat >> "$FALLBACK_PROBE" <<'PROBE'
+process.stdout.write("fallback stdout\n");
+process.stderr.write("fallback stderr\n");
+console.log("fallback console");
+console.error("fallback error");
+process.stdout.write("partial");
+process.exit(0);
+PROBE
+
+fallback_rc=0
+"$JSSE" "$FALLBACK_PROBE" > "$TMP/jsse-fallback.out" 2> "$TMP/jsse-fallback.err" || fallback_rc=$?
+if [ "$fallback_rc" -ne 0 ]; then
+    echo "FAIL: jsse fallback without --node exited $fallback_rc" >&2
+    [ -s "$TMP/jsse-fallback.out" ] && cat "$TMP/jsse-fallback.out" >&2
+    [ -s "$TMP/jsse-fallback.err" ] && cat "$TMP/jsse-fallback.err" >&2
+    FAIL=1
+elif ! diff -u - "$TMP/jsse-fallback.out" > "$TMP/fallback.diff" <<'EXPECTED'; then
+fallback stdout
+fallback stderr
+fallback console
+fallback error
+partial
+EXPECTED
+    echo "FAIL: jsse fallback without --node output differed:" >&2
+    cat "$TMP/fallback.diff" >&2
+    FAIL=1
+elif [ -s "$TMP/jsse-fallback.err" ]; then
+    echo "FAIL: jsse fallback without --node wrote stderr:" >&2
+    cat "$TMP/jsse-fallback.err" >&2
+    FAIL=1
+else
+    echo "  jsse: fallback stdout/stderr/console without --node — OK"
+fi
+
 echo ""
 if [ "$FAIL" -eq 0 ]; then
     echo "OK: node-shim self-test passed on jsse (cross-checked against Node)"

--- a/scripts/run-node-shim-selftest.sh
+++ b/scripts/run-node-shim-selftest.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Cross-check the Node host-compat readable-output layer (scripts/node-shim.js,
+# issue #230) on jsse against Node.
+#
+# It concatenates the shim in front of scripts/node-shim.selftest.js (exactly as
+# run-library-tests.sh prepends the shim to a bundle), runs the result on jsse
+# with --node and on Node, and requires BOTH to exit 0 and produce byte-identical
+# stdout. Node is the reference oracle for the deterministic surfaces the
+# self-test asserts (util.format specifiers, byte-accurate stdout, console
+# shapes); util.inspect is only smoke-tested, never byte-compared.
+#
+# Usage: ./scripts/run-node-shim-selftest.sh [--no-build]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+JSSE="$PROJECT_DIR/target/release/jsse"
+
+BUILD=1
+for arg in "$@"; do
+    case "$arg" in
+        --no-build) BUILD=0 ;;
+        *) echo "unknown option: $arg" >&2; exit 2 ;;
+    esac
+done
+
+if [ "$BUILD" -eq 1 ]; then
+    echo "Building jsse (release)..."
+    (cd "$PROJECT_DIR" && cargo build --release)
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FINAL="$TMP/selftest.bundle.js"
+cat "$SCRIPT_DIR/node-shim.js" "$SCRIPT_DIR/node-shim.selftest.js" > "$FINAL"
+
+run_engine() {  # <label> <cmd...> → writes $TMP/<label>.out, sets RC
+    local label="$1"; shift
+    RC=0
+    "$@" "$FINAL" > "$TMP/$label.out" 2> "$TMP/$label.err" || RC=$?
+}
+
+FAIL=0
+
+echo ""
+echo "== jsse --node =="
+run_engine jsse "$JSSE" --node
+JSSE_RC="$RC"
+cat "$TMP/jsse.out"
+[ -s "$TMP/jsse.err" ] && { echo "--- jsse stderr ---"; cat "$TMP/jsse.err"; }
+if [ "$JSSE_RC" -ne 0 ]; then
+    echo "FAIL: jsse exited $JSSE_RC" >&2
+    FAIL=1
+fi
+
+if command -v node >/dev/null 2>&1; then
+    echo ""
+    echo "== node (reference) =="
+    run_engine node node
+    NODE_RC="$RC"
+    [ -s "$TMP/node.err" ] && { echo "--- node stderr ---"; cat "$TMP/node.err"; }
+    if [ "$NODE_RC" -ne 0 ]; then
+        echo "FAIL: node exited $NODE_RC" >&2
+        FAIL=1
+    fi
+
+    if ! diff -u "$TMP/node.out" "$TMP/jsse.out" > "$TMP/diff.txt"; then
+        echo "FAIL: jsse and Node stdout differ (--- node, +++ jsse):" >&2
+        cat "$TMP/diff.txt" >&2
+        FAIL=1
+    fi
+else
+    echo "WARNING: node not found — skipping cross-check (jsse-only)" >&2
+fi
+
+# ---- process.exit probe ---------------------------------------------------
+# The self-test above never drives exit (it must reach its plan line), so cover
+# process.exit(code) separately: a real, uncatchable exit with the right code.
+# A try/catch around it must not swallow the exit, and the trailing log must not
+# run. Expected on both engines: exit code 3, no "UNREACHABLE" on stdout.
+echo ""
+echo "== process.exit probe =="
+EXIT_PROBE="$TMP/exit-probe.js"
+cat "$SCRIPT_DIR/node-shim.js" > "$EXIT_PROBE"
+cat >> "$EXIT_PROBE" <<'PROBE'
+try { process.exit(3); } catch (e) {}
+console.log("UNREACHABLE");
+PROBE
+
+check_exit() {  # <label> <cmd...>
+    local label="$1"; shift
+    local rc=0
+    "$@" "$EXIT_PROBE" > "$TMP/$label-exit.out" 2>&1 || rc=$?
+    if [ "$rc" -ne 3 ]; then
+        echo "FAIL: $label process.exit(3) exited $rc (expected 3)" >&2
+        FAIL=1
+    elif grep -q "UNREACHABLE" "$TMP/$label-exit.out"; then
+        echo "FAIL: $label process.exit was catchable / did not exit immediately" >&2
+        FAIL=1
+    else
+        echo "  $label: exit 3, uncatchable — OK"
+    fi
+}
+
+check_exit jsse "$JSSE" --node
+command -v node >/dev/null 2>&1 && check_exit node node
+
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+    echo "OK: node-shim self-test passed on jsse (cross-checked against Node)"
+    exit 0
+fi
+echo "FAILED: node-shim self-test" >&2
+exit 1


### PR DESCRIPTION
## Summary

Builds the **readable-output layer** of `scripts/node-shim.js` (Epic #227,
foundation slice 3 of 5) on top of the #229 Rust syscall floor, so a real-world
library's Node-written test runner renders output the way it does on Node:

- **`process`** — byte-accurate `stdout`/`stderr.write` via `__host_write`,
  `hrtime()`/`hrtime.bigint()` via `__host_hrtime`, a real uncatchable
  `exit(code)` via `__host_exit`, plus `argv`/`env`/`platform`/`arch`/
  `version`/`versions.node`/`cwd()`/`nextTick`/`pid` (static stubs — #229 added
  no syscall for those, and this slice is about output). Each surface degrades to
  a pure-JS fallback when the floor is absent.
- **`console`** — full method set (`log`/`info`/`warn`/`error`/`debug`/`trace`/
  `dir`/`assert`/`group`/`groupEnd`/`groupCollapsed`/`count`/`countReset`/
  `time`/`timeEnd`/`timeLog`/`table`), all built on `util.format` +
  `process.stdout/stderr.write`. Retires acorn's ad-hoc `console.group` stub into
  the shared shim.
- **`util.format`** — `%s %d %i %f %j %o %O %c %%` matching Node semantics for
  the deterministic specifiers (including Node's "lone string argument is
  returned verbatim" rule, so `format("%%")` is `"%%"` but `format("%%", x)`
  substitutes).
- **`util.inspect`** — best-effort (depth, cycles, common types); intentionally
  not byte-compatible with Node's inspect.

The library harness now runs **jsse with `--node`** (jsse-only; Node has no such
flag) so the shim can reach the floor. The shim stays a complete no-op on real
Node, which is what keeps the identical bundle a valid reference oracle.

**No `src/` changes** — the shim is a `scripts/`-only prepend, never baked into
jsse's global object, so **test262 is untouched**.

## Test plan

- [x] `./scripts/run-node-shim-selftest.sh` — new self-test (54 checks) passes on
  jsse `--node` and Node with **byte-identical stdout** (Node is the oracle for
  the deterministic surfaces; `util.inspect` smoke-tested structurally). Includes
  a `process.exit(3)` probe asserting a real, uncatchable exit with the right
  code on both engines.
- [x] `./scripts/run-acorn-tests.sh` — **13,507** green on jsse and Node
  (cross-checked). acorn is the print-heavy suite the PR bar calls for: thousands
  of result lines rendered through the shared shim, matching Node.
- [x] `./scripts/run-library-tests.sh decimal.js` — **22,624** green (cross-checked).
- [x] `./scripts/run-library-tests.sh big.js` — **47,456** green (cross-checked).
- [x] `./scripts/lint.sh` — rustfmt + clippy clean (no Rust changes).

## Coordination with #231 / PR #248

The parallel Buffer slice (#231, PR #248) does **not** touch `scripts/node-shim.js`,
so there is no conflict on the rewritten shim. It does independently edit
`scripts/run-library-tests.sh` and `scripts/README.md` (textual merge conflicts
to expect) and adds its own `scripts/run-shim-fixtures.sh`. Two notes for the
merge:

- Suggest **#230 merges first** (epic order is #230 → #231), then #248 rebases.
- #248's `node-buffer-shim.js` was written against the *old* `node-shim.js`; it
  should be re-validated against this rewrite once both land. The two cross-check
  harnesses (this PR's `run-node-shim-selftest.sh`, #248's `run-shim-fixtures.sh`)
  are complementary and could be unified in a follow-up.

Fixes #230
