### PR TITLE
fix: exclude unary calls from tail position

### DIFF
--- a/docs/specs/2026-07-16-unary-tail-position-design.md
+++ b/docs/specs/2026-07-16-unary-tail-position-design.md
@@ -1,0 +1,68 @@
+# Unary-expression tail-position design
+
+## Context
+
+AJV 8.17.1 rejects a valid meta-schema while evaluating its
+`validSchemaType` helper. The helper reaches an ordinary-object branch ending
+in `!Array.isArray(schema)`, but JSSE can propagate an enclosing tail-position
+state into that unary operand. The call then produces a `TailCall` completion,
+so the surrounding logical and unary expressions do not apply their remaining
+operations. For an ordinary object, the raw `false` result escapes instead of
+being negated to `true`.
+
+ECMAScript's `HasCallInTailPosition` static semantics explicitly return
+`false` for every `UnaryExpression` production. Conditional, logical, and
+parenthesized expressions have separate productions that selectively preserve
+tail position.
+
+## Requirements
+
+- Never treat a call nested in a unary expression as a tail-position call.
+- Preserve proper-tail-call handling in the conditional and logical expression
+  branches that the specification does classify as tail positions.
+- Restore AJV's normal meta-schema compilation without an AJV-specific engine
+  path or compatibility shim.
+- Add spec-derived regression coverage for the expression shape that exposed
+  the bug.
+
+## Approaches considered
+
+1. Replace the evaluator's dynamic tail-position state with parse-time
+   annotations for every expression. This could make the static semantics
+   explicit across the AST, but it is a broad architectural change for one
+   missing exclusion.
+2. Reset tail-position state at function entry or around callback execution.
+   This would prevent the observed leak, but it risks disabling valid proper
+   tail calls in concise bodies and nested conditional or logical branches.
+3. Save and clear tail-position state while evaluating a unary operand, then
+   restore it before returning. This directly implements the unary production's
+   static semantics and matches the evaluator's existing scoped handling for
+   conditional tests and call operands.
+
+JSSE will use approach 3.
+
+## Design
+
+The `Expression::Unary` evaluation arm will save `in_tail_position`, set it to
+`false` for the recursive operand evaluation, and restore the saved value on
+both normal and abrupt completion paths. The unary operation then consumes the
+normal operand value as before. No parser, AST, call-dispatch, or general
+tail-call changes are needed.
+
+The regression will live in `test262-extra` because test262 has positive
+proper-tail-call coverage for conditional and logical expressions but no
+focused negative case for a call beneath a unary operator. It will use the
+AJV-shaped nested conditional/logical predicate and assert the array, ordinary
+object, and object-rejects-array cases.
+
+## Validation
+
+- Demonstrate that the new custom regression fails before the evaluator change
+  and passes after it.
+- Re-run the minimal AJV 8.17.1 bundle with schema validation enabled and
+  require the same `true false` validator results as Node.
+- Run targeted test262 coverage for unary, conditional, logical, call, and
+  return expressions to guard both the fixed exclusion and retained tail-call
+  positions.
+- Run the repository quality gate and full test262 suite without updating the
+  feature-branch baseline.

--- a/docs/specs/2026-07-16-unary-tail-position-design.md
+++ b/docs/specs/2026-07-16-unary-tail-position-design.md
@@ -43,9 +43,11 @@ JSSE will use approach 3.
 
 ## Design
 
-The `Expression::Unary` evaluation arm will save `in_tail_position`, set it to
-`false` for the recursive operand evaluation, and restore the saved value on
-both normal and abrupt completion paths. The unary operation then consumes the
+The `Expression::Unary`, `Expression::Typeof`, `Expression::Void`, and
+`Expression::Delete` evaluation arms will suppress `in_tail_position` for
+recursive operand evaluation and restore the saved value on both normal and
+abrupt completion paths. These four AST variants collectively represent all
+seven unary-expression productions. The unary operation then consumes the
 normal operand value as before. No parser, AST, call-dispatch, or general
 tail-call changes are needed.
 

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -306,6 +306,14 @@ impl Interpreter {
         Ok(())
     }
 
