### PR TITLE
test: complete node harness framework semantics

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -167,8 +167,12 @@ prints — the line the verdict parses — equals the one real `qunit-extras` pr
 on Node. `config.noglobals` is intentionally **not** enforced on the jsse side:
 the Node oracle enforces it and the suite passes it there, so enforcing on jsse
 could only add jsse-specific failures the oracle lacks and diverge the count.
-Async tests (`assert.async`) are bounded by a 30 s per-test timeout so a `done()`
-that never fires becomes a failure instead of stalling the run.
+QUnit uses default autostart after synchronous registration (and `QUnit.load()`
+re-checks it), while nested modules inherit outer hooks with QUnit's module and
+per-test ordering. Async QUnit tests (`assert.async`) and callback-style TAP
+tests/hooks (`function (done) { ... }`) are bounded by a 10 s timeout so a
+completion callback that never fires becomes a failure instead of stalling the
+run.
 
 ### Harness self-test (`run-harness-selftest.sh`)
 

--- a/scripts/harness-fixtures/qunit-autostart.fixture.js
+++ b/scripts/harness-fixtures/qunit-autostart.fixture.js
@@ -1,0 +1,8 @@
+// QUnit's default autostart runs tests after synchronous registration without
+// requiring QUnit.load() or QUnit.start().
+//
+// Expected summary: PASS: 1  FAIL: 0  TOTAL: 1
+
+QUnit.test("default autostart", function (assert) {
+  assert.ok(true, "registered test ran");
+});

--- a/scripts/harness-fixtures/qunit-load.fixture.js
+++ b/scripts/harness-fixtures/qunit-load.fixture.js
@@ -1,0 +1,14 @@
+// QUnit.load() re-checks autostart after an earlier registration phase left it
+// disabled. Deferring registration by one microtask ensures this specifically
+// exercises load(), after the harness's initial autostart check has passed.
+//
+// Expected summary: PASS: 1  FAIL: 0  TOTAL: 1
+
+QUnit.config.autostart = false;
+Promise.resolve().then(function () {
+  QUnit.test("load starts an autostart suite", function (assert) {
+    assert.ok(true, "registered test ran");
+  });
+  QUnit.config.autostart = true;
+  QUnit.load();
+});

--- a/scripts/harness-fixtures/qunit-nested-hook-state.fixture.js
+++ b/scripts/harness-fixtures/qunit-nested-hook-state.fixture.js
@@ -1,0 +1,59 @@
+// Self-test for nested-module hook-state inheritance in the QUnit adapter of
+// node-test-harness.js. Validated on jsse alone (the harness is inert on Node);
+// run-harness-selftest.sh asserts the exact summary line.
+//
+// In QUnit, a nested module inherits its parent module's testEnvironment: state
+// assigned to `this` in a parent `before` hook is the base context that a child
+// module's own hooks and its tests see. Every case below was cross-checked
+// against real qunit@2.26.0 — all three tests pass there, for 4 passing
+// assertions total (1 + 2 + 1). The harness summary counts assertions (like
+// qunit-extras' summary, the Node oracle), so it must reproduce
+// PASS: 4  FAIL: 0  TOTAL: 4. Without the parent-env inheritance this drops to
+// PASS: 1  FAIL: 3  TOTAL: 4 (the inherited-`this` assertions fail).
+//
+// Expected summary: PASS: 4  FAIL: 0  TOTAL: 4
+
+// A child test sees this.fixture set by the parent module's before hook, even
+// though the child module has no hooks of its own.
+QUnit.module("parent-before", function (hooks) {
+  hooks.before(function () {
+    this.fixture = 42;
+  });
+  QUnit.module("child", function () {
+    QUnit.test("child test sees parent before state", function (assert) {
+      assert.equal(this.fixture, 42, "inherited this.fixture");
+    });
+  });
+});
+
+// A child module's own before hook sees the parent's before state, and the test
+// sees both the inherited value and the child-derived one.
+QUnit.module("parent-before-layered", function (hooks) {
+  hooks.before(function () {
+    this.a = "p";
+  });
+  QUnit.module("child-layered", function (h2) {
+    h2.before(function () {
+      this.b = this.a + "-c"; // must observe the parent's this.a
+    });
+    QUnit.test("child before layers on parent before", function (assert) {
+      assert.equal(this.a, "p", "inherited this.a");
+      assert.equal(this.b, "p-c", "derived this.b");
+    });
+  });
+});
+
+// A child before hook overrides an inherited value (child wins), matching QUnit.
+QUnit.module("parent-before-override", function (hooks) {
+  hooks.before(function () {
+    this.v = "parent";
+  });
+  QUnit.module("child-override", function (h3) {
+    h3.before(function () {
+      this.v = "child";
+    });
+    QUnit.test("child before overrides parent value", function (assert) {
+      assert.equal(this.v, "child", "overridden this.v");
+    });
+  });
+});

