### PR TITLE
test: add js-sha256 Node-compat harness

### DIFF
--- a/docs/specs/2026-07-16-js-sha256-library-harness-design.md
+++ b/docs/specs/2026-07-16-js-sha256-library-harness-design.md
@@ -1,0 +1,63 @@
+# js-sha256 library harness design
+
+## Context
+
+Issue #236 tracks four independent Node-compatibility library targets and
+requires one library per pull request. This slice adds `js-sha256`, whose
+deterministic SHA-224/SHA-256 and HMAC vectors exercise UTF-16 input handling,
+32-bit Number bitwise operations, and ArrayBuffer/TypedArray element access
+without requiring entropy or another host API.
+
+The upstream Node entry repeats the same vector files under several module
+loader configurations and includes a worker-only smoke test. A single esbuild
+bundle cannot reproduce Node's `require.cache` eviction, and JSSE does not
+provide workers. The cryptographic behavior itself lives in two self-contained
+upstream vector files.
+
+## Requirements
+
+- Pin an immutable upstream js-sha256 release.
+- Run the upstream SHA-224/SHA-256 and HMAC vector files without copying their
+  cases into JSSE.
+- Exercise string, Array, Buffer, TypedArray, and ArrayBuffer inputs.
+- Use the shared in-process Mocha-shaped harness on JSSE and real Mocha on Node.
+- Require equal, non-zero test counts on both engines.
+- Keep Node host compatibility in `scripts/`; do not add it to JSSE globals.
+
+## Approaches considered
+
+1. Add `qs` first. It provides broader string and object coverage, but its tape
+   suite requires assertion semantics that the shared harness does not yet
+   expose.
+2. Add `tweetnacl-js` first. Its known-answer vectors are deterministic and
+   valuable, but tape integration and its heavier curve arithmetic make it a
+   larger first slice.
+3. Add `js-sha256` first. Its compact Mocha suite fits the existing
+   describe/it runner and isolates dense bitwise, UTF-8, and typed-array
+   behavior. This is the selected approach.
+
+## Design
+
+Add a `scripts/libs/js-sha256.sh` configuration pinned to upstream `v0.11.1`.
+Its prepare hook installs only the pinned assertion and Mocha dependencies and
+copies a repository-owned bundle entry into the clone.
+
+The entry detects JSSE's `--node` host floor. On JSSE it uses the shared
+Mocha-shaped harness, adding Mocha's `context` alias locally. On Node it creates
+a real programmatic Mocha runner before loading the same upstream vector files.
+Both paths expose the module's SHA functions and `expect.js` in the global
+shape expected by those files, enable their Buffer cases, and load each vector
+file once.
+
+The existing PASS/FAIL/TOTAL summary is parsed by the library verdict. The
+exact observed count is locked in the config, so changes to bundling or
+upstream preparation cannot silently reduce coverage.
+
+## Validation
+
+- Run js-sha256 on Node alone to establish the oracle count.
+- Run the default js-sha256 harness to require JSSE/Node agreement.
+- If an engine defect is found, add focused spec-derived coverage and run the
+  corresponding test262 area before changing engine code.
+- Run the shared harness and Buffer shim self-tests, repository quality gate,
+  and full test262 suite to catch regressions.

--- a/docs/specs/2026-07-16-js-sha256-library-harness-design.md
+++ b/docs/specs/2026-07-16-js-sha256-library-harness-design.md
@@ -39,15 +39,19 @@ upstream vector files.
 ## Design
 
 Add a `scripts/libs/js-sha256.sh` configuration pinned to upstream `v0.11.1`.
-Its prepare hook installs only the pinned assertion and Mocha dependencies and
-copies a repository-owned bundle entry into the clone.
+Its prepare hook installs only the pinned Mocha dependency and copies a
+repository-owned bundle entry into the clone.
 
 The entry detects JSSE's `--node` host floor. On JSSE it uses the shared
 Mocha-shaped harness, adding Mocha's `context` alias locally. On Node it creates
 a real programmatic Mocha runner before loading the same upstream vector files.
-Both paths expose the module's SHA functions and `expect.js` in the global
-shape expected by those files, enable their Buffer cases, and load each vector
-file once.
+Both paths expose the module's SHA functions and the two assertion operations
+used by the upstream files in their expected global shapes, enable the Buffer
+cases, and load each vector file once. The focused assertion seam avoids
+bundling `expect.js` 0.3.1, whose sloppy-mode initialization writes to a
+function's read-only `length` property and throws after strict-mode bundling.
+Both paths also select upstream's browser/webpack mode so the vectors exercise
+the library's pure-JavaScript implementation instead of Node's native `crypto`.
 
 The existing PASS/FAIL/TOTAL summary is parsed by the library verdict. The
 exact observed count is locked in the config, so changes to bundling or

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -170,6 +170,10 @@ could only add jsse-specific failures the oracle lacks and diverge the count.
 Async tests (`assert.async`) are bounded by a 30 s per-test timeout so a `done()`
 that never fires becomes a failure instead of stalling the run.
 
