### PR TITLE
fix: preserve tagged template substitutions across GC

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1308,24 +1308,41 @@ impl Interpreter {
                     }
                 };
 
+                // The tag, its receiver, and each substitution value are held
+                // in Rust locals until EvaluateCall invokes the tag. Later
+                // substitutions can run arbitrary JavaScript (and therefore a
+                // GC safepoint), so keep all previously evaluated values live.
+                let gc_frame = self.gc_root_frame();
+                self.gc_root_value(&func_val);
+                self.gc_root_value(&this_val);
                 let template_obj = self.get_template_object(tmpl);
+                self.gc_root_value(&template_obj);
 
                 let mut call_args = vec![template_obj];
                 for sub_expr in &tmpl.expressions {
                     match self.eval_expr(sub_expr, env) {
-                        Completion::Normal(v) => call_args.push(v),
-                        other => return other,
+                        Completion::Normal(v) => {
+                            self.gc_root_value(&v);
+                            call_args.push(v);
+                        }
+                        other => {
+                            self.gc_unroot_frame(gc_frame);
+                            return other;
+                        }
                     }
                 }
 
                 if saved_tail {
+                    self.gc_unroot_frame(gc_frame);
                     return Completion::TailCall {
                         func: func_val,
                         this: this_val,
                         args: call_args,
                     };
                 }
-                self.call_function(&func_val, &this_val, &call_args)
+                let result = self.call_function(&func_val, &this_val, &call_args);
+                self.gc_unroot_frame(gc_frame);
+                result
             }
         }
     }

--- a/test262-extra/tagged-template-substitution-gc-rooting.js
+++ b/test262-extra/tagged-template-substitution-gc-rooting.js
@@ -1,0 +1,19 @@
+/*---
+description: >
+  Earlier tagged-template substitution values remain live while later
+  substitutions are evaluated.
+info: |
+  ArgumentListEvaluation passes the template object followed by each
+  substitution value to EvaluateCall. Evaluating a later substitution must not
+  make an earlier substitution unreachable before that call.
+  ECMAScript section: sec-runtime-semantics-argumentlistevaluation.
+---*/
+
+function tag(strings) {
+  return Array.prototype.slice.call(arguments, 1);
+}
+
+var values = tag`${{marker: "first"}}${($262.gc(), {marker: "second"})}`;
+
+assert.sameValue(values[0].marker, "first");
+assert.sameValue(values[1].marker, "second");


### PR DESCRIPTION
## Summary

- root the tag, receiver, template object, and accumulated substitution values while later tagged-template substitutions execute arbitrary JavaScript
- add a forced-GC regression for an earlier substitution surviving evaluation of a later substitution
- restore AJV generated-validator correctness under sustained code generation

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (293 unit tests + smoke oracle)
- `uv run python scripts/run-custom-tests.py` (6/6)
- tagged-template test262 + regression (50/50)
- AJV v8.17.1 corpus on a clean #280 composite (5,480/5,480; issue baseline 5,466/5,480)
- full test262 (99,546/99,568): the 22 failures are existing Intl locale-data failures reproduced by an exact `origin/main` binary; 323 unrelated new passes, and no issue-related regression

Closes #274