### PR TITLE
fix(intl): localize DateTimeFormat output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "smallvec",
  "tinystr",
  "unicode-ident",
+ "writeable",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ icu_calendar = { version = "2.0", features = ["unstable"] }
 fixed_decimal = { version = "0.7", features = ["ryu"] }
 tinystr = "0.8"
 icu_normalizer = "2.1.1"
+writeable = "0.6"
 rustc-hash = "2"
 smallvec = "1"
 getrandom = "0.4"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An agent-coded JS engine in Rust. I didn't touch a single line of code here. Not
 
 Read more: [jsse - a JavaScript engine built by an agent](https://p.ocmatos.com/blog/jsse-a-javascript-engine-built-by-an-agent.html).
 
-Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **99,546 / 99,568 (99.98%)**.
+Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **99,568 / 99,568 (100.00%)**.
 
 *ES Modules now supported with dynamic `import()` and `import.meta`. Async tests run with Promise/async-await support.*
 

--- a/docs/specs/2026-07-16-intl-datetimeformat-locale-data-design.md
+++ b/docs/specs/2026-07-16-intl-datetimeformat-locale-data-design.md
@@ -1,0 +1,61 @@
+# Locale-backed `Intl.DateTimeFormat` output
+
+## Problem
+
+`Intl.DateTimeFormat` resolves non-English locales but formats many values with
+English symbol tables and hand-built patterns. This makes the resolved locale
+disagree with `format()` and `formatToParts()`, and loses locale-specific date
+and time glue such as English `at`.
+
+ECMA-262 delegates locale-sensitive date methods to ECMA-402. ECMA-402's
+`PartitionDateTimePattern` requires output parts to follow the effective locale
+and selected formatting options, while leaving the locale data
+implementation-defined. JSSE already uses ICU4X for other `Intl` services.
+
+## Design
+
+Add an ICU4X formatting seam in `datetimeformat.rs`:
+
+- Translate supported `DtfOptions` combinations into an ICU4X dynamic field
+  set and formatter preferences.
+- Construct an ISO local date/time from the already-resolved JS time zone and
+  let ICU4X convert it to the requested calendar.
+- Include time-zone data when requested so ICU4X also selects localized
+  date/time/zone glue and names.
+- Collect ICU4X's annotated output into ECMA-402-style `{ type, value }` parts.
+  `format()` joins the same parts, keeping it consistent with
+  `formatToParts()`.
+- Fall back to the existing JSSE formatter when ICU4X cannot represent an
+  arbitrary ECMA-402 component combination or cannot format an edge-case
+  value. The fallback preserves current conformance instead of rejecting a
+  previously accepted format.
+
+The initial seam covers date/time styles and the common explicit field sets
+supported by ICU4X: standalone year/month/weekday, month-day, year-month,
+year-month-day, their weekday forms, time, and supported time-zone styles.
+Narrow fields and component sets outside ICU4X's semantic field-set model stay
+on the existing path.
+
+## Alternatives
+
+Loading only localized month, weekday, era, and day-period symbols would be a
+smaller change, but it would retain the incorrect hand-built field ordering,
+punctuation, spacing, and date/time glue.
+
+Replacing the existing formatter entirely would remove duplicated behavior,
+but ICU4X's semantic field sets cannot express every independent ECMA-402
+component combination. A wholesale replacement would therefore risk
+regressions in already-passing test262 cases.
+
+## Validation
+
+Repository-owned tests will assert:
+
+- French long month and weekday names.
+- Russian standalone month names.
+- Locale-specific date/time glue in both `format()` and `formatToParts()`.
+- Concatenating `formatToParts()` values equals `format()`.
+
+The existing DateTimeFormat test262 directory and full project quality gate
+remain regression checks. The full test262 run determines whether README pass
+statistics need updating.

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1713,16 +1713,27 @@ fn normalize_icu_datetime_parts(
 
         if part_type == "second"
             && opts.fractional_second_digits.is_some()
-            && let Some((seconds, fraction)) = value
-                .split_once('.')
-                .or_else(|| value.split_once('\u{66b}'))
+            && let Some(sep_idx) = value.find(|c: char| !c.is_numeric())
         {
-            normalized.push(("second".to_string(), seconds.to_string()));
+            // ICU merges the fractional second into the "second" part using the
+            // locale's decimal separator (a comma in fr-FR/de-DE, a dot
+            // elsewhere). Split on the actual separator ICU emitted rather than
+            // a fixed set. All numbering systems reaching this ICU path use
+            // decimal digits (hanidec takes the non-ICU fallback), so the first
+            // non-numeric character is the separator. ICU4X keeps the base
+            // locale's separator even under the "arab" numbering system, but
+            // ECMA-402/CLDR use the Arabic decimal separator there, so keep that
+            // one correction.
+            let (seconds, rest) = value.split_at(sep_idx);
+            let mut rest_chars = rest.chars();
+            let separator = rest_chars.next().unwrap();
+            let fraction = rest_chars.as_str();
             let decimal = if matches!(opts.numbering_system.as_str(), "arab" | "arabext") {
-                "\u{66b}"
+                '\u{66b}'
             } else {
-                "."
+                separator
             };
+            normalized.push(("second".to_string(), seconds.to_string()));
             normalized.push(("literal".to_string(), decimal.to_string()));
             normalized.push(("fractionalSecond".to_string(), fraction.to_string()));
             continue;

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1438,6 +1438,362 @@ fn resolve_hour_cycle(opts: &DtfOptions) -> &str {
     locale_default_hour_cycle(&opts.locale)
 }
 
+#[derive(Default)]
+struct IcuDateTimePartsWriter {
+    parts: Vec<(String, String)>,
+    active_parts: Vec<writeable::Part>,
+}
+
+impl std::fmt::Write for IcuDateTimePartsWriter {
+    fn write_str(&mut self, value: &str) -> std::fmt::Result {
+        let part_type = self
+            .active_parts
+            .iter()
+            .rev()
+            .find(|part| part.category == "datetime")
+            .map_or("literal", |part| part.value);
+
+        if let Some((last_type, last_value)) = self.parts.last_mut()
+            && last_type == part_type
+        {
+            last_value.push_str(value);
+        } else {
+            self.parts.push((part_type.to_string(), value.to_string()));
+        }
+        Ok(())
+    }
+}
+
+impl writeable::PartsWrite for IcuDateTimePartsWriter {
+    type SubPartsWrite = Self;
+
+    fn with_part(
+        &mut self,
+        part: writeable::Part,
+        mut write: impl FnMut(&mut Self::SubPartsWrite) -> std::fmt::Result,
+    ) -> std::fmt::Result {
+        self.active_parts.push(part);
+        let result = write(self);
+        self.active_parts.pop();
+        result
+    }
+}
+
+fn icu_datetime_length(opts: &DtfOptions) -> Option<icu::datetime::options::Length> {
+    use icu::datetime::options::Length;
+
+    let style_length = |style: &str| match style {
+        "full" | "long" => Some(Length::Long),
+        "medium" => Some(Length::Medium),
+        "short" => Some(Length::Short),
+        _ => None,
+    };
+
+    if let Some(style) = opts.date_style.as_deref() {
+        return style_length(style);
+    }
+    if let Some(style) = opts.time_style.as_deref() {
+        return style_length(style);
+    }
+
+    let text_styles = [
+        opts.weekday.as_deref(),
+        opts.era.as_deref(),
+        opts.month.as_deref(),
+    ];
+    if text_styles.contains(&Some("narrow")) {
+        return None;
+    }
+    if text_styles.contains(&Some("long")) {
+        Some(Length::Long)
+    } else if text_styles.contains(&Some("short")) {
+        Some(Length::Medium)
+    } else {
+        Some(Length::Short)
+    }
+}
+
+fn icu_datetime_field_set(
+    opts: &DtfOptions,
+) -> Option<icu::datetime::fieldsets::enums::CompositeFieldSet> {
+    use icu::datetime::fieldsets::builder::{DateFields, FieldSetBuilder, ZoneStyle};
+    use icu::datetime::options::{SubsecondDigits, TimePrecision, YearStyle};
+
+    if !matches!(opts.calendar.as_str(), "gregory" | "iso8601")
+        || opts.numbering_system == "hanidec"
+        || opts.day_period.is_some()
+        || (opts.date_style.is_some()
+            && matches!(
+                opts.temporal_type,
+                Some(TemporalType::PlainYearMonth) | Some(TemporalType::PlainMonthDay)
+            ))
+    {
+        return None;
+    }
+
+    let mut builder = FieldSetBuilder::new();
+    builder.length = Some(icu_datetime_length(opts)?);
+
+    let date_fields = if let Some(style) = opts.date_style.as_deref() {
+        match style {
+            "full" => Some(DateFields::YMDE),
+            "long" | "medium" | "short" => Some(DateFields::YMD),
+            _ => return None,
+        }
+    } else {
+        let year = opts.year.is_some();
+        let month = opts.month.is_some();
+        let day = opts.day.is_some();
+        let weekday = opts.weekday.is_some();
+        match (year, month, day, weekday) {
+            (false, false, false, false) => None,
+            (false, false, false, true) => Some(DateFields::E),
+            (false, false, true, false) => Some(DateFields::D),
+            (false, false, true, true) => Some(DateFields::DE),
+            (false, true, false, false) => Some(DateFields::M),
+            (false, true, true, false) => Some(DateFields::MD),
+            (false, true, true, true) => Some(DateFields::MDE),
+            (true, false, false, false) => Some(DateFields::Y),
+            (true, true, false, false) => Some(DateFields::YM),
+            (true, true, true, false) => Some(DateFields::YMD),
+            (true, true, true, true) => Some(DateFields::YMDE),
+            _ => return None,
+        }
+    };
+    builder.date_fields = date_fields;
+
+    if opts.era.is_some() && opts.year.is_none() && opts.date_style.is_none() {
+        return None;
+    }
+    if opts.era.is_some() {
+        builder.year_style = Some(YearStyle::WithEra);
+    } else if opts.year.as_deref() == Some("numeric")
+        || matches!(opts.date_style.as_deref(), Some("full" | "long" | "medium"))
+    {
+        builder.year_style = Some(YearStyle::Full);
+    }
+
+    let time_precision = if let Some(style) = opts.time_style.as_deref() {
+        match style {
+            "full" | "long" | "medium" => Some(TimePrecision::Second),
+            "short" => Some(TimePrecision::Minute),
+            _ => return None,
+        }
+    } else if opts.hour.is_some() {
+        if let Some(digits) = opts.fractional_second_digits {
+            let digits = match digits {
+                1 => SubsecondDigits::S1,
+                2 => SubsecondDigits::S2,
+                3 => SubsecondDigits::S3,
+                _ => return None,
+            };
+            Some(TimePrecision::Subsecond(digits))
+        } else if opts.second.is_some() {
+            Some(TimePrecision::Second)
+        } else if opts.minute.is_some() {
+            Some(TimePrecision::Minute)
+        } else {
+            Some(TimePrecision::Hour)
+        }
+    } else if opts.minute.is_some()
+        || opts.second.is_some()
+        || opts.fractional_second_digits.is_some()
+    {
+        return None;
+    } else {
+        None
+    };
+    builder.time_precision = time_precision;
+
+    let is_plain = matches!(
+        opts.temporal_type,
+        Some(TemporalType::PlainDate)
+            | Some(TemporalType::PlainTime)
+            | Some(TemporalType::PlainDateTime)
+            | Some(TemporalType::PlainYearMonth)
+            | Some(TemporalType::PlainMonthDay)
+    );
+    builder.zone_style = if let Some(style) = opts.time_zone_name.as_deref() {
+        Some(match style {
+            "short" => ZoneStyle::SpecificShort,
+            "long" => ZoneStyle::SpecificLong,
+            "shortOffset" => ZoneStyle::LocalizedOffsetShort,
+            "longOffset" => ZoneStyle::LocalizedOffsetLong,
+            "shortGeneric" => ZoneStyle::GenericShort,
+            "longGeneric" => ZoneStyle::GenericLong,
+            _ => return None,
+        })
+    } else if !is_plain {
+        match opts.time_style.as_deref() {
+            Some("full") => Some(ZoneStyle::SpecificLong),
+            Some("long") => Some(ZoneStyle::SpecificShort),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    builder.build_composite().ok()
+}
+
+fn set_icu_datetime_keyword(
+    locale: &mut icu::locale::Locale,
+    key: &str,
+    value: &str,
+) -> Option<()> {
+    use icu::locale::extensions::unicode::{Key, Value};
+
+    locale
+        .extensions
+        .unicode
+        .keywords
+        .set(key.parse::<Key>().ok()?, value.parse::<Value>().ok()?);
+    Some(())
+}
+
+fn icu_datetime_locale(opts: &DtfOptions) -> Option<icu::locale::Locale> {
+    let mut locale = opts.locale.parse::<icu::locale::Locale>().ok()?;
+    set_icu_datetime_keyword(&mut locale, "ca", &opts.calendar)?;
+    set_icu_datetime_keyword(&mut locale, "nu", &opts.numbering_system)?;
+
+    let hour_cycle = resolve_hour_cycle(opts);
+    if hour_cycle == "h24" {
+        return None;
+    }
+    set_icu_datetime_keyword(&mut locale, "hc", hour_cycle)?;
+    Some(locale)
+}
+
+fn collect_icu_datetime_parts(
+    formatted: &impl writeable::Writeable,
+) -> Option<Vec<(String, String)>> {
+    let mut writer = IcuDateTimePartsWriter::default();
+    formatted.write_to_parts(&mut writer).ok()?;
+    Some(writer.parts)
+}
+
+fn normalize_icu_datetime_parts(
+    parts: Vec<(String, String)>,
+    opts: &DtfOptions,
+) -> Vec<(String, String)> {
+    let mut normalized = Vec::with_capacity(parts.len() + 2);
+    for (part_type, mut value) in parts {
+        let requested_style = match part_type.as_str() {
+            "year" => opts.year.as_deref(),
+            "month" => opts.month.as_deref(),
+            "day" => opts.day.as_deref(),
+            "hour" => opts.hour.as_deref(),
+            "minute" => opts.minute.as_deref(),
+            "second" => opts.second.as_deref(),
+            _ => None,
+        };
+        if part_type == "year"
+            && (opts.date_style.as_deref() == Some("short") || requested_style == Some("2-digit"))
+            && value.chars().count() > 2
+            && value.chars().all(char::is_numeric)
+        {
+            let mut digits = value.chars().rev().take(2).collect::<Vec<_>>();
+            digits.reverse();
+            value = digits.into_iter().collect();
+        }
+        if requested_style == Some("2-digit")
+            && value.chars().count() == 1
+            && value.chars().all(char::is_numeric)
+        {
+            value.insert_str(0, &transliterate_digits("0", &opts.numbering_system));
+        }
+        if part_type == "timeZoneName" && parse_offset_timezone(&opts.time_zone) == Some((0, 0)) {
+            let zero_offset_suffix =
+                format!("+{}", transliterate_digits("0", &opts.numbering_system));
+            if let Some(prefix) = value.strip_suffix(&zero_offset_suffix) {
+                value = prefix.to_string();
+            }
+        }
+
+        if part_type == "second"
+            && opts.fractional_second_digits.is_some()
+            && let Some((seconds, fraction)) = value
+                .split_once('.')
+                .or_else(|| value.split_once('\u{66b}'))
+        {
+            normalized.push(("second".to_string(), seconds.to_string()));
+            let decimal = if matches!(opts.numbering_system.as_str(), "arab" | "arabext") {
+                "\u{66b}"
+            } else {
+                "."
+            };
+            normalized.push(("literal".to_string(), decimal.to_string()));
+            normalized.push(("fractionalSecond".to_string(), fraction.to_string()));
+            continue;
+        }
+
+        normalized.push((part_type, value));
+    }
+    normalized
+}
+
+fn format_with_icu(ms: f64, opts: &DtfOptions) -> Option<Vec<(String, String)>> {
+    use icu::datetime::DateTimeFormatter;
+    use icu::datetime::input::{Date, DateTime, Time, ZonedDateTime};
+    use icu::time::zone::{IanaParser, UtcOffset};
+
+    let field_set = icu_datetime_field_set(opts)?;
+    let locale = icu_datetime_locale(opts)?;
+    let formatter = DateTimeFormatter::try_new(locale.into(), field_set).ok()?;
+
+    let is_plain = matches!(
+        opts.temporal_type,
+        Some(TemporalType::PlainDate)
+            | Some(TemporalType::PlainTime)
+            | Some(TemporalType::PlainDateTime)
+            | Some(TemporalType::PlainYearMonth)
+            | Some(TemporalType::PlainMonthDay)
+    );
+    let adjusted_ms = if is_plain {
+        ms
+    } else {
+        ms + tz_offset_ms(&opts.time_zone, ms)
+    };
+    let components = timestamp_to_components(adjusted_ms);
+    let datetime = DateTime {
+        date: Date::try_new_iso(
+            components.year,
+            components.month as u8,
+            components.day as u8,
+        )
+        .ok()?,
+        time: Time::try_new(
+            components.hour as u8,
+            components.minute as u8,
+            components.second as u8,
+            components.millisecond * 1_000_000,
+        )
+        .ok()?,
+    };
+
+    let zone = if is_plain {
+        icu::datetime::input::TimeZoneInfo::utc().at_date_time_iso(datetime)
+    } else {
+        let offset_seconds = (tz_offset_ms(&opts.time_zone, ms) / 1000.0) as i32;
+        let offset = UtcOffset::try_from_seconds(offset_seconds).ok()?;
+        let time_zone = if parse_offset_timezone(&opts.time_zone).is_some() {
+            icu::datetime::input::TimeZone::UNKNOWN
+        } else {
+            IanaParser::new().parse(&opts.time_zone)
+        };
+        time_zone
+            .with_offset(Some(offset))
+            .at_date_time_iso(datetime)
+    };
+    let zoned = ZonedDateTime {
+        date: datetime.date,
+        time: datetime.time,
+        zone,
+    };
+    let parts = collect_icu_datetime_parts(&formatter.format(&zoned))?;
+    Some(normalize_icu_datetime_parts(parts, opts))
+}
+
 fn has_time_component(opts: &DtfOptions) -> bool {
     opts.hour.is_some()
         || opts.minute.is_some()
@@ -1722,6 +2078,9 @@ fn transliterate_digits(s: &str, ns: &str) -> String {
 }
 
 fn format_with_options(ms: f64, opts: &DtfOptions) -> String {
+    if let Some(parts) = format_with_icu(ms, opts) {
+        return parts.into_iter().map(|(_, value)| value).collect();
+    }
     let raw = format_with_options_raw(ms, opts);
     transliterate_digits(&raw, &opts.numbering_system)
 }
@@ -3770,6 +4129,9 @@ fn format_time_style_to_parts(
 }
 
 fn format_to_parts_with_options(ms: f64, opts: &DtfOptions) -> Vec<(String, String)> {
+    if let Some(parts) = format_with_icu(ms, opts) {
+        return parts;
+    }
     let raw = format_to_parts_with_options_raw(ms, opts);
     if opts.numbering_system == "latn" {
         return raw;

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1675,6 +1675,7 @@ fn collect_icu_datetime_parts(
 fn normalize_icu_datetime_parts(
     parts: Vec<(String, String)>,
     opts: &DtfOptions,
+    short_year_two_digit: bool,
 ) -> Vec<(String, String)> {
     let mut normalized = Vec::with_capacity(parts.len() + 2);
     for (part_type, mut value) in parts {
@@ -1688,7 +1689,7 @@ fn normalize_icu_datetime_parts(
             _ => None,
         };
         if part_type == "year"
-            && (opts.date_style.as_deref() == Some("short") || requested_style == Some("2-digit"))
+            && (short_year_two_digit || requested_style == Some("2-digit"))
             && value.chars().count() > 2
             && value.chars().all(char::is_numeric)
         {
@@ -1791,7 +1792,52 @@ fn format_with_icu(ms: f64, opts: &DtfOptions) -> Option<Vec<(String, String)>> 
         zone,
     };
     let parts = collect_icu_datetime_parts(&formatter.format(&zoned))?;
-    Some(normalize_icu_datetime_parts(parts, opts))
+    // For dateStyle:"short", ICU4X may expand the year to a full year outside its
+    // 2-digit-year window even for locales whose short pattern uses two digits
+    // (e.g. en-US in 1886). Node/ICU always follow the pattern width, so probe
+    // the locale's short-year width (only when the year actually came out full)
+    // and let normalization truncate it back to two digits when appropriate.
+    let short_year_two_digit = opts.date_style.as_deref() == Some("short")
+        && parts.iter().any(|(part_type, value)| {
+            part_type == "year" && value.chars().count() > 2 && value.chars().all(char::is_numeric)
+        })
+        && icu_short_year_is_two_digit(&formatter);
+    Some(normalize_icu_datetime_parts(
+        parts,
+        opts,
+        short_year_two_digit,
+    ))
+}
+
+/// Whether the effective locale's short-date pattern uses a two-digit year.
+///
+/// ICU4X's `YearStyle::Auto` yields a two-digit year only inside its
+/// 2-digit-year window (1950..=2049) and expands to a full year outside it,
+/// whereas ECMA-402/Node follow the locale's short-date pattern width for every
+/// year (`yy` -> two digits, `y` -> full). Formatting a reference instant inside
+/// the window exposes the pattern width without the disambiguation expansion.
+fn icu_short_year_is_two_digit(
+    formatter: &icu::datetime::DateTimeFormatter<
+        icu::datetime::fieldsets::enums::CompositeFieldSet,
+    >,
+) -> bool {
+    use icu::datetime::input::{Date, DateTime, Time, ZonedDateTime};
+
+    let (Ok(date), Ok(time)) = (Date::try_new_iso(2000, 6, 15), Time::try_new(12, 0, 0, 0)) else {
+        return false;
+    };
+    let datetime = DateTime { date, time };
+    let zone = icu::datetime::input::TimeZoneInfo::utc().at_date_time_iso(datetime);
+    let zoned = ZonedDateTime { date, time, zone };
+    match collect_icu_datetime_parts(&formatter.format(&zoned)) {
+        Some(parts) => parts.iter().any(|(part_type, value)| {
+            part_type == "year"
+                && !value.is_empty()
+                && value.chars().count() <= 2
+                && value.chars().all(char::is_numeric)
+        }),
+        None => false,
+    }
 }
 
 fn has_time_component(opts: &DtfOptions) -> bool {

--- a/test262-extra/Intl-DateTimeFormat-locale-data.js
+++ b/test262-extra/Intl-DateTimeFormat-locale-data.js
@@ -144,3 +144,60 @@ assertSame(
   }).format(recentShort),
   '02/01/20',
   'explicit year:2-digit still truncates to two digits');
+
+// fractionalSecond must be split out of the "second" part using the locale's
+// own decimal separator. Many locales (fr-FR, de-DE) use a comma, not a dot,
+// and the "arab" numbering system uses the Arabic decimal separator.
+function partValue(parts, type) {
+  for (var i = 0; i < parts.length; i++) {
+    if (parts[i].type === type) {
+      return parts[i].value;
+    }
+  }
+  return undefined;
+}
+
+function separatorAfterSecond(parts) {
+  for (var i = 0; i < parts.length - 1; i++) {
+    if (parts[i].type === 'second' && parts[i + 1].type === 'literal') {
+      return parts[i + 1].value;
+    }
+  }
+  return undefined;
+}
+
+var fracTimestamp = Date.UTC(2020, 0, 2, 3, 4, 5, 6);
+
+function fractionalFormat(locale) {
+  return new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    fractionalSecondDigits: 3,
+    hourCycle: 'h23',
+    timeZone: 'UTC'
+  });
+}
+
+var frFractional = fractionalFormat('fr-FR');
+assertSame(frFractional.format(fracTimestamp), '03:04:05,006',
+  'French fractional second uses a comma decimal separator');
+var frParts = frFractional.formatToParts(fracTimestamp);
+assertSame(partValue(frParts, 'second'), '05',
+  'French formatToParts second part excludes the fraction');
+assertSame(partValue(frParts, 'fractionalSecond'), '006',
+  'French formatToParts exposes a fractionalSecond part');
+assertSame(separatorAfterSecond(frParts), ',',
+  'French fractionalSecond literal is a comma');
+
+var enFractional = fractionalFormat('en-US');
+assertSame(enFractional.format(fracTimestamp), '03:04:05.006',
+  'English fractional second keeps the dot decimal separator');
+assertSame(separatorAfterSecond(enFractional.formatToParts(fracTimestamp)), '.',
+  'English fractionalSecond literal is a dot');
+
+var arabFractional = fractionalFormat('en-US-u-nu-arab');
+assertSame(arabFractional.format(fracTimestamp), '٠٣:٠٤:٠٥٫٠٠٦',
+  'Arabic-numbered fractional second uses the Arabic decimal separator');
+assertSame(separatorAfterSecond(arabFractional.formatToParts(fracTimestamp)), '٫',
+  'Arabic-numbered fractionalSecond literal is the Arabic decimal separator');

--- a/test262-extra/Intl-DateTimeFormat-locale-data.js
+++ b/test262-extra/Intl-DateTimeFormat-locale-data.js
@@ -1,0 +1,99 @@
+// Intl.DateTimeFormat output must use the effective locale's symbols and
+// patterns instead of English fallback tables.
+//
+// Spec: ECMA-402 PartitionDateTimePattern and FormatDateTimePattern create
+// parts according to the effective locale and the selected format record.
+
+function assertSame(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Test262Error(
+      message + ': expected "' + expected + '", got "' + actual + '"');
+  }
+}
+
+assertSame(
+  new Intl.DateTimeFormat('fr', {
+    month: 'long',
+    timeZone: 'UTC'
+  }).format(0),
+  'janvier',
+  'French long month name');
+
+assertSame(
+  new Intl.DateTimeFormat('fr', {
+    weekday: 'long',
+    timeZone: 'UTC'
+  }).format(0),
+  'jeudi',
+  'French long weekday name');
+
+assertSame(
+  new Intl.DateTimeFormat('ru', {
+    month: 'long',
+    timeZone: 'UTC'
+  }).format(Date.UTC(2020, 2, 1)),
+  'март',
+  'Russian standalone long month name');
+
+assertSame(
+  new Intl.DateTimeFormat('my', {
+    hour: 'numeric',
+    hour12: true,
+    timeZone: 'UTC'
+  }).format(0),
+  'နံနက် ၁၂',
+  'Burmese day period, digits, and field order');
+
+assertSame(
+  new Intl.DateTimeFormat('fr', {
+    year: 'numeric',
+    era: 'short',
+    timeZone: 'UTC'
+  }).format(Date.parse('0000-01-01T00:00:00Z')),
+  '1 av. J.-C.',
+  'French era name');
+
+var dateTime = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  timeZoneName: 'short',
+  timeZone: 'UTC'
+});
+var timestamp = Date.UTC(1982, 4, 25, 9, 23);
+var formatted = dateTime.format(timestamp);
+if (formatted.indexOf(' at ') < 0) {
+  throw new Test262Error(
+    'long English date/time pattern must use locale glue " at ", got "' +
+    formatted + '"');
+}
+
+var parts = dateTime.formatToParts(timestamp);
+var joined = '';
+var foundGlue = false;
+for (var i = 0; i < parts.length; i++) {
+  joined += parts[i].value;
+  if (parts[i].type === 'literal' && parts[i].value === ' at ') {
+    foundGlue = true;
+  }
+}
+assertSame(joined, formatted, 'formatToParts values must reproduce format');
+if (!foundGlue) {
+  throw new Test262Error(
+    'formatToParts must expose locale date/time glue as a literal');
+}
+
+assertSame(
+  new Intl.DateTimeFormat('fr', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZoneName: 'short',
+    timeZone: 'UTC'
+  }).format(timestamp),
+  '25 mai 1982 à 09:23 UTC',
+  'French date/time pattern and glue');

--- a/test262-extra/Intl-DateTimeFormat-locale-data.js
+++ b/test262-extra/Intl-DateTimeFormat-locale-data.js
@@ -97,3 +97,50 @@ assertSame(
   }).format(timestamp),
   '25 mai 1982 à 09:23 UTC',
   'French date/time pattern and glue');
+
+// dateStyle:"short" year width follows the locale's own short-date pattern
+// (en-US uses two digits, fr-FR/ja-JP use the full year) for every year, not
+// just years inside ICU's 2-digit window. Only an explicit year:"2-digit"
+// forces the two-digit form everywhere.
+var recentShort = Date.UTC(2020, 0, 2);
+var historicalShort = Date.UTC(1886, 4, 1);
+
+assertSame(
+  new Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeZone: 'UTC' })
+    .format(recentShort),
+  '02/01/2020',
+  'French dateStyle:short keeps the locale full year (recent)');
+
+assertSame(
+  new Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeZone: 'UTC' })
+    .format(historicalShort),
+  '01/05/1886',
+  'French dateStyle:short keeps the locale full year (historical)');
+
+assertSame(
+  new Intl.DateTimeFormat('ja-JP', { dateStyle: 'short', timeZone: 'UTC' })
+    .format(recentShort),
+  '2020/01/02',
+  'Japanese dateStyle:short keeps the locale full year');
+
+assertSame(
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeZone: 'UTC' })
+    .format(recentShort),
+  '1/2/20',
+  'English dateStyle:short uses a two-digit year (recent, in ICU window)');
+
+assertSame(
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeZone: 'UTC' })
+    .format(historicalShort),
+  '5/1/86',
+  'English dateStyle:short uses a two-digit year (historical, out of window)');
+
+assertSame(
+  new Intl.DateTimeFormat('fr-FR', {
+    year: '2-digit',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: 'UTC'
+  }).format(recentShort),
+  '02/01/20',
+  'explicit year:2-digit still truncates to two digits');


### PR DESCRIPTION
## Summary

- format supported Gregorian and ISO Intl.DateTimeFormat field sets with ICU4X locale data instead of English tables
- preserve the existing formatter as a compatibility fallback for unsupported calendars and option combinations
- expose ICU-backed values and locale pattern literals consistently through format and formatToParts
- add regression coverage for French, Russian, Burmese, eras, date/time glue, and parts parity

## Validation

- ./scripts/lint.sh
- cargo build --release
- cargo test --release
- uv run python scripts/run-custom-tests.py
- TZ=UTC uv run python scripts/run-test262.py test262/test/intl402/DateTimeFormat/ — 488/488
- TZ=UTC uv run python scripts/run-test262.py — 99,568/99,568, zero regressions, 323 new passes

The test262 commands use TZ=UTC to match the repository baseline; the unattended workspace host is Europe/Berlin. The Luxon harness referenced by the issue is on the separate #235 branch and is not present on this branch.

Closes #262