### PR TITLE
feat: implement per-realm Math.random PRNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An agent-coded JS engine in Rust. I didn't touch a single line of code here. Not
 
 Read more: [jsse - a JavaScript engine built by an agent](https://p.ocmatos.com/blog/jsse-a-javascript-engine-built-by-an-agent.html).
 
-Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **99,488 / 99,515 (99.97%)**.
+Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **99,546 / 99,568 (99.98%)**.
 
 *ES Modules now supported with dynamic `import()` and `import.meta`. Async tests run with Promise/async-await support.*
 

--- a/docs/specs/2026-07-16-math-random-design.md
+++ b/docs/specs/2026-07-16-math-random-design.md
@@ -1,0 +1,61 @@
+# `Math.random` PRNG design
+
+## Context
+
+ECMAScript `Math.random` must return approximately uniformly distributed
+Numbers in `[0, 1)`. Each realm's function must produce a distinct sequence.
+JSSE currently returns the constant `0.5`, which satisfies test262's range
+check but prevents randomness-dependent library tests from exercising their
+real assertions.
+
+## Requirements
+
+- Replace the constant with an approximately uniform pseudo-random sequence.
+- Keep independent state on each `Realm`, matching the specification's
+  per-realm sequence requirement.
+- Preserve the existing `Math.random` function shape and `[0, 1)` result range.
+- Do not expose a deterministic seeding interface without a separate contract
+  for its CLI/API behavior.
+- Remove the lodash harness skips that exist only because of the constant stub.
+
+## Approaches considered
+
+1. Read OS entropy for every call. This is the smallest state model, but it
+   makes a frequently called non-cryptographic API perform a system entropy
+   request each time.
+2. Add a general-purpose RNG crate. This supplies a maintained algorithm, but
+   adds a dependency for a small operation that JSSE can implement directly.
+3. Seed a small per-realm PRNG once from the existing `getrandom` dependency.
+   This keeps calls fast, introduces no dependency, and maps the state directly
+   to the specification's realm boundary.
+
+JSSE will use approach 3.
+
+## Design
+
+`Realm` owns a 64-bit SplitMix64 state. A process seed is initialized once from
+OS entropy, and each realm combines it with a process-local monotonic realm
+counter so distinct realms start from distinct states. A `math_random` method
+advances and mixes the state, discards the low 11 bits, and divides the
+remaining 53-bit integer by `2^53`. The result is always a positive-sign Number
+greater than or equal to zero and strictly less than one.
+
+If the OS entropy source is unavailable, process seeding falls back to a fixed
+non-zero base while the realm counter still gives each realm a distinct initial
+state. `Math.random` is not a cryptographic API, so entropy failure must not add
+a new observable exception to the built-in.
+
+The native `Math.random` function calls the current function realm's
+`math_random` method. JSSE already switches `current_realm_id` to a native
+function's creation realm during calls, so cross-realm calls update the correct
+state.
+
+## Validation
+
+- Add a `test262-extra` regression that samples successive calls, verifies the
+  range, and requires more than one observed result. This fails on the `0.5`
+  stub.
+- Run the official `test262/test/built-ins/Math/random/` tests.
+- Remove the three lodash random/shuffle skip fragments and run the lodash
+  library harness to exercise its distribution-dependent assertions.
+- Run the repository quality gate and full test262 suite to catch regressions.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -209,9 +209,6 @@ routed through lodash's own `skipAssert(N)` on jsse (Node still runs them, so th
 count matches). `scripts/patch-lodash-jsse.js` applies these; each is a jsse
 characteristic surfaced by the suite, tracked as a follow-up:
 
-- **`lodash.random` / `lodash.shuffle`** — jsse's `Math.random` is a deterministic
-  `0.5` stub by design (`src/interpreter/builtins/mod.rs`), so tests asserting a
-  distribution of outputs can't pass.
 - **"should work with extremely large arrays"** (flatten, min/max) — 500k-element
   operations run for minutes on the tree-walker (a performance limit, not a
   correctness one).

