### PR TITLE
ci: run Miri over unsafe-adjacent modules

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,40 @@
+name: Miri
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  miri:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: nightly
+          components: miri
+
+      - name: Run Miri over unsafe-adjacent tests
+        run: |
+          set -euo pipefail
+          for test_filter in \
+            'interpreter::property_map::tests::' \
+            'interpreter::object_arena::tests::' \
+            'interpreter::gc::tests::' \
+            'interpreter::key_intern::tests::' \
+            'interpreter::types::shared_buffer_tests::' \
+            'interpreter::builtins::atomics::tests::' \
+            'interpreter::tests::shared_array_buffer_atomics_smoke'
+          do
+            cargo +nightly miri test "$test_filter"
+          done

--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -1486,3 +1486,111 @@ fn write_i64_to_buffer(buf: &mut [u8], offset: usize, kind: TypedArrayKind, val:
         _ => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn completion_number(completion: Completion) -> f64 {
+        match completion {
+            Completion::Normal(JsValue::Number(value)) => value,
+            _ => panic!("expected a numeric normal completion"),
+        }
+    }
+
+    fn bigint(value: i64) -> JsValue {
+        JsValue::BigInt(JsBigInt {
+            value: num_bigint::BigInt::from(value),
+        })
+    }
+
+    fn completion_bigint(completion: Completion) -> num_bigint::BigInt {
+        match completion {
+            Completion::Normal(JsValue::BigInt(value)) => value.value,
+            _ => panic!("expected a BigInt normal completion"),
+        }
+    }
+
+    #[test]
+    fn shared_atomic_helpers_cover_all_integer_widths() {
+        let buffer = SharedBufferInner::new(vec![0; 32], 1);
+        let number_kinds = [
+            (TypedArrayKind::Int8, 0),
+            (TypedArrayKind::Uint8, 1),
+            (TypedArrayKind::Int16, 2),
+            (TypedArrayKind::Uint16, 4),
+            (TypedArrayKind::Int32, 8),
+            (TypedArrayKind::Uint32, 12),
+        ];
+
+        for (kind, offset) in number_kinds {
+            atomic_store_shared(&buffer, offset, kind, false, &JsValue::Number(5.0));
+            assert_eq!(
+                completion_number(atomic_load_shared(&buffer, offset, kind, false)),
+                5.0
+            );
+            assert_eq!(
+                completion_number(atomic_compare_exchange_shared(
+                    &buffer,
+                    offset,
+                    kind,
+                    false,
+                    &JsValue::Number(5.0),
+                    &JsValue::Number(7.0),
+                )),
+                5.0
+            );
+            assert_eq!(
+                completion_number(atomic_rmw_shared(
+                    &buffer,
+                    offset,
+                    kind,
+                    false,
+                    &JsValue::Number(3.0),
+                    i64::wrapping_add,
+                    i64::wrapping_add,
+                )),
+                7.0
+            );
+            assert_eq!(
+                completion_number(atomic_load_shared(&buffer, offset, kind, false)),
+                10.0
+            );
+        }
+
+        let kind = TypedArrayKind::BigInt64;
+        let offset = 16;
+        atomic_store_shared(&buffer, offset, kind, true, &bigint(5));
+        assert_eq!(
+            completion_bigint(atomic_load_shared(&buffer, offset, kind, true)),
+            num_bigint::BigInt::from(5)
+        );
+        assert_eq!(
+            completion_bigint(atomic_compare_exchange_shared(
+                &buffer,
+                offset,
+                kind,
+                true,
+                &bigint(5),
+                &bigint(7),
+            )),
+            num_bigint::BigInt::from(5)
+        );
+        assert_eq!(
+            completion_bigint(atomic_rmw_shared(
+                &buffer,
+                offset,
+                kind,
+                true,
+                &bigint(3),
+                i64::wrapping_add,
+                i64::wrapping_add,
+            )),
+            num_bigint::BigInt::from(7)
+        );
+        assert_eq!(
+            completion_bigint(atomic_load_shared(&buffer, offset, kind, true)),
+            num_bigint::BigInt::from(10)
+        );
+    }
+}

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -3699,6 +3699,38 @@ pub(crate) struct SetRecord {
 }
 
 #[cfg(test)]
+mod shared_buffer_tests {
+    use super::SharedBufferInner;
+
+    #[test]
+    fn shared_buffer_byte_views_survive_mutation_and_resize() {
+        let buffer = SharedBufferInner::new((0..10).collect(), 1);
+        assert_eq!(buffer.to_vec(), (0..10).collect::<Vec<_>>());
+
+        buffer.with_write(|bytes| {
+            bytes[0] = 10;
+            bytes[9] = 19;
+        });
+        assert_eq!(buffer.to_vec(), vec![10, 1, 2, 3, 4, 5, 6, 7, 8, 19]);
+
+        buffer.resize(13, 0xaa);
+        assert_eq!(
+            buffer.to_vec(),
+            vec![10, 1, 2, 3, 4, 5, 6, 7, 8, 19, 0xaa, 0xaa, 0xaa]
+        );
+
+        buffer.resize(3, 0);
+        assert_eq!(buffer.to_vec(), vec![10, 1, 2]);
+
+        buffer.resize(10, 0xbb);
+        assert_eq!(
+            buffer.to_vec(),
+            vec![10, 1, 2, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb]
+        );
+    }
+}
+
+#[cfg(test)]
 mod kind_accessor_tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

- add a weekly and manually dispatched nightly Miri workflow
- run narrowly scoped arena, GC, property-map, key-interning, shared-buffer, and Atomics tests
- add direct unit coverage for shared-buffer byte casts and every supported atomic integer width
- ignore intentional Rc-cycle leaks while retaining Miri checks for aliasing, invalid access, and uninitialized data

## Validation

- complete workflow-equivalent Miri loop: green
- cargo fmt --check: green
- cargo clippy: green
- cargo build --release: green
- cargo test --release: 293 unit tests and smoke oracle green
- actionlint and zizmor: green
- targeted Atomics and SharedArrayBuffer test262: 986/986 green
- full test262: 99,546/99,568; 22 unrelated Intl regressions and 323 new passes relative to the current baseline. A representative regression was reproduced with a separately built, unmodified origin/main binary, confirming it is not caused by this cfg(test)-only Rust coverage.

Closes #194