+The assembled bundle uses a `.cjs` suffix so Node always evaluates the
+reference oracle as CommonJS. This is independent of any unrelated ancestor
+`package.json` that may declare `"type": "module"` above the `/tmp` cache.
+
 ### Harness self-test (`run-harness-selftest.sh`)
 
 Because the harness is jsse-only (inert on Node), it can't be cross-checked
@@ -200,6 +204,7 @@ assertions).
 | `decimal.js` | v10.6.0 | ✅ 22,624 (cross-checked) | seconds |
 | `big.js` | v6.2.2 | ✅ 47,456 (cross-checked) | ~7 min — heavy arbitrary-precision division/sqrt/pow on the tree-walker |
 | `lodash` | 4.17.21 | ✅ 6,794 (cross-checked) | QUnit via the shared harness; a few tests skipped on jsse — see below |
+| `js-sha256` | v0.11.1 | ✅ 916 (cross-checked) | Pure-JS SHA-224/SHA-256 and HMAC vectors; string, Buffer, TypedArray, and ArrayBuffer inputs |
 | `bignumber.js` | v9.1.2 | ⚠️ blocked | see below; green on Node today |
 
 ### lodash skip list (jsse only; each preserves the assertion count via `skipAssert`)

--- a/scripts/libs/js-sha256-jsse-entry.js
+++ b/scripts/libs/js-sha256-jsse-entry.js
@@ -1,0 +1,81 @@
+// jsse bundle entry for js-sha256's deterministic SHA-224/SHA-256 and HMAC
+// vectors. The upstream Node entry repeats these files under several module
+// loader configurations by evicting require.cache, which is not meaningful
+// after esbuild has bundled every module once. Load the vector files once here
+// while preserving all of their string, Array, Buffer, TypedArray, and
+// ArrayBuffer cases.
+
+var runningOnJsse = typeof __host_write !== "undefined";
+var mocha;
+
+if (runningOnJsse) {
+  // node-test-harness.js provides describe/it but js-sha256 also uses Mocha's
+  // context alias.
+  globalThis.context = globalThis.describe;
+} else {
+  // The shared harness is deliberately inert on Node. Install real Mocha's
+  // globals so Node remains an independent framework oracle.
+  var Mocha = require("mocha");
+  mocha = new Mocha();
+  mocha.suite.emit("pre-require", globalThis, "tests/jsse-entry.js", mocha);
+}
+
+// The vector files use exactly two expect.js operations. Upstream's expect.js
+// 0.3.1 mutates Function#length while installing its fluent chain; that was a
+// silent no-op in its original sloppy CommonJS wrapper but throws after esbuild
+// places it in strict code. Keep the upstream cases unchanged and provide their
+// small assertion seam directly.
+globalThis.expect = function (actual) {
+  var chain = {
+    be: function (expected) {
+      if (actual !== expected) {
+        throw new Error("expected " + actual + " to be " + expected);
+      }
+    },
+    throwError: function (pattern) {
+      if (typeof actual !== "function") {
+        throw new Error("expected a function");
+      }
+      try {
+        actual();
+      } catch (error) {
+        var message =
+          error && typeof error.message !== "undefined"
+            ? String(error.message)
+            : String(error);
+        if (!pattern || pattern.test(message)) return;
+        throw new Error("expected error " + message + " to match " + pattern);
+      }
+      throw new Error("expected function to throw");
+    },
+  };
+  return { to: chain };
+};
+
+// node-shim.js advertises process.versions.node, but this target is intended to
+// exercise js-sha256's own implementation rather than its native crypto fast
+// path. This is the same browser/webpack mode used by upstream's Node entry.
+globalThis.window = globalThis;
+globalThis.JS_SHA256_NO_NODE_JS = true;
+
+var hashes = require("../src/sha256.js");
+globalThis.sha256 = hashes.sha256;
+globalThis.sha224 = hashes.sha224;
+globalThis.BUFFER = true;
+
+require("./test.js");
+require("./hmac-test.js");
+
+if (!runningOnJsse) {
+  var runner = mocha.run(function (failures) {
+    console.log(
+      "    PASS: " +
+        runner.stats.passes +
+        "  FAIL: " +
+        runner.stats.failures +
+        "  TOTAL: " +
+        runner.stats.tests
+    );
+    process.exitCode = failures ? 1 : 0;
+  });
+}