--- a/scripts/patch-lodash-jsse.js
+++ b/scripts/patch-lodash-jsse.js
@@ -63,9 +63,6 @@ replaceOnce(
 // 3) Tests that cannot pass on jsse for reasons outside this harness's scope.
 //    Skip each on jsse with skipAssert(<its expect count>) so the total is
 //    preserved; Node still runs them for real. Each is tracked as a follow-up:
-//      * lodash.random / lodash.shuffle — jsse's Math.random is a deterministic
-//        0.5 stub by design (src/interpreter/builtins/mod.rs), so randomness-
-//        dependent expectations can't hold.
 //      * "extremely large arrays" — 500k-element operations run for minutes on
 //        the tree-walker (perf limitation).
 //      * lone surrogates — jsse's regex matches lone surrogates where lodash's
@@ -95,9 +92,6 @@ function skipTests(fragments, guard) {
 skipTests(
   [
     "should work with extremely large arrays",
-    "should return \\`0\\` or \\`1\\` when no arguments are given",
-    "should swap \\`min\\` and \\`max\\` when \\`min\\` > \\`max\\`",
-    "should shuffle small collections",
     "should match lone surrogates",
     "should work when hot",
   ],

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2297,8 +2297,8 @@ impl Interpreter {
         let random_fn = self.create_function(JsFunction::native(
             "random".to_string(),
             0,
-            |_interp, _this, _args| {
-                Completion::Normal(JsValue::Number(0.5)) // deterministic for testing
+            |interp, _this, _args| {
+                Completion::Normal(JsValue::Number(interp.realm_mut().math_random()))
             },
         ));
         self.get_object_cell_expect(math_obj_id)

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -129,8 +129,8 @@ impl Interpreter {
         // __host_random_bytes(n) -> Uint8Array
         //
         // A fresh Uint8Array of `n` cryptographically-secure bytes from the OS
-        // entropy source. Backs getRandomValues / crypto.randomBytes. (jsse's
-        // Math.random is deterministic, so this is the only real entropy.)
+        // entropy source. Backs getRandomValues / crypto.randomBytes;
+        // Math.random remains a non-cryptographic PRNG.
         let random_fn = self.create_function(JsFunction::native(
             "__host_random_bytes".to_string(),
             1,

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -8,9 +8,8 @@ use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
-use std::sync::Arc;
-use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
 
 /// Process-global monotonic counter for `JsObjectData.shape_id`. Starts at 1;
 /// `0` is reserved as an invalid sentinel. Mirrors the existing
@@ -28,6 +27,25 @@ static NEXT_SAB_ID: AtomicU64 = AtomicU64::new(1);
 
 pub fn next_sab_id() -> u64 {
     NEXT_SAB_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+const SPLITMIX64_GAMMA: u64 = 0x9E37_79B9_7F4A_7C15;
+const MATH_RANDOM_FALLBACK_SEED: u64 = 0xA076_1D64_78BD_642F;
+static MATH_RANDOM_PROCESS_SEED: OnceLock<u64> = OnceLock::new();
+static NEXT_MATH_RANDOM_REALM: AtomicU64 = AtomicU64::new(0);
+
+#[inline]
+fn splitmix64_mix(mut value: u64) -> u64 {
+    value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^ (value >> 31)
+}
+
+fn new_math_random_state() -> u64 {
+    let process_seed = *MATH_RANDOM_PROCESS_SEED
+        .get_or_init(|| getrandom::u64().unwrap_or(MATH_RANDOM_FALLBACK_SEED));
+    let realm_index = NEXT_MATH_RANDOM_REALM.fetch_add(1, Ordering::Relaxed);
+    process_seed ^ splitmix64_mix(realm_index)
 }
 
 pub struct SharedBufferInner {
@@ -317,6 +335,7 @@ pub type EnvRef = Rc<RefCell<Environment>>;
 #[allow(clippy::type_complexity)]
 pub struct Realm {
     pub(crate) global_env: EnvRef,
+    math_random_state: u64,
     pub(crate) global_object: Option<u64>,
     pub(crate) throw_type_error: Option<JsValue>,
     pub(crate) template_cache: FxHashMap<u64, u64>,
@@ -420,6 +439,7 @@ impl Realm {
     pub(crate) fn new(global_env: EnvRef) -> Self {
         Self {
             global_env,
+            math_random_state: new_math_random_state(),
             global_object: None,
             throw_type_error: None,
             template_cache: FxHashMap::default(),
@@ -513,6 +533,12 @@ impl Realm {
             sloppy_arguments_getter: None,
             iterator_helper_prototype: None,
         }
+    }
+
+    pub(crate) fn math_random(&mut self) -> f64 {
+        self.math_random_state = self.math_random_state.wrapping_add(SPLITMIX64_GAMMA);
+        let random_bits = splitmix64_mix(self.math_random_state) >> 11;
+        random_bits as f64 / 9_007_199_254_740_992.0
     }
 
     pub(crate) fn collect_roots(&self, worklist: &mut Vec<u64>) {

--- a/test262-extra/Math-random-distribution.js
+++ b/test262-extra/Math-random-distribution.js
@@ -1,0 +1,38 @@
+// Math.random must return approximately uniformly distributed Numbers in
+// [0, 1), and successive calls must form a pseudo-random sequence rather than
+// a constant value.
+// Spec: ECMAScript, sec-math.random.
+
+var first = Math.random();
+var varied = false;
+
+for (var i = 0; i < 100; i++) {
+  var value = Math.random();
+  if (typeof value !== "number" || value < 0 || value >= 1) {
+    throw new Test262Error("Math.random returned an invalid value: " + value);
+  }
+  if (value === 0 && 1 / value < 0) {
+    throw new Test262Error("Math.random returned negative zero");
+  }
+  if (value !== first) {
+    varied = true;
+  }
+}
+
+if (!varied) {
+  throw new Test262Error("Math.random returned a constant sequence");
+}
+
+var randomA = $262.createRealm().global.Math.random;
+var randomB = $262.createRealm().global.Math.random;
+var realmSequencesDiffer = false;
+
+for (var j = 0; j < 16; j++) {
+  if (randomA() !== randomB()) {
+    realmSequencesDiffer = true;
+  }
+}
+
+if (!realmSequencesDiffer) {
+  throw new Test262Error("distinct realms produced the same random sequence");
+}


### PR DESCRIPTION
## Summary

- replace the constant `0.5` stub with a per-realm SplitMix64 PRNG seeded from OS entropy
- add spec-focused coverage for range, non-constant output, and distinct realm sequences
- remove the three lodash random/shuffle assertion skips now that their distribution tests pass
- record the current full test262 result in README

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (291 unit tests + smoke oracle)
- `./scripts/lint.sh`
- `test262-extra/Math-random-distribution.js`: 2/2
- `test262/test/built-ins/Math/random/`: 10/10
- lodash: 6,794/6,794 assertions on jsse and the same bundle on Node
- full test262: 99,546/99,568 (99.98%)

The full runner reported 22 baseline regressions in unrelated Intl/Temporal DateTimeFormat tests. The exact same 22 scenarios fail against an unchanged `origin/main` binary, so they are pre-existing baseline/environment drift; `test262-pass.txt` remains unchanged.

Closes #255