### PR TITLE
test: add js-md5 Node-compat harness

### DIFF
--- a/docs/specs/2026-07-17-js-md5-library-harness-design.md
+++ b/docs/specs/2026-07-17-js-md5-library-harness-design.md
@@ -1,0 +1,68 @@
+# js-md5 library harness design
+
+## Context
+
+Issue #301 is the js-md5 follow-up to the js-sha256 Node-compatibility slice.
+The upstream suite is deterministic and exercises MD5 and HMAC-MD5 through
+string, Array, Buffer, TypedArray, and ArrayBuffer inputs. Its implementation is
+a useful engine stress test for UTF-16-to-UTF-8 conversion and dense 32-bit
+Number bitwise operations.
+
+Upstream's Node entry repeats the same vector files under several module-loader
+configurations and includes Worker tests. A single esbuild bundle cannot
+reproduce `require.cache` eviction, and JSSE does not expose the Worker host API.
+The cryptographic coverage itself is contained in two self-contained vector
+files with generated Mocha cases.
+
+## Requirements
+
+- Pin an immutable upstream js-md5 release.
+- Run the upstream MD5 and HMAC-MD5 vector files without copying their cases.
+- Exercise every input and output shape registered by those vector files,
+  including UTF-8 strings, Buffer, TypedArray, and ArrayBuffer values.
+- Use the shared in-process Mocha-shaped harness on JSSE and real Mocha on Node.
+- Require equal, non-zero test counts on both engines and lock the observed
+  count in the library configuration.
+- Keep Node host compatibility in `scripts/`; do not add default globals to
+  JSSE.
+
+## Approaches considered
+
+1. Load the two upstream vector files once through a focused bundle entry. This
+   retains the library's behavioral cases while fitting the existing js-sha256
+   harness pattern. This is the selected approach.
+2. Reproduce upstream's full Node entry. Its repeated module modes depend on
+   `require.cache`, and its Worker cases require a host API outside this slice;
+   bundling it would provide misleading rather than faithful coverage.
+3. Generate separate bundles for each loader mode and emulate Workers. This
+   would add substantial harness complexity for repeated cryptographic vectors
+   and host behavior that the issue does not require.
+
+## Design
+
+Add `scripts/libs/js-md5.sh`, pinned to upstream `v0.8.3`. Its prepare hook
+removes unrelated development tooling, installs pinned Mocha for the Node
+oracle, and copies a repository-owned entry into the upstream clone.
+
+The entry detects JSSE's `--node` host floor. On JSSE it uses the shared
+Mocha-shaped runner and installs Mocha's `context` alias. On Node it creates a
+real programmatic Mocha runner before loading the identical upstream files.
+Both paths install the two `expect.js` operations used by the vectors directly,
+select js-md5's pure-JavaScript path, enable Buffer cases, expose the imported
+`md5` function globally, and load `test.js` and `hmac-test.js` once.
+
+The library verdict parses the common PASS/FAIL/TOTAL summary, rejects non-zero
+engine exits through the generalized runner, and requires the exact count
+observed on both engines.
+
+## Validation
+
+- Run js-md5 on Node alone to establish the oracle count.
+- Run the default js-md5 harness with a clean cache to require JSSE/Node
+  agreement.
+- Run the shared harness and shim fixture self-tests.
+- Run targeted test262 coverage for Number bitwise operators, TypedArray,
+  ArrayBuffer, and `String.prototype.charCodeAt`.
+- Run the repository format, lint, release build, release tests, and full
+  test262 suite. Since this design changes only scripts and documentation, the
+  full suite must match the current main-branch result.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -219,6 +219,7 @@ assertions).
 | `ajv` | v8.17.1 | ⚠️ 5,466 / 5,480 (Node: 5,480) | ~4 min; four codegen option variants across drafts 6, 7, 2019-09, and 2020-12; residuals tracked in #274 and #275 |
 | `prismjs` | v1.30.0 | ✅ 2,563 (cross-checked) | token streams for ~290 grammars; 3 jsse-only skips — see below |
 | `js-sha256` | v0.11.1 | ✅ 916 (cross-checked) | Pure-JS SHA-224/SHA-256 and HMAC vectors; string, Buffer, TypedArray, and ArrayBuffer inputs |