--- a/scripts/harness-fixtures/qunit.fixture.js
+++ b/scripts/harness-fixtures/qunit.fixture.js
@@ -8,7 +8,7 @@
 // tests, expect() planning, raises, and — via one deliberately failing
 // assertion — that failures are detected and counted (not just passes).
 //
-// Expected summary: PASS: 20  FAIL: 1  TOTAL: 21
+// Expected summary: PASS: 23  FAIL: 1  TOTAL: 24
 
 QUnit.module("primitives");
 QUnit.test("equality asserts", function (assert) {
@@ -60,6 +60,98 @@ QUnit.test("a failing assertion is counted as FAIL", function (assert) {
   assert.expect(2);
   assert.ok(true, "this passes");
   assert.strictEqual(1, 2, "this deliberately fails");
+});
+
+var nestedOrder = [];
+QUnit.module("nested parent", function (hooks) {
+  hooks.before(function () {
+    nestedOrder.push("parent before");
+  });
+  hooks.beforeEach(function () {
+    nestedOrder.push("parent beforeEach");
+  });
+  hooks.afterEach(function () {
+    nestedOrder.push("parent afterEach");
+  });
+  hooks.after(function () {
+    nestedOrder.push("parent after");
+  });
+
+  QUnit.test("parent test before child", function (assert) {
+    nestedOrder.push("parent test before child");
+    assert.deepEqual(
+      nestedOrder,
+      ["parent before", "parent beforeEach", "parent test before child"],
+      "parent hooks start at the first test"
+    );
+  });
+
+  QUnit.module("nested child", function (childHooks) {
+    childHooks.before(function () {
+      nestedOrder.push("child before");
+    });
+    childHooks.beforeEach(function () {
+      nestedOrder.push("child beforeEach");
+    });
+    childHooks.afterEach(function () {
+      nestedOrder.push("child afterEach");
+    });
+    childHooks.after(function () {
+      nestedOrder.push("child after");
+    });
+
+    QUnit.test("child inherits parent per-test hooks", function (assert) {
+      nestedOrder.push("child test");
+      assert.deepEqual(
+        nestedOrder.slice(-4),
+        [
+          "child before",
+          "parent beforeEach",
+          "child beforeEach",
+          "child test",
+        ],
+        "beforeEach hooks run outermost to innermost"
+      );
+    });
+  });
+
+  QUnit.test("parent test after child", function (assert) {
+    nestedOrder.push("parent test after child");
+    assert.deepEqual(
+      nestedOrder.slice(-5),
+      [
+        "child afterEach",
+        "parent afterEach",
+        "child after",
+        "parent beforeEach",
+        "parent test after child",
+      ],
+      "child hooks close before execution returns to the parent"
+    );
+  });
+});
+
+QUnit.done(function () {
+  var expected = [
+    "parent before",
+    "parent beforeEach",
+    "parent test before child",
+    "parent afterEach",
+    "child before",
+    "parent beforeEach",
+    "child beforeEach",
+    "child test",
+    "child afterEach",
+    "parent afterEach",
+    "child after",
+    "parent beforeEach",
+    "parent test after child",
+    "parent afterEach",
+    "parent after",
+  ];
+  if (nestedOrder.join("|") !== expected.join("|")) {
+    throw new Error("nested QUnit hook order wrong: " + nestedOrder.join(","));
+  }
 });
 
 QUnit.config.noglobals = true;

--- a/scripts/harness-fixtures/tap-suite-hook-failure.fixture.js
+++ b/scripts/harness-fixtures/tap-suite-hook-failure.fixture.js
@@ -1,0 +1,68 @@
+// Self-test for suite-level (before all / after all) hook FAILURE containment in
+// the describe/it TAP runner in node-test-harness.js. Validated on jsse alone
+// (the harness is inert on Node); run-harness-selftest.sh asserts the exact
+// summary line.
+//
+// A failing suite-level hook must be recorded as a single `not ok` and the run
+// must continue — it must NOT propagate to the top-level harness catch, which
+// would collapse every count to `PASS: 0  FAIL: 1  TOTAL: 1` and discard the
+// real results of sibling suites. This is the suite-level analogue of the
+// per-test beforeEach/afterEach containment exercised by tap.fixture.js.
+//
+// Covers: a done(error) `before all` (children skipped, siblings still run), a
+// synchronously-throwing `before all` (non-callback path also contained), and a
+// done(error) `after all` (its tests still count, the hook adds one failure). A
+// timed-out hook rejects through the identical path, so it is not re-exercised
+// here (it would cost ASYNC_TIMEOUT_MS of wall-clock).
+//
+// Expected summary: PASS: 2  FAIL: 3  TOTAL: 5
+
+describe("suite-with-failing-before", function () {
+  before(function (done) {
+    setTimeout(function () {
+      done(new Error("deliberate before-all failure"));
+    }, 0);
+  });
+
+  // Both of these must be skipped: a failed `before all` leaves fixture state
+  // unreliable, so the whole subtree (direct tests and nested suites) is skipped.
+  it("must not run when before-all fails", function () {
+    throw new Error("test body ran despite a failed before-all hook");
+  });
+  describe("nested under a failing before", function () {
+    it("nested test must not run either", function () {
+      throw new Error("nested test ran despite a failed before-all hook");
+    });
+  });
+});
+
+describe("sibling-suite", function () {
+  // Proves the run continues after a prior suite's before-all failed.
+  it("runs normally after a sibling's before-all failed", function () {
+    if (1 + 1 !== 2) throw new Error("unreachable");
+  });
+});
+
+describe("suite-with-throwing-before", function () {
+  // Non-callback (synchronous throw) before-all is contained the same way.
+  before(function () {
+    throw new Error("deliberate synchronous before-all failure");
+  });
+  it("must not run when before-all throws", function () {
+    throw new Error("test body ran despite a throwing before-all hook");
+  });
+});
+
+describe("suite-with-failing-after", function () {
+  after(function (done) {
+    setTimeout(function () {
+      done(new Error("deliberate after-all failure"));
+    }, 0);
+  });
+
+  // The test itself passes and is counted; the after-all failure adds exactly
+  // one more `not ok` without discarding this pass.
+  it("passes before the after-all hook fails", function () {
+    if (1 + 1 !== 2) throw new Error("unreachable");
+  });
+});

--- a/scripts/harness-fixtures/tap.fixture.js
+++ b/scripts/harness-fixtures/tap.fixture.js
@@ -4,17 +4,42 @@
 //
 // Covers: nested suites, definition-order execution, before/after (once per
 // suite) and beforeEach/afterEach (per test, parent chain), async it bodies,
-// the test() alias, and — via one deliberate throw — failure detection.
+// the test() alias, and — via deliberate throw/done(error) failures — failure
+// detection.
 //
-// Expected summary: PASS: 4  FAIL: 1  TOTAL: 5
+// Expected summary: PASS: 5  FAIL: 2  TOTAL: 7
 
 var order = [];
 
 describe("outer", function () {
   before(function () { order.push("before-outer"); });
+  before(function (done) {
+    setTimeout(function () {
+      order.push("before-outer-done");
+      done();
+    }, 0);
+  });
   beforeEach(function () { order.push("beforeEach-outer"); });
+  beforeEach(function (done) {
+    setTimeout(function () {
+      order.push("beforeEach-outer-done");
+      done();
+    }, 0);
+  });
   afterEach(function () { order.push("afterEach-outer"); });
+  afterEach(function (done) {
+    setTimeout(function () {
+      order.push("afterEach-outer-done");
+      done();
+    }, 0);
+  });
   after(function () { order.push("after-outer"); });
+  after(function (done) {
+    setTimeout(function () {
+      order.push("after-outer-done");
+      done();
+    }, 0);
+  });
 
   it("passes synchronously", function () {
     if (1 + 1 !== 2) throw new Error("math is broken");
@@ -24,16 +49,33 @@ describe("outer", function () {
     await new Promise(function (r) { setTimeout(r, 0); });
   });
 
+  it("waits for a done callback", function (done) {
+    setTimeout(function () {
+      order.push("done-test-complete");
+      done();
+    }, 0);
+  });
+
   it("fails as expected", function () {
     throw new Error("deliberate failure");
+  });
+
+  it("fails when done receives an error", function (done) {
+    setTimeout(function () {
+      done(new Error("deliberate done failure"));
+    }, 0);
   });
 
   describe("inner", function () {
     beforeEach(function () { order.push("beforeEach-inner"); });
     it("nested test passes", function () {
       // beforeEach chain runs outermost -> innermost.
-      var seen = order.slice(-2);
-      if (seen[0] !== "beforeEach-outer" || seen[1] !== "beforeEach-inner") {
+      var seen = order.slice(-3);
+      if (
+        seen[0] !== "beforeEach-outer" ||
+        seen[1] !== "beforeEach-outer-done" ||
+        seen[2] !== "beforeEach-inner"
+      ) {
         throw new Error("beforeEach ordering wrong: " + order.join(","));
       }
     });
@@ -43,5 +85,20 @@ describe("outer", function () {
 test("top-level test() alias runs last (definition order)", function () {
   if (order.indexOf("before-outer") === -1) {
     throw new Error("outer suite did not run before root test");
+  }
+  if (order.indexOf("before-outer-done") === -1) {
+    throw new Error("done-style before hook did not complete");
+  }
+  if (order.indexOf("beforeEach-outer-done") === -1) {
+    throw new Error("done-style beforeEach hook did not complete");
+  }
+  if (order.indexOf("afterEach-outer-done") === -1) {
+    throw new Error("done-style afterEach hook did not complete");
+  }
+  if (order.indexOf("after-outer-done") === -1) {
+    throw new Error("done-style after hook did not complete");
+  }
+  if (order.indexOf("done-test-complete") === -1) {
+    throw new Error("done-style test did not complete");
   }
 });

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -452,10 +452,10 @@
       modules: [],
     };
 
-    var modules = [];
     var rootModule = { name: "", tests: [] };
-    modules.push(rootModule);
     var currentModule = rootModule;
+    var moduleStack = [];
+    var testsInOrder = [];
 
     var stats = { all: 0, bad: 0 };
     var doneCbs = [],
@@ -464,6 +464,7 @@
       moduleDoneCbs = [],
       logCbs = [];
     var started = false;
+    var autostartScheduled = false;
     var totalTests = 0;
 
     function normalizeHooks(hooks) {
@@ -483,9 +484,16 @@
         nested = hooks;
         hooks = undefined;
       }
-      var mod = { name: name, tests: [], hooks: normalizeHooks(hooks) };
-      modules.push(mod);
       var prev = currentModule;
+      var parent = moduleStack.length
+        ? moduleStack[moduleStack.length - 1]
+        : rootModule;
+      var mod = {
+        name: name,
+        parent: parent,
+        tests: [],
+        hooks: normalizeHooks(hooks),
+      };
       currentModule = mod;
       if (typeof nested === "function") {
         // Modern QUnit passes a registrar whose before/beforeEach/afterEach/after
@@ -507,27 +515,36 @@
             mod.hooks.after = fn;
           },
         };
-        nested.call(registrar, registrar);
-        currentModule = prev;
+        moduleStack.push(mod);
+        try {
+          nested.call(registrar, registrar);
+        } finally {
+          moduleStack.pop();
+          currentModule = prev;
+        }
       }
     }
 
     function testFn(name, callback) {
-      currentModule.tests.push({
+      var testObj = {
         testName: name,
         module: currentModule,
         callback: callback,
-      });
+      };
+      currentModule.tests.push(testObj);
+      testsInOrder.push(testObj);
       totalTests++;
     }
 
     function skipFn(name) {
-      currentModule.tests.push({
+      var testObj = {
         testName: name,
         module: currentModule,
         callback: null,
         skip: true,
-      });
+      };
+      currentModule.tests.push(testObj);
+      testsInOrder.push(testObj);
       totalTests++;
     }
 
@@ -745,6 +762,23 @@
       }
     }
 
+    function moduleChain(mod) {
+      var chain = [];
+      while (mod && mod !== rootModule) {
+        chain.unshift(mod);
+        mod = mod.parent;
+      }
+      return chain;
+    }
+
+    async function runTestHooks(testObj, kind, assert) {
+      var chain = moduleChain(testObj.module);
+      if (kind === "afterEach") chain.reverse();
+      for (var i = 0; i < chain.length; i++) {
+        await runHook(chain[i].hooks[kind], testObj, assert);
+      }
+    }
+
     async function runTest(testObj) {
       testObj.assertions = [];
       testObj.expected = null;
@@ -764,10 +798,9 @@
       }
 
       var assert = makeAssert(testObj);
-      var hooks = testObj.module.hooks || {};
 
       try {
-        await runHook(hooks.beforeEach, testObj, assert);
+        await runTestHooks(testObj, "beforeEach", assert);
         var ret = testObj.callback.call(testObj.testEnv, assert);
         await Promise.resolve(ret);
         if (testObj.pending > 0) {
@@ -812,7 +845,7 @@
       // suites reset fixtures/globals/timers here, so skipping it would leak
       // dirty state into later tests. A throw here is recorded as a failure.
       try {
-        await runHook(hooks.afterEach, testObj, assert);
+        await runTestHooks(testObj, "afterEach", assert);
       } catch (e) {
         pushFailure(
           testObj,
@@ -966,23 +999,40 @@
       }, GLOBAL_WATCHDOG_MS);
 
       var count = 0;
-      for (var m = 0; m < modules.length && !aborted; m++) {
-        var mod = modules[m];
-        if (mod.tests.length === 0) continue;
-        await runModuleHook(mod, "before");
-        for (var t = 0; t < mod.tests.length && !aborted; t++) {
-          await runTest(mod.tests[t]);
-          count++;
-          if (count % 200 === 0) await yieldTick();
-          // Liveness on stderr (ignored by the verdict, which parses the final
-          // stdout summary) so a slow tree-walker run is visibly progressing.
-          if (count % 1000 === 0) {
-            process.stderr.write(
-              "… " + count + " tests run (" + stats.bad + " failing assertions)\n"
-            );
-          }
+      var activeModules = [];
+      for (var t = 0; t < testsInOrder.length && !aborted; t++) {
+        var testObj = testsInOrder[t];
+        var nextModules = moduleChain(testObj.module);
+        var common = 0;
+        while (
+          common < activeModules.length &&
+          common < nextModules.length &&
+          activeModules[common] === nextModules[common]
+        ) {
+          common++;
         }
-        await runModuleHook(mod, "after");
+        for (var close = activeModules.length - 1; close >= common; close--) {
+          await runModuleHook(activeModules[close], "after");
+        }
+        activeModules.length = common;
+        for (var open = common; open < nextModules.length; open++) {
+          await runModuleHook(nextModules[open], "before");
+          activeModules.push(nextModules[open]);
+        }
+
+        await runTest(testObj);
+        count++;
+        if (count % 200 === 0) await yieldTick();
+        // Liveness on stderr (ignored by the verdict, which parses the final
+        // stdout summary) so a slow tree-walker run is visibly progressing.
+        if (count % 1000 === 0) {
+          process.stderr.write(
+            "… " + count + " tests run (" + stats.bad + " failing assertions)\n"
+          );
+        }
+      }
+      for (var close = activeModules.length - 1; close >= 0; close--) {
+        await runModuleHook(activeModules[close], "after");
       }
       if (aborted) abortedAt = count;
       // The run is done — cancel the watchdog so no pending host timer keeps the
@@ -1046,6 +1096,15 @@
       });
     }
 
+    function scheduleAutostart() {
+      if (autostartScheduled) return;
+      autostartScheduled = true;
+      Promise.resolve().then(function () {
+        autostartScheduled = false;
+        if (config.autostart && totalTests > 0) start();
+      });
+    }
+
     var QUnit = {
       config: config,
       module: moduleFn,
@@ -1054,7 +1113,7 @@
       todo: testFn,
       only: testFn,
       start: start,
-      load: function () {},
+      load: scheduleAutostart,
       begin: function (cb) {
         beginCbs.push(cb);
       },
@@ -1087,6 +1146,7 @@
         return objectType(obj) === type;
       },
     };
+    scheduleAutostart();
     return QUnit;
   }
 
@@ -1176,9 +1236,37 @@
       return out;
     }
 
+    function invokeRunnable(fn, ctx) {
+      if (fn.length === 0) return Promise.resolve(fn.call(ctx));
+      return new Promise(function (resolve, reject) {
+        var settled = false;
+        var guardId = schedule(function () {
+          if (settled) return;
+          settled = true;
+          reject(
+            new Error(
+              "done callback timed out after " + ASYNC_TIMEOUT_MS + "ms"
+            )
+          );
+        }, ASYNC_TIMEOUT_MS);
+        function done(error) {
+          if (settled) return;
+          settled = true;
+          unschedule(guardId);
+          if (error) reject(error);
+          else resolve();
+        }
+        try {
+          fn.call(ctx, done);
+        } catch (e) {
+          done(e);
+        }
+      });
+    }
+
     async function runHooks(hooks, ctx) {
       for (var i = 0; i < hooks.length; i++) {
-        await Promise.resolve(hooks[i].call(ctx));
+        await invokeRunnable(hooks[i], ctx);
       }
     }
 
@@ -1195,7 +1283,7 @@
         errText = "";
       try {
         await runHooks(eachHook(t.suite, "beforeEach"), testCtx);
-        await Promise.resolve(t.fn.call(testCtx));
+        await invokeRunnable(t.fn, testCtx);
       } catch (e) {
         ok = false;
         errText = e && e.stack ? e.stack : String(e);

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -935,8 +935,10 @@
 
     // Module-level before/after run once per module (before its first test /
     // after its last), sharing `mod.sharedEnv`; each test gets a shallow copy of
-    // that env (see runTest). Assertions or throws in a hook fold into the stats
-    // like a test's would.
+    // that env (see runTest). For nested modules, `mod.sharedEnv` is seeded from
+    // the parent chain when the module is opened (see runAll), so a hook here
+    // also sees ancestor `before` state. Assertions or throws in a hook fold
+    // into the stats like a test's would.
     async function runModuleHook(mod, kind) {
       var hook = mod.hooks && mod.hooks[kind];
       if (typeof hook !== "function") return;
@@ -1016,8 +1018,17 @@
         }
         activeModules.length = common;
         for (var open = common; open < nextModules.length; open++) {
-          await runModuleHook(nextModules[open], "before");
-          activeModules.push(nextModules[open]);
+          var opening = nextModules[open];
+          // Inherit the ancestor chain's module env so a nested module's own
+          // before/after hooks and its tests see `this` state set by parent
+          // module hooks — QUnit's nested testEnvironment inheritance. The
+          // parent (nextModules[open - 1]) is already open with its before hook
+          // applied; layer this module's own env (if re-entered) on top of a
+          // shallow copy of it, matching QUnit's per-module testEnvironment copy.
+          var parentEnv = open > 0 ? nextModules[open - 1].sharedEnv : null;
+          opening.sharedEnv = Object.assign({}, parentEnv, opening.sharedEnv);
+          await runModuleHook(opening, "before");
+          activeModules.push(opening);
         }
 
         await runTest(testObj);

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -1270,6 +1270,20 @@
       }
     }
 
+    // Emit a TAP `not ok` for the current counter value plus its YAML diagnostic
+    // block, and bump the failure count. Shared by failing tests and failing
+    // suite-level hooks so both report identically.
+    function reportFailure(name, errText) {
+      console.log("not ok " + counter + " - " + name);
+      console.log("  ---");
+      var lines = String(errText).split("\n");
+      for (var i = 0; i < lines.length; i++) {
+        console.log("  " + lines[i]);
+      }
+      console.log("  ...");
+      failed++;
+    }
+
     async function runOneTest(t) {
       counter++;
       var name = fullName(t.suite, t.name);
@@ -1304,30 +1318,50 @@
         console.log("ok " + counter + " - " + name);
         passed++;
       } else {
-        console.log("not ok " + counter + " - " + name);
-        console.log("  ---");
-        var lines = String(errText).split("\n");
-        for (var e2 = 0; e2 < lines.length; e2++) {
-          console.log("  " + lines[e2]);
-        }
-        console.log("  ...");
-        failed++;
+        reportFailure(name, errText);
       }
     }
 
     async function runSuite(suite) {
       var ctx = {};
-      await runHooks(suite.before, ctx);
-      // Children run in definition order (tests interleaved with nested suites).
-      for (var i = 0; i < suite.children.length; i++) {
-        var child = suite.children[i];
-        if (child.kind === "test") {
-          await runOneTest(child.test);
-        } else {
-          await runSuite(child.suite);
+      // Suite-level before/after hooks are contained the same way per-test hooks
+      // are in runOneTest: a failing hook (thrown, done(error), or timed out) is
+      // recorded as a single `not ok` and the run continues, rather than the
+      // rejection propagating to the top-level harness catch and collapsing every
+      // count to PASS: 0  FAIL: 1  TOTAL: 1. A failed `before all` skips this
+      // suite's children (their fixture state is unreliable) but lets sibling
+      // suites still run; `after all` runs regardless, for cleanup.
+      var beforeFailed = false;
+      try {
+        await runHooks(suite.before, ctx);
+      } catch (e) {
+        counter++;
+        beforeFailed = true;
+        reportFailure(
+          fullName(suite, '"before all" hook'),
+          e && e.stack ? e.stack : String(e)
+        );
+      }
+      if (!beforeFailed) {
+        // Children run in definition order (tests interleaved with nested suites).
+        for (var i = 0; i < suite.children.length; i++) {
+          var child = suite.children[i];
+          if (child.kind === "test") {
+            await runOneTest(child.test);
+          } else {
+            await runSuite(child.suite);
+          }
         }
       }
-      await runHooks(suite.after, ctx);
+      try {
+        await runHooks(suite.after, ctx);
+      } catch (e) {
+        counter++;
+        reportFailure(
+          fullName(suite, '"after all" hook'),
+          e && e.stack ? e.stack : String(e)
+        );
+      }
     }
 
     async function runAll() {


### PR DESCRIPTION
## Summary

- start QUnit suites through default autostart and `QUnit.load()` after registration
- preserve nested QUnit module ancestry, definition order, inherited per-test hooks, and module hook boundaries
- await mocha/tape-style `done` callbacks for tests and hooks with error propagation and a cancellable timeout
- add deterministic harness fixtures for all three semantics and document the supported behavior

No engine globals, Rust sources, dependencies, test262 files, or pass baselines change.

## Validation

- `./scripts/run-harness-selftest.sh --no-build` — green
- `node --check scripts/node-test-harness.js` — green
- `./scripts/lint.sh` — green (`cargo fmt --check`, clippy with warnings denied)
- `cargo build --release` — green
- `cargo test --release` — 291 unit tests + smoke oracle green
- `uv run python scripts/run-custom-tests.py` — 6/6 green
- targeted ExpectedArgumentCount/function-length test262 — 8/8 green
- lodash — jsse 6,794/6,794; Node CommonJS oracle 6,794/6,794
- full test262 — 99,546/99,568 with 22 pre-existing/environmental Intl402 DateTimeFormat/Temporal baseline failures; this scripts-only diff has no engine or dependency changes

The stock lodash Node command is affected on this host by an unrelated `/tmp/package.json` with `"type": "module"`; reading the identical final bundle as CommonJS validates the Node oracle without mutating that external project. Details are recorded on #256.

Closes #256
