### PR TITLE
fix: reject repeated done callbacks in TAP harness

### DIFF
--- a/scripts/harness-fixtures/tap-interval-repeated-done.fixture.js
+++ b/scripts/harness-fixtures/tap-interval-repeated-done.fixture.js
@@ -1,0 +1,14 @@
+// Self-test for a repeated completion callback scheduled by setInterval in the
+// describe/it TAP runner in node-test-harness.js. The interval clears itself on
+// its first tick; final TAP emission must wait for that tick and reject the late
+// duplicate without treating the interval as indefinitely pending work.
+//
+// Expected summary: PASS: 0  FAIL: 1  TOTAL: 1
+
+it("fails when a final interval repeats done", function (done) {
+  done();
+  var id = setInterval(function () {
+    clearInterval(id);
+    done();
+  }, 5);
+});

--- a/scripts/harness-fixtures/tap-repeated-done.fixture.js
+++ b/scripts/harness-fixtures/tap-repeated-done.fixture.js
@@ -6,7 +6,7 @@
 // the first call succeeded. The following test proves the duplicate failure is
 // contained and does not stop the rest of the suite.
 //
-// Expected summary: PASS: 1  FAIL: 2  TOTAL: 3
+// Expected summary: PASS: 2  FAIL: 3  TOTAL: 5
 
 describe("repeated done callbacks", function () {
   it("fails when done is called twice", function (done) {
@@ -17,6 +17,16 @@ describe("repeated done callbacks", function () {
   it("fails when the second done carries an error", function (done) {
     done();
     done(new Error("second completion must not be ignored"));
+  });
+
+  it("fails when done is repeated after settlement", function (done) {
+    done();
+    setTimeout(done, 5);
+  });
+
+  // Keep the suite active long enough for the preceding test's late callback.
+  it("waits while the late duplicate fires", function (done) {
+    setTimeout(done, 20);
   });
 
   it("continues with later tests", function () {});

--- a/scripts/harness-fixtures/tap-repeated-done.fixture.js
+++ b/scripts/harness-fixtures/tap-repeated-done.fixture.js
@@ -1,0 +1,23 @@
+// Self-test for repeated completion callbacks in the describe/it TAP runner in
+// node-test-harness.js. Validated on jsse alone (the harness is inert on Node);
+// run-harness-selftest.sh asserts the exact summary line.
+//
+// A callback-style test that invokes done() more than once must fail even when
+// the first call succeeded. The following test proves the duplicate failure is
+// contained and does not stop the rest of the suite.
+//
+// Expected summary: PASS: 1  FAIL: 2  TOTAL: 3
+
+describe("repeated done callbacks", function () {
+  it("fails when done is called twice", function (done) {
+    done();
+    done();
+  });
+
+  it("fails when the second done carries an error", function (done) {
+    done();
+    done(new Error("second completion must not be ignored"));
+  });
+
+  it("continues with later tests", function () {});
+});

--- a/scripts/harness-fixtures/tap-repeated-done.fixture.js
+++ b/scripts/harness-fixtures/tap-repeated-done.fixture.js
@@ -21,16 +21,21 @@ describe("repeated done callbacks", function () {
 
   it("continues with later tests", function () {});
 
-  // Keep this test last: final TAP emission must wait for its owned timer.
-  it("fails when a final nested timer repeats done", function (done) {
+  // Keep this test last: final TAP emission must wait for a timer created after
+  // the synchronous runnable has returned and its promise continuation runs.
+  it("fails when a final promise continuation repeats done", function (done) {
     done();
-    setTimeout(function () {
+    Promise.resolve().then(function () {
       setTimeout(done, 5);
-    }, 0);
+    });
   });
 
   after(function (done) {
     done();
-    setTimeout(done, 5);
+    setTimeout(function () {
+      Promise.resolve().then(function () {
+        setTimeout(done, 5);
+      });
+    }, 0);
   });
 });

--- a/scripts/harness-fixtures/tap-repeated-done.fixture.js
+++ b/scripts/harness-fixtures/tap-repeated-done.fixture.js
@@ -6,7 +6,7 @@
 // the first call succeeded. The following test proves the duplicate failure is
 // contained and does not stop the rest of the suite.
 //
-// Expected summary: PASS: 2  FAIL: 3  TOTAL: 5
+// Expected summary: PASS: 1  FAIL: 4  TOTAL: 5
 
 describe("repeated done callbacks", function () {
   it("fails when done is called twice", function (done) {
@@ -19,15 +19,18 @@ describe("repeated done callbacks", function () {
     done(new Error("second completion must not be ignored"));
   });
 
-  it("fails when done is repeated after settlement", function (done) {
+  it("continues with later tests", function () {});
+
+  // Keep this test last: final TAP emission must wait for its owned timer.
+  it("fails when a final nested timer repeats done", function (done) {
+    done();
+    setTimeout(function () {
+      setTimeout(done, 5);
+    }, 0);
+  });
+
+  after(function (done) {
     done();
     setTimeout(done, 5);
   });
-
-  // Keep the suite active long enough for the preceding test's late callback.
-  it("waits while the late duplicate fires", function (done) {
-    setTimeout(done, 20);
-  });
-
-  it("continues with later tests", function () {});
 });

--- a/scripts/harness-fixtures/tap-suite-hook-failure.fixture.js
+++ b/scripts/harness-fixtures/tap-suite-hook-failure.fixture.js
@@ -11,9 +11,10 @@
 //
 // Covers: a done(error) `before all` (children skipped, siblings still run), a
 // synchronously-throwing `before all` (non-callback path also contained), and a
-// done(error) `after all` (its tests still count, the hook adds one failure). A
-// timed-out hook rejects through the identical path, so it is not re-exercised
-// here (it would cost ASYNC_TIMEOUT_MS of wall-clock).
+// done(error) `after all` whose late second done must reuse the original hook
+// result. Its tests still count, and the hook adds exactly one failure. A hook
+// timeout rejects through the identical path, so it is not re-exercised here
+// (it would cost ASYNC_TIMEOUT_MS of wall-clock).
 //
 // Expected summary: PASS: 2  FAIL: 3  TOTAL: 5
 
@@ -57,6 +58,7 @@ describe("suite-with-failing-after", function () {
   after(function (done) {
     setTimeout(function () {
       done(new Error("deliberate after-all failure"));
+      setTimeout(done, 5);
     }, 0);
   });
 

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -73,6 +73,10 @@
   // those runner timers MUST be cleared once they are no longer needed.
   var queueAdd = null; // (fn, ms, args, interval) -> id
   var queueRemove = null; // (id) -> void
+  var activeTimerOwner = null;
+  var waitForOwnedTimers = function () {
+    return Promise.resolve();
+  };
   var MAX_PUMP_DELAY_MS = 100;
   if (nativeSetTimeout) {
     var timerQueue = [];
@@ -122,12 +126,15 @@
         var idx = timerQueue.indexOf(t);
         if (idx !== -1) timerQueue.splice(idx, 1);
         firingTimer = t;
+        var previousTimerOwner = activeTimerOwner;
+        activeTimerOwner = t.owner;
         try {
           t.fn.apply(undefined, t.args);
         } catch (e) {
           // A host setTimeout callback that throws would crash the process; for
           // a test runner, keep pumping so one bad callback can't wedge the run.
         }
+        activeTimerOwner = previousTimerOwner;
         firingTimer = null;
         // Re-arm intervals unless the callback cleared this very timer. While it
         // was firing it was out of the queue, so removeTimer couldn't splice it —
@@ -140,7 +147,7 @@
       schedulePump();
     }
 
-    function addTimer(fn, ms, extraArgs, interval) {
+    function addTimer(fn, ms, extraArgs, interval, owner) {
       if (typeof fn !== "function") return 0;
       var id = timerIdCounter++;
       var delay = typeof ms === "number" && ms > 0 ? ms : 0;
@@ -150,6 +157,7 @@
         fn: fn,
         args: extraArgs,
         interval: interval,
+        owner: owner,
         cancelled: false,
       });
       schedulePump();
@@ -174,17 +182,62 @@
       }
     }
 
-    queueAdd = addTimer;
+    queueAdd = function (fn, ms, extraArgs, interval) {
+      return addTimer(fn, ms, extraArgs, interval, null);
+    };
     queueRemove = removeTimer;
     g.setTimeout = function (fn, ms) {
-      return addTimer(fn, ms, Array.prototype.slice.call(arguments, 2), null);
+      return addTimer(
+        fn,
+        ms,
+        Array.prototype.slice.call(arguments, 2),
+        null,
+        activeTimerOwner
+      );
     };
     g.setInterval = function (fn, ms) {
       var iv = typeof ms === "number" && ms > 0 ? ms : 0;
-      return addTimer(fn, ms, Array.prototype.slice.call(arguments, 2), iv);
+      return addTimer(
+        fn,
+        ms,
+        Array.prototype.slice.call(arguments, 2),
+        iv,
+        activeTimerOwner
+      );
     };
     g.clearTimeout = removeTimer;
     g.clearInterval = removeTimer;
+
+    // Wait for one-shot timers spawned by completed callback-style TAP
+    // runnables. This lets a final test or hook's duplicate done() fire before
+    // TAP output is frozen, without waiting on unrelated timers or intervals.
+    waitForOwnedTimers = function (timeoutMs) {
+      var deadline = Date.now() + timeoutMs;
+      return new Promise(function (resolve) {
+        function poll() {
+          var now = Date.now();
+          var next = Infinity;
+          for (var i = 0; i < timerQueue.length; i++) {
+            var timer = timerQueue[i];
+            if (
+              !timer.cancelled &&
+              timer.interval == null &&
+              timer.owner &&
+              timer.owner.waitForTimers &&
+              timer.fireAt < next
+            ) {
+              next = timer.fireAt;
+            }
+          }
+          if (next === Infinity || now >= deadline) {
+            resolve();
+            return;
+          }
+          queueAdd(poll, Math.min(next, deadline) - now, [], null);
+        }
+        poll();
+      });
+    };
   }
 
   // Runner-internal scheduling, backed by the queue's own add/remove (never the
@@ -1331,10 +1384,12 @@
         var settled = false;
         var doneCalled = false;
         var duplicateReported = false;
+        var timerOwner = { waitForTimers: true };
         var settleId = null;
         var guardId = schedule(function () {
           if (settled || doneCalled) return;
           settled = true;
+          timerOwner.waitForTimers = false;
           reject(
             new Error(
               "done callback timed out after " + ASYNC_TIMEOUT_MS + "ms"
@@ -1345,6 +1400,7 @@
           if (doneCalled) {
             if (duplicateReported) return;
             duplicateReported = true;
+            timerOwner.waitForTimers = false;
             var duplicateError = new Error("done() called multiple times");
             if (settled) {
               if (onLateError) onLateError(duplicateError);
@@ -1367,10 +1423,14 @@
             else resolve();
           }, 0);
         }
+        var previousTimerOwner = activeTimerOwner;
+        activeTimerOwner = timerOwner;
         try {
           fn.call(ctx, done);
         } catch (e) {
           done(e);
+        } finally {
+          activeTimerOwner = previousTimerOwner;
         }
       });
     }
@@ -1527,6 +1587,7 @@
     async function runAll() {
       console.log("TAP version 13");
       await runSuite(rootSuite);
+      await waitForOwnedTimers(ASYNC_TIMEOUT_MS);
       emitResults();
       console.log("1.." + counter);
       console.log("# tests " + counter);

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -73,8 +73,7 @@
   // those runner timers MUST be cleared once they are no longer needed.
   var queueAdd = null; // (fn, ms, args, interval) -> id
   var queueRemove = null; // (id) -> void
-  var activeTimerOwner = null;
-  var waitForOwnedTimers = function () {
+  var waitForUserTimers = function () {
     return Promise.resolve();
   };
   var MAX_PUMP_DELAY_MS = 100;
@@ -126,15 +125,12 @@
         var idx = timerQueue.indexOf(t);
         if (idx !== -1) timerQueue.splice(idx, 1);
         firingTimer = t;
-        var previousTimerOwner = activeTimerOwner;
-        activeTimerOwner = t.owner;
         try {
           t.fn.apply(undefined, t.args);
         } catch (e) {
           // A host setTimeout callback that throws would crash the process; for
           // a test runner, keep pumping so one bad callback can't wedge the run.
         }
-        activeTimerOwner = previousTimerOwner;
         firingTimer = null;
         // Re-arm intervals unless the callback cleared this very timer. While it
         // was firing it was out of the queue, so removeTimer couldn't splice it —
@@ -147,7 +143,7 @@
       schedulePump();
     }
 
-    function addTimer(fn, ms, extraArgs, interval, owner) {
+    function addTimer(fn, ms, extraArgs, interval, internal) {
       if (typeof fn !== "function") return 0;
       var id = timerIdCounter++;
       var delay = typeof ms === "number" && ms > 0 ? ms : 0;
@@ -157,7 +153,7 @@
         fn: fn,
         args: extraArgs,
         interval: interval,
-        owner: owner,
+        internal: internal,
         cancelled: false,
       });
       schedulePump();
@@ -183,7 +179,7 @@
     }
 
     queueAdd = function (fn, ms, extraArgs, interval) {
-      return addTimer(fn, ms, extraArgs, interval, null);
+      return addTimer(fn, ms, extraArgs, interval, true);
     };
     queueRemove = removeTimer;
     g.setTimeout = function (fn, ms) {
@@ -192,7 +188,7 @@
         ms,
         Array.prototype.slice.call(arguments, 2),
         null,
-        activeTimerOwner
+        false
       );
     };
     g.setInterval = function (fn, ms) {
@@ -202,18 +198,21 @@
         ms,
         Array.prototype.slice.call(arguments, 2),
         iv,
-        activeTimerOwner
+        false
       );
     };
     g.clearTimeout = removeTimer;
     g.clearInterval = removeTimer;
 
-    // Wait for one-shot timers spawned by completed callback-style TAP
-    // runnables. This lets a final test or hook's duplicate done() fire before
-    // TAP output is frozen, without waiting on unrelated timers or intervals.
-    waitForOwnedTimers = function (timeoutMs) {
+    // Give user one-shot timers a bounded chance to expose a late duplicate
+    // done() before TAP output is frozen. A quiet turn lets promise continuations
+    // from the last timer enqueue follow-up work. Intervals and runner-internal
+    // timers are excluded; an unrelated user timeout can delay output only until
+    // it fires or this existing async timeout expires.
+    waitForUserTimers = function (timeoutMs) {
       var deadline = Date.now() + timeoutMs;
       return new Promise(function (resolve) {
+        var quietTurn = false;
         function poll() {
           var now = Date.now();
           var next = Infinity;
@@ -222,17 +221,26 @@
             if (
               !timer.cancelled &&
               timer.interval == null &&
-              timer.owner &&
-              timer.owner.waitForTimers &&
+              !timer.internal &&
               timer.fireAt < next
             ) {
               next = timer.fireAt;
             }
           }
-          if (next === Infinity || now >= deadline) {
+          if (now >= deadline) {
             resolve();
             return;
           }
+          if (next === Infinity) {
+            if (quietTurn) {
+              resolve();
+              return;
+            }
+            quietTurn = true;
+            queueAdd(poll, 0, [], null);
+            return;
+          }
+          quietTurn = false;
           queueAdd(poll, Math.min(next, deadline) - now, [], null);
         }
         poll();
@@ -1384,12 +1392,10 @@
         var settled = false;
         var doneCalled = false;
         var duplicateReported = false;
-        var timerOwner = { waitForTimers: true };
         var settleId = null;
         var guardId = schedule(function () {
           if (settled || doneCalled) return;
           settled = true;
-          timerOwner.waitForTimers = false;
           reject(
             new Error(
               "done callback timed out after " + ASYNC_TIMEOUT_MS + "ms"
@@ -1400,7 +1406,6 @@
           if (doneCalled) {
             if (duplicateReported) return;
             duplicateReported = true;
-            timerOwner.waitForTimers = false;
             var duplicateError = new Error("done() called multiple times");
             if (settled) {
               if (onLateError) onLateError(duplicateError);
@@ -1423,14 +1428,10 @@
             else resolve();
           }, 0);
         }
-        var previousTimerOwner = activeTimerOwner;
-        activeTimerOwner = timerOwner;
         try {
           fn.call(ctx, done);
         } catch (e) {
           done(e);
-        } finally {
-          activeTimerOwner = previousTimerOwner;
         }
       });
     }
@@ -1587,7 +1588,7 @@
     async function runAll() {
       console.log("TAP version 13");
       await runSuite(rootSuite);
-      await waitForOwnedTimers(ASYNC_TIMEOUT_MS);
+      await waitForUserTimers(ASYNC_TIMEOUT_MS);
       emitResults();
       console.log("1.." + counter);
       console.log("# tests " + counter);

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -1198,6 +1198,7 @@
     var currentSuite = rootSuite;
     var started = false;
     var counter = 0;
+    var results = [];
     var passed = 0,
       failed = 0;
 
@@ -1324,11 +1325,12 @@
       return out;
     }
 
-    function invokeRunnable(fn, ctx) {
+    function invokeRunnable(fn, ctx, onLateError) {
       if (fn.length === 0) return Promise.resolve(fn.call(ctx));
       return new Promise(function (resolve, reject) {
         var settled = false;
         var doneCalled = false;
+        var duplicateReported = false;
         var settleId = null;
         var guardId = schedule(function () {
           if (settled || doneCalled) return;
@@ -1340,13 +1342,20 @@
           );
         }, ASYNC_TIMEOUT_MS);
         function done(error) {
-          if (settled) return;
           if (doneCalled) {
-            settled = true;
-            unschedule(settleId);
-            reject(new Error("done() called multiple times"));
+            if (duplicateReported) return;
+            duplicateReported = true;
+            var duplicateError = new Error("done() called multiple times");
+            if (settled) {
+              if (onLateError) onLateError(duplicateError);
+            } else {
+              settled = true;
+              unschedule(settleId);
+              reject(duplicateError);
+            }
             return;
           }
+          if (settled) return;
           doneCalled = true;
           unschedule(guardId);
           // Settle on the next runner tick so a synchronous second completion
@@ -1366,61 +1375,99 @@
       });
     }
 
-    async function runHooks(hooks, ctx) {
+    async function runHooks(hooks, ctx, onLateError) {
       for (var i = 0; i < hooks.length; i++) {
-        await invokeRunnable(hooks[i], ctx);
+        await invokeRunnable(hooks[i], ctx, onLateError);
       }
     }
 
-    // Emit a TAP `not ok` for the current counter value plus its YAML diagnostic
-    // block, and bump the failure count. Shared by failing tests and failing
-    // suite-level hooks so both report identically.
-    function reportFailure(name, errText) {
-      console.log("not ok " + counter + " - " + name);
-      console.log("  ---");
-      var lines = String(errText).split("\n");
-      for (var i = 0; i < lines.length; i++) {
-        console.log("  " + lines[i]);
+    // Buffer results until suite execution finishes so a duplicate done()
+    // callback from an earlier runnable can still turn its pass into a failure.
+    function recordResult(name, skipped) {
+      var result = {
+        number: ++counter,
+        name: name,
+        skipped: !!skipped,
+        ok: true,
+        errText: "",
+      };
+      results.push(result);
+      return result;
+    }
+
+    function failResult(result, err) {
+      if (!result.ok) return;
+      result.ok = false;
+      result.errText = err && err.stack ? err.stack : String(err);
+    }
+
+    function recordFailure(name, err) {
+      var result = recordResult(name, false);
+      failResult(result, err);
+    }
+
+    function emitResults() {
+      for (var i = 0; i < results.length; i++) {
+        var result = results[i];
+        if (result.ok) {
+          console.log(
+            "ok " +
+              result.number +
+              " - " +
+              result.name +
+              (result.skipped ? " # SKIP" : "")
+          );
+          passed++;
+          continue;
+        }
+        console.log("not ok " + result.number + " - " + result.name);
+        console.log("  ---");
+        var lines = result.errText.split("\n");
+        for (var j = 0; j < lines.length; j++) {
+          console.log("  " + lines[j]);
+        }
+        console.log("  ...");
+        failed++;
       }
-      console.log("  ...");
-      failed++;
     }
 
     async function runOneTest(t) {
-      counter++;
       var name = fullName(t.suite, t.name);
+      var result = recordResult(name, t.skip);
       if (t.skip) {
-        console.log("ok " + counter + " - " + name + " # SKIP");
-        passed++;
         return;
       }
+      function recordLateFailure(error) {
+        failResult(result, error);
+      }
       var testCtx = {};
-      var ok = true,
-        errText = "";
       try {
-        await runHooks(eachHook(t.suite, "beforeEach"), testCtx);
-        await invokeRunnable(t.fn, testCtx);
+        await runHooks(
+          eachHook(t.suite, "beforeEach"),
+          testCtx,
+          recordLateFailure
+        );
+        await invokeRunnable(t.fn, testCtx, recordLateFailure);
       } catch (e) {
-        ok = false;
-        errText = e && e.stack ? e.stack : String(e);
+        failResult(result, e);
       }
       // afterEach must run even when beforeEach or the test body threw (mocha/
       // jest do this) so suites that reset globals/timers/shared state there
       // don't leak dirty state into later tests. A throw here fails the test if
       // it was otherwise passing.
       try {
-        await runHooks(eachHook(t.suite, "afterEach"), testCtx);
+        await runHooks(
+          eachHook(t.suite, "afterEach"),
+          testCtx,
+          recordLateFailure
+        );
       } catch (e) {
-        if (ok) {
-          ok = false;
-          errText = "afterEach hook: " + (e && e.stack ? e.stack : String(e));
+        if (result.ok) {
+          failResult(
+            result,
+            "afterEach hook: " + (e && e.stack ? e.stack : String(e))
+          );
         }
-      }
-      if (ok) {
-        console.log("ok " + counter + " - " + name);
-        passed++;
-      } else {
-        reportFailure(name, errText);
       }
     }
 
@@ -1447,15 +1494,14 @@
       // suite's children (their fixture state is unreliable) but lets sibling
       // suites still run; `after all` runs regardless, for cleanup.
       var beforeFailed = false;
+      var beforeName = fullName(suite, '"before all" hook');
       try {
-        await runHooks(suite.before, ctx);
+        await runHooks(suite.before, ctx, function (error) {
+          recordFailure(beforeName, error);
+        });
       } catch (e) {
-        counter++;
         beforeFailed = true;
-        reportFailure(
-          fullName(suite, '"before all" hook'),
-          e && e.stack ? e.stack : String(e)
-        );
+        recordFailure(beforeName, e);
       }
       if (!beforeFailed) {
         // Children run in definition order (tests interleaved with nested suites).
@@ -1468,20 +1514,20 @@
           }
         }
       }
+      var afterName = fullName(suite, '"after all" hook');
       try {
-        await runHooks(suite.after, ctx);
+        await runHooks(suite.after, ctx, function (error) {
+          recordFailure(afterName, error);
+        });
       } catch (e) {
-        counter++;
-        reportFailure(
-          fullName(suite, '"after all" hook'),
-          e && e.stack ? e.stack : String(e)
-        );
+        recordFailure(afterName, e);
       }
     }
 
     async function runAll() {
       console.log("TAP version 13");
       await runSuite(rootSuite);
+      emitResults();
       console.log("1.." + counter);
       console.log("# tests " + counter);
       console.log("# pass " + passed);

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -1328,8 +1328,10 @@
       if (fn.length === 0) return Promise.resolve(fn.call(ctx));
       return new Promise(function (resolve, reject) {
         var settled = false;
+        var doneCalled = false;
+        var settleId = null;
         var guardId = schedule(function () {
-          if (settled) return;
+          if (settled || doneCalled) return;
           settled = true;
           reject(
             new Error(
@@ -1339,10 +1341,22 @@
         }, ASYNC_TIMEOUT_MS);
         function done(error) {
           if (settled) return;
-          settled = true;
+          if (doneCalled) {
+            settled = true;
+            unschedule(settleId);
+            reject(new Error("done() called multiple times"));
+            return;
+          }
+          doneCalled = true;
           unschedule(guardId);
-          if (error) reject(error);
-          else resolve();
+          // Settle on the next runner tick so a synchronous second completion
+          // can replace the first result with a duplicate-done failure.
+          settleId = schedule(function () {
+            if (settled) return;
+            settled = true;
+            if (error) reject(error);
+            else resolve();
+          }, 0);
         }
         try {
           fn.call(ctx, done);

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -126,6 +126,7 @@
         if (idx !== -1) timerQueue.splice(idx, 1);
         firingTimer = t;
         try {
+          t.fires++;
           t.fn.apply(undefined, t.args);
         } catch (e) {
           // A host setTimeout callback that throws would crash the process; for
@@ -154,6 +155,7 @@
         args: extraArgs,
         interval: interval,
         internal: internal,
+        fires: 0,
         cancelled: false,
       });
       schedulePump();
@@ -204,14 +206,17 @@
     g.clearTimeout = removeTimer;
     g.clearInterval = removeTimer;
 
-    // Give user one-shot timers a bounded chance to expose a late duplicate
-    // done() before TAP output is frozen. A quiet turn lets promise continuations
-    // from the last timer enqueue follow-up work. Intervals and runner-internal
-    // timers are excluded; an unrelated user timeout can delay output only until
-    // it fires or this existing async timeout expires.
+    // Give user timers a bounded chance to expose a late duplicate done() before
+    // TAP output is frozen. One-shot timers drain normally; each user interval
+    // waits for at most its next tick, so a persistent interval cannot block
+    // output for its whole lifetime. A quiet turn lets promise continuations
+    // from the last timer enqueue follow-up work. Runner-internal timers are
+    // excluded; unrelated user work can delay output only until its next event
+    // or this existing async timeout expires.
     waitForUserTimers = function (timeoutMs) {
       var deadline = Date.now() + timeoutMs;
       return new Promise(function (resolve) {
+        var intervalTargets = [];
         var quietTurn = false;
         function poll() {
           var now = Date.now();
@@ -219,9 +224,16 @@
           for (var i = 0; i < timerQueue.length; i++) {
             var timer = timerQueue[i];
             if (
+              timer.interval != null &&
+              intervalTargets[timer.id] === undefined
+            ) {
+              intervalTargets[timer.id] = timer.fires + 1;
+            }
+            if (
               !timer.cancelled &&
-              timer.interval == null &&
               !timer.internal &&
+              (timer.interval == null ||
+                timer.fires < intervalTargets[timer.id]) &&
               timer.fireAt < next
             ) {
               next = timer.fireAt;
@@ -1465,6 +1477,27 @@
     function recordFailure(name, err) {
       var result = recordResult(name, false);
       failResult(result, err);
+      return result;
+    }
+
+    function makeHookFailureRecorder(name) {
+      var result = null;
+      return function (error) {
+        if (result === null) result = recordFailure(name, error);
+      };
+    }
+
+    async function runSuiteHooks(hooks, ctx, name) {
+      for (var i = 0; i < hooks.length; i++) {
+        var recordHookFailure = makeHookFailureRecorder(name);
+        try {
+          await invokeRunnable(hooks[i], ctx, recordHookFailure);
+        } catch (e) {
+          recordHookFailure(e);
+          return false;
+        }
+      }
+      return true;
     }
 
     function emitResults() {
@@ -1554,16 +1587,8 @@
       // count to PASS: 0  FAIL: 1  TOTAL: 1. A failed `before all` skips this
       // suite's children (their fixture state is unreliable) but lets sibling
       // suites still run; `after all` runs regardless, for cleanup.
-      var beforeFailed = false;
       var beforeName = fullName(suite, '"before all" hook');
-      try {
-        await runHooks(suite.before, ctx, function (error) {
-          recordFailure(beforeName, error);
-        });
-      } catch (e) {
-        beforeFailed = true;
-        recordFailure(beforeName, e);
-      }
+      var beforeFailed = !(await runSuiteHooks(suite.before, ctx, beforeName));
       if (!beforeFailed) {
         // Children run in definition order (tests interleaved with nested suites).
         for (var i = 0; i < suite.children.length; i++) {
@@ -1576,13 +1601,7 @@
         }
       }
       var afterName = fullName(suite, '"after all" hook');
-      try {
-        await runHooks(suite.after, ctx, function (error) {
-          recordFailure(afterName, error);
-        });
-      } catch (e) {
-        recordFailure(afterName, e);
-      }
+      await runSuiteHooks(suite.after, ctx, afterName);
     }
 
     async function runAll() {


### PR DESCRIPTION
Summary:
- reject synchronous and post-settlement repeated done() calls in callback-style TAP tests and hooks
- buffer TAP rows so late duplicates update the original result without duplicate TAP IDs
- drain user one-shot timers and wait for at most the next tick of each user interval before freezing TAP output
- require one quiet macrotask turn so promise continuations can enqueue follow-up timers
- give each suite hook an idempotent failure recorder shared by its rejection and late-duplicate paths
- cover synchronous, promise/timer, interval, and suite-hook repeated completion regressions

Validation:
- node --check scripts/node-test-harness.js
- ./scripts/run-harness-selftest.sh --no-build
- forced-Node interval and suite-hook fixtures
- cargo fmt --check
- cargo clippy
- ./scripts/lint.sh
- cargo build --release
- cargo test --release (294 unit tests plus smoke oracle)
- uv run python scripts/run-custom-tests.py (7/7)
- ./scripts/run-library-tests.sh js-sha256 (916/916 on jsse and Node)
- full test262: 99,546/99,568; same 22 environment-sensitive Intl baseline mismatches and 323 existing new passes. This branch has no engine/Cargo diff, so README and the baseline remain unchanged.

Closes #272