### PR TITLE
ci: run Rust tests with nextest and lint edited targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
@@ -44,7 +47,7 @@ jobs:
         run: cargo build --release
 
       - name: Run unit tests
-        run: cargo test
+        run: cargo nextest run --release
 
       - uses: astral-sh/setup-uv@v7
 

--- a/docs/specs/2026-07-16-nextest-clippy-hook-design.md
+++ b/docs/specs/2026-07-16-nextest-clippy-hook-design.md
@@ -31,7 +31,7 @@ settings migration. For an existing `.rs` file:
 
 1. Format only the edited file with `cargo fmt`.
 2. Map the file to its Cargo target:
-   - `src/main.rs` and modules below `src/` use `--bin jsse`;
+   - `src/main.rs`, modules below `src/`, and `build.rs` use `--all-targets`;
    - a future `src/lib.rs` uses `--lib`;
    - `tests/<name>.rs`, `examples/<name>.rs`, and `benches/<name>.rs` use the
      corresponding named target.
@@ -40,9 +40,16 @@ settings migration. For an existing `.rs` file:
    Clippy fails, which returns actionable PostToolUse feedback to Claude.
 
 Cargo and Clippy compile crates rather than arbitrary source files, so the
-containing target is the narrowest reliable scope. Filtering full-crate JSON
-diagnostics to the edited file was considered, but could hide errors caused by
-the edit at another source location while retaining the same compile cost.
+containing target is the narrowest reliable scope. A bare `--bin jsse` was
+considered for `src/` modules but rejected: JSSE is a binary-only crate, so that
+compiles only the non-test build and silently skips `#[cfg(test)]` source
+(inline test modules and files such as `src/interpreter/tests.rs`), reporting
+success without ever linting the edit. `--all-targets` also compiles the
+cfg(test) build, and on this crate (no `benches/` or `examples/`) it resolves to
+just the binary plus its test build and the single integration test. Filtering
+full-crate JSON diagnostics to the edited file was considered, but could hide
+errors caused by the edit at another source location while retaining the same
+compile cost.
 
 Rust files outside known Cargo targets are formatted but do not trigger
 Clippy. Non-Rust files remain a no-op.

--- a/docs/specs/2026-07-16-nextest-clippy-hook-design.md
+++ b/docs/specs/2026-07-16-nextest-clippy-hook-design.md
@@ -1,0 +1,59 @@
+# Nextest CI and edit-time Clippy design
+
+## Goal
+
+Run Rust tests in CI with per-test process isolation, and report Clippy
+failures immediately after Claude Code edits a Rust file without making the
+hook unnecessarily slow.
+
+## CI design
+
+Install a prebuilt `cargo-nextest` with
+`taiki-e/install-action@nextest`, following nextest's recommended GitHub
+Actions setup and the repository's existing use of tool-specific installer
+tags. Replace the existing unit-test command with
+`cargo nextest run --release`.
+
+Nextest does not run doctests, but JSSE currently has no library target and
+`cargo test --doc --release` reports that there are no library targets. The
+replacement therefore does not remove existing doctest coverage. If a library
+target is introduced later, CI should add a separate doctest command.
+
+Building nextest from source with `cargo install --locked` was considered, but
+would add avoidable compile time to every clean CI runner. Downloading an
+archive directly was also considered, but the installer action provides a
+clearer, maintained integration.
+
+## PostToolUse hook design
+
+Keep `scripts/fmt-hook.sh` as the configured hook entry point to avoid a
+settings migration. For an existing `.rs` file:
+
+1. Format only the edited file with `cargo fmt`.
+2. Map the file to its Cargo target:
+   - `src/main.rs` and modules below `src/` use `--bin jsse`;
+   - a future `src/lib.rs` uses `--lib`;
+   - `tests/<name>.rs`, `examples/<name>.rs`, and `benches/<name>.rs` use the
+     corresponding named target.
+3. Run Clippy with `-D warnings` for only that target.
+4. Exit with status 2 and write diagnostics to stderr when formatting or
+   Clippy fails, which returns actionable PostToolUse feedback to Claude.
+
+Cargo and Clippy compile crates rather than arbitrary source files, so the
+containing target is the narrowest reliable scope. Filtering full-crate JSON
+diagnostics to the edited file was considered, but could hide errors caused by
+the edit at another source location while retaining the same compile cost.
+
+Rust files outside known Cargo targets are formatted but do not trigger
+Clippy. Non-Rust files remain a no-op.
+
+## Verification
+
+- Run the existing release tests and compare them with
+  `cargo nextest run --release` to detect reliance on shared in-process state.
+- Test hook no-op behavior, formatting, target selection, and lint-failure
+  feedback with temporary fixtures or command wrappers.
+- Measure a warm hook invocation to confirm incremental Clippy latency is
+  suitable for edit-time use.
+- Run the repository's full local quality gate before opening the pull
+  request.