+    fn with_tail_position_suppressed<T>(&mut self, evaluate: impl FnOnce(&mut Self) -> T) -> T {
+        let saved_tail = self.in_tail_position;
+        self.in_tail_position = false;
+        let result = evaluate(self);
+        self.in_tail_position = saved_tail;
+        result
+    }
+
     pub(crate) fn eval_expr(&mut self, expr: &Expression, env: &EnvRef) -> Completion {
         // Catchable stack-depth guard for expression evaluation. Every
         // expression node — and each recursive descent into an operand —
@@ -371,16 +379,11 @@ impl Interpreter {
                 // branch that is otherwise evaluated in tail position: the
                 // call result still has to be transformed by the unary
                 // operator before the surrounding function can return.
-                let saved_tail = self.in_tail_position;
-                self.in_tail_position = false;
-                let val = match self.eval_expr(operand, env) {
-                    Completion::Normal(v) => v,
-                    other => {
-                        self.in_tail_position = saved_tail;
-                        return other;
-                    }
-                };
-                self.in_tail_position = saved_tail;
+                let val =
+                    match self.with_tail_position_suppressed(|this| this.eval_expr(operand, env)) {
+                        Completion::Normal(v) => v,
+                        other => return other,
+                    };
                 self.eval_unary(*op, &val)
             }
             Expression::Binary(op, left, right) => {
@@ -592,17 +595,18 @@ impl Interpreter {
                         }
                     }
                 }
