### PR TITLE
fix(regexp): preserve quantified empty v sets

### DIFF
--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -867,8 +867,9 @@ impl VClassSet {
         let has_strings = !s.strings.is_empty();
 
         if !has_ranges && !has_strings {
-            // Empty set: match nothing
-            return "(?!)".to_string();
+            // Empty sets are always-failing consuming atoms, so zero-count
+            // quantifiers over them can still match the empty string.
+            return "[^\\s\\S]".to_string();
         }
 
         let mut char_class = String::new();

--- a/test262-extra/RegExp-v-empty-class-set-composition.js
+++ b/test262-extra/RegExp-v-empty-class-set-composition.js
@@ -1,0 +1,29 @@
+// Empty v-mode class sets remain always-failing atoms when quantified.
+// Spec: ECMAScript 2026, sec-compileatom,
+// sec-runtime-semantics-repeatmatcher-abstract-operation
+
+function sameMatch(regexp, input, expected, message) {
+  var match = regexp.exec(input);
+  if (match === null || match[0] !== expected) {
+    throw new Test262Error(
+      message + ': expected ' + expected + ', got ' + match
+    );
+  }
+}
+
+function noMatch(regexp, input, message) {
+  var match = regexp.exec(input);
+  if (match !== null) {
+    throw new Test262Error(message + ': expected null, got ' + match);
+  }
+}
+
+sameMatch(/[\d&&\D]*/v, '', '', 'zero-or-more empty intersection');
+sameMatch(/[\w--\w]*/v, '', '', 'zero-or-more empty subtraction');
+sameMatch(/[[a]--[a]]?/v, '', '', 'optional nested empty subtraction');
+sameMatch(/[\d&&\D]{0,2}/v, '', '', 'bounded empty intersection');
+sameMatch(/x[\d&&\D]*y/v, 'xy', 'xy', 'empty intersection in sequence');
+
+noMatch(/[\d&&\D]/v, '', 'bare empty intersection');
+noMatch(/[\d&&\D]+/v, '', 'one-or-more empty intersection');
+noMatch(/[\d&&\D]{1,2}/v, '', 'positive bounded empty intersection');


### PR DESCRIPTION
## Summary

- serialize an empty `v`-mode class set as the consuming never-match class `[^\s\S]`
- preserve empty matches for zero-permitting quantifiers without changing bare or positive-count failures
- cover empty intersections, subtractions, nesting, bounded quantifiers, and sequence composition

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release` (293 unit tests + smoke oracle)
- `uv run python scripts/run-custom-tests.py` (6/6)
- `uv run python scripts/run-custom-tests.py test262-extra/RegExp-v-empty-class-set-composition.js` (1/1)
- `uv run python scripts/run-test262.py test262/test/built-ins/RegExp/unicodeSets/` (228/228)
- full `uv run python scripts/run-test262.py`: 99,546/99,568, matching the existing README count; the runner reports 22 baseline regressions in unrelated Intl/Temporal formatting and 323 unrelated new passes. Eight representative Intl regressions reproduce unchanged with an isolated `origin/main` build, so no README or baseline file was changed.

Closes #282
