### PR TITLE
fix(intl): preserve es-ES numeric hour width

### DIFF
--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1653,7 +1653,7 @@ fn normalize_icu_datetime_parts(
             value = digits.into_iter().collect();
         }
         if part_type == "hour"
-            && requested_style == Some("numeric")
+            && requested_style != Some("2-digit")
             && matches!(opts.locale.split("-u-").next(), Some("es") | Some("es-ES"))
             && value.chars().count() == 2
             && value.chars().all(char::is_numeric)
@@ -1663,7 +1663,11 @@ fn normalize_icu_datetime_parts(
             // This covers both the language-only `es` (its base data is Spain's)
             // and `es-ES`, but not region-carrying Latin-American tags such as
             // `es-MX`/`es-419`, whose matched numeric-hour format legitimately
-            // has two digits.
+            // has two digits. The `hour` option domain is {numeric, 2-digit,
+            // undefined}, so `!= 2-digit` un-pads both `hour: "numeric"` and the
+            // timeStyle presets (whose hour option is undefined but which use the
+            // same unpadded H record); only an explicit `hour: "2-digit"` keeps
+            // the leading zero.
             let zero = transliterate_digits("0", &opts.numbering_system);
             if let Some(unpadded) = value.strip_prefix(&zero) {
                 value = unpadded.to_string();

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1652,6 +1652,21 @@ fn normalize_icu_datetime_parts(
             digits.reverse();
             value = digits.into_iter().collect();
         }
+        if part_type == "hour"
+            && requested_style == Some("numeric")
+            && opts.locale.split("-u-").next() == Some("es-ES")
+            && value.chars().count() == 2
+            && value.chars().all(char::is_numeric)
+        {
+            // ICU4X 2.1's processed es-ES time data uses HH, while the
+            // locale's ECMA-402/CLDR format record uses the unpadded H form.
+            // Correct that data divergence without changing locales whose
+            // matched numeric-hour format legitimately has two digits.
+            let zero = transliterate_digits("0", &opts.numbering_system);
+            if let Some(unpadded) = value.strip_prefix(&zero) {
+                value = unpadded.to_string();
+            }
+        }
         if requested_style == Some("2-digit")
             && value.chars().count() == 1
             && value.chars().all(char::is_numeric)

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1654,14 +1654,16 @@ fn normalize_icu_datetime_parts(
         }
         if part_type == "hour"
             && requested_style == Some("numeric")
-            && opts.locale.split("-u-").next() == Some("es-ES")
+            && matches!(opts.locale.split("-u-").next(), Some("es") | Some("es-ES"))
             && value.chars().count() == 2
             && value.chars().all(char::is_numeric)
         {
-            // ICU4X 2.1's processed es-ES time data uses HH, while the
-            // locale's ECMA-402/CLDR format record uses the unpadded H form.
-            // Correct that data divergence without changing locales whose
-            // matched numeric-hour format legitimately has two digits.
+            // ICU4X 2.1's processed Spain-based Spanish time data uses HH, while
+            // the locale's ECMA-402/CLDR format record uses the unpadded H form.
+            // This covers both the language-only `es` (its base data is Spain's)
+            // and `es-ES`, but not region-carrying Latin-American tags such as
+            // `es-MX`/`es-419`, whose matched numeric-hour format legitimately
+            // has two digits.
             let zero = transliterate_digits("0", &opts.numbering_system);
             if let Some(unpadded) = value.strip_prefix(&zero) {
                 value = unpadded.to_string();

--- a/test262-extra/Intl-DateTimeFormat-locale-data.js
+++ b/test262-extra/Intl-DateTimeFormat-locale-data.js
@@ -215,10 +215,16 @@ function numericHms(locale) {
   }).format(numericHourTimestamp);
 }
 
+assertSame(numericHms('es'), '3:04:05',
+  'language-only Spanish resolves to Spain data and stays unpadded');
+assertSame(numericHms('es-u-hc-h23'), '3:04:05',
+  'Spanish numeric hour with a Unicode hour-cycle extension stays unpadded');
 assertSame(numericHms('ca-ES'), '3:04:05',
   'Catalan numeric hour remains unpadded');
 assertSame(numericHms('es-MX'), '03:04:05',
   'Mexican Spanish numeric hour remains padded');
+assertSame(numericHms('es-419'), '03:04:05',
+  'Latin-American Spanish (es-419) numeric hour remains padded');
 assertSame(numericHms('en-US'), '03:04:05',
   'English numeric hour remains padded');
 assertSame(numericHms('fr-FR'), '03:04:05',

--- a/test262-extra/Intl-DateTimeFormat-locale-data.js
+++ b/test262-extra/Intl-DateTimeFormat-locale-data.js
@@ -232,6 +232,58 @@ assertSame(numericHms('fr-FR'), '03:04:05',
 assertSame(numericHms('it-IT'), '03:04:05',
   'Italian numeric hour remains padded in an h:m:s pattern');
 
+// timeStyle presets select the same unpadded-H record as hour:"numeric" for
+// Spain-based Spanish (the hour option is undefined, so the correction must key
+// off "not explicitly 2-digit" rather than requiring hour:"numeric"). Only an
+// explicit hour:"2-digit" keeps the leading zero, and region-carrying
+// Latin-American es-* stay padded.
+function timeStyleHour(locale, style, timestamp) {
+  return new Intl.DateTimeFormat(locale, {
+    timeStyle: style,
+    hourCycle: 'h23',
+    timeZone: 'UTC'
+  }).format(timestamp === undefined ? numericHourTimestamp : timestamp);
+}
+
+assertSame(timeStyleHour('es-ES', 'medium'), '3:04:05',
+  'Spanish timeStyle:medium uses the unpadded H hour');
+assertSame(timeStyleHour('es-ES', 'short'), '3:04',
+  'Spanish timeStyle:short uses the unpadded H hour');
+assertSame(timeStyleHour('es', 'medium'), '3:04:05',
+  'language-only Spanish timeStyle:medium uses the unpadded H hour');
+assertSame(timeStyleHour('es-ES', 'medium', Date.UTC(2020, 0, 2, 0, 4, 5)), '0:04:05',
+  'Spanish timeStyle midnight hour is a single zero, not 00');
+assertSame(timeStyleHour('es-ES', 'medium', Date.UTC(2020, 0, 2, 13, 4, 5)), '13:04:05',
+  'Spanish timeStyle two-digit hours (13) are left untouched');
+assertSame(timeStyleHour('es-MX', 'medium'), '03:04:05',
+  'Mexican Spanish timeStyle hour remains padded');
+
+// The correction reaches every formatter entry point, not just format().
+var esTimeStyle = new Intl.DateTimeFormat('es-ES', {
+  timeStyle: 'medium',
+  hourCycle: 'h23',
+  timeZone: 'UTC'
+});
+var laterHour = Date.UTC(2020, 0, 2, 5, 4, 5);
+assertSame(partValue(esTimeStyle.formatToParts(numericHourTimestamp), 'hour'), '3',
+  'Spanish timeStyle formatToParts exposes an unpadded hour');
+assertSame(esTimeStyle.formatRange(numericHourTimestamp, laterHour),
+  '3:04:05 – 5:04:05',
+  'Spanish timeStyle formatRange un-pads both endpoint hours');
+
+// An explicit hour:"2-digit" must still keep its leading zero even in an
+// otherwise all-numeric time (guards the "!= 2-digit" broadening).
+assertSame(
+  new Intl.DateTimeFormat('es-ES', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+    timeZone: 'UTC'
+  }).format(numericHourTimestamp),
+  '03:04:05',
+  'explicit Spanish 2-digit hour stays padded alongside numeric minute/second');
+
 // fractionalSecond must be split out of the "second" part using the locale's
 // own decimal separator. Many locales (fr-FR, de-DE) use a comma, not a dot,
 // and the "arab" numbering system uses the Arabic decimal separator.

--- a/test262-extra/Intl-DateTimeFormat-locale-data.js
+++ b/test262-extra/Intl-DateTimeFormat-locale-data.js
@@ -145,9 +145,6 @@ assertSame(
   '02/01/20',
   'explicit year:2-digit still truncates to two digits');
 
-// fractionalSecond must be split out of the "second" part using the locale's
-// own decimal separator. Many locales (fr-FR, de-DE) use a comma, not a dot,
-// and the "arab" numbering system uses the Arabic decimal separator.
 function partValue(parts, type) {
   for (var i = 0; i < parts.length; i++) {
     if (parts[i].type === type) {
@@ -157,6 +154,81 @@ function partValue(parts, type) {
   return undefined;
 }
 
+// An hour selected as "numeric" follows the effective locale's matched
+// DateTime Format Record. Spanish (Spain) uses the unpadded H pattern even
+// when minute and second fields are also present.
+var numericHourTimestamp = Date.UTC(2020, 0, 2, 3, 4, 5);
+var esNumericHour = new Intl.DateTimeFormat('es-ES', {
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  hourCycle: 'h23',
+  timeZone: 'UTC'
+});
+
+assertSame(
+  esNumericHour.format(numericHourTimestamp),
+  '3:04:05',
+  'Spanish numeric hour follows the unpadded H pattern');
+
+assertSame(
+  partValue(esNumericHour.formatToParts(numericHourTimestamp), 'hour'),
+  '3',
+  'Spanish formatToParts exposes an unpadded numeric hour');
+
+assertSame(
+  new Intl.DateTimeFormat('es-ES', {
+    hour: 'numeric',
+    hourCycle: 'h23',
+    timeZone: 'UTC'
+  }).format(numericHourTimestamp),
+  '3',
+  'standalone Spanish numeric hour follows the unpadded H pattern');
+
+assertSame(
+  new Intl.DateTimeFormat('es-ES', {
+    hour: '2-digit',
+    hourCycle: 'h23',
+    timeZone: 'UTC'
+  }).format(numericHourTimestamp),
+  '03',
+  'explicit Spanish 2-digit hour remains padded');
+
+assertSame(
+  new Intl.DateTimeFormat('es-ES-u-nu-arab', {
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hourCycle: 'h23',
+    timeZone: 'UTC'
+  }).format(numericHourTimestamp),
+  '٣:٠٤:٠٥',
+  'Spanish numeric hour removes the locale zero digit');
+
+function numericHms(locale) {
+  return new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hourCycle: 'h23',
+    timeZone: 'UTC'
+  }).format(numericHourTimestamp);
+}
+
+assertSame(numericHms('ca-ES'), '3:04:05',
+  'Catalan numeric hour remains unpadded');
+assertSame(numericHms('es-MX'), '03:04:05',
+  'Mexican Spanish numeric hour remains padded');
+assertSame(numericHms('en-US'), '03:04:05',
+  'English numeric hour remains padded');
+assertSame(numericHms('fr-FR'), '03:04:05',
+  'French numeric hour remains padded');
+assertSame(numericHms('it-IT'), '03:04:05',
+  'Italian numeric hour remains padded in an h:m:s pattern');
+
+// fractionalSecond must be split out of the "second" part using the locale's
+// own decimal separator. Many locales (fr-FR, de-DE) use a comma, not a dot,
+// and the "arab" numbering system uses the Arabic decimal separator.
 function separatorAfterSecond(parts) {
   for (var i = 0; i < parts.length - 1; i++) {
     if (parts[i].type === 'second' && parts[i + 1].type === 'literal') {


### PR DESCRIPTION
## Summary

- correct ICU4X 2.1's padded `es-ES` numeric-hour output using the locale's unpadded `H` width
- preserve explicit `hour: "2-digit"` and the matched widths of representative locales
- cover `format()`, `formatToParts()`, standalone time, Arabic digits, and locale guards in `test262-extra`

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (294 unit tests + smoke oracle)
- `./scripts/lint.sh`
- `uv run python scripts/run-custom-tests.py --jsse target/release/jsse` (7/7)
- `TZ=UTC uv run python scripts/run-test262.py test262/test/intl402/DateTimeFormat/` (488/488)
- `TZ=UTC uv run python scripts/run-test262.py` (99,568/99,568; zero regressions)

Closes #291