-                let val = match self.eval_expr(operand, env) {
-                    Completion::Normal(v) => v,
-                    other => return other,
-                };
+                let val =
+                    match self.with_tail_position_suppressed(|this| this.eval_expr(operand, env)) {
+                        Completion::Normal(v) => v,
+                        other => return other,
+                    };
                 Completion::Normal(JsValue::String(JsString::from_str(typeof_val(
                     &val,
                     &self.objects,
                 ))))
             }
             Expression::Void(operand) => {
-                match self.eval_expr(operand, env) {
+                match self.with_tail_position_suppressed(|this| this.eval_expr(operand, env)) {
                     Completion::Normal(_) => {}
                     other => return other,
                 }
@@ -620,7 +624,9 @@ impl Interpreter {
                             ));
                         }
                         if let MemberProperty::Computed(expr) = prop {
-                            match self.eval_expr(expr, env) {
+                            match self
+                                .with_tail_position_suppressed(|this| this.eval_expr(expr, env))
+                            {
                                 Completion::Normal(_) => {}
                                 other => return other,
                             }
@@ -629,19 +635,25 @@ impl Interpreter {
                             self.create_reference_error("Unsupported reference to 'super'"),
                         );
                     }
-                    let obj_val = match self.eval_expr(obj_expr, env) {
+                    let obj_val = match self
+                        .with_tail_position_suppressed(|this| this.eval_expr(obj_expr, env))
+                    {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
                     let key = match prop {
                         MemberProperty::Dot(name) => name.clone(),
-                        MemberProperty::Computed(expr) => match self.eval_expr(expr, env) {
-                            Completion::Normal(v) => match self.to_property_key(&v) {
-                                Ok(s) => s,
-                                Err(e) => return Completion::Throw(e),
-                            },
-                            other => return other,
-                        },
+                        MemberProperty::Computed(expr) => {
+                            match self
+                                .with_tail_position_suppressed(|this| this.eval_expr(expr, env))
+                            {
+                                Completion::Normal(v) => match self.to_property_key(&v) {
+                                    Ok(s) => s,
+                                    Err(e) => return Completion::Throw(e),
+                                },
+                                other => return other,
+                            }
+                        }
                         MemberProperty::Private(_) => {
                             return Completion::Throw(
                                 self.create_type_error("Private fields cannot be deleted"),
@@ -846,11 +858,13 @@ impl Interpreter {
                     Completion::Normal(JsValue::Boolean(true))
                 }
                 Expression::OptionalChain(base, chain) => {
-                    self.eval_delete_optional_chain(base, chain, env)
+                    self.with_tail_position_suppressed(|this| {
+                        this.eval_delete_optional_chain(base, chain, env)
+                    })
                 }
                 _ => {
                     // Evaluate the expression for side effects, then return true
-                    match self.eval_expr(expr, env) {
+                    match self.with_tail_position_suppressed(|this| this.eval_expr(expr, env)) {
                         Completion::Normal(_) => Completion::Normal(JsValue::Boolean(true)),
                         other => other,
                     }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -365,10 +365,22 @@ impl Interpreter {
                 self.create_type_error("Private identifier can only be used with 'in' operator"),
             ),
             Expression::Unary(op, operand) => {
+                // §15.10.2 HasCallInTailPosition: a call nested in a unary
+                // expression is not in tail position. This matters when the
+                // unary expression is reached through a conditional/logical
+                // branch that is otherwise evaluated in tail position: the
+                // call result still has to be transformed by the unary
+                // operator before the surrounding function can return.
+                let saved_tail = self.in_tail_position;
+                self.in_tail_position = false;
                 let val = match self.eval_expr(operand, env) {
                     Completion::Normal(v) => v,
-                    other => return other,
+                    other => {
+                        self.in_tail_position = saved_tail;
+                        return other;
+                    }
                 };
+                self.in_tail_position = saved_tail;
                 self.eval_unary(*op, &val)
             }
             Expression::Binary(op, left, right) => {

--- a/test262-extra/tail-call-unary-expression-not-tail-position.js
+++ b/test262-extra/tail-call-unary-expression-not-tail-position.js
@@ -1,0 +1,18 @@
+/*---
+description: A call nested in a unary expression is not a tail position call
+esid: sec-static-semantics-hascallintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+---*/
+
+function isSchemaType(schema, schemaType) {
+  return schemaType === "array"
+    ? Array.isArray(schema)
+    : schemaType === "object"
+      ? schema && typeof schema === "object" && !Array.isArray(schema)
+      : false;
+}
+
+assert.sameValue(isSchemaType([], "array"), true);
+assert.sameValue(isSchemaType({}, "object"), true);
+assert.sameValue(isSchemaType([], "object"), false);

--- a/test262-extra/tail-call-unary-expression-not-tail-position.js
+++ b/test262-extra/tail-call-unary-expression-not-tail-position.js
@@ -16,3 +16,30 @@ function isSchemaType(schema, schemaType) {
 assert.sameValue(isSchemaType([], "array"), true);
 assert.sameValue(isSchemaType({}, "object"), true);
 assert.sameValue(isSchemaType([], "object"), false);
+
+function returnsNumber() {
+  return 42;
+}
+
+function fallback() {
+  return "fallback";
+}
+
+function voidCall(useUnary) {
+  return useUnary ? void returnsNumber() : fallback();
+}
+
+function typeofCall(useUnary) {
+  return useUnary ? typeof returnsNumber() : fallback();
+}
+
+function deleteCall(useUnary) {
+  return useUnary ? delete returnsNumber() : fallback();
+}
+
+assert.sameValue(voidCall(true), undefined);
+assert.sameValue(voidCall(false), "fallback");
+assert.sameValue(typeofCall(true), "number");
+assert.sameValue(typeofCall(false), "fallback");
+assert.sameValue(deleteCall(true), true);
+assert.sameValue(deleteCall(false), "fallback");


### PR DESCRIPTION
## Summary

- suppress proper-tail-call state while evaluating unary operands, as required by HasCallInTailPosition
- add an AJV-shaped test262-extra regression for a negated call beneath conditional and logical expressions
- restore AJV 8.17.1 meta-schema compilation with normal schema validation enabled

## Validation

- cargo fmt --check
- cargo clippy
- cargo build --release
- cargo test --release (293 unit tests plus smoke oracle)
- ./scripts/lint.sh
- targeted unary/tail-call test262: 484/484
- focused test262-extra regression: 1/1
- ordinary custom tests: 6/6
- minimal AJV bundle: true false, matching Node
- full test262: 99,546/99,568; the 22 reported Intl baseline failures reproduce identically with a clean binary from origin/main (Intl subset 6,660/6,682), so this branch introduces no baseline regression
- full test262-extra: 56/58; the two unrelated existing strict-mode failures are Eval-scoping.js and with-gc-root.js

Closes #266