--- a/scripts/fmt-hook.sh
+++ b/scripts/fmt-hook.sh
@@ -1,12 +1,75 @@
-#!/bin/bash
-# PostToolUse hook: run rustfmt on any .rs file after Edit/Write
-# Uses `cargo fmt` to pick up the edition from Cargo.toml (edition 2024).
+#!/usr/bin/env bash
+# PostToolUse hook: format edited Rust files and Clippy their Cargo target.
 
 input=$(cat)
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+file_path=$(jq -r '.tool_input.file_path // empty' <<<"$input" 2>/dev/null) ||
+    exit 0
 
-if [[ "$file_path" == *.rs && -f "$file_path" ]]; then
-    cargo fmt -- "$file_path" 2>/dev/null
+if [[ "$file_path" != *.rs ]]; then
+    exit 0
+fi
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+if [[ "$file_path" != /* ]]; then
+    file_path="$repo_root/$file_path"
+fi
+
+if [[ ! -f "$file_path" ]]; then
+    exit 0
+fi
+
+file_dir=$(cd -- "$(dirname -- "$file_path")" 2>/dev/null && pwd -P) ||
+    exit 0
+file_path="$file_dir/$(basename -- "$file_path")"
+
+if ! fmt_output=$(cargo fmt --manifest-path "$repo_root/Cargo.toml" -- "$file_path" 2>&1); then
+    printf 'rustfmt failed for %s:\n%s\n' "$file_path" "$fmt_output" >&2
+    exit 2
+fi
+
+case "$file_path" in
+    "$repo_root/src/lib.rs")
+        target_args=(--lib)
+        ;;
+    "$repo_root/src/bin/"*.rs)
+        target_path=${file_path#"$repo_root/src/bin/"}
+        target_name=${target_path%%/*}
+        target_name=${target_name%.rs}
+        target_args=(--bin "$target_name")
+        ;;
+    "$repo_root/src/"*.rs | "$repo_root/build.rs")
+        target_args=(--bin jsse)
+        ;;
+    "$repo_root/tests/"*.rs)
+        target_path=${file_path#"$repo_root/tests/"}
+        if [[ "$target_path" == */* ]]; then
+            target_args=(--tests)
+        else
+            target_args=(--test "${target_path%.rs}")
+        fi
+        ;;
+    "$repo_root/examples/"*.rs)
+        target_path=${file_path#"$repo_root/examples/"}
+        target_name=${target_path%%/*}
+        target_args=(--example "${target_name%.rs}")
+        ;;
+    "$repo_root/benches/"*.rs)
+        target_path=${file_path#"$repo_root/benches/"}
+        target_name=${target_path%%/*}
+        target_args=(--bench "${target_name%.rs}")
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+if ! clippy_output=$(
+    cargo clippy --manifest-path "$repo_root/Cargo.toml" --quiet \
+        "${target_args[@]}" -- -D warnings 2>&1
+); then
+    relative_path=${file_path#"$repo_root/"}
+    printf 'Clippy failed for %s:\n%s\n' "$relative_path" "$clippy_output" >&2
+    exit 2
 fi
 
 exit 0

--- a/scripts/fmt-hook.sh
+++ b/scripts/fmt-hook.sh
@@ -38,7 +38,10 @@ case "$file_path" in
         target_args=(--bin "$target_name")
         ;;
     "$repo_root/src/"*.rs | "$repo_root/build.rs")
-        target_args=(--bin jsse)
+        # --all-targets so Clippy also compiles the cfg(test) build; a bare
+        # --bin jsse skips #[cfg(test)] source (e.g. src/interpreter/tests.rs)
+        # and would report success without ever linting the edit.
+        target_args=(--all-targets)
         ;;
     "$repo_root/tests/"*.rs)
         target_path=${file_path#"$repo_root/tests/"}

--- a/scripts/test_fmt_hook.py
+++ b/scripts/test_fmt_hook.py
@@ -68,7 +68,7 @@ class FmtHookTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertEqual(self.cargo_commands(), [])
 
-    def test_source_file_formats_and_clippies_binary_target(self):
+    def test_source_file_formats_and_clippies_all_targets(self):
         result = self.run_hook(REPO_ROOT / "src" / "interpreter" / "eval.rs")
 
         self.assertEqual(result.returncode, 0)
@@ -78,9 +78,20 @@ class FmtHookTests(unittest.TestCase):
                 f"fmt --manifest-path {REPO_ROOT}/Cargo.toml -- "
                 f"{REPO_ROOT}/src/interpreter/eval.rs",
                 f"clippy --manifest-path {REPO_ROOT}/Cargo.toml --quiet "
-                "--bin jsse -- -D warnings",
+                "--all-targets -- -D warnings",
             ],
         )
+
+    def test_cfg_test_source_is_clippied_with_all_targets(self):
+        # A #[cfg(test)]-gated module (e.g. src/interpreter/tests.rs) is not
+        # compiled by --bin jsse, so it must go through --all-targets or the
+        # hook would report success without ever linting the edit.
+        result = self.run_hook(
+            REPO_ROOT / "src" / "interpreter" / "tests.rs"
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--all-targets -- -D warnings", self.cargo_commands()[1])
 
     def test_integration_test_uses_its_named_target(self):
         result = self.run_hook(REPO_ROOT / "tests" / "test262_smoke_oracle.rs")

--- a/scripts/test_fmt_hook.py
+++ b/scripts/test_fmt_hook.py
@@ -1,0 +1,121 @@
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / "scripts" / "fmt-hook.sh"
+
+
+class FmtHookTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.cargo_log = self.root / "cargo.log"
+        fake_cargo = self.root / "cargo"
+        fake_cargo.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                printf '%s\\n' "$*" >> "$CARGO_LOG"
+                if [[ "$1" == "fmt" && "${FAIL_FMT:-}" == "1" ]]; then
+                    echo "fake rustfmt failure" >&2
+                    exit 1
+                fi
+                if [[ "$1" == "clippy" && "${FAIL_CLIPPY:-}" == "1" ]]; then
+                    echo "fake clippy failure" >&2
+                    exit 1
+                fi
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_cargo.chmod(fake_cargo.stat().st_mode | stat.S_IXUSR)
+        self.env = os.environ.copy()
+        self.env["PATH"] = f"{self.root}:{self.env['PATH']}"
+        self.env["CARGO_LOG"] = str(self.cargo_log)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_hook(
+        self, file_path: Path, **extra_env: str
+    ) -> subprocess.CompletedProcess:
+        env = self.env | extra_env
+        return subprocess.run(
+            [str(HOOK)],
+            input=json.dumps({"tool_input": {"file_path": str(file_path)}}),
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def cargo_commands(self) -> list[str]:
+        if not self.cargo_log.exists():
+            return []
+        return self.cargo_log.read_text(encoding="utf-8").splitlines()
+
+    def test_non_rust_file_is_a_noop(self):
+        result = self.run_hook(REPO_ROOT / "README.md")
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(self.cargo_commands(), [])
+
+    def test_source_file_formats_and_clippies_binary_target(self):
+        result = self.run_hook(REPO_ROOT / "src" / "interpreter" / "eval.rs")
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            self.cargo_commands(),
+            [
+                f"fmt --manifest-path {REPO_ROOT}/Cargo.toml -- "
+                f"{REPO_ROOT}/src/interpreter/eval.rs",
+                f"clippy --manifest-path {REPO_ROOT}/Cargo.toml --quiet "
+                "--bin jsse -- -D warnings",
+            ],
+        )
+
+    def test_integration_test_uses_its_named_target(self):
+        result = self.run_hook(REPO_ROOT / "tests" / "test262_smoke_oracle.rs")
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn(
+            "--test test262_smoke_oracle -- -D warnings",
+            self.cargo_commands()[1],
+        )
+
+    def test_rust_file_outside_a_cargo_target_is_only_formatted(self):
+        rust_file = self.root / "standalone.rs"
+        rust_file.touch()
+
+        result = self.run_hook(rust_file)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(len(self.cargo_commands()), 1)
+        self.assertTrue(self.cargo_commands()[0].startswith("fmt "))
+
+    def test_clippy_failure_is_returned_as_post_tool_feedback(self):
+        result = self.run_hook(REPO_ROOT / "src" / "main.rs", FAIL_CLIPPY="1")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Clippy failed for src/main.rs", result.stderr)
+        self.assertIn("fake clippy failure", result.stderr)
+
+    def test_rustfmt_failure_stops_before_clippy(self):
+        result = self.run_hook(REPO_ROOT / "src" / "main.rs", FAIL_FMT="1")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("rustfmt failed", result.stderr)
+        self.assertIn("fake rustfmt failure", result.stderr)
+        self.assertEqual(len(self.cargo_commands()), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- install cargo-nextest from its maintained prebuilt action and run the CI Rust suite in release mode with per-test process isolation
- extend the existing PostToolUse formatter hook to run Clippy for the edited file containing Cargo target and return actionable exit-2 feedback
- add focused hook tests for no-op behavior, target selection, formatting failures, and Clippy failures
- document the design choices, including why no doctest step is needed for this binary-only package

Measured PostToolUse latency was 51.32 seconds for the initial cold Clippy build and 4.84 seconds for a warm incremental invocation.

## Validation

- cargo fmt --check
- cargo clippy
- cargo build --release
- cargo test --release (292 passed)
- cargo nextest run --release (292 passed)
- uv run python -m unittest discover -s scripts -p test_*.py (9 passed)
- uv run python scripts/run-custom-tests.py (6 passed)
- actionlint .github/workflows/ci.yml
- zizmor .github/workflows/ci.yml
- TZ=UTC uv run python scripts/run-test262.py (99,568/99,568 passed; zero regressions; baseline unchanged)

Closes #195