### PR TITLE
Deepen builtin accessor registration with define_getter helper

### DIFF
--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -358,43 +358,26 @@ impl Interpreter {
         );
 
         // Map.prototype.size (getter)
-        let size_getter = self.create_function(JsFunction::native(
-            "get size".to_string(),
-            0,
-            |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
-                {
-                    let borrowed = obj.borrow();
-                    let is_map = borrowed.map_data().is_some() && borrowed.class_name == "Map";
-                    let map_data = if is_map {
-                        borrowed.map_data().cloned()
-                    } else {
-                        None
-                    };
-                    drop(borrowed);
-                    if let Some(entries) = map_data {
-                        let count = entries.iter().filter(|e| e.is_some()).count();
-                        return Completion::Normal(JsValue::Number(count as f64));
-                    }
+        self.define_getter(proto_id, "size", |interp, this, _args| {
+            if let JsValue::Object(o) = this
+                && let Some(obj) = interp.get_object_cell(o.id)
+            {
+                let borrowed = obj.borrow();
+                let is_map = borrowed.map_data().is_some() && borrowed.class_name == "Map";
+                let map_data = if is_map {
+                    borrowed.map_data().cloned()
+                } else {
+                    None
+                };
+                drop(borrowed);
+                if let Some(entries) = map_data {
+                    let count = entries.iter().filter(|e| e.is_some()).count();
+                    return Completion::Normal(JsValue::Number(count as f64));
                 }
-                let err = interp.create_type_error("Map.prototype.size requires a Map");
-                Completion::Throw(err)
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                "size".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(size_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            let err = interp.create_type_error("Map.prototype.size requires a Map");
+            Completion::Throw(err)
+        });
 
         // Map.prototype.getOrInsert
         self.define_method(proto_id, "getOrInsert", 2, |interp, this, args| {
@@ -1108,42 +1091,25 @@ impl Interpreter {
         );
 
         // Set.prototype.size (getter)
-        let size_getter = self.create_function(JsFunction::native(
-            "get size".to_string(),
-            0,
-            |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
-                {
-                    let (has_set, set_data) = {
-                        let b = obj.borrow();
-                        (
-                            b.set_data().is_some() && b.class_name != "WeakSet",
-                            b.set_data().cloned(),
-                        )
-                    };
-                    if has_set && let Some(entries) = set_data {
-                        let count = entries.iter().filter(|e| e.is_some()).count();
-                        return Completion::Normal(JsValue::Number(count as f64));
-                    }
+        self.define_getter(proto_id, "size", |interp, this, _args| {
+            if let JsValue::Object(o) = this
+                && let Some(obj) = interp.get_object_cell(o.id)
+            {
+                let (has_set, set_data) = {
+                    let b = obj.borrow();
+                    (
+                        b.set_data().is_some() && b.class_name != "WeakSet",
+                        b.set_data().cloned(),
+                    )
+                };
+                if has_set && let Some(entries) = set_data {
+                    let count = entries.iter().filter(|e| e.is_some()).count();
+                    return Completion::Normal(JsValue::Number(count as f64));
                 }
-                let err = interp.create_type_error("Set.prototype.size requires a Set");
-                Completion::Throw(err)
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                "size".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(size_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            let err = interp.create_type_error("Set.prototype.size requires a Set");
+            Completion::Throw(err)
+        });
 
         // ES2025 Set methods
 

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -42,38 +42,28 @@ impl Interpreter {
         }
 
         // get disposed
-        let disposed_getter = self.create_function(JsFunction::native(
-            "get disposed".to_string(),
-            0,
-            |interp, this, _args| {
-                let disposed = if let JsValue::Object(o) = this {
-                    interp.get_object_cell(o.id).and_then(|cell| {
-                        let b = cell.borrow();
-                        if b.class_name == "DisposableStack"
-                            && let Some(ds) = b.disposable_stack()
-                        {
-                            Some(ds.disposed)
-                        } else {
-                            None
-                        }
-                    })
-                } else {
-                    None
-                };
-                match disposed {
-                    Some(d) => Completion::Normal(JsValue::Boolean(d)),
-                    None => Completion::Throw(interp.create_type_error(
-                        "DisposableStack.prototype.disposed called on non-DisposableStack",
-                    )),
-                }
-            },
-        ));
-        self.get_object_cell_expect(ds_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "disposed".to_string(),
-                PropertyDescriptor::accessor(Some(disposed_getter), None, false, true),
-            );
+        self.define_getter(ds_proto_id, "disposed", |interp, this, _args| {
+            let disposed = if let JsValue::Object(o) = this {
+                interp.get_object_cell(o.id).and_then(|cell| {
+                    let b = cell.borrow();
+                    if b.class_name == "DisposableStack"
+                        && let Some(ds) = b.disposable_stack()
+                    {
+                        Some(ds.disposed)
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            };
+            match disposed {
+                Some(d) => Completion::Normal(JsValue::Boolean(d)),
+                None => Completion::Throw(interp.create_type_error(
+                    "DisposableStack.prototype.disposed called on non-DisposableStack",
+                )),
+            }
+        });
 
         // use(value)
         let use_fn = self.create_function(JsFunction::native(
@@ -583,38 +573,28 @@ impl Interpreter {
         }
 
         // get disposed
-        let disposed_getter = self.create_function(JsFunction::native(
-            "get disposed".to_string(),
-            0,
-            |interp, this, _args| {
-                let disposed = if let JsValue::Object(o) = this {
-                    interp.get_object_cell(o.id).and_then(|cell| {
-                        let b = cell.borrow();
-                        if b.class_name == "AsyncDisposableStack"
-                            && let Some(ds) = b.disposable_stack()
-                        {
-                            Some(ds.disposed)
-                        } else {
-                            None
-                        }
-                    })
-                } else {
-                    None
-                };
-                match disposed {
-                    Some(d) => Completion::Normal(JsValue::Boolean(d)),
-                    None => Completion::Throw(interp.create_type_error(
-                        "AsyncDisposableStack.prototype.disposed called on non-AsyncDisposableStack",
-                    )),
-                }
-            },
-        ));
-        self.get_object_cell_expect(ads_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "disposed".to_string(),
-                PropertyDescriptor::accessor(Some(disposed_getter), None, false, true),
-            );
+        self.define_getter(ads_proto_id, "disposed", |interp, this, _args| {
+            let disposed = if let JsValue::Object(o) = this {
+                interp.get_object_cell(o.id).and_then(|cell| {
+                    let b = cell.borrow();
+                    if b.class_name == "AsyncDisposableStack"
+                        && let Some(ds) = b.disposable_stack()
+                    {
+                        Some(ds.disposed)
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            };
+            match disposed {
+                Some(d) => Completion::Normal(JsValue::Boolean(d)),
+                None => Completion::Throw(interp.create_type_error(
+                    "AsyncDisposableStack.prototype.disposed called on non-AsyncDisposableStack",
+                )),
+            }
+        });
 
         // use(value)
         let use_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/number.rs
+++ b/src/interpreter/builtins/number.rs
@@ -322,35 +322,17 @@ impl Interpreter {
         }
 
         // description getter
-        let desc_getter = self.create_function(JsFunction::Native(
-            "get description".to_string(),
-            0,
-            Rc::new(|interp, this, _args| {
-                let Some(sym) = this_symbol_value(interp, this) else {
-                    let err =
-                        interp.create_type_error("Symbol.prototype.description requires a Symbol");
-                    return Completion::Throw(err);
-                };
-                match sym.description {
-                    Some(d) => Completion::Normal(JsValue::String(d)),
-                    None => Completion::Normal(JsValue::Undefined),
-                }
-            }),
-            false,
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                "description".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(desc_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+        self.define_getter(proto_id, "description", |interp, this, _args| {
+            let Some(sym) = this_symbol_value(interp, this) else {
+                let err =
+                    interp.create_type_error("Symbol.prototype.description requires a Symbol");
+                return Completion::Throw(err);
+            };
+            match sym.description {
+                Some(d) => Completion::Normal(JsValue::String(d)),
+                None => Completion::Normal(JsValue::Undefined),
+            }
+        });
 
         // [Symbol.toPrimitive]
         let to_prim_fn = self.create_function(JsFunction::Native(

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -8787,61 +8787,43 @@ impl Interpreter {
         self.realm_mut().regexp_string_iterator_prototype = Some(rsi_proto_id);
 
         // RegExp.prototype.flags getter (§22.2.5.3)
-        let flags_getter = self.create_function(JsFunction::native(
-            "get flags".to_string(),
-            0,
-            |interp, this_val, _args| {
-                let obj_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
-                        let err = interp.create_type_error(
-                            "RegExp.prototype.flags requires that 'this' be an Object",
-                        );
-                        return Completion::Throw(err);
-                    }
-                };
-                if interp.get_object_cell(obj_id).is_none() {
+        self.define_getter(regexp_proto_id, "flags", |interp, this_val, _args| {
+            let obj_id = match this_val {
+                JsValue::Object(o) => o.id,
+                _ => {
                     let err = interp.create_type_error(
                         "RegExp.prototype.flags requires that 'this' be an Object",
                     );
                     return Completion::Throw(err);
                 }
-                let mut result = String::new();
-                let flags_to_check: &[(&str, char)] = &[
-                    ("hasIndices", 'd'),
-                    ("global", 'g'),
-                    ("ignoreCase", 'i'),
-                    ("multiline", 'm'),
-                    ("dotAll", 's'),
-                    ("unicode", 'u'),
-                    ("unicodeSets", 'v'),
-                    ("sticky", 'y'),
-                ];
-                for (prop, ch) in flags_to_check {
-                    let val = match interp.get_object_property(obj_id, prop, this_val) {
-                        Completion::Normal(v) => v,
-                        other => return other,
-                    };
-                    if interp.to_boolean_val(&val) {
-                        result.push(*ch);
-                    }
+            };
+            if interp.get_object_cell(obj_id).is_none() {
+                let err = interp
+                    .create_type_error("RegExp.prototype.flags requires that 'this' be an Object");
+                return Completion::Throw(err);
+            }
+            let mut result = String::new();
+            let flags_to_check: &[(&str, char)] = &[
+                ("hasIndices", 'd'),
+                ("global", 'g'),
+                ("ignoreCase", 'i'),
+                ("multiline", 'm'),
+                ("dotAll", 's'),
+                ("unicode", 'u'),
+                ("unicodeSets", 'v'),
+                ("sticky", 'y'),
+            ];
+            for (prop, ch) in flags_to_check {
+                let val = match interp.get_object_property(obj_id, prop, this_val) {
+                    Completion::Normal(v) => v,
+                    other => return other,
+                };
+                if interp.to_boolean_val(&val) {
+                    result.push(*ch);
                 }
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
-            },
-        ));
-        self.get_object_cell_expect(regexp_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "flags".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(flags_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Normal(JsValue::String(JsString::from_str(&result)))
+        });
 
         // Flag property getters on prototype (§22.2.5.x)
         let flag_props: &[(&str, char)] = &[
@@ -8915,56 +8897,39 @@ impl Interpreter {
         }
 
         // source getter (§22.2.5.10)
-        let source_getter = self.create_function(JsFunction::native(
-            "get source".to_string(),
-            0,
-            move |interp, this_val, _args| {
-                let obj_ref = match this_val {
-                    JsValue::Object(o) => o,
-                    _ => {
-                        return Completion::Throw(interp.create_error_in_realm(
-                            my_realm_id,
-                            "TypeError",
-                            "RegExp.prototype.source requires that 'this' be an Object",
-                        ));
-                    }
-                };
-                let obj = match interp.get_object_cell(obj_ref.id) {
-                    Some(o) => o,
-                    None => return Completion::Normal(JsValue::Undefined),
-                };
-                if obj.borrow().class_name != "RegExp" {
-                    if obj_ref.id == regexp_proto_id {
-                        return Completion::Normal(JsValue::String(JsString::from_str("(?:)")));
-                    }
+        self.define_getter(regexp_proto_id, "source", move |interp, this_val, _args| {
+            let obj_ref = match this_val {
+                JsValue::Object(o) => o,
+                _ => {
                     return Completion::Throw(interp.create_error_in_realm(
                         my_realm_id,
                         "TypeError",
-                        "RegExp.prototype.source requires that 'this' be a RegExp object",
+                        "RegExp.prototype.source requires that 'this' be an Object",
                     ));
                 }
-                let source_opt = obj.borrow().regexp().map(|r| r.source.clone());
-                if let Some(ref s) = source_opt {
-                    let escaped = escape_regexp_pattern_code_units(&s.code_units);
-                    Completion::Normal(JsValue::String(escaped))
-                } else {
-                    Completion::Normal(JsValue::String(JsString::from_str("(?:)")))
+            };
+            let obj = match interp.get_object_cell(obj_ref.id) {
+                Some(o) => o,
+                None => return Completion::Normal(JsValue::Undefined),
+            };
+            if obj.borrow().class_name != "RegExp" {
+                if obj_ref.id == regexp_proto_id {
+                    return Completion::Normal(JsValue::String(JsString::from_str("(?:)")));
                 }
-            },
-        ));
-        self.get_object_cell_expect(regexp_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "source".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(source_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+                return Completion::Throw(interp.create_error_in_realm(
+                    my_realm_id,
+                    "TypeError",
+                    "RegExp.prototype.source requires that 'this' be a RegExp object",
+                ));
+            }
+            let source_opt = obj.borrow().regexp().map(|r| r.source.clone());
+            if let Some(ref s) = source_opt {
+                let escaped = escape_regexp_pattern_code_units(&s.code_units);
+                Completion::Normal(JsValue::String(escaped))
+            } else {
+                Completion::Normal(JsValue::String(JsString::from_str("(?:)")))
+            }
+        });
 
         let regexp_proto_rc_id = regexp_proto_id;
 

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -39,275 +39,187 @@ impl Interpreter {
         self.realm_mut().arraybuffer_prototype = Some(ab_proto_id);
 
         // byteLength getter
-        let byte_length_getter = self.create_function(JsFunction::native(
-            "get byteLength".to_string(),
-            0,
-            |interp, this_val, _args| {
-                enum Probe {
-                    NotAB,
-                    Shared,
-                    Detached,
-                    Bytes(usize),
-                }
-                let probe = if let JsValue::Object(o) = this_val {
-                    interp
-                        .get_object_cell(o.id)
-                        .map(|cell| {
-                            let r = cell.borrow();
-                            if let Some(buf_data) = r.arraybuffer_data() {
-                                if r.arraybuffer_is_shared() {
-                                    Probe::Shared
-                                } else if r.arraybuffer_detached().as_ref().is_some_and(|d| d.get())
-                                {
-                                    Probe::Detached
-                                } else {
-                                    Probe::Bytes(buffer_len(buf_data))
-                                }
+        self.define_getter(ab_proto_id, "byteLength", |interp, this_val, _args| {
+            enum Probe {
+                NotAB,
+                Shared,
+                Detached,
+                Bytes(usize),
+            }
+            let probe = if let JsValue::Object(o) = this_val {
+                interp
+                    .get_object_cell(o.id)
+                    .map(|cell| {
+                        let r = cell.borrow();
+                        if let Some(buf_data) = r.arraybuffer_data() {
+                            if r.arraybuffer_is_shared() {
+                                Probe::Shared
+                            } else if r.arraybuffer_detached().as_ref().is_some_and(|d| d.get()) {
+                                Probe::Detached
                             } else {
-                                Probe::NotAB
+                                Probe::Bytes(buffer_len(buf_data))
                             }
-                        })
-                        .unwrap_or(Probe::NotAB)
-                } else {
-                    Probe::NotAB
-                };
-                match probe {
-                    Probe::Shared | Probe::NotAB => {
-                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
-                    }
-                    Probe::Detached => Completion::Normal(JsValue::Number(0.0)),
-                    Probe::Bytes(n) => Completion::Normal(JsValue::Number(n as f64)),
+                        } else {
+                            Probe::NotAB
+                        }
+                    })
+                    .unwrap_or(Probe::NotAB)
+            } else {
+                Probe::NotAB
+            };
+            match probe {
+                Probe::Shared | Probe::NotAB => {
+                    Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-            },
-        ));
-        self.get_object_cell_expect(ab_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "byteLength".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(byte_length_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+                Probe::Detached => Completion::Normal(JsValue::Number(0.0)),
+                Probe::Bytes(n) => Completion::Normal(JsValue::Number(n as f64)),
+            }
+        });
 
         // detached getter
-        let detached_getter = self.create_function(JsFunction::native(
-            "get detached".to_string(),
-            0,
-            |interp, this_val, _args| {
-                enum Probe {
-                    NotAB,
-                    Shared,
-                    Detached(bool),
-                }
-                let probe = if let JsValue::Object(o) = this_val {
-                    interp
-                        .get_object_cell(o.id)
-                        .map(|cell| {
-                            let r = cell.borrow();
-                            if r.arraybuffer_data().is_some() {
-                                if r.arraybuffer_is_shared() {
-                                    Probe::Shared
-                                } else {
-                                    let det =
-                                        r.arraybuffer_detached().as_ref().is_some_and(|d| d.get());
-                                    Probe::Detached(det)
-                                }
+        self.define_getter(ab_proto_id, "detached", |interp, this_val, _args| {
+            enum Probe {
+                NotAB,
+                Shared,
+                Detached(bool),
+            }
+            let probe = if let JsValue::Object(o) = this_val {
+                interp
+                    .get_object_cell(o.id)
+                    .map(|cell| {
+                        let r = cell.borrow();
+                        if r.arraybuffer_data().is_some() {
+                            if r.arraybuffer_is_shared() {
+                                Probe::Shared
                             } else {
-                                Probe::NotAB
+                                let det =
+                                    r.arraybuffer_detached().as_ref().is_some_and(|d| d.get());
+                                Probe::Detached(det)
                             }
-                        })
-                        .unwrap_or(Probe::NotAB)
-                } else {
-                    Probe::NotAB
-                };
-                match probe {
-                    Probe::NotAB | Probe::Shared => {
-                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
-                    }
-                    Probe::Detached(b) => Completion::Normal(JsValue::Boolean(b)),
+                        } else {
+                            Probe::NotAB
+                        }
+                    })
+                    .unwrap_or(Probe::NotAB)
+            } else {
+                Probe::NotAB
+            };
+            match probe {
+                Probe::NotAB | Probe::Shared => {
+                    Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-            },
-        ));
-        self.get_object_cell_expect(ab_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "detached".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(detached_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+                Probe::Detached(b) => Completion::Normal(JsValue::Boolean(b)),
+            }
+        });
 
         // resizable getter
-        let resizable_getter = self.create_function(JsFunction::native(
-            "get resizable".to_string(),
-            0,
-            |interp, this_val, _args| {
-                enum Probe {
-                    NotAB,
-                    Shared,
-                    Resizable(bool),
-                }
-                let probe = if let JsValue::Object(o) = this_val {
-                    interp
-                        .get_object_cell(o.id)
-                        .map(|cell| {
-                            let r = cell.borrow();
-                            if r.arraybuffer_data().is_some() {
-                                if r.arraybuffer_is_shared() {
-                                    Probe::Shared
-                                } else {
-                                    Probe::Resizable(r.arraybuffer_max_byte_length().is_some())
-                                }
+        self.define_getter(ab_proto_id, "resizable", |interp, this_val, _args| {
+            enum Probe {
+                NotAB,
+                Shared,
+                Resizable(bool),
+            }
+            let probe = if let JsValue::Object(o) = this_val {
+                interp
+                    .get_object_cell(o.id)
+                    .map(|cell| {
+                        let r = cell.borrow();
+                        if r.arraybuffer_data().is_some() {
+                            if r.arraybuffer_is_shared() {
+                                Probe::Shared
                             } else {
-                                Probe::NotAB
+                                Probe::Resizable(r.arraybuffer_max_byte_length().is_some())
                             }
-                        })
-                        .unwrap_or(Probe::NotAB)
-                } else {
-                    Probe::NotAB
-                };
-                match probe {
-                    Probe::NotAB | Probe::Shared => {
-                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
-                    }
-                    Probe::Resizable(b) => Completion::Normal(JsValue::Boolean(b)),
+                        } else {
+                            Probe::NotAB
+                        }
+                    })
+                    .unwrap_or(Probe::NotAB)
+            } else {
+                Probe::NotAB
+            };
+            match probe {
+                Probe::NotAB | Probe::Shared => {
+                    Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-            },
-        ));
-        self.get_object_cell_expect(ab_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "resizable".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(resizable_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+                Probe::Resizable(b) => Completion::Normal(JsValue::Boolean(b)),
+            }
+        });
 
         // immutable getter
-        let immutable_getter = self.create_function(JsFunction::native(
-            "get immutable".to_string(),
-            0,
-            |interp, this_val, _args| {
-                enum Probe {
-                    NotAB,
-                    Shared,
-                    Immutable(bool),
-                }
-                let probe = if let JsValue::Object(o) = this_val {
-                    interp
-                        .get_object_cell(o.id)
-                        .map(|cell| {
-                            let r = cell.borrow();
-                            if r.arraybuffer_data().is_some() {
-                                if r.arraybuffer_is_shared() {
-                                    Probe::Shared
-                                } else {
-                                    Probe::Immutable(r.arraybuffer_is_immutable())
-                                }
+        self.define_getter(ab_proto_id, "immutable", |interp, this_val, _args| {
+            enum Probe {
+                NotAB,
+                Shared,
+                Immutable(bool),
+            }
+            let probe = if let JsValue::Object(o) = this_val {
+                interp
+                    .get_object_cell(o.id)
+                    .map(|cell| {
+                        let r = cell.borrow();
+                        if r.arraybuffer_data().is_some() {
+                            if r.arraybuffer_is_shared() {
+                                Probe::Shared
                             } else {
-                                Probe::NotAB
+                                Probe::Immutable(r.arraybuffer_is_immutable())
                             }
-                        })
-                        .unwrap_or(Probe::NotAB)
-                } else {
-                    Probe::NotAB
-                };
-                match probe {
-                    Probe::NotAB | Probe::Shared => {
-                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
-                    }
-                    Probe::Immutable(b) => Completion::Normal(JsValue::Boolean(b)),
+                        } else {
+                            Probe::NotAB
+                        }
+                    })
+                    .unwrap_or(Probe::NotAB)
+            } else {
+                Probe::NotAB
+            };
+            match probe {
+                Probe::NotAB | Probe::Shared => {
+                    Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-            },
-        ));
-        self.get_object_cell_expect(ab_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "immutable".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(immutable_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+                Probe::Immutable(b) => Completion::Normal(JsValue::Boolean(b)),
+            }
+        });
 
         // maxByteLength getter
-        let max_byte_length_getter = self.create_function(JsFunction::native(
-            "get maxByteLength".to_string(),
-            0,
-            |interp, this_val, _args| {
-                enum Probe {
-                    NotAB,
-                    Shared,
-                    Detached,
-                    Max(usize),
-                }
-                let probe = if let JsValue::Object(o) = this_val {
-                    interp
-                        .get_object_cell(o.id)
-                        .map(|cell| {
-                            let r = cell.borrow();
-                            if r.arraybuffer_data().is_some() {
-                                if r.arraybuffer_is_shared() {
-                                    Probe::Shared
-                                } else if r.arraybuffer_detached().as_ref().is_some_and(|d| d.get())
-                                {
-                                    Probe::Detached
-                                } else {
-                                    let max =
-                                        r.arraybuffer_max_byte_length().unwrap_or_else(|| {
-                                            buffer_len(r.arraybuffer_data().unwrap())
-                                        });
-                                    Probe::Max(max)
-                                }
+        self.define_getter(ab_proto_id, "maxByteLength", |interp, this_val, _args| {
+            enum Probe {
+                NotAB,
+                Shared,
+                Detached,
+                Max(usize),
+            }
+            let probe = if let JsValue::Object(o) = this_val {
+                interp
+                    .get_object_cell(o.id)
+                    .map(|cell| {
+                        let r = cell.borrow();
+                        if r.arraybuffer_data().is_some() {
+                            if r.arraybuffer_is_shared() {
+                                Probe::Shared
+                            } else if r.arraybuffer_detached().as_ref().is_some_and(|d| d.get()) {
+                                Probe::Detached
                             } else {
-                                Probe::NotAB
+                                let max = r
+                                    .arraybuffer_max_byte_length()
+                                    .unwrap_or_else(|| buffer_len(r.arraybuffer_data().unwrap()));
+                                Probe::Max(max)
                             }
-                        })
-                        .unwrap_or(Probe::NotAB)
-                } else {
-                    Probe::NotAB
-                };
-                match probe {
-                    Probe::NotAB | Probe::Shared => {
-                        Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
-                    }
-                    Probe::Detached => Completion::Normal(JsValue::Number(0.0)),
-                    Probe::Max(n) => Completion::Normal(JsValue::Number(n as f64)),
+                        } else {
+                            Probe::NotAB
+                        }
+                    })
+                    .unwrap_or(Probe::NotAB)
+            } else {
+                Probe::NotAB
+            };
+            match probe {
+                Probe::NotAB | Probe::Shared => {
+                    Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-            },
-        ));
-        self.get_object_cell_expect(ab_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "maxByteLength".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(max_byte_length_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+                Probe::Detached => Completion::Normal(JsValue::Number(0.0)),
+                Probe::Max(n) => Completion::Normal(JsValue::Number(n as f64)),
+            }
+        });
 
         // slice
         let slice_fn =
@@ -1233,103 +1145,52 @@ impl Interpreter {
         self.realm_mut().shared_arraybuffer_prototype = Some(sab_proto_id);
 
         // byteLength getter
-        let byte_length_getter = self.create_function(JsFunction::native(
-            "get byteLength".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
+        self.define_getter(sab_proto_id, "byteLength", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object_cell(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if obj_ref.arraybuffer_is_shared()
+                    && let Some(buf) = obj_ref.arraybuffer_data()
                 {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.arraybuffer_is_shared()
-                        && let Some(buf) = obj_ref.arraybuffer_data()
-                    {
-                        return Completion::Normal(JsValue::Number(buffer_len(buf) as f64));
-                    }
+                    return Completion::Normal(JsValue::Number(buffer_len(buf) as f64));
                 }
-                Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
-            },
-        ));
-        self.get_object_cell_expect(sab_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "byteLength".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(byte_length_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
+        });
 
         // maxByteLength getter
-        let max_byte_length_getter = self.create_function(JsFunction::native(
-            "get maxByteLength".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
+        self.define_getter(sab_proto_id, "maxByteLength", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object_cell(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if obj_ref.arraybuffer_is_shared()
+                    && let Some(buf) = obj_ref.arraybuffer_data()
                 {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.arraybuffer_is_shared()
-                        && let Some(buf) = obj_ref.arraybuffer_data()
-                    {
-                        let max = obj_ref
-                            .arraybuffer_max_byte_length()
-                            .unwrap_or_else(|| buffer_len(buf));
-                        return Completion::Normal(JsValue::Number(max as f64));
-                    }
+                    let max = obj_ref
+                        .arraybuffer_max_byte_length()
+                        .unwrap_or_else(|| buffer_len(buf));
+                    return Completion::Normal(JsValue::Number(max as f64));
                 }
-                Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
-            },
-        ));
-        self.get_object_cell_expect(sab_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "maxByteLength".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(max_byte_length_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
+        });
 
         // growable getter
-        let growable_getter = self.create_function(JsFunction::native(
-            "get growable".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.arraybuffer_is_shared() {
-                        return Completion::Normal(JsValue::Boolean(
-                            obj_ref.arraybuffer_max_byte_length().is_some(),
-                        ));
-                    }
+        self.define_getter(sab_proto_id, "growable", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if obj_ref.arraybuffer_is_shared() {
+                    return Completion::Normal(JsValue::Boolean(
+                        obj_ref.arraybuffer_max_byte_length().is_some(),
+                    ));
                 }
-                Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
-            },
-        ));
-        self.get_object_cell_expect(sab_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "growable".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(growable_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
+        });
 
         // grow(newLength)
         let grow_fn = self.create_function(JsFunction::native(
@@ -1690,135 +1551,65 @@ impl Interpreter {
         self.realm_mut().typed_array_prototype = Some(proto_id);
 
         // byteOffset getter
-        let byte_offset_getter = self.create_function(JsFunction::native(
-            "get byteOffset".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if let Some(ta) = obj_ref.typed_array_info() {
-                        if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                            return Completion::Normal(JsValue::Number(0.0));
-                        }
-                        return Completion::Normal(JsValue::Number(ta.byte_offset as f64));
+        self.define_getter(proto_id, "byteOffset", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object_cell(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if let Some(ta) = obj_ref.typed_array_info() {
+                    if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
+                        return Completion::Normal(JsValue::Number(0.0));
                     }
+                    return Completion::Normal(JsValue::Number(ta.byte_offset as f64));
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                "byteOffset".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(byte_offset_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a TypedArray"))
+        });
         // byteLength getter
-        let byte_length_getter = self.create_function(JsFunction::native(
-            "get byteLength".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if let Some(ta) = obj_ref.typed_array_info() {
-                        if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                            return Completion::Normal(JsValue::Number(0.0));
-                        }
-                        return Completion::Normal(JsValue::Number(
-                            typed_array_byte_length(ta) as f64
-                        ));
+        self.define_getter(proto_id, "byteLength", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object_cell(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if let Some(ta) = obj_ref.typed_array_info() {
+                    if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
+                        return Completion::Normal(JsValue::Number(0.0));
                     }
+                    return Completion::Normal(JsValue::Number(typed_array_byte_length(ta) as f64));
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                "byteLength".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(byte_length_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a TypedArray"))
+        });
         // length getter
-        let length_getter = self.create_function(JsFunction::native(
-            "get length".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if let Some(ta) = obj_ref.typed_array_info() {
-                        if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                            return Completion::Normal(JsValue::Number(0.0));
-                        }
-                        return Completion::Normal(JsValue::Number(typed_array_length(ta) as f64));
+        self.define_getter(proto_id, "length", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object_cell(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if let Some(ta) = obj_ref.typed_array_info() {
+                    if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
+                        return Completion::Normal(JsValue::Number(0.0));
                     }
+                    return Completion::Normal(JsValue::Number(typed_array_length(ta) as f64));
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                "length".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(length_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a TypedArray"))
+        });
 
         // buffer getter (returns the ArrayBuffer object - we need to find it)
-        let buffer_getter = self.create_function(JsFunction::native(
-            "get buffer".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+        self.define_getter(proto_id, "buffer", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if obj_ref.typed_array_info().is_some()
+                    && let Some(buf_id) = obj_ref.view_buffer_object_id()
                 {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.typed_array_info().is_some()
-                        && let Some(buf_id) = obj_ref.view_buffer_object_id()
-                    {
-                        return Completion::Normal(JsValue::Object(JsObject { id: buf_id }));
-                    }
+                    return Completion::Normal(JsValue::Object(JsObject { id: buf_id }));
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                "buffer".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(buffer_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a TypedArray"))
+        });
 
         // [Symbol.iterator] = values
         let proto_id_for_iter = proto_id;
@@ -5345,135 +5136,84 @@ impl Interpreter {
         self.realm_mut().dataview_prototype = Some(dv_proto_id);
 
         // Getters: buffer, byteOffset, byteLength
-        let buffer_getter = self.create_function(JsFunction::native(
-            "get buffer".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if obj_ref.data_view_info().is_some() {
-                        if let Some(buf_id) = obj_ref.view_buffer_object_id() {
-                            return Completion::Normal(JsValue::Object(JsObject { id: buf_id }));
-                        }
-                        return Completion::Normal(JsValue::Undefined);
+        self.define_getter(dv_proto_id, "buffer", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if obj_ref.data_view_info().is_some() {
+                    if let Some(buf_id) = obj_ref.view_buffer_object_id() {
+                        return Completion::Normal(JsValue::Object(JsObject { id: buf_id }));
                     }
+                    return Completion::Normal(JsValue::Undefined);
                 }
-                Completion::Throw(interp.create_type_error("not a DataView"))
-            },
-        ));
-        self.get_object_cell_expect(dv_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "buffer".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(buffer_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a DataView"))
+        });
 
         // byteOffset getter
-        let dv_byte_offset_getter = self.create_function(JsFunction::native(
-            "get byteOffset".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if let Some(dv) = obj_ref.data_view_info() {
-                        if dv.is_detached.get() {
-                            return Completion::Throw(
-                                interp.create_type_error("DataView buffer is detached"),
-                            );
-                        }
-                        let buf_len = buffer_len(&dv.buffer);
-                        if dv.is_length_tracking {
-                            if dv.byte_offset > buf_len {
-                                return Completion::Throw(
-                                    interp.create_type_error("DataView is out of bounds"),
-                                );
-                            }
-                        } else if dv.byte_offset + dv.byte_length > buf_len {
+        self.define_getter(dv_proto_id, "byteOffset", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if let Some(dv) = obj_ref.data_view_info() {
+                    if dv.is_detached.get() {
+                        return Completion::Throw(
+                            interp.create_type_error("DataView buffer is detached"),
+                        );
+                    }
+                    let buf_len = buffer_len(&dv.buffer);
+                    if dv.is_length_tracking {
+                        if dv.byte_offset > buf_len {
                             return Completion::Throw(
                                 interp.create_type_error("DataView is out of bounds"),
                             );
                         }
-                        return Completion::Normal(JsValue::Number(dv.byte_offset as f64));
+                    } else if dv.byte_offset + dv.byte_length > buf_len {
+                        return Completion::Throw(
+                            interp.create_type_error("DataView is out of bounds"),
+                        );
                     }
+                    return Completion::Normal(JsValue::Number(dv.byte_offset as f64));
                 }
-                Completion::Throw(interp.create_type_error("not a DataView"))
-            },
-        ));
-        self.get_object_cell_expect(dv_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "byteOffset".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(dv_byte_offset_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a DataView"))
+        });
         // byteLength getter
-        let dv_byte_length_getter = self.create_function(JsFunction::native(
-            "get byteLength".to_string(),
-            0,
-            |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
-                {
-                    let obj_ref = obj.borrow();
-                    if let Some(dv) = obj_ref.data_view_info() {
-                        if dv.is_detached.get() {
+        self.define_getter(dv_proto_id, "byteLength", |interp, this_val, _args| {
+            if let JsValue::Object(o) = this_val
+                && let Some(obj) = interp.get_object(o.id)
+            {
+                let obj_ref = obj.borrow();
+                if let Some(dv) = obj_ref.data_view_info() {
+                    if dv.is_detached.get() {
+                        return Completion::Throw(
+                            interp.create_type_error("DataView buffer is detached"),
+                        );
+                    }
+                    let buf_len = buffer_len(&dv.buffer);
+                    if dv.is_length_tracking {
+                        if dv.byte_offset > buf_len {
                             return Completion::Throw(
-                                interp.create_type_error("DataView buffer is detached"),
+                                interp.create_type_error("DataView is out of bounds"),
                             );
                         }
-                        let buf_len = buffer_len(&dv.buffer);
-                        if dv.is_length_tracking {
-                            if dv.byte_offset > buf_len {
-                                return Completion::Throw(
-                                    interp.create_type_error("DataView is out of bounds"),
-                                );
-                            }
-                            return Completion::Normal(JsValue::Number(
-                                (buf_len - dv.byte_offset) as f64,
-                            ));
-                        } else {
-                            if dv.byte_offset + dv.byte_length > buf_len {
-                                return Completion::Throw(
-                                    interp.create_type_error("DataView is out of bounds"),
-                                );
-                            }
-                            return Completion::Normal(JsValue::Number(dv.byte_length as f64));
+                        return Completion::Normal(JsValue::Number(
+                            (buf_len - dv.byte_offset) as f64,
+                        ));
+                    } else {
+                        if dv.byte_offset + dv.byte_length > buf_len {
+                            return Completion::Throw(
+                                interp.create_type_error("DataView is out of bounds"),
+                            );
                         }
+                        return Completion::Normal(JsValue::Number(dv.byte_length as f64));
                     }
                 }
-                Completion::Throw(interp.create_type_error("not a DataView"))
-            },
-        ));
-        self.get_object_cell_expect(dv_proto_id)
-            .borrow_mut()
-            .insert_property(
-                "byteLength".to_string(),
-                PropertyDescriptor {
-                    value: None,
-                    writable: None,
-                    get: Some(dv_byte_length_getter),
-                    set: None,
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                },
-            );
+            }
+            Completion::Throw(interp.create_type_error("not a DataView"))
+        });
 
         // DataView get/set methods
         // Spec ordering for GetViewValue:

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1404,6 +1404,29 @@ impl Interpreter {
         func
     }
 
+    /// Install a read-only builtin accessor: mints a native getter function
+    /// named `"get {name}"` with length 0 (per spec: getters have no formal
+    /// parameters) and defines it under `name` on `target_id` as
+    /// `{ get, enumerable: false, configurable: true }`. Companion to
+    /// `define_method`; concentrates the accessor-install "dance" that was
+    /// otherwise open-coded as a six-field `PropertyDescriptor` literal at
+    /// every builtin getter site. Returns the getter function value.
+    pub(crate) fn define_getter(
+        &mut self,
+        target_id: u64,
+        name: &str,
+        f: impl Fn(&mut Interpreter, &JsValue, &[JsValue]) -> Completion + 'static,
+    ) -> JsValue {
+        let getter = self.create_function(JsFunction::native(format!("get {name}"), 0, f));
+        self.get_object_cell_expect(target_id)
+            .borrow_mut()
+            .insert_property(
+                name.to_string(),
+                PropertyDescriptor::accessor(Some(getter.clone()), None, false, true),
+            );
+        getter
+    }
+
     /// Get a fresh `Rc::clone` of the slot's `Rc<RefCell<…>>` if live.
     /// New callers should prefer `get_object_cell` / `get_object_cell_expect`
     /// (returns `&RefCell<…>`) to avoid the per-call `Rc::clone`; this

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -149,6 +149,68 @@ fn define_method_installs_a_correctly_shaped_builtin() {
 }
 
 #[test]
+fn define_getter_installs_a_correctly_shaped_accessor() {
+    let mut interp = Interpreter::new();
+    let target_id = interp.create_object_id();
+
+    let getter = interp.define_getter(target_id, "answer", |_interp, _this, _args| {
+        Completion::Normal(JsValue::Number(42.0))
+    });
+
+    // Raw stored descriptor (get_own_property would complete an absent setter
+    // to `undefined`); this pins exactly what define_getter installs.
+    let desc = interp
+        .get_object_cell_expect(target_id)
+        .borrow()
+        .get_own_property_full("answer")
+        .expect("answer property installed");
+
+    // Read-only accessor: getter present, no setter, no data slots.
+    assert!(desc.get.is_some(), "accessor must carry a getter");
+    assert!(desc.set.is_none(), "read-only accessor has no setter");
+    assert!(desc.value.is_none(), "accessor has no data value");
+    assert_eq!(desc.writable, None, "accessor has no writable attribute");
+    assert_eq!(
+        desc.enumerable,
+        Some(false),
+        "builtin accessors must not be enumerable"
+    );
+    assert_eq!(
+        desc.configurable,
+        Some(true),
+        "builtin accessors must stay configurable"
+    );
+
+    // define_getter must return the same function it installed as the getter.
+    let installed_getter = desc.get.expect("getter value present");
+    assert!(
+        matches!((&installed_getter, &getter), (JsValue::Object(a), JsValue::Object(b)) if a.id == b.id),
+        "returned getter must be the one installed on the accessor"
+    );
+
+    // Getter bookkeeping: name is prefixed with "get ", length is 0 (per spec).
+    let JsValue::Object(fn_obj) = &getter else {
+        panic!("expected getter to be a function object")
+    };
+    let fn_cell = interp.get_object_cell_expect(fn_obj.id);
+    match fn_cell.borrow().get_own_property("name").unwrap().value {
+        Some(JsValue::String(ref s)) => assert_eq!(s.to_rust_string(), "get answer"),
+        ref other => panic!("expected name string, got {other:?}"),
+    }
+    match fn_cell.borrow().get_own_property("length").unwrap().value {
+        Some(JsValue::Number(n)) => assert_eq!(n, 0.0),
+        ref other => panic!("expected length number, got {other:?}"),
+    }
+
+    // The getter is callable and returns its computed value.
+    let target_val = JsValue::Object(crate::types::JsObject { id: target_id });
+    match interp.call_function(&getter, &target_val, &[]) {
+        Completion::Normal(JsValue::Number(n)) => assert_eq!(n, 42.0),
+        other => panic!("unexpected completion: {other:?}"),
+    }
+}
+
+#[test]
 fn microtask_queue_drains_before_run_returns() {
     let interp = run_script(
         r#"


### PR DESCRIPTION
## Refactoring goal

Surfaced by an architecture audit (mattpocock/skills `improve-codebase-architecture`). The audit's top low-risk / high-leverage **deepening opportunity**: the accessor-install *dance* is open-coded at every built-in getter site.

The engine already has `Interpreter::define_method`, which collapsed the method-install boilerplate (`create_function` → `insert_builtin`) into one deep call. The **accessor** half never got the same treatment: each read-only getter still hand-wrote

```rust
let x_getter = self.create_function(JsFunction::native("get x".to_string(), 0, |..| { .. }));
self.get_object_cell_expect(proto_id).borrow_mut().insert_property(
    "x".to_string(),
    PropertyDescriptor { value: None, writable: None, get: Some(x_getter),
                         set: None, enumerable: Some(false), configurable: Some(true) },
);
```

The **interface** (install a read-only getter) was buried under an **implementation** repeated ~dozens of times — a shallow, leaky seam. Deletion test: removing the six-field literal concentrates the descriptor shape in one module rather than scattering it.

## What changed

- **New `Interpreter::define_getter(target_id, name, f)`** (`src/interpreter/mod.rs`), companion to `define_method`. Mints the `get {name}` native (length 0, per spec) and installs `{ get, enumerable: false, configurable: true }` in one place. Returns the getter value.
- **Adopted at 22 sites across 5 core built-in modules:**
  - `typedarray.rs` — `ArrayBuffer` / `SharedArrayBuffer` / `%TypedArray%` / `DataView` getters (`byteLength`, `byteOffset`, `length`, `buffer`, `maxByteLength`, `resizable`, `growable`, `detached`, `immutable`)
  - `collections.rs` — `Map.prototype.size`, `Set.prototype.size`
  - `regexp.rs` — `RegExp.prototype.flags`, `RegExp.prototype.source`
  - `number.rs` — `Symbol.prototype.description`
  - `disposable.rs` — `DisposableStack` / `AsyncDisposableStack` `disposed`
- **Net ~280 fewer lines** (539 insertions, 821 deletions).

### Intentionally out of scope
- **Symbol-keyed getters** (`get [Symbol.species]`, `get [Symbol.toStringTag]`) and **get+set accessors** (e.g. `Iterator.prototype.constructor`) are left untouched — the helper is read-only and string-keyed by design.
- **Temporal / Intl getters** (~30) use a different registration shape (`PropertyDescriptor` field order differs, wrapped in scope blocks, several are loop/table-driven). Converting them cleanly is a separate mechanical pass; deferred to keep this diff uniform and fully verified. Good follow-up.

## Tests

Built test-first (TDD, mattpocock/skills `tdd`):

- **New unit test** `define_getter_installs_a_correctly_shaped_accessor` (`src/interpreter/tests.rs`), mirroring the existing `define_method_installs_a_correctly_shaped_builtin`. Pins the raw stored descriptor (`get` present, no `set`/`value`/`writable`, `enumerable: false`, `configurable: true`), the getter's `.name == "get answer"` and `.length == 0`, that the returned value is the installed getter, and that it computes on call. Written **RED** (helper absent → compile error) → **GREEN**.
- **Behavior preservation** — the converted getters' `.name` / `.length` / `enumerable` / `configurable` are asserted directly by test262:
  - Full **`built-ins/` sweep: 47,031 scenarios, 100%, 0 regressions**
  - Per-domain: TypedArray, TypedArrayConstructors, ArrayBuffer, SharedArrayBuffer, DataView, Map, Set, WeakMap, WeakSet, Number, Symbol, RegExp, DisposableStack, AsyncDisposableStack — all 100% / 0 regressions
- `cargo test --release` — 291 passed (+ test262 smoke oracle)
- `./scripts/lint.sh` — rustfmt + `clippy -D warnings` clean
- `run-custom-tests.py` — 6/6