--- a/scripts/libs/js-sha256.sh
+++ b/scripts/libs/js-sha256.sh
@@ -1,0 +1,37 @@
+# js-sha256 — deterministic SHA-224/SHA-256 and HMAC vectors over strings,
+# Arrays, Buffer, TypedArrays, and ArrayBuffers.
+#
+# The upstream Node entry repeats the same vector files under several module
+# loader configurations using require.cache eviction and adds a worker smoke
+# test. esbuild bundles each module once and jsse has no Worker host surface, so
+# lib_prepare installs a focused entry that runs both cryptographic vector files
+# once. On jsse, node-test-harness.js supplies the Mocha-shaped runner; on Node,
+# the entry runs real Mocha and emits the same PASS/FAIL/TOTAL summary.
+
+LIB_REPO="https://github.com/emn178/js-sha256.git"
+LIB_REF="v0.11.1"
+LIB_ENTRY="tests/jsse-entry.js"
+LIB_ESBUILD_PLATFORM="node"
+LIB_SHIM="node-test-harness.js"
+LIB_EXPECT_COUNT="916"   # locked: v0.11.1 vectors, equal on jsse and Node
+LIB_TIMEOUT="300"
+
+lib_prepare() {
+    # Keep preparation small and deterministic: the coverage and worker
+    # dependencies from upstream's Node entry are not used by this bundle.
+    node -e "const p=require('./package.json'); p.devDependencies={}; p.scripts={}; require('fs').writeFileSync('package.json', JSON.stringify(p,null,2)+'\n')"
+    npm install --no-save --no-audit --no-fund mocha@10.8.2
+    cp "$SCRIPT_DIR/libs/js-sha256-jsse-entry.js" "$LIB_ENTRY"
+}
+
+lib_verdict() {
+    local out="$1" line P F T
+    line="$(grep -oE 'PASS: [0-9]+[[:space:]]+FAIL: [0-9]+[[:space:]]+TOTAL: [0-9]+' "$out" | tail -1 || true)"
+    if [ -z "$line" ]; then echo "FAIL 0"; return 1; fi
+    if [[ "$line" =~ PASS:\ ([0-9]+)[[:space:]]+FAIL:\ ([0-9]+)[[:space:]]+TOTAL:\ ([0-9]+) ]]; then
+        P="${BASH_REMATCH[1]}"; F="${BASH_REMATCH[2]}"; T="${BASH_REMATCH[3]}"
+        if [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
+        echo "FAIL $T"; return 1
+    fi
+    echo "FAIL 0"; return 1
+}

--- a/scripts/run-library-tests.sh
+++ b/scripts/run-library-tests.sh
@@ -116,7 +116,12 @@ source "$CONFIG"
 LIB_CACHE="$CACHE_ROOT/$LIB"
 REPO_DIR="$LIB_CACHE/repo"
 BUNDLE="$LIB_CACHE/bundle.js"
-FINAL="$LIB_CACHE/final.js"
+# Use a .cjs suffix so Node always treats the reference bundle as CommonJS,
+# even when an unrelated ancestor package.json (for example /tmp/package.json)
+# declares "type": "module". esbuild's platform=node output may retain dynamic
+# requires for Node built-ins, so accidentally loading it as ESM breaks the
+# reference oracle before the library suite starts.
+FINAL="$LIB_CACHE/final.cjs"
 PREPARED_MARKER="$LIB_CACHE/.prepared"
 
 if [ "$CLEAN" -eq 1 ]; then


### PR DESCRIPTION
## Summary

- pin js-sha256 v0.11.1 and run its pure-JS SHA-224/SHA-256 and HMAC vectors
- cross-check 916 tests between JSSE’s shared Mocha-shaped harness and real Mocha on Node
- make Node oracle bundles unconditionally CommonJS via a `.cjs` suffix, independent of ambient `/tmp/package.json` settings

## Validation

- `./scripts/run-library-tests.sh js-sha256 --clean` (916/916 on JSSE and Node)
- `./scripts/run-harness-selftest.sh --no-build`
- `./scripts/run-shim-fixtures.sh` (260/260 on JSSE and Node)
- `./scripts/run-library-tests.sh decimal.js --node --clean` (22,624/22,624)
- targeted test262 for bitwise operators, TypedArray, ArrayBuffer, charCodeAt, and codePointAt (3,828/3,828)
- `cargo fmt --check`; `cargo clippy`; `cargo build --release`; `cargo test --release`; `./scripts/lint.sh`
- full test262: 99,546/99,568, matching `main`’s README. The runner reports 22 pre-existing Intl402 failures as regressions plus 323 new passes because `origin/main:test262-pass.txt` has 99,247 stale entries; this PR has no `src`, Cargo, test262-extra, or test262 changes.

This is the js-sha256 one-library slice required by the issue; qs, tweetnacl-js, js-md5, and uuid remain separate PR-sized work.

Closes #236