### PR TITLE
fix(intl): reject unknown IANA time zones

### DIFF
--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -237,57 +237,9 @@ fn is_valid_timezone(tz: &str) -> bool {
     if parse_offset_timezone(tz).is_some() {
         return true;
     }
-    // Use canonicalize_timezone to check if it matches a known TZ
-    let canonical = canonicalize_timezone(tz);
-    if canonical.eq_ignore_ascii_case(tz) && canonical != tz {
-        return true;
-    }
-    if canonical == tz {
-        let lower_canonical = canonicalize_timezone(&tz.to_ascii_lowercase());
-        if lower_canonical != tz.to_ascii_lowercase() {
-            return true;
-        }
-        let upper_canonical = canonicalize_timezone(&tz.to_ascii_uppercase());
-        if upper_canonical != tz.to_ascii_uppercase() {
-            return true;
-        }
-    }
-    // Accept valid IANA-style patterns we might not have in our list
-    if !tz.is_ascii() {
-        return false;
-    }
-    let valid_chars = tz
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '/' || c == '_' || c == '-' || c == '+');
-    if !valid_chars {
-        return false;
-    }
-    if tz.contains('/') {
-        let parts: Vec<&str> = tz.split('/').collect();
-        if parts.len() >= 2 && parts.len() <= 4 {
-            let region_upper = parts[0].to_uppercase();
-            return matches!(
-                region_upper.as_str(),
-                "AFRICA"
-                    | "AMERICA"
-                    | "ANTARCTICA"
-                    | "ARCTIC"
-                    | "ASIA"
-                    | "ATLANTIC"
-                    | "AUSTRALIA"
-                    | "BRAZIL"
-                    | "CANADA"
-                    | "CHILE"
-                    | "ETC"
-                    | "EUROPE"
-                    | "INDIAN"
-                    | "MEXICO"
-                    | "PACIFIC"
-                    | "US"
-            );
-        }
-    }
-    false
+    chrono_tz::TZ_VARIANTS
+        .iter()
+        .any(|known| known.name().eq_ignore_ascii_case(tz))
 }
 
 fn canonicalize_timezone(tz: &str) -> String {
@@ -896,7 +848,10 @@ fn canonicalize_timezone(tz: &str) -> String {
         }
     }
 
-    tz.to_string()
+    chrono_tz::TZ_VARIANTS
+        .iter()
+        .find(|known| known.name().eq_ignore_ascii_case(tz))
+        .map_or_else(|| tz.to_string(), |known| known.name().to_string())
 }
 
 fn default_numbering_system_for_locale(locale: &str) -> &'static str {

--- a/test262-extra/Intl-DateTimeFormat-unknown-IANA-time-zone.js
+++ b/test262-extra/Intl-DateTimeFormat-unknown-IANA-time-zone.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2026 Paulo Matos. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-createdatetimeformat
+description: Unknown IANA-shaped time zone identifiers are rejected
+---*/
+
+assert.throws(RangeError, function () {
+  new Intl.DateTimeFormat("en", { timeZone: "America/Blorp" });
+});


### PR DESCRIPTION
## Summary

- validate named `Intl.DateTimeFormat` time zones against chrono-tz's available IANA identifiers
- preserve ASCII-case-insensitive canonical casing, including identifiers newer than the hand-maintained table
- add a test262-extra regression for an unknown identifier beneath a valid IANA region

## Validation

- `cargo fmt --check`
- `./scripts/lint.sh`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (293 unit tests + smoke oracle pass)
- focused DateTimeFormat regression/invalid/case/canonicalization tests (8/8 pass)
- full test262: 99,546 / 99,568 (99.98%), unchanged from README.md

The full runner exits nonzero because `origin/main:test262-pass.txt` contains 99,247 entries and is inconsistent with the current documented result: 22 unrelated Intl locale-output scenarios are reported as regressions while 323 current passes are absent from the baseline. Details are recorded on issue #264. No baseline or README files were changed.

Closes #264
