### PR TITLE
fix(intl): preserve mixed DateTimeFormat field widths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,16 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "calendrical_calculations"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97f73e95d668625c9b28a3072e6326773785a0cf807de9f3d632778438f3d38"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+]
+
+[[package]]
+name = "calendrical_calculations"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a0b39595c6ee54a8d0900204ba4c401d0ab4eb45adaf07178e8d017541529e7"
@@ -243,6 +253,17 @@ checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fixed_decimal"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0febbeb1118a9ecdee6e4520ead6b54882e843dd0592ad233247dbee84c53db8"
+dependencies = [
+ "displaydoc",
+ "smallvec",
+ "writeable 0.5.5",
+]
+
+[[package]]
+name = "fixed_decimal"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79c3c892f121fff406e5dd6b28c1b30096b95111c30701a899d4f2b18da6d1bd"
@@ -250,7 +271,7 @@ dependencies = [
  "displaydoc",
  "ryu",
  "smallvec",
- "writeable",
+ "writeable 0.6.2",
 ]
 
 [[package]]
@@ -300,22 +321,39 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ab713dd86fa032cb5487f9ac3a85d47b5dcf4c7b8c7dd00210b3cadd6a6551"
 dependencies = [
- "icu_calendar",
+ "icu_calendar 2.1.1",
  "icu_casemap",
  "icu_collator",
  "icu_collections",
- "icu_datetime",
- "icu_decimal",
+ "icu_datetime 2.1.1",
+ "icu_decimal 2.1.1",
  "icu_experimental",
  "icu_list",
  "icu_locale",
  "icu_normalizer",
  "icu_pattern",
- "icu_plurals",
+ "icu_plurals 2.1.1",
  "icu_properties",
- "icu_provider",
+ "icu_provider 2.1.1",
  "icu_segmenter",
  "icu_time",
+]
+
+[[package]]
+name = "icu_calendar"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7265b2137f9a36f7634a308d91f984574bbdba8cfd95ceffe1c345552275a8ff"
+dependencies = [
+ "calendrical_calculations 0.1.3",
+ "displaydoc",
+ "icu_calendar_data 1.5.1",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -324,17 +362,23 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e"
 dependencies = [
- "calendrical_calculations",
+ "calendrical_calculations 0.2.3",
  "displaydoc",
- "icu_calendar_data",
+ "icu_calendar_data 2.1.1",
  "icu_locale",
  "icu_locale_core",
- "icu_provider",
+ "icu_provider 2.1.1",
  "ixdtf",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.8.3",
+ "zerovec 0.11.6",
 ]
+
+[[package]]
+name = "icu_calendar_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "820499e77e852162190608b4f444e7b4552619150eafc39a9e39333d9efae9e1"
 
 [[package]]
 name = "icu_calendar_data"
@@ -352,10 +396,10 @@ dependencies = [
  "icu_collections",
  "icu_locale_core",
  "icu_properties",
- "icu_provider",
+ "icu_provider 2.1.1",
  "potential_utf",
- "writeable",
- "zerovec",
+ "writeable 0.6.2",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -376,11 +420,11 @@ dependencies = [
  "icu_locale_core",
  "icu_normalizer",
  "icu_properties",
- "icu_provider",
+ "icu_provider 2.1.1",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
- "zerovec",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -398,9 +442,33 @@ dependencies = [
  "displaydoc",
  "potential_utf",
  "serde",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
- "zerovec",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_datetime"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d115efb85e08df3fd77e77f52e7e087545a783fffba8be80bfa2102f306b1780"
+dependencies = [
+ "displaydoc",
+ "either",
+ "fixed_decimal 0.5.6",
+ "icu_calendar 1.5.2",
+ "icu_datetime_data 1.5.1",
+ "icu_decimal 1.5.0",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_plurals 1.5.0",
+ "icu_provider 1.5.0",
+ "icu_timezone",
+ "litemap 0.7.5",
+ "smallvec",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -410,21 +478,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9d49f41ded8e63761b6b4c3120dfdc289415a1ed10107db6198eb311057ca5"
 dependencies = [
  "displaydoc",
- "fixed_decimal",
- "icu_calendar",
- "icu_datetime_data",
- "icu_decimal",
+ "fixed_decimal 0.7.2",
+ "icu_calendar 2.1.1",
+ "icu_datetime_data 2.1.2",
+ "icu_decimal 2.1.1",
  "icu_locale",
  "icu_locale_core",
  "icu_pattern",
- "icu_plurals",
- "icu_provider",
+ "icu_plurals 2.1.1",
+ "icu_provider 2.1.1",
  "icu_time",
  "potential_utf",
- "tinystr",
- "writeable",
- "zerovec",
+ "tinystr 0.8.3",
+ "writeable 0.6.2",
+ "zerovec 0.11.6",
 ]
+
+[[package]]
+name = "icu_datetime_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef5f04076123cab1b7a926a7083db27fe0d7a0e575adb984854aae3f3a6507d"
 
 [[package]]
 name = "icu_datetime_data"
@@ -434,19 +508,39 @@ checksum = "46597233625417b7c8052a63d916e4fdc73df21614ac0b679492a5d6e3b01aeb"
 
 [[package]]
 name = "icu_decimal"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8fd98f86ec0448d85e1edf8884e4e318bb2e121bd733ec929a05c0a5e8b0eb"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal 0.5.6",
+ "icu_decimal_data 1.5.1",
+ "icu_locid_transform",
+ "icu_provider 1.5.0",
+ "writeable 0.5.5",
+]
+
+[[package]]
+name = "icu_decimal"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38c52231bc348f9b982c1868a2af3195199623007ba2c7650f432038f5b3e8e"
 dependencies = [
- "fixed_decimal",
- "icu_decimal_data",
+ "fixed_decimal 0.7.2",
+ "icu_decimal_data 2.1.1",
  "icu_locale",
  "icu_locale_core",
- "icu_provider",
+ "icu_provider 2.1.1",
  "serde",
- "writeable",
- "zerovec",
+ "writeable 0.6.2",
+ "zerovec 0.11.6",
 ]
+
+[[package]]
+name = "icu_decimal_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c95dd97f5ccf6d837a9c115496ec7d36646fa86ca18e7f1412115b4c820ae2"
 
 [[package]]
 name = "icu_decimal_data"
@@ -462,29 +556,29 @@ checksum = "f4ffa4d60b9cb8b024082afaf9e94d853184e483ec69322c74dc437bf8a882a5"
 dependencies = [
  "displaydoc",
  "either",
- "fixed_decimal",
+ "fixed_decimal 0.7.2",
  "icu_casemap",
  "icu_collections",
- "icu_decimal",
+ "icu_decimal 2.1.1",
  "icu_experimental_data",
  "icu_list",
  "icu_locale",
  "icu_locale_core",
  "icu_normalizer",
  "icu_pattern",
- "icu_plurals",
+ "icu_plurals 2.1.1",
  "icu_properties",
- "icu_provider",
- "litemap",
+ "icu_provider 2.1.1",
+ "litemap 0.8.1",
  "num-bigint 0.4.7",
  "num-rational",
  "num-traits",
  "potential_utf",
  "smallvec",
- "tinystr",
- "writeable",
- "zerotrie",
- "zerovec",
+ "tinystr 0.8.3",
+ "writeable 0.6.2",
+ "zerotrie 0.2.3",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -501,11 +595,11 @@ checksum = "d3a0b7b126e2fc42777d3c348611553d540bd3683caa39b387c5dd1036bb21a8"
 dependencies = [
  "icu_list_data",
  "icu_locale",
- "icu_provider",
+ "icu_provider 2.1.1",
  "regex-automata",
  "serde",
- "writeable",
- "zerovec",
+ "writeable 0.6.2",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -523,10 +617,10 @@ dependencies = [
  "icu_collections",
  "icu_locale_core",
  "icu_locale_data",
- "icu_provider",
+ "icu_provider 2.1.1",
  "potential_utf",
- "tinystr",
- "zerovec",
+ "tinystr 0.8.3",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -536,11 +630,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
- "litemap",
+ "litemap 0.8.1",
  "serde",
- "tinystr",
- "writeable",
- "zerovec",
+ "tinystr 0.8.3",
+ "writeable 0.6.2",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -548,6 +642,39 @@ name = "icu_locale_data"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831"
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap 0.7.5",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -558,12 +685,12 @@ dependencies = [
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
- "icu_provider",
+ "icu_provider 2.1.1",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -581,9 +708,23 @@ dependencies = [
  "displaydoc",
  "either",
  "serde",
- "writeable",
- "yoke",
- "zerovec",
+ "writeable 0.6.2",
+ "yoke 0.8.2",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_plurals"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a70e7c025dbd5c501b0a5c188cd11666a424f0dadcd4f0a95b7dafde3b114"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal 0.5.6",
+ "icu_locid_transform",
+ "icu_plurals_data 1.5.1",
+ "icu_provider 1.5.0",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -592,12 +733,18 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f9cfe49f5b1d1163cc58db451562339916a9ca5cbcaae83924d41a0bf839474"
 dependencies = [
- "fixed_decimal",
+ "fixed_decimal 0.7.2",
  "icu_locale",
- "icu_plurals_data",
- "icu_provider",
- "zerovec",
+ "icu_plurals_data 2.1.1",
+ "icu_provider 2.1.1",
+ "zerovec 0.11.6",
 ]
+
+[[package]]
+name = "icu_plurals_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a483403238cb7d6a876a77a5f8191780336d80fe7b8b00bfdeb20be6abbfd112"
 
 [[package]]
 name = "icu_plurals_data"
@@ -614,10 +761,10 @@ dependencies = [
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
- "icu_provider",
+ "icu_provider 2.1.1",
  "serde",
- "zerotrie",
- "zerovec",
+ "zerotrie 0.2.3",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -625,6 +772,23 @@ name = "icu_properties_data"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec 0.10.4",
+]
 
 [[package]]
 name = "icu_provider"
@@ -636,11 +800,22 @@ dependencies = [
  "icu_locale_core",
  "serde",
  "stable_deref_trait",
- "writeable",
- "yoke",
+ "writeable 0.6.2",
+ "yoke 0.8.2",
  "zerofrom",
- "zerotrie",
- "zerovec",
+ "zerotrie 0.2.3",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -652,11 +827,11 @@ dependencies = [
  "core_maths",
  "icu_collections",
  "icu_locale",
- "icu_provider",
+ "icu_provider 2.1.1",
  "icu_segmenter_data",
  "potential_utf",
  "utf8_iter",
- "zerovec",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -671,16 +846,16 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8242b00da3b3b6678f731437a11c8833a43c821ae081eca60ba1b7579d45b6d8"
 dependencies = [
- "calendrical_calculations",
+ "calendrical_calculations 0.2.3",
  "displaydoc",
- "icu_calendar",
+ "icu_calendar 2.1.1",
  "icu_locale_core",
- "icu_provider",
+ "icu_provider 2.1.1",
  "icu_time_data",
  "ixdtf",
  "serde",
- "zerotrie",
- "zerovec",
+ "zerotrie 0.2.3",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -688,6 +863,27 @@ name = "icu_time_data"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e10b0e5e87a2c84bd5fa407705732052edebe69291d347d0c3033785470edbf"
+
+[[package]]
+name = "icu_timezone"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91ba6a585939a020c787235daa8aee856d9bceebd6355e283c0c310bc6de96"
+dependencies = [
+ "displaydoc",
+ "icu_calendar 1.5.2",
+ "icu_provider 1.5.0",
+ "icu_timezone_data",
+ "tinystr 0.7.6",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_timezone_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adcf7b613a268af025bc2a2532b4b9ee294e6051c5c0832d8bff20ac0232e68"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -719,20 +915,22 @@ dependencies = [
  "chrono-tz",
  "clap",
  "fancy-regex",
- "fixed_decimal",
+ "fixed_decimal 0.7.2",
  "getrandom",
  "iana-time-zone",
  "icu",
- "icu_calendar",
+ "icu_calendar 2.1.1",
+ "icu_datetime 1.5.1",
  "icu_normalizer",
+ "icu_provider 1.5.0",
  "num-bigint 0.5.1",
  "regex",
  "rustc-hash",
  "ryu-js",
  "smallvec",
- "tinystr",
+ "tinystr 0.8.3",
  "unicode-ident",
- "writeable",
+ "writeable 0.6.2",
 ]
 
 [[package]]
@@ -746,6 +944,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litemap"
@@ -851,8 +1055,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "serde_core",
- "writeable",
- "zerovec",
+ "writeable 0.6.2",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -1016,13 +1220,23 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
- "zerovec",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -1170,6 +1384,12 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
@@ -1179,13 +1399,37 @@ dependencies = [
 
 [[package]]
 name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.8.2",
  "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1223,13 +1467,35 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb594dd55d87335c5f60177cee24f19457a5ec10a065e0a3014722ad252d0a1f"
+dependencies = [
+ "displaydoc",
+ "yoke 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec-derive 0.10.3",
 ]
 
 [[package]]
@@ -1239,9 +1505,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.11.3",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ iana-time-zone = "0.1"
 chrono-tz = "0.10"
 icu = { version = "2.0", features = ["experimental"] }
 icu_calendar = { version = "2.0", features = ["unstable"] }
+# ICU4X 2's semantic field sets have one shared text length. ICU4X 1.5 retains
+# the classical per-field skeleton matcher used only to select mixed-width patterns.
+icu_datetime_legacy = { package = "icu_datetime", version = "=1.5.1", features = ["experimental"] }
+icu_provider_legacy = { package = "icu_provider", version = "=1.5.0" }
 fixed_decimal = { version = "0.7", features = ["ryu"] }
 tinystr = "0.8"
 icu_normalizer = "2.1.1"

--- a/docs/specs/2026-07-17-intl-datetimeformat-mixed-field-widths-design.md
+++ b/docs/specs/2026-07-17-intl-datetimeformat-mixed-field-widths-design.md
@@ -23,8 +23,10 @@ seam for explicit component sets whose requested textual widths differ:
   preserving each requested numeric and textual width.
 - Load the locale's classical skeleton and date/time glue data through the
   ICU4X 1.5 compiled-data surface, which still exposes component-based pattern
-  selection. Accept only an all-fields match; otherwise retain the existing
-  fallback behavior.
+  selection. Accept an all-fields match, plus ICU4X 1.5's fractional-second
+  result after the matcher has appended the requested fraction and the final
+  pattern is verified to contain exactly the requested fields (plus an implied
+  day period); otherwise retain the existing fallback behavior.
 - Serialize the selected UTS 35 pattern and parse it with ICU4X 2.x.
 - Use ICU4X 2.x `FixedCalendarDateTimeNames` to load the names required by that
   pattern and format the already time-zone-adjusted Gregorian input. Collect
@@ -56,8 +58,9 @@ correctness.
 The public seam is the JavaScript `Intl.DateTimeFormat` API. Repository-owned
 tests will compare literal `format()` results for mixed long/short/narrow
 weekday, era, and month widths in representative English, French, Japanese,
-and Russian locales. They will also assert that `formatToParts()` exposes each
-requested value and concatenates to `format()`.
+and German locales. They will also assert that `formatToParts()` exposes each
+requested value, concatenates to `format()`, and keeps mixed widths when
+fractional seconds are present.
 
 The targeted DateTimeFormat test262 directory and the full test262 suite remain
 regression gates. Since test262 does not assert locale-dependent byte output,

--- a/docs/specs/2026-07-17-intl-datetimeformat-mixed-field-widths-design.md
+++ b/docs/specs/2026-07-17-intl-datetimeformat-mixed-field-widths-design.md
@@ -1,0 +1,64 @@
+# Independent textual widths in `Intl.DateTimeFormat`
+
+## Problem
+
+The ICU4X 2.x semantic `FieldSetBuilder` accepts one `Length` for an entire
+date field set. An ECMA-402 request can independently select `long`, `short`,
+or `narrow` for `weekday`, `era`, and textual `month`, so reducing those
+requests to one length changes observable field values. Falling back to JSSE's
+hand-written formatter preserves widths only in English and therefore is not a
+locale-correct solution.
+
+ECMA-262 delegates the locale-sensitive date methods to ECMA-402. ECMA-402's
+date-time format record retains each requested component independently, while
+the selected locale pattern controls ordering and literals. `format()` and
+`formatToParts()` must be produced from the same selected pattern.
+
+## Design
+
+Use ICU4X's classical component-skeleton matcher as a narrow compatibility
+seam for explicit component sets whose requested textual widths differ:
+
+- Translate the resolved `DtfOptions` components into ICU classical fields,
+  preserving each requested numeric and textual width.
+- Load the locale's classical skeleton and date/time glue data through the
+  ICU4X 1.5 compiled-data surface, which still exposes component-based pattern
+  selection. Accept only an all-fields match; otherwise retain the existing
+  fallback behavior.
+- Serialize the selected UTS 35 pattern and parse it with ICU4X 2.x.
+- Use ICU4X 2.x `FixedCalendarDateTimeNames` to load the names required by that
+  pattern and format the already time-zone-adjusted Gregorian input. Collect
+  its annotated output through the existing parts writer and normalization.
+- Keep the current ICU4X 2.x semantic field-set path unchanged for uniform
+  widths, styles, and other requests.
+
+The old ICU surface chooses only the pattern. ICU4X 2.x remains responsible for
+localized symbols, numbering, time-zone names, and annotated parts, avoiding
+two competing output implementations.
+
+## Alternatives
+
+Formatting the composite field set several times and substituting individual
+values is smaller, but it cannot repair literals selected for the wrong global
+length. For example, Japanese commonly wraps abbreviated weekdays in
+parentheses but not long weekdays.
+
+Rewriting widths in an ICU4X 2.x semantic pattern has the same structural
+problem: the starting pattern was selected from one global length and can have
+the wrong punctuation, padding, or ordering for the mixed skeleton.
+
+Routing mixed widths to the existing JSSE formatter restores English widths
+but emits English names for non-English locales, directly regressing locale
+correctness.
+
+## Validation
+
+The public seam is the JavaScript `Intl.DateTimeFormat` API. Repository-owned
+tests will compare literal `format()` results for mixed long/short/narrow
+weekday, era, and month widths in representative English, French, Japanese,
+and Russian locales. They will also assert that `formatToParts()` exposes each
+requested value and concatenates to `format()`.
+
+The targeted DateTimeFormat test262 directory and the full test262 suite remain
+regression gates. Since test262 does not assert locale-dependent byte output,
+the new `test262-extra` coverage is the primary regression test.

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1468,6 +1468,390 @@ fn icu_datetime_length(opts: &DtfOptions) -> Option<icu::datetime::options::Leng
     }
 }
 
+fn has_mixed_textual_widths(opts: &DtfOptions) -> bool {
+    let mut requested = [None; 3];
+    requested[0] = opts.weekday.as_deref();
+    requested[1] = opts.era.as_deref();
+    requested[2] = opts
+        .month
+        .as_deref()
+        .filter(|style| matches!(*style, "long" | "short" | "narrow"));
+
+    let mut widths = requested
+        .into_iter()
+        .flatten()
+        .filter(|style| matches!(*style, "long" | "short" | "narrow"));
+    let Some(first) = widths.next() else {
+        return false;
+    };
+    widths.any(|width| width != first)
+}
+
+fn legacy_icu_text_style(style: &str) -> Option<icu_datetime_legacy::options::components::Text> {
+    use icu_datetime_legacy::options::components::Text;
+
+    match style {
+        "long" => Some(Text::Long),
+        "short" => Some(Text::Short),
+        "narrow" => Some(Text::Narrow),
+        _ => None,
+    }
+}
+
+fn legacy_icu_numeric_style(
+    style: &str,
+) -> Option<icu_datetime_legacy::options::components::Numeric> {
+    use icu_datetime_legacy::options::components::Numeric;
+
+    match style {
+        "numeric" => Some(Numeric::Numeric),
+        "2-digit" => Some(Numeric::TwoDigit),
+        _ => None,
+    }
+}
+
+fn legacy_icu_pattern_string(
+    pattern: &icu_datetime_legacy::pattern::runtime::Pattern<'_>,
+) -> String {
+    use icu_datetime_legacy::fields::FieldLength;
+    use icu_datetime_legacy::pattern::PatternItem;
+
+    fn push_literal(output: &mut String, literal: &str) {
+        if literal.is_empty() {
+            return;
+        }
+        if literal
+            .chars()
+            .any(|ch| ch.is_ascii_alphabetic() || ch == '\'')
+        {
+            output.push('\'');
+            for ch in literal.chars() {
+                if ch == '\'' {
+                    output.push('\'');
+                }
+                output.push(ch);
+            }
+            output.push('\'');
+        } else {
+            output.push_str(literal);
+        }
+    }
+
+    let mut output = String::new();
+    let mut literal = String::new();
+    for item in pattern.items.iter() {
+        match item {
+            PatternItem::Literal(ch) => literal.push(ch),
+            PatternItem::Field(field) => {
+                push_literal(&mut output, &literal);
+                literal.clear();
+                let length = match field.length {
+                    FieldLength::One | FieldLength::NumericOverride(_) => 1,
+                    FieldLength::TwoDigit => 2,
+                    FieldLength::Abbreviated => 3,
+                    FieldLength::Wide => 4,
+                    FieldLength::Narrow => 5,
+                    FieldLength::Six => 6,
+                    FieldLength::Fixed(length) => usize::from(length),
+                };
+                output.extend(std::iter::repeat_n(char::from(field.symbol), length));
+            }
+        }
+    }
+    push_literal(&mut output, &literal);
+    output
+}
+
+fn legacy_icu_pattern_contains_fields(
+    pattern: &icu_datetime_legacy::pattern::runtime::Pattern<'_>,
+    requested: &[icu_datetime_legacy::fields::Field],
+) -> bool {
+    use icu_datetime_legacy::fields::{Field, FieldLength, FieldSymbol};
+    use icu_datetime_legacy::pattern::PatternItem;
+
+    fn same_kind(requested: FieldSymbol, actual: FieldSymbol) -> bool {
+        match (requested, actual) {
+            (FieldSymbol::Era, FieldSymbol::Era)
+            | (FieldSymbol::Year(_), FieldSymbol::Year(_))
+            | (FieldSymbol::Month(_), FieldSymbol::Month(_))
+            | (FieldSymbol::Week(_), FieldSymbol::Week(_))
+            | (FieldSymbol::Day(_), FieldSymbol::Day(_))
+            | (FieldSymbol::Weekday(_), FieldSymbol::Weekday(_))
+            | (FieldSymbol::DayPeriod(_), FieldSymbol::DayPeriod(_))
+            | (FieldSymbol::Hour(_), FieldSymbol::Hour(_))
+            | (FieldSymbol::Minute, FieldSymbol::Minute)
+            | (FieldSymbol::TimeZone(_), FieldSymbol::TimeZone(_)) => true,
+            (FieldSymbol::Second(requested), FieldSymbol::Second(actual)) => requested == actual,
+            _ => false,
+        }
+    }
+
+    fn normalized_length(field: Field) -> FieldLength {
+        match (field.symbol, field.length) {
+            (
+                FieldSymbol::Era | FieldSymbol::Weekday(_),
+                FieldLength::One | FieldLength::TwoDigit,
+            ) => FieldLength::Abbreviated,
+            (_, FieldLength::NumericOverride(_)) => FieldLength::One,
+            (_, length) => length,
+        }
+    }
+
+    fn requested_field_matches(requested: Field, actual: Field) -> bool {
+        same_kind(requested.symbol, actual.symbol)
+            && (matches!(requested.symbol, FieldSymbol::TimeZone(_))
+                || normalized_length(requested) == normalized_length(actual))
+    }
+
+    let actual = pattern
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            PatternItem::Field(field) => Some(field),
+            PatternItem::Literal(_) => None,
+        })
+        .collect::<Vec<_>>();
+    let hour_requested = requested
+        .iter()
+        .any(|field| matches!(field.symbol, FieldSymbol::Hour(_)));
+
+    requested.iter().all(|requested| {
+        actual
+            .iter()
+            .any(|actual| requested_field_matches(*requested, *actual))
+    }) && actual.iter().all(|actual| {
+        requested
+            .iter()
+            .any(|requested| requested_field_matches(*requested, *actual))
+            || (hour_requested && matches!(actual.symbol, FieldSymbol::DayPeriod(_)))
+    })
+}
+
+fn icu_mixed_width_pattern(
+    opts: &DtfOptions,
+    locale: &icu::locale::Locale,
+) -> Option<icu::datetime::pattern::DateTimePattern> {
+    use icu_datetime_legacy::fields::{
+        Day, Field, FieldLength, FieldSymbol, Hour, Month, Second, TimeZone, Weekday, Year,
+    };
+    use icu_datetime_legacy::options::{components, preferences};
+    use icu_datetime_legacy::provider::calendar::{
+        DateSkeletonPatternsV1Marker, GregorianDateLengthsV1Marker,
+    };
+    use icu_datetime_legacy::skeleton::{BestSkeleton, create_best_pattern_for_fields};
+    use icu_provider_legacy::prelude::{DataProvider, DataRequest};
+
+    if !has_mixed_textual_widths(opts)
+        || opts.date_style.is_some()
+        || opts.time_style.is_some()
+        || !matches!(opts.calendar.as_str(), "gregory" | "iso8601")
+        || opts.numbering_system == "hanidec"
+        || opts.day_period.is_some()
+    {
+        return None;
+    }
+
+    let mut bag = components::Bag::default();
+    let mut fields = Vec::new();
+
+    if let Some(style) = opts.era.as_deref() {
+        let style = legacy_icu_text_style(style)?;
+        bag.era = Some(style);
+        fields.push(Field {
+            symbol: FieldSymbol::Era,
+            length: match style {
+                components::Text::Long => FieldLength::Wide,
+                components::Text::Short => FieldLength::Abbreviated,
+                components::Text::Narrow => FieldLength::Narrow,
+                _ => return None,
+            },
+        });
+    }
+    if let Some(style) = opts.year.as_deref() {
+        bag.year = Some(match style {
+            "numeric" => components::Year::Numeric,
+            "2-digit" => components::Year::TwoDigit,
+            _ => return None,
+        });
+        fields.push(Field {
+            symbol: FieldSymbol::Year(Year::Calendar),
+            length: if style == "2-digit" {
+                FieldLength::TwoDigit
+            } else {
+                FieldLength::One
+            },
+        });
+    }
+    if let Some(style) = opts.month.as_deref() {
+        let style = match style {
+            "numeric" => components::Month::Numeric,
+            "2-digit" => components::Month::TwoDigit,
+            "long" => components::Month::Long,
+            "short" => components::Month::Short,
+            "narrow" => components::Month::Narrow,
+            _ => return None,
+        };
+        bag.month = Some(style);
+        fields.push(Field {
+            symbol: FieldSymbol::Month(Month::Format),
+            length: match style {
+                components::Month::Numeric => FieldLength::One,
+                components::Month::TwoDigit => FieldLength::TwoDigit,
+                components::Month::Long => FieldLength::Wide,
+                components::Month::Short => FieldLength::Abbreviated,
+                components::Month::Narrow => FieldLength::Narrow,
+                _ => return None,
+            },
+        });
+    }
+    if let Some(style) = opts.day.as_deref() {
+        let style = legacy_icu_numeric_style(style)?;
+        bag.day = Some(match style {
+            components::Numeric::Numeric => components::Day::NumericDayOfMonth,
+            components::Numeric::TwoDigit => components::Day::TwoDigitDayOfMonth,
+            _ => return None,
+        });
+        fields.push(Field {
+            symbol: FieldSymbol::Day(Day::DayOfMonth),
+            length: match style {
+                components::Numeric::Numeric => FieldLength::One,
+                components::Numeric::TwoDigit => FieldLength::TwoDigit,
+                _ => return None,
+            },
+        });
+    }
+    if let Some(style) = opts.weekday.as_deref() {
+        let style = legacy_icu_text_style(style)?;
+        bag.weekday = Some(style);
+        fields.push(Field {
+            symbol: FieldSymbol::Weekday(Weekday::Format),
+            length: match style {
+                components::Text::Long => FieldLength::Wide,
+                components::Text::Short => FieldLength::One,
+                components::Text::Narrow => FieldLength::Narrow,
+                _ => return None,
+            },
+        });
+    }
+
+    let hour_cycle = match resolve_hour_cycle(opts) {
+        "h11" => preferences::HourCycle::H11,
+        "h12" => preferences::HourCycle::H12,
+        "h23" => preferences::HourCycle::H23,
+        "h24" => preferences::HourCycle::H24,
+        _ => return None,
+    };
+    bag.preferences = Some(preferences::Bag::from_hour_cycle(hour_cycle));
+    if let Some(style) = opts.hour.as_deref() {
+        let style = legacy_icu_numeric_style(style)?;
+        bag.hour = Some(style);
+        fields.push(Field {
+            symbol: FieldSymbol::Hour(match hour_cycle {
+                preferences::HourCycle::H11 | preferences::HourCycle::H12 => Hour::H12,
+                preferences::HourCycle::H23 | preferences::HourCycle::H24 => Hour::H23,
+            }),
+            length: match style {
+                components::Numeric::Numeric => FieldLength::One,
+                components::Numeric::TwoDigit => FieldLength::TwoDigit,
+                _ => return None,
+            },
+        });
+    }
+    if let Some(style) = opts.minute.as_deref() {
+        let style = legacy_icu_numeric_style(style)?;
+        bag.minute = Some(style);
+        fields.push(Field {
+            symbol: FieldSymbol::Minute,
+            length: match style {
+                components::Numeric::Numeric => FieldLength::One,
+                components::Numeric::TwoDigit => FieldLength::TwoDigit,
+                _ => return None,
+            },
+        });
+    }
+    if let Some(style) = opts.second.as_deref() {
+        let style = legacy_icu_numeric_style(style)?;
+        bag.second = Some(style);
+        fields.push(Field {
+            symbol: FieldSymbol::Second(Second::Second),
+            length: match style {
+                components::Numeric::Numeric => FieldLength::One,
+                components::Numeric::TwoDigit => FieldLength::TwoDigit,
+                _ => return None,
+            },
+        });
+    }
+    if let Some(digits) = opts.fractional_second_digits {
+        let digits = u8::try_from(digits).ok()?;
+        bag.fractional_second = Some(digits);
+        fields.push(Field {
+            symbol: FieldSymbol::Second(Second::FractionalSecond),
+            length: FieldLength::Fixed(digits),
+        });
+    }
+    if let Some(style) = opts.time_zone_name.as_deref() {
+        let style = match style {
+            "short" => components::TimeZoneName::ShortSpecific,
+            "long" => components::TimeZoneName::LongSpecific,
+            "shortOffset" | "longOffset" => components::TimeZoneName::GmtOffset,
+            "shortGeneric" => components::TimeZoneName::ShortGeneric,
+            "longGeneric" => components::TimeZoneName::LongGeneric,
+            _ => return None,
+        };
+        bag.time_zone_name = Some(style);
+        fields.push(Field {
+            symbol: FieldSymbol::TimeZone(TimeZone::LowerV),
+            length: FieldLength::One,
+        });
+    }
+
+    let legacy_locale = locale
+        .to_string()
+        .parse::<icu_provider_legacy::DataLocale>()
+        .ok()?;
+    let request = || DataRequest {
+        locale: &legacy_locale,
+        metadata: Default::default(),
+    };
+    let lengths = <icu_datetime_legacy::provider::Baked as DataProvider<
+        GregorianDateLengthsV1Marker,
+    >>::load(&icu_datetime_legacy::provider::Baked, request())
+    .ok()?
+    .take_payload()
+    .ok()?;
+    let skeletons = <icu_datetime_legacy::provider::Baked as DataProvider<
+        DateSkeletonPatternsV1Marker,
+    >>::load(&icu_datetime_legacy::provider::Baked, request())
+    .ok()?
+    .take_payload()
+    .ok()?;
+
+    let pattern = match create_best_pattern_for_fields(
+        skeletons.get(),
+        &lengths.get().length_combinations,
+        &fields,
+        &bag,
+        false,
+    ) {
+        BestSkeleton::AllFieldsMatch(pattern) => {
+            pattern.expect_pattern("mixed-width fields do not use plural variants")
+        }
+        // ICU4X 1.5 classifies a skeleton with fractional seconds as missing a
+        // field even after create_best_pattern_for_fields appends that field to
+        // the selected seconds pattern. This is the only incomplete-match case
+        // that is safe to accept; all other cases keep the existing fallback.
+        BestSkeleton::MissingOrExtraFields(pattern) if opts.fractional_second_digits.is_some() => {
+            let pattern = pattern.expect_pattern("mixed-width fields do not use plural variants");
+            if !legacy_icu_pattern_contains_fields(&pattern, &fields) {
+                return None;
+            }
+            pattern
+        }
+        BestSkeleton::MissingOrExtraFields(_) | BestSkeleton::NoMatch => return None,
+    };
+    legacy_icu_pattern_string(&pattern).parse().ok()
+}
+
 fn icu_datetime_field_set(
     opts: &DtfOptions,
 ) -> Option<icu::datetime::fieldsets::enums::CompositeFieldSet> {
@@ -1627,6 +2011,14 @@ fn collect_icu_datetime_parts(
     Some(writer.parts)
 }
 
+fn collect_icu_datetime_pattern_parts(
+    formatted: &impl writeable::TryWriteable,
+) -> Option<Vec<(String, String)>> {
+    let mut writer = IcuDateTimePartsWriter::default();
+    formatted.try_write_to_parts(&mut writer).ok()?.ok()?;
+    Some(writer.parts)
+}
+
 fn normalize_icu_datetime_parts(
     parts: Vec<(String, String)>,
     opts: &DtfOptions,
@@ -1704,9 +2096,14 @@ fn format_with_icu(ms: f64, opts: &DtfOptions) -> Option<Vec<(String, String)>> 
     use icu::datetime::input::{Date, DateTime, Time, ZonedDateTime};
     use icu::time::zone::{IanaParser, UtcOffset};
 
-    let field_set = icu_datetime_field_set(opts)?;
     let locale = icu_datetime_locale(opts)?;
-    let formatter = DateTimeFormatter::try_new(locale.into(), field_set).ok()?;
+    let mixed_width_pattern = icu_mixed_width_pattern(opts, &locale);
+    let formatter = if mixed_width_pattern.is_none() {
+        let field_set = icu_datetime_field_set(opts)?;
+        Some(DateTimeFormatter::try_new(locale.clone().into(), field_set).ok()?)
+    } else {
+        None
+    };
 
     let is_plain = matches!(
         opts.temporal_type,
@@ -1752,12 +2149,36 @@ fn format_with_icu(ms: f64, opts: &DtfOptions) -> Option<Vec<(String, String)>> 
             .with_offset(Some(offset))
             .at_date_time_iso(datetime)
     };
-    let zoned = ZonedDateTime {
-        date: datetime.date,
-        time: datetime.time,
-        zone,
+    let parts = if let Some(pattern) = mixed_width_pattern {
+        use icu::calendar::{Date as CalendarDate, Gregorian};
+        use icu::datetime::fieldsets::enums::CompositeFieldSet;
+        use icu::datetime::pattern::FixedCalendarDateTimeNames;
+
+        let date = CalendarDate::try_new_gregorian(
+            components.year,
+            components.month as u8,
+            components.day as u8,
+        )
+        .ok()?;
+        let zoned = ZonedDateTime {
+            date,
+            time: datetime.time,
+            zone,
+        };
+        let mut names = FixedCalendarDateTimeNames::<Gregorian, CompositeFieldSet>::try_new(
+            locale.clone().into(),
+        )
+        .ok()?;
+        let pattern_formatter = names.include_for_pattern(&pattern).ok()?;
+        collect_icu_datetime_pattern_parts(&pattern_formatter.format(&zoned))?
+    } else {
+        let zoned = ZonedDateTime {
+            date: datetime.date,
+            time: datetime.time,
+            zone,
+        };
+        collect_icu_datetime_parts(&formatter.as_ref()?.format(&zoned))?
     };
-    let parts = collect_icu_datetime_parts(&formatter.format(&zoned))?;
     // For dateStyle:"short", ICU4X may expand the year to a full year outside its
     // 2-digit-year window even for locales whose short pattern uses two digits
     // (e.g. en-US in 1886). Node/ICU always follow the pattern width, so probe
@@ -1767,7 +2188,7 @@ fn format_with_icu(ms: f64, opts: &DtfOptions) -> Option<Vec<(String, String)>> 
         && parts.iter().any(|(part_type, value)| {
             part_type == "year" && value.chars().count() > 2 && value.chars().all(char::is_numeric)
         })
-        && icu_short_year_is_two_digit(&formatter);
+        && icu_short_year_is_two_digit(formatter.as_ref()?);
     Some(normalize_icu_datetime_parts(
         parts,
         opts,

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1512,8 +1512,9 @@ fn legacy_icu_numeric_style(
 
 fn legacy_icu_pattern_string(
     pattern: &icu_datetime_legacy::pattern::runtime::Pattern<'_>,
+    offset_style: Option<&str>,
 ) -> String {
-    use icu_datetime_legacy::fields::FieldLength;
+    use icu_datetime_legacy::fields::{FieldLength, FieldSymbol};
     use icu_datetime_legacy::pattern::PatternItem;
 
     fn push_literal(output: &mut String, literal: &str) {
@@ -1545,6 +1546,17 @@ fn legacy_icu_pattern_string(
             PatternItem::Field(field) => {
                 push_literal(&mut output, &literal);
                 literal.clear();
+                // The legacy components::Bag exposes a single GmtOffset variant,
+                // so shortOffset and longOffset both resolve to the long
+                // localized-GMT token. Emit the requested localized-GMT width
+                // directly instead: `O` (short, e.g. GMT-5) or `OOOO` (long,
+                // e.g. GMT-05:00). ICU4X 2.0 honors this distinction when the
+                // generated pattern string is reparsed.
+                if let (Some(style), FieldSymbol::TimeZone(_)) = (offset_style, field.symbol) {
+                    let count = if style == "shortOffset" { 1 } else { 4 };
+                    output.extend(std::iter::repeat_n('O', count));
+                    continue;
+                }
                 let length = match field.length {
                     FieldLength::One | FieldLength::NumericOverride(_) => 1,
                     FieldLength::TwoDigit => 2,
@@ -1849,7 +1861,13 @@ fn icu_mixed_width_pattern(
         }
         BestSkeleton::MissingOrExtraFields(_) | BestSkeleton::NoMatch => return None,
     };
-    legacy_icu_pattern_string(&pattern).parse().ok()
+    let offset_style = opts
+        .time_zone_name
+        .as_deref()
+        .filter(|style| matches!(*style, "shortOffset" | "longOffset"));
+    legacy_icu_pattern_string(&pattern, offset_style)
+        .parse()
+        .ok()
 }
 
 fn icu_datetime_field_set(

--- a/test262-extra/Intl-DateTimeFormat-mixed-textual-field-widths.js
+++ b/test262-extra/Intl-DateTimeFormat-mixed-textual-field-widths.js
@@ -138,3 +138,40 @@ assertSame(enDateTimeFields.month, 'January',
   'fractional seconds do not narrow the English month');
 assertSame(enDateTimeFields.fractionalSecond, '123',
   'mixed-width pattern retains fractional seconds');
+
+// A time-zone name requested alongside mixed textual widths must retain its own
+// requested width: shortOffset is the short localized GMT format (GMT-5) and
+// longOffset is the long form (GMT-05:00). ECMA-402 FormatDateTimePattern keeps
+// these distinct; they must not collapse to a single offset width.
+function assertOffsetName(timeZone, timeZoneName, ms, expected, message) {
+  var options = {
+    weekday: 'long', month: 'short', day: 'numeric', year: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+    timeZone: timeZone, timeZoneName: timeZoneName
+  };
+  var parts = new Intl.DateTimeFormat('en-US', options).formatToParts(ms);
+  var actual;
+  for (var i = 0; i < parts.length; i++) {
+    if (parts[i].type === 'timeZoneName') {
+      actual = parts[i].value;
+      break;
+    }
+  }
+  assertSame(actual, expected, message);
+}
+
+var januaryNoon = Date.UTC(1970, 0, 1, 12, 0, 0);
+var julyNoon = Date.UTC(1970, 6, 1, 12, 0, 0);
+
+assertOffsetName('America/New_York', 'shortOffset', januaryNoon, 'GMT-5',
+  'mixed widths keep short offset (winter)');
+assertOffsetName('America/New_York', 'longOffset', januaryNoon, 'GMT-05:00',
+  'mixed widths keep long offset (winter)');
+assertOffsetName('America/New_York', 'shortOffset', julyNoon, 'GMT-4',
+  'mixed widths keep short offset (summer)');
+assertOffsetName('America/New_York', 'longOffset', julyNoon, 'GMT-04:00',
+  'mixed widths keep long offset (summer)');
+assertOffsetName('Asia/Kolkata', 'shortOffset', januaryNoon, 'GMT+5:30',
+  'mixed widths keep short half-hour offset');
+assertOffsetName('Asia/Kolkata', 'longOffset', januaryNoon, 'GMT+05:30',
+  'mixed widths keep long half-hour offset');

--- a/test262-extra/Intl-DateTimeFormat-mixed-textual-field-widths.js
+++ b/test262-extra/Intl-DateTimeFormat-mixed-textual-field-widths.js
@@ -1,0 +1,140 @@
+// Intl.DateTimeFormat must preserve independently requested textual component
+// widths while selecting the effective locale's pattern.
+//
+// Spec: ECMA-402 BasicFormatMatcher and FormatDateTimePattern preserve the
+// requested weekday, era, and month representations in the selected format.
+
+function assertSame(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Test262Error(
+      message + ': expected "' + expected + '", got "' + actual + '"');
+  }
+}
+
+var timestamp = Date.UTC(1970, 0, 1);
+
+function assertFormat(locale, options, expected, expectedFields, message) {
+  options.timeZone = 'UTC';
+  var formatter = new Intl.DateTimeFormat(locale, options);
+  var formatted = formatter.format(timestamp);
+  assertSame(formatted, expected, message);
+
+  var parts = formatter.formatToParts(timestamp);
+  var joined = '';
+  for (var i = 0; i < parts.length; i++) {
+    joined += parts[i].value;
+  }
+  assertSame(joined, formatted, message + ' formatToParts values reproduce format');
+
+  for (var field in expectedFields) {
+    var actual;
+    for (var j = 0; j < parts.length; j++) {
+      if (parts[j].type === field) {
+        actual = parts[j].value;
+        break;
+      }
+    }
+    assertSame(actual, expectedFields[field], message + ' ' + field + ' part');
+  }
+}
+
+assertFormat('en-US', {
+  weekday: 'short',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+}, 'Thu, January 1, 1970', {
+  weekday: 'Thu', month: 'January'
+}, 'English short weekday and long month');
+
+assertFormat('en-US', {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+}, 'Thursday, Jan 1, 1970', {
+  weekday: 'Thursday', month: 'Jan'
+}, 'English long weekday and short month');
+
+assertFormat('en-US', {
+  weekday: 'narrow',
+  era: 'long',
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+}, 'T, Jan 1, 1970 Anno Domini', {
+  weekday: 'T', month: 'Jan', era: 'Anno Domini'
+}, 'English narrow weekday, short month, and long era');
+
+assertFormat('fr-FR', {
+  weekday: 'short',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+}, 'jeu. 1 janvier 1970', {
+  weekday: 'jeu.', month: 'janvier'
+}, 'French short weekday and long month');
+
+assertFormat('fr-FR', {
+  weekday: 'long',
+  era: 'short',
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+}, 'jeudi 1 janv. 1970 ap. J.-C.', {
+  weekday: 'jeudi', month: 'janv.', era: 'ap. J.-C.'
+}, 'French long weekday, short month, and short era');
+
+assertFormat('ja-JP', {
+  weekday: 'short',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+}, '1970年1月1日(木)', {
+  weekday: '木', month: '1'
+}, 'Japanese short weekday and long month');
+
+assertFormat('ja-JP', {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+}, '1970年1月1日木曜日', {
+  weekday: '木曜日', month: '1'
+}, 'Japanese long weekday and short month');
+
+assertFormat('de-DE', {
+  weekday: 'narrow',
+  era: 'long',
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+}, 'D, 1. Jan. 1970 n. Chr.', {
+  weekday: 'D', month: 'Jan.', era: 'n. Chr.'
+}, 'German narrow weekday, short month, and long era');
+
+var enDateTime = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+  second: '2-digit',
+  fractionalSecondDigits: 3,
+  timeZone: 'UTC'
+});
+var enDateTimeParts = enDateTime.formatToParts(
+  Date.UTC(1970, 0, 1, 15, 4, 5, 123));
+var enDateTimeFields = {};
+for (var k = 0; k < enDateTimeParts.length; k++) {
+  if (enDateTimeParts[k].type !== 'literal') {
+    enDateTimeFields[enDateTimeParts[k].type] = enDateTimeParts[k].value;
+  }
+}
+assertSame(enDateTimeFields.weekday, 'Thu',
+  'fractional seconds do not widen the English weekday');
+assertSame(enDateTimeFields.month, 'January',
+  'fractional seconds do not narrow the English month');
+assertSame(enDateTimeFields.fractionalSecond, '123',
+  'mixed-width pattern retains fractional seconds');


### PR DESCRIPTION
## Summary

- Preserve independently requested weekday, era, and textual month widths when Intl.DateTimeFormat selects a localized pattern.
- Use ICU4X 1.5 classical skeleton data only for mixed-width pattern selection, while ICU4X 2 continues to provide localized names, numbering, zones, and annotated parts.
- Add exact format and formatToParts coverage for English, French, Japanese, and German, plus a fractional-seconds composite case.

## Validation

- ./scripts/lint.sh
- cargo build --release
- cargo test --release (294 unit tests and smoke oracle passed)
- uv run python scripts/run-custom-tests.py (7/7)
- TZ=UTC uv run python scripts/run-test262.py test262-extra/Intl-DateTimeFormat-mixed-textual-field-widths.js (2/2)
- TZ=UTC uv run python scripts/run-test262.py test262/test/intl402/DateTimeFormat/ (488/488)
- TZ=UTC uv run python scripts/run-test262.py (99,568/99,568; zero regressions)

The test262 runs set TZ=UTC because this host defaults to Europe/Berlin; without TZ, 18 existing local-Date tests fail independently of this change.

Closes #289