+| `js-md5` | v0.8.3 | ✅ 550 (cross-checked) | Pure-JS MD5 and HMAC-MD5 vectors; UTF-8 strings, Buffer, TypedArray, and ArrayBuffer inputs |
 | `luxon` | 3.7.2 | ⚠️ 1,045 / 1,152 | exact count cross-checked; Node is 1,152 / 1,152; blocked on #262–#265 |
 | `bignumber.js` | v9.1.2 | ⚠️ blocked | see below; green on Node today |
 

--- a/scripts/libs/js-md5-jsse-entry.js
+++ b/scripts/libs/js-md5-jsse-entry.js
@@ -1,0 +1,80 @@
+// jsse bundle entry for js-md5's deterministic MD5 and HMAC-MD5 vectors. The
+// upstream Node entry repeats these files under several module configurations
+// by evicting require.cache and also covers Workers. Those host and loader modes
+// are not meaningful after esbuild has bundled every module once. Load the
+// vector files once here while preserving all string, Array, Buffer,
+// TypedArray, and ArrayBuffer cases.
+
+var runningOnJsse = typeof __host_write !== "undefined";
+var mocha;
+
+if (runningOnJsse) {
+  // node-test-harness.js provides describe/it but js-md5 also uses Mocha's
+  // context alias.
+  globalThis.context = globalThis.describe;
+} else {
+  // The shared harness is deliberately inert on Node. Install real Mocha's
+  // globals so Node remains an independent framework oracle.
+  var Mocha = require("mocha");
+  mocha = new Mocha();
+  mocha.suite.emit("pre-require", globalThis, "tests/jsse-entry.js", mocha);
+}
+
+// The vector files use exactly two expect.js operations. Upstream's expect.js
+// 0.3.1 mutates Function#length while installing its fluent chain; that was a
+// silent no-op in its original sloppy CommonJS wrapper but throws after esbuild
+// places it in strict code. Keep the upstream cases unchanged and provide their
+// small assertion seam directly.
+globalThis.expect = function (actual) {
+  var chain = {
+    be: function (expected) {
+      if (actual !== expected) {
+        throw new Error("expected " + actual + " to be " + expected);
+      }
+    },
+    throwError: function (pattern) {
+      if (typeof actual !== "function") {
+        throw new Error("expected a function");
+      }
+      try {
+        actual();
+      } catch (error) {
+        var message =
+          error && typeof error.message !== "undefined"
+            ? String(error.message)
+            : String(error);
+        if (!pattern || pattern.test(message)) return;
+        throw new Error("expected error " + message + " to match " + pattern);
+      }
+      throw new Error("expected function to throw");
+    },
+  };
+  return { to: chain };
+};
+
+// node-shim.js advertises process.versions.node, but this target is intended to
+// exercise js-md5's own implementation rather than its native crypto fast path.
+// This is the same browser/webpack mode used by upstream's Node entry.
+globalThis.window = globalThis;
+globalThis.JS_MD5_NO_NODE_JS = true;
+
+var md5 = require("../src/md5.js");
+globalThis.md5 = md5;
+globalThis.BUFFER = true;
+
+require("./test.js");
+require("./hmac-test.js");
+
+if (!runningOnJsse) {
+  var runner = mocha.run(function (failures) {
+    console.log(
+      "    PASS: " +
+        runner.stats.passes +
+        "  FAIL: " +
+        runner.stats.failures +
+        "  TOTAL: " +
+        runner.stats.tests
+    );
+    process.exitCode = failures ? 1 : 0;
+  });
+}

