### PR TITLE
ci: migrate Semgrep off archived action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: astral-sh/setup-uv@v7
+
       - name: Run Semgrep
-        uses: semgrep/semgrep-action@v1
-        with:
-          config: auto
+        run: uvx semgrep@1.170.0 scan --config auto --error --jobs 1 src/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -27,10 +27,3 @@ rules:
       # tag can be pushed back to main. It uploads only the packaged binary and
       # checksums (no .git), so the token cannot leak via artifacts.
       - release.yml
-
-  # semgrep/semgrep-action is archived. Migrating off it (to the semgrep CLI /
-  # container) changes an existing, green scan job, so it is tracked as a
-  # separate follow-up rather than bundled into this hardening change.
-  archived-uses:
-    ignore:
-      - semgrep.yml


### PR DESCRIPTION
## Summary

- replace the archived `semgrep/semgrep-action@v1` wrapper with Semgrep `1.170.0` run through `uvx`
- preserve automatic rule selection and blocking-on-findings behavior with `--config auto --error`
- scan the production Rust engine scope already established by `scripts/semgrep.sh`; `spec/` and `test262/` are outside the target
- remove the obsolete `archived-uses` exception from the zizmor configuration

The worker count is fixed at one for predictable resource usage. On the autonomous runner, Semgrep's default worker selection exhausted its io_uring allocation because the host advertises a very large CPU count; one worker changes performance only, not coverage.

The archived action's latest successful log is false-green: bundled Semgrep 1.36.0 raises `invalid rule severity value: MEDIUM`, and `semgrep ci` suppresses that failure. Current Semgrep reports 40 pre-existing findings outside `src/` (intentional workflow tag pins, Dependabot cooldown policy, JavaScript engine test-fixture `eval`, and a static patch-script regex), but zero findings in the engine source. The scope choice and alternatives are documented in [issue #196](https://github.com/pmatos/jsse/issues/196#issuecomment-4990831124).

## Validation

- `uvx semgrep@1.170.0 scan --config auto --error --jobs 1 src/` — 73 tracked files, 51 applicable rules, 0 findings
- actionlint 1.7.7 — pass
- `uvx zizmor@1.26.1 .github/workflows/` — no findings after removing the exception
- `cargo fmt --check` — pass
- `cargo clippy` — pass
- `cargo build --release` — pass
- `cargo test --release` — 291 unit tests + smoke-oracle harness pass
- full test262 completed all 99,568 scenarios: 99,546 pass, 22 baseline regressions, 323 new passes. The 22 failures are pre-existing Intl DateTime/Temporal formatting mismatches: this branch has no diff from `origin/main` in `src/`, Cargo files, README, or `test262-pass.txt`, and a single-worker focused rerun reproduces them immediately.

Closes #196
