### PR TITLE
fix: stop cyclic array joins exhausting call depth

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -1332,22 +1332,37 @@ impl Interpreter {
             } else {
                 ",".to_string()
             };
-            let mut parts = Vec::with_capacity(len);
-            for i in 0..len {
-                let elem = match obj_get(interp, &o, &i.to_string()) {
-                    Ok(v) => v,
-                    Err(c) => return c,
-                };
-                if elem.is_undefined() || elem.is_null() {
-                    parts.push(String::new());
-                } else {
-                    match interp.to_string_value(&elem) {
-                        Ok(s) => parts.push(s),
-                        Err(e) => return Completion::Throw(e),
+
+            let receiver_id = match &o {
+                JsValue::Object(obj) => obj.id,
+                _ => unreachable!("ToObject must return an object"),
+            };
+            if interp.active_array_joins.contains(&receiver_id) {
+                return Completion::Normal(JsValue::String(JsString::from_str("")));
+            }
+
+            interp.active_array_joins.push(receiver_id);
+            let result = (|| {
+                let mut parts = Vec::with_capacity(len);
+                for i in 0..len {
+                    let elem = match obj_get(interp, &o, &i.to_string()) {
+                        Ok(v) => v,
+                        Err(c) => return c,
+                    };
+                    if elem.is_undefined() || elem.is_null() {
+                        parts.push(String::new());
+                    } else {
+                        match interp.to_string_value(&elem) {
+                            Ok(s) => parts.push(s),
+                            Err(e) => return Completion::Throw(e),
+                        }
                     }
                 }
-            }
-            Completion::Normal(JsValue::String(JsString::from_str(&parts.join(&sep))))
+                Completion::Normal(JsValue::String(JsString::from_str(&parts.join(&sep))))
+            })();
+            let popped_receiver = interp.active_array_joins.pop();
+            debug_assert_eq!(popped_receiver, Some(receiver_id));
+            result
         });
 
         // Array.prototype.toString

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -90,6 +90,11 @@ pub struct Interpreter {
     generator_context: Option<GeneratorContext>,
     pub(crate) destructuring_yield: bool,
     pub(crate) pending_iter_close: Vec<JsValue>,
+    /// Object IDs whose `Array.prototype.join` calls are currently converting
+    /// elements. Re-entering `join` for the same receiver through element
+    /// stringification contributes an empty string instead of recursing until
+    /// the native-stack guard fires.
+    pub(crate) active_array_joins: Vec<u64>,
     pub(crate) generator_inline_iters: FxHashMap<u64, Vec<JsValue>>,
     pub(crate) scheduler: scheduler::JobScheduler,
     cached_has_instance_key: Option<String>,
@@ -327,6 +332,7 @@ impl Interpreter {
             generator_context: None,
             destructuring_yield: false,
             pending_iter_close: Vec::new(),
+            active_array_joins: Vec::new(),
             generator_inline_iters: FxHashMap::default(),
             scheduler: scheduler::JobScheduler::default(),
             cached_has_instance_key: None,

--- a/tests/array-join-cyclic.js
+++ b/tests/array-join-cyclic.js
@@ -1,0 +1,52 @@
+// Array.prototype.join (§23.1.3.18) must not recurse until the engine's
+// call-depth guard fires when element stringification reaches the same active
+// join receiver.
+
+function sameValue(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + JSON.stringify(expected) +
+      ", got " + JSON.stringify(actual));
+  }
+}
+
+var selfCycle = [];
+selfCycle.push(1, selfCycle, 2);
+sameValue(selfCycle.join("-"), "1--2", "direct cycle");
+
+var left = [];
+var right = [left];
+left.push(right);
+sameValue(left.join(), "", "mutual cycle");
+
+var generic = { length: 1 };
+generic[0] = generic;
+generic.join = Array.prototype.join;
+generic.toString = Array.prototype.toString;
+sameValue(String(generic), "", "generic cycle");
+
+// Separator coercion precedes element conversion, so a reentrant join from the
+// separator is not yet cyclic and must still inspect the receiver.
+var separatorLog = [];
+var separatorArray = [1];
+var separator = {
+  toString: function () {
+    separatorLog.push(separatorArray.join("-"));
+    return ",";
+  },
+};
+sameValue(separatorArray.join(separator), "1", "separator result");
+sameValue(separatorLog.join(), "1", "separator reentrant join");
+
+// An abrupt element conversion must remove the receiver from the active stack.
+var afterThrow = [{
+  toString: function () {
+    throw new Error("sentinel");
+  },
+}];
+try {
+  afterThrow.join();
+} catch (error) {
+  sameValue(error.message, "sentinel", "element error");
+}
+afterThrow[0] = "recovered";
+sameValue(afterThrow.join(), "recovered", "active join state unwinds");


### PR DESCRIPTION
## Summary

- track active `Array.prototype.join` receivers during element conversion so direct, mutual, and generic cyclic joins contribute an empty string
- preserve separator-coercion ordering and unwind the active receiver on abrupt completion without changing the native call-depth guard
- add custom regression coverage for cyclic joins, separator re-entry, and throw cleanup

## Validation

- dependent AJV v8.17.1 corpus bundle: issue cases 39 and 4036 pass with no call-depth error (5,478 pass / 2 unrelated failures tracked by #274)
- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (293 unit tests + smoke oracle)
- `./scripts/lint.sh`
- `uv run python scripts/run-custom-tests.py` (7/7)
- targeted Array join/toString test262 (68/68)
- `TZ=UTC uv run python scripts/run-test262.py` (99,568/99,568; zero regressions)

The UTC setting matches the repository baseline environment. With the host timezone set to Europe/Berlin, 22 pre-existing Intl local-date scenarios fail due to an unrelated timezone conversion issue.

Closes #275