### PR TITLE
fix: honor engine exit codes in library verdicts

### DIFF
--- a/scripts/libs/js-sha256.sh
+++ b/scripts/libs/js-sha256.sh
@@ -25,12 +25,12 @@ lib_prepare() {
 }
 
 lib_verdict() {
-    local out="$1" line P F T
+    local out="$1" rc="$2" line P F T
     line="$(grep -oE 'PASS: [0-9]+[[:space:]]+FAIL: [0-9]+[[:space:]]+TOTAL: [0-9]+' "$out" | tail -1 || true)"
     if [ -z "$line" ]; then echo "FAIL 0"; return 1; fi
     if [[ "$line" =~ PASS:\ ([0-9]+)[[:space:]]+FAIL:\ ([0-9]+)[[:space:]]+TOTAL:\ ([0-9]+) ]]; then
         P="${BASH_REMATCH[1]}"; F="${BASH_REMATCH[2]}"; T="${BASH_REMATCH[3]}"
-        if [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
+        if [ "$rc" -eq 0 ] && [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
         echo "FAIL $T"; return 1
     fi
     echo "FAIL 0"; return 1

--- a/scripts/libs/lodash.sh
+++ b/scripts/libs/lodash.sh
@@ -39,12 +39,12 @@ lib_prepare() {
 }
 
 lib_verdict() {
-    local out="$1" line P F T
+    local out="$1" rc="$2" line P F T
     line="$(grep -oE 'PASS: [0-9]+[[:space:]]+FAIL: [0-9]+[[:space:]]+TOTAL: [0-9]+' "$out" | tail -1 || true)"
     if [ -z "$line" ]; then echo "FAIL 0"; return 1; fi
     if [[ "$line" =~ PASS:\ ([0-9]+)[[:space:]]+FAIL:\ ([0-9]+)[[:space:]]+TOTAL:\ ([0-9]+) ]]; then
         P="${BASH_REMATCH[1]}"; F="${BASH_REMATCH[2]}"; T="${BASH_REMATCH[3]}"
-        if [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
+        if [ "$rc" -eq 0 ] && [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
         echo "FAIL $T"; return 1
     fi
     echo "FAIL 0"; return 1

--- a/scripts/libs/luxon.sh
+++ b/scripts/libs/luxon.sh
@@ -28,12 +28,12 @@ lib_prepare() {
 }
 
 lib_verdict() {
-    local out="$1" line P F T
+    local out="$1" rc="$2" line P F T
     line="$(grep -oE 'PASS: [0-9]+[[:space:]]+FAIL: [0-9]+[[:space:]]+TOTAL: [0-9]+' "$out" | tail -1 || true)"
     if [ -z "$line" ]; then echo "FAIL 0"; return 1; fi
     if [[ "$line" =~ PASS:\ ([0-9]+)[[:space:]]+FAIL:\ ([0-9]+)[[:space:]]+TOTAL:\ ([0-9]+) ]]; then
         P="${BASH_REMATCH[1]}"; F="${BASH_REMATCH[2]}"; T="${BASH_REMATCH[3]}"
-        if [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
+        if [ "$rc" -eq 0 ] && [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
         echo "FAIL $T"; return 1
     fi
     echo "FAIL 0"; return 1


### PR DESCRIPTION
## Summary

- capture the engine exit code in the js-sha256, lodash, and luxon verdict hooks
- require a zero engine exit in addition to a zero-failure, nonempty summary
- preserve the parsed test count when a timeout or crash turns the verdict into FAIL

## Validation

- focused PASS/FAIL/TOTAL verdict matrix for clean exit, timeout, crash, reported failure, and empty suite
- `bash -n scripts/libs/js-sha256.sh scripts/libs/lodash.sh scripts/libs/luxon.sh`
- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release`
- `./scripts/lint.sh`
- `TZ=UTC uv run python scripts/run-test262.py` — 99,568/99,568 passed, zero regressions

The host workspace uses Europe/Berlin; an initial unqualified full run exposed 22 pre-existing timezone-sensitive Intl failures. All 22 passed under UTC, and the UTC-normalized full run matched the 100% result recorded in README. No baseline or README update was needed.

Closes #294