### PR TITLE
fix: honor Mocha only exclusivity in test harness

### DIFF
--- a/docs/specs/2026-07-17-node-test-harness-only-design.md
+++ b/docs/specs/2026-07-17-node-test-harness-only-design.md
@@ -1,0 +1,62 @@
+# Node test harness `.only` design
+
+## Scope
+
+Make the TAP `describe`/`it` frontend in `scripts/node-test-harness.js` match
+Mocha's exclusive-test selection for `describe.only()` and `it.only()`. The
+QUnit adapter, engine globals, and ECMAScript implementation are unchanged.
+
+ECMA-262 defines the language but leaves environment-specific objects and
+functions outside its scope. `describe` and `it` are test-runner globals, so
+Mocha's documented behavior and implementation are the semantic reference;
+test262 has no applicable conformance tests for this host-side helper.
+
+## Selection model
+
+Each suite records the tests and immediate child suites registered through an
+`.only` function. Registration still stores every child in the existing ordered
+`children` list, because a later `.only` must be able to exclude earlier
+siblings without changing definition-time behavior.
+
+Immediately before execution, the root is checked recursively for exclusive
+entries. If none exist, the tree is left untouched. Otherwise, filter each
+suite using Mocha's precedence rules:
+
+1. If a suite has direct exclusive tests, retain only those tests and discard
+   all of that suite's child suites.
+2. Otherwise, discard that suite's direct tests. Retain direct exclusive child
+   suites, filtering them further only when they contain nested exclusive
+   entries. Also retain ordinary child suites whose descendants contain an
+   exclusive entry, after filtering those descendants.
+3. Preserve the retained entries' original definition order.
+
+An exclusive suite with no nested exclusives therefore runs all descendants.
+An `it.only` inside that suite narrows it to exclusive tests. Multiple exclusive
+entries at the same applicable level form a subset, matching Mocha 3 and newer.
+
+## Skip and hook behavior
+
+Focus determines which tree entries participate in the run; `skip` remains an
+orthogonal state on retained entries. A focused test beneath `describe.skip`
+is reported as skipped, and its body and hooks do not run. Skipped, unfocused
+siblings disappear with other unfocused entries.
+
+Hooks run only on retained suite paths. Existing ancestor hook ordering and
+suite-hook failure containment are unchanged.
+
+## Validation
+
+Add a dedicated TAP harness fixture covering:
+
+- ordinary siblings excluded by focused tests and suites;
+- multiple `it.only` tests;
+- all descendants of `describe.only`;
+- nested focus narrowing an exclusive suite;
+- direct exclusive tests taking precedence over child suites;
+- focus within a skipped suite; and
+- hooks on selected and unselected paths.
+
+The fixture must fail under the current aliases and produce a deterministic
+summary after the filter is implemented. Run the harness self-test plus the
+repository quality gates. Because this patch changes only a prepended library
+test shim, the test262 pass count and README baseline should not change.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -153,7 +153,9 @@ shared core (which includes QUnit's own `equiv`, ported verbatim, for
 
 It also aliases Node's `global` to `globalThis`, which many bundles rely on for
 their root-object detection. The TAP frontend supports Jest's array-table
-`test.each` form in addition to the basic globals.
+`test.each` form in addition to the basic globals. Mocha-style `describe.only`
+and `it.only` filter the registered suite tree globally, including nested
+focus, direct-test precedence, and focused skipped tests.
 
 Layer it into a library by setting `LIB_SHIM="node-test-harness.js"` (it is
 prepended after `node-shim.js` and `node-buffer-shim.js`). Like the other shims

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -155,7 +155,8 @@ It also aliases Node's `global` to `globalThis`, which many bundles rely on for
 their root-object detection. The TAP frontend supports Jest's array-table
 `test.each` form in addition to the basic globals. Mocha-style `describe.only`
 and `it.only` filter the registered suite tree globally, including nested
-focus, direct-test precedence, and focused skipped tests.
+focus, direct-test precedence, and focused skipped tests; the exclusive table
+form `test.only.each` registers each generated row as a focused test.
 
 Layer it into a library by setting `LIB_SHIM="node-test-harness.js"` (it is
 prepended after `node-shim.js` and `node-buffer-shim.js`). Like the other shims

--- a/scripts/harness-fixtures/tap-only-each.fixture.js
+++ b/scripts/harness-fixtures/tap-only-each.fixture.js
@@ -1,0 +1,28 @@
+// Self-test for the exclusive table form test.only.each(table)(name, fn).
+//
+// The reported regression: replacing the old `it.only = it` alias with a bare
+// function dropped the `.each` helper, so test.only.each(...) threw
+// `TypeError: test.only.each is not a function` at registration. This fixture
+// guards the *semantics*, not just absence-of-throw: each row must register as
+// a FOCUSED test, so the ordinary siblings are dropped and only the two rows
+// run. A naive fix that restored `.each` but registered rows as ordinary tests
+// would leave the siblings in place — they would run, throw, and this fixture
+// would fail with FAIL: 2.
+//
+// Expected summary: PASS: 2  FAIL: 0  TOTAL: 2
+
+describe("test.only.each exclusivity", function () {
+  test("ordinary sibling before the table is dropped", function () {
+    throw new Error("unfocused sibling ran (before .each)");
+  });
+
+  test.only.each([[1], [2]])("focused row %d runs", function (n) {
+    if (n !== 1 && n !== 2) {
+      throw new Error("unexpected row value: " + n);
+    }
+  });
+
+  test("ordinary sibling after the table is dropped", function () {
+    throw new Error("unfocused sibling ran (after .each)");
+  });
+});

--- a/scripts/harness-fixtures/tap-only-suites.fixture.js
+++ b/scripts/harness-fixtures/tap-only-suites.fixture.js
@@ -1,0 +1,53 @@
+// Self-test for Mocha-compatible describe.only selection in the describe/it
+// TAP runner. A focused suite includes all descendants and preserves skip.
+//
+// Expected summary: PASS: 5  FAIL: 0  TOTAL: 5
+
+describe.only("focused suite", function () {
+  var ready = false;
+
+  before(function () {
+    ready = true;
+  });
+
+  it("runs a direct test", function () {
+    if (!ready) throw new Error("focused suite hook did not run");
+  });
+
+  describe("ordinary nested suite", function () {
+    it("runs a nested test", function () {
+      if (!ready) throw new Error("ancestor hook did not run");
+    });
+  });
+
+  it.skip("retains a skipped test", function () {
+    throw new Error("skipped focused test ran");
+  });
+});
+
+describe.only("focused suite narrowed by nested focus", function () {
+  it("does not run a direct test", function () {
+    throw new Error("outer unfocused test ran");
+  });
+
+  describe("ordinary nested sibling", function () {
+    it("does not run", function () {
+      throw new Error("ordinary nested sibling ran");
+    });
+  });
+
+  describe.only("nested focused suite", function () {
+    it("runs all tests in the nested focus", function () {});
+    it("runs another nested focused test", function () {});
+  });
+});
+
+describe("ordinary sibling suite", function () {
+  before(function () {
+    throw new Error("unfocused suite hook ran");
+  });
+
+  it("does not run", function () {
+    throw new Error("unfocused suite test ran");
+  });
+});

--- a/scripts/harness-fixtures/tap-only-tests.fixture.js
+++ b/scripts/harness-fixtures/tap-only-tests.fixture.js
@@ -1,0 +1,64 @@
+// Self-test for global it.only selection across nested suite branches and a
+// skipped suite. Retained entries stay in definition order.
+//
+// Expected summary: PASS: 4  FAIL: 0  TOTAL: 4
+
+var order = [];
+
+describe("first branch", function () {
+  beforeEach(function () {
+    order.push("first-hook");
+  });
+
+  it("does not run an ordinary sibling", function () {
+    throw new Error("unfocused test ran");
+  });
+
+  it.only("runs the first focused test", function () {
+    order.push("first-test");
+  });
+
+  it.only("runs the second focused test", function () {
+    if (order.join(",") !== "first-hook,first-test,first-hook") {
+      throw new Error("focused tests lost definition order");
+    }
+  });
+});
+
+describe("second branch", function () {
+  describe("nested path", function () {
+    it.only("runs focus in another branch", function () {});
+  });
+
+  describe("ordinary nested sibling", function () {
+    it("does not run", function () {
+      throw new Error("unfocused nested suite ran");
+    });
+  });
+});
+
+describe("skipped branch", function () {
+  describe.skip("skipped focused suite", function () {
+    before(function () {
+      throw new Error("skipped focused hook ran");
+    });
+
+    it.only("reports the focused test as skipped", function () {
+      throw new Error("skipped focused test ran");
+    });
+
+    it("drops an unfocused skipped sibling", function () {
+      throw new Error("unfocused skipped test ran");
+    });
+  });
+});
+
+describe("unfocused branch", function () {
+  before(function () {
+    throw new Error("unfocused branch hook ran");
+  });
+
+  it("does not run", function () {
+    throw new Error("unfocused branch test ran");
+  });
+});

--- a/scripts/harness-fixtures/tap-only.fixture.js
+++ b/scripts/harness-fixtures/tap-only.fixture.js
@@ -1,0 +1,14 @@
+// Self-test for Mocha-compatible exclusive test selection in the describe/it
+// TAP runner. Validated through the harness's emitted summary.
+//
+// Expected summary: PASS: 1  FAIL: 0  TOTAL: 1
+
+it.only("runs the focused test", function () {});
+
+// Direct exclusive tests take precedence over child suites at the same level,
+// even when the child suite is itself marked exclusive.
+describe.only("does not run an exclusive sibling suite", function () {
+  it("does not run", function () {
+    throw new Error("exclusive suite ran despite direct it.only");
+  });
+});

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -1180,6 +1180,8 @@
         // A single ordered list of children (tests and nested suites) so
         // execution follows definition order, the way mocha/jest run them.
         children: [],
+        onlyTests: [],
+        onlySuites: [],
         before: [],
         after: [],
         beforeEach: [],
@@ -1201,13 +1203,14 @@
     var passed = 0,
       failed = 0;
 
-    function addSuite(name, fn, skipped) {
+    function addSuite(name, fn, skipped, exclusive) {
       var suite = makeSuite(
         name,
         currentSuite,
         skipped || currentSuite.skipped
       );
       currentSuite.children.push({ kind: "suite", suite: suite });
+      if (exclusive) currentSuite.onlySuites.push(suite);
       var prev = currentSuite;
       currentSuite = suite;
       if (typeof fn === "function") fn.call(suite);
@@ -1216,10 +1219,10 @@
     }
 
     function describe(name, fn) {
-      return addSuite(name, fn, false);
+      return addSuite(name, fn, false, false);
     }
 
-    function addTest(name, fn, skipped) {
+    function addTest(name, fn, skipped, exclusive) {
       var test = {
         name: name,
         fn: fn,
@@ -1230,6 +1233,7 @@
         kind: "test",
         test: test,
       });
+      if (exclusive) currentSuite.onlyTests.push(test);
       test.timeout = test.slow = test.retries = function () {
         return test;
       };
@@ -1237,7 +1241,7 @@
     }
 
     function it(name, fn) {
-      return addTest(name, fn, false);
+      return addTest(name, fn, false, false);
     }
 
     function formatEachName(template, row, index) {
@@ -1277,18 +1281,57 @@
     };
 
     function xit(name) {
-      return addTest(name, null, true);
+      return addTest(name, null, true, false);
     }
 
     // Mocha's skip helpers still execute suite definition callbacks so nested
     // tests are registered and included in the total, but their bodies/hooks
     // do not run. AJV's JSON-Schema-Test-Suite uses both forms extensively.
     describe.skip = function (name, fn) {
-      return addSuite(name, fn, true);
+      return addSuite(name, fn, true, false);
     };
-    describe.only = describe;
+    describe.only = function (name, fn) {
+      return addSuite(name, fn, false, true);
+    };
     it.skip = xit;
-    it.only = it;
+    it.only = function (name, fn) {
+      return addTest(name, fn, false, true);
+    };
+
+    function hasOnly(suite) {
+      if (suite.onlyTests.length || suite.onlySuites.length) return true;
+      for (var i = 0; i < suite.children.length; i++) {
+        var child = suite.children[i];
+        if (child.kind === "suite" && hasOnly(child.suite)) return true;
+      }
+      return false;
+    }
+
+    function filterOnly(suite) {
+      // Match Mocha's Suite#filterOnly precedence: direct exclusive tests win
+      // over every child suite, including suites that are themselves focused.
+      if (suite.onlyTests.length) {
+        suite.children = suite.children.filter(function (child) {
+          return (
+            child.kind === "test" &&
+            suite.onlyTests.indexOf(child.test) !== -1
+          );
+        });
+        return true;
+      }
+      // With no direct exclusive tests, keep direct exclusive suites in full
+      // unless nested focus narrows them. Ordinary suites survive only when a
+      // focused descendant survives their recursive filter.
+      suite.children = suite.children.filter(function (child) {
+        if (child.kind !== "suite") return false;
+        if (suite.onlySuites.indexOf(child.suite) !== -1) {
+          if (hasOnly(child.suite)) filterOnly(child.suite);
+          return true;
+        }
+        return filterOnly(child.suite);
+      });
+      return suite.children.length > 0;
+    }
 
     function hookRegister(kind) {
       return function (fn) {
@@ -1467,6 +1510,7 @@
 
     async function runAll() {
       console.log("TAP version 13");
+      if (hasOnly(rootSuite)) filterOnly(rootSuite);
       await runSuite(rootSuite);
       console.log("1.." + counter);
       console.log("# tests " + counter);
@@ -1500,7 +1544,7 @@
       it: it,
       xit: xit,
       xdescribe: function (name, fn) {
-        return addSuite(name, fn, true);
+        return addSuite(name, fn, true, false);
       },
       before: hookRegister("before"),
       after: hookRegister("after"),

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -1266,19 +1266,25 @@
 
     // Jest's array-table form: test.each([[a, b], [c, d]])(name, callback).
     // The callback receives each row as positional arguments and every row is
-    // registered as a distinct test, preserving the oracle-visible count.
-    it.each = function (table) {
-      return function (name, fn) {
-        for (var i = 0; i < table.length; i++) {
-          (function (row, index) {
-            var args = Array.isArray(row) ? row : [row];
-            it(formatEachName(name, args, index), function () {
-              return fn.apply(this, args);
-            });
-          })(table[i], i);
-        }
+    // registered as a distinct test, preserving the oracle-visible count. The
+    // per-row registrar is a parameter so it.only.each can register each row as
+    // a *focused* test (mirroring Mocha/Jest's test.only.each) rather than an
+    // ordinary one.
+    function eachRegistrar(register) {
+      return function (table) {
+        return function (name, fn) {
+          for (var i = 0; i < table.length; i++) {
+            (function (row, index) {
+              var args = Array.isArray(row) ? row : [row];
+              register(formatEachName(name, args, index), function () {
+                return fn.apply(this, args);
+              });
+            })(table[i], i);
+          }
+        };
       };
-    };
+    }
+    it.each = eachRegistrar(it);
 
     function xit(name) {
       return addTest(name, null, true, false);
@@ -1297,6 +1303,11 @@
     it.only = function (name, fn) {
       return addTest(name, fn, false, true);
     };
+    // test.only.each(table)(...) must register each row as a *focused* test so
+    // exclusivity applies to the generated rows (global `test` aliases `it`, so
+    // this covers test.only.each too). Without it, replacing the old
+    // `it.only = it` alias would drop `.each` and throw at registration.
+    it.only.each = eachRegistrar(it.only);
 
     function hasOnly(suite) {
       if (suite.onlyTests.length || suite.onlySuites.length) return true;


### PR DESCRIPTION
## Summary

- track exclusive tests and suites while preserving definition order
- filter the registered tree before execution with Mocha direct-test precedence, nested focus, and skip interactions
- add end-to-end harness fixtures whose selected totals were cross-checked against Mocha 11.7.6

## Validation

- cargo fmt --check
- cargo clippy
- cargo build --release
- cargo test --release (294 unit tests plus smoke oracle)
- ./scripts/lint.sh
- ./scripts/run-harness-selftest.sh --no-build
- uv run python scripts/run-custom-tests.py (7/7)
- Node syntax checks for the harness and new fixtures
- full test262: 99,546 / 99,568; the exact 22 Intl402 failures are the pre-existing locale-data drift documented in merged PR #280, and this branch has no engine, dependency, test262 baseline, or README diff from origin/main

Closes #293