### PR TITLE
fix: run xdescribe callback so nested skipped tests register

### DIFF
--- a/scripts/harness-fixtures/tap.fixture.js
+++ b/scripts/harness-fixtures/tap.fixture.js
@@ -4,10 +4,10 @@
 //
 // Covers: nested suites, definition-order execution, before/after (once per
 // suite) and beforeEach/afterEach (per test, parent chain), async it bodies,
-// the test() alias, Jest-style test.each tables, and — via deliberate
-// throw/done(error) failures — failure detection.
+// the test() alias, Jest-style test.each tables, skipped suites (xdescribe),
+// and — via deliberate throw/done(error) failures — failure detection.
 //
-// Expected summary: PASS: 7  FAIL: 2  TOTAL: 9
+// Expected summary: PASS: 9  FAIL: 2  TOTAL: 11
 
 var order = [];
 
@@ -78,6 +78,21 @@ describe("outer", function () {
       ) {
         throw new Error("beforeEach ordering wrong: " + order.join(","));
       }
+    });
+  });
+});
+
+// xdescribe is Mocha's alias for describe.skip: its callback still runs so
+// nested tests register (and count in the total) as skipped, but no hook or
+// body executes.
+xdescribe("xdescribe suite", function () {
+  before(function () { throw new Error("xdescribe suite hook ran"); });
+  it("registers its tests without running them", function () {
+    throw new Error("xdescribe suite test ran");
+  });
+  describe("nested inside xdescribe", function () {
+    it("inherits the skipped state", function () {
+      throw new Error("nested xdescribe test ran");
     });
   });
 });

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -1172,10 +1172,14 @@
   // suites use and is self-verified by scripts/shim-fixtures. Emits TAP 13.
   // ==========================================================================
   function installTap() {
-    function makeSuite(name, parent) {
+    function makeSuite(name, parent, skipped) {
       return {
         name: name,
         parent: parent,
+        // A skipped suite (xdescribe) still registers and reports every nested
+        // test, but none of its hooks or bodies run. Inherited so nested
+        // describe/it blocks are skipped too.
+        skipped: !!skipped || (parent ? parent.skipped : false),
         // A single ordered list of children (tests and nested suites) so
         // execution follows definition order, the way mocha/jest run them.
         children: [],
@@ -1193,19 +1197,24 @@
     var passed = 0,
       failed = 0;
 
-    function describe(name, fn) {
-      var suite = makeSuite(name, currentSuite);
+    function addSuite(name, fn, skipped) {
+      var suite = makeSuite(name, currentSuite, skipped);
       currentSuite.children.push({ kind: "suite", suite: suite });
       var prev = currentSuite;
       currentSuite = suite;
       if (typeof fn === "function") fn.call(suite);
       currentSuite = prev;
+      return suite;
+    }
+
+    function describe(name, fn) {
+      return addSuite(name, fn, false);
     }
 
     function it(name, fn) {
       currentSuite.children.push({
         kind: "test",
-        test: { name: name, fn: fn, suite: currentSuite },
+        test: { name: name, fn: fn, suite: currentSuite, skip: currentSuite.skipped },
       });
     }
 
@@ -1374,6 +1383,19 @@
 
     async function runSuite(suite) {
       var ctx = {};
+      // A skipped suite (xdescribe) still registers and reports every nested
+      // test, but none of its hooks or test bodies run.
+      if (suite.skipped) {
+        for (var s = 0; s < suite.children.length; s++) {
+          var skippedChild = suite.children[s];
+          if (skippedChild.kind === "test") {
+            await runOneTest(skippedChild.test);
+          } else {
+            await runSuite(skippedChild.suite);
+          }
+        }
+        return;
+      }
       // Suite-level before/after hooks are contained the same way per-test hooks
       // are in runOneTest: a failing hook (thrown, done(error), or timed out) is
       // recorded as a single `not ok` and the run continues, rather than the
@@ -1448,8 +1470,8 @@
       describe: describe,
       it: it,
       xit: xit,
-      xdescribe: function (name) {
-        describe(name, function () {});
+      xdescribe: function (name, fn) {
+        return addSuite(name, fn, true);
       },
       before: hookRegister("before"),
       after: hookRegister("after"),


### PR DESCRIPTION
## What

`xdescribe` in `scripts/node-test-harness.js` dropped its callback and registered an empty suite (`describe(name, function () {})`), so any nested tests never registered and vanished from the TAP total. Mocha treats `xdescribe` as an alias for `describe.skip`: the callback still runs so nested tests register as pending/skipped and are counted in the total. With the old behaviour a suite like `xdescribe('s', () => it('child', ...))` reported `TOTAL: 0` on jsse while Node/Mocha reports the pending child.

## Fix

- Add suite-level skip propagation: `makeSuite` gains a `skipped` flag that children inherit, and `runSuite` reports a skipped suite's nested tests as `# SKIP` without running its hooks or bodies.
- Route `xdescribe` through a new `addSuite` helper (`describe → addSuite(name, fn, false)`, `xdescribe → addSuite(name, fn, true)`) so nested `describe`/`it` blocks inside an `xdescribe` are skipped too. The no-callback `xdescribe(name)` form stays a no-op (the `typeof fn === "function"` guard in `addSuite`).

## Tests

Added `xdescribe` coverage to the TAP self-test fixture (`scripts/harness-fixtures/tap.fixture.js`) — a throwing `before` hook that must not run, plus a nested `describe` — taking the fixture to `PASS: 9  FAIL: 2  TOTAL: 11`. `./scripts/run-harness-selftest.sh` is green with the fix and fails on the old undercounting behaviour.

JS-only change (no engine source) → test262 unaffected.

## Note

This is the standalone version of the same fix carried by #280 (the AJV harness PR, which surfaced the bug). Landing it here fixes the harness on `main` directly so future branches don't reintroduce the buggy form.