--- a/scripts/libs/js-md5.sh
+++ b/scripts/libs/js-md5.sh
@@ -1,0 +1,37 @@
+# js-md5 — deterministic MD5 and HMAC-MD5 vectors over strings, Arrays,
+# Buffer, TypedArrays, and ArrayBuffers.
+#
+# The upstream Node entry repeats the same vector files under several module
+# loader configurations using require.cache eviction and adds Worker tests.
+# esbuild bundles each module once and jsse has no Worker host surface, so
+# lib_prepare installs a focused entry that runs both cryptographic vector files
+# once. On jsse, node-test-harness.js supplies the Mocha-shaped runner; on Node,
+# the entry runs real Mocha and emits the same PASS/FAIL/TOTAL summary.
+
+LIB_REPO="https://github.com/emn178/js-md5.git"
+LIB_REF="v0.8.3"
+LIB_ENTRY="tests/jsse-entry.js"
+LIB_ESBUILD_PLATFORM="node"
+LIB_SHIM="node-test-harness.js"
+LIB_EXPECT_COUNT="550"   # locked: v0.8.3 vectors, equal on jsse and Node
+LIB_TIMEOUT="300"
+
+lib_prepare() {
+    # Keep preparation small and deterministic: the coverage, documentation,
+    # AMD, and Worker dependencies from upstream are not used by this bundle.
+    node -e "const p=require('./package.json'); p.devDependencies={}; p.scripts={}; require('fs').writeFileSync('package.json', JSON.stringify(p,null,2)+'\n')"
+    npm install --no-save --no-audit --no-fund mocha@10.8.2
+    cp "$SCRIPT_DIR/libs/js-md5-jsse-entry.js" "$LIB_ENTRY"
+}
+
+lib_verdict() {
+    local out="$1" line P F T
+    line="$(grep -oE 'PASS: [0-9]+[[:space:]]+FAIL: [0-9]+[[:space:]]+TOTAL: [0-9]+' "$out" | tail -1 || true)"
+    if [ -z "$line" ]; then echo "FAIL 0"; return 1; fi
+    if [[ "$line" =~ PASS:\ ([0-9]+)[[:space:]]+FAIL:\ ([0-9]+)[[:space:]]+TOTAL:\ ([0-9]+) ]]; then
+        P="${BASH_REMATCH[1]}"; F="${BASH_REMATCH[2]}"; T="${BASH_REMATCH[3]}"
+        if [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
+        echo "FAIL $T"; return 1
+    fi
+    echo "FAIL 0"; return 1
+}

--- a/scripts/libs/js-md5.sh
+++ b/scripts/libs/js-md5.sh
@@ -25,12 +25,12 @@ lib_prepare() {
 }
 
 lib_verdict() {
-    local out="$1" line P F T
+    local out="$1" rc="$2" line P F T
     line="$(grep -oE 'PASS: [0-9]+[[:space:]]+FAIL: [0-9]+[[:space:]]+TOTAL: [0-9]+' "$out" | tail -1 || true)"
     if [ -z "$line" ]; then echo "FAIL 0"; return 1; fi
     if [[ "$line" =~ PASS:\ ([0-9]+)[[:space:]]+FAIL:\ ([0-9]+)[[:space:]]+TOTAL:\ ([0-9]+) ]]; then
         P="${BASH_REMATCH[1]}"; F="${BASH_REMATCH[2]}"; T="${BASH_REMATCH[3]}"
-        if [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
+        if [ "$rc" -eq 0 ] && [ "$F" -eq 0 ] && [ "$T" -gt 0 ]; then echo "PASS $T"; return 0; fi
         echo "FAIL $T"; return 1
     fi
     echo "FAIL 0"; return 1


### PR DESCRIPTION
## Summary

- pin js-md5 v0.8.3 and run its pure-JavaScript MD5 and HMAC-MD5 vectors
- cross-check 550 generated tests between JSSE's shared Mocha-shaped harness and real Mocha on Node
- cover UTF-8 strings, Arrays, Buffer, TypedArray, ArrayBuffer, output formats, and error cases without changing default globals

## Validation

- `./scripts/run-library-tests.sh js-md5 --node --clean` (550/550 on Node)
- `./scripts/run-library-tests.sh js-md5` (550/550 on JSSE and Node)
- `./scripts/run-harness-selftest.sh --no-build`
- `./scripts/run-shim-fixtures.sh` (260/260 on JSSE and Node)
- targeted bitwise, shift, TypedArray, ArrayBuffer, and `charCodeAt` test262 coverage (3,828/3,828)
- `cargo fmt --check`; `cargo clippy`; `cargo build --release`; `cargo test --release`; `./scripts/lint.sh`
- `TZ=UTC uv run python scripts/run-test262.py` (99,568/99,568, zero regressions)

The UTC setting matches the 100% baseline environment. An initial run in the workspace's Europe/Berlin host zone reproduced 22 pre-existing DateTimeFormat/Temporal failures caused by JSSE applying the current local offset to historical local dates; the isolated 22 scenarios and the full suite are green under UTC, and this branch has no engine, Cargo, test262, or test262-extra changes.

Closes #301
