### PR TITLE
fix: honor exotic Set in prototype-ignoring setters

### DIFF
--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -651,11 +651,15 @@ impl Interpreter {
                                 PropertyDescriptor::data(v, true, true, true),
                             );
                         }
-                    } else if let Some(od) = interp.get_object_cell(this_id)
-                        && !od.borrow_mut().set_property_value(&prop_key, v)
-                    {
-                        let err = interp.create_type_error("Cannot set property");
-                        return Completion::Throw(err);
+                    } else {
+                        match interp.set_object_property(this_id, &prop_key, v, this) {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                let err = interp.create_type_error("Cannot set property");
+                                return Completion::Throw(err);
+                            }
+                            Err(err) => return Completion::Throw(err),
+                        }
                     }
                     Completion::Normal(JsValue::Undefined)
                 },
@@ -814,11 +818,14 @@ impl Interpreter {
                         }
                     } else {
                         // Set(this, "constructor", v, true)
-                        if let Some(od) = interp.get_object_cell(this_id)
-                            && !od.borrow_mut().set_property_value("constructor", v)
-                        {
-                            let err = interp.create_type_error("Cannot set property constructor");
-                            return Completion::Throw(err);
+                        match interp.set_object_property(this_id, "constructor", v, this) {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                let err =
+                                    interp.create_type_error("Cannot set property constructor");
+                                return Completion::Throw(err);
+                            }
+                            Err(err) => return Completion::Throw(err),
                         }
                     }
                     Completion::Normal(JsValue::Undefined)

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -744,7 +744,7 @@ impl Interpreter {
                             };
                         }
                         // 5a. Set(this, "stack", v, true) (fires set trap).
-                        return match interp.proxy_set(o_id, "stack", v, this_val) {
+                        return match interp.set_object_property(o_id, "stack", v, this_val) {
                             Ok(true) => Completion::Normal(JsValue::Undefined),
                             Ok(false) => Completion::Throw(
                                 interp.create_type_error("Cannot set property 'stack'"),
@@ -765,32 +765,13 @@ impl Interpreter {
                             }
                         }
                         // 5a. Set(this, "stack", v, true) with receiver == this.
-                        Some(desc) => {
-                            if desc.is_accessor_descriptor() {
-                                match desc.set {
-                                    Some(setter_fn) if !matches!(setter_fn, JsValue::Undefined) => {
-                                        match interp.call_function(&setter_fn, this_val, &[v]) {
-                                            Completion::Normal(_) => {
-                                                Completion::Normal(JsValue::Undefined)
-                                            }
-                                            other => other,
-                                        }
-                                    }
-                                    _ => Completion::Throw(interp.create_type_error(
-                                        "Cannot set property 'stack' which has only a getter",
-                                    )),
-                                }
-                            } else if desc.writable == Some(false) {
-                                Completion::Throw(interp.create_type_error(
-                                    "Cannot assign to read only property 'stack'",
-                                ))
-                            } else {
-                                if let Some(cell) = interp.get_object_cell(o_id) {
-                                    cell.borrow_mut().set_property_value("stack", v);
-                                }
-                                Completion::Normal(JsValue::Undefined)
-                            }
-                        }
+                        Some(_) => match interp.set_object_property(o_id, "stack", v, this_val) {
+                            Ok(true) => Completion::Normal(JsValue::Undefined),
+                            Ok(false) => Completion::Throw(
+                                interp.create_type_error("Cannot set property 'stack'"),
+                            ),
+                            Err(e) => Completion::Throw(e),
+                        },
                     }
                 },
             ));

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -5,7 +5,6 @@ impl Interpreter {
     /// accessor setter invocation, prototype-chain walk, and receiver logic.
     /// Returns `Ok(true)` on success, `Ok(false)` if the set was rejected
     /// (e.g. read-only property), `Err(e)` if an exception was thrown.
-    #[allow(dead_code)]
     pub(crate) fn set_object_property(
         &mut self,
         obj_id: u64,
@@ -13,6 +12,14 @@ impl Interpreter {
         value: JsValue,
         receiver: &JsValue,
     ) -> Result<bool, JsValue> {
+        // Module namespace exotic [[Set]] (§10.4.6.9) always rejects the set,
+        // even though exported bindings have writable own data descriptors.
+        if self
+            .get_object_cell(obj_id)
+            .is_some_and(|obj| obj.borrow().module_namespace().is_some())
+        {
+            return Ok(false);
+        }
         self.proxy_set(obj_id, key, value, receiver)
     }
 

--- a/test262-extra/SetterThatIgnoresPrototypeProperties-module-namespace-set-dep.mjs
+++ b/test262-extra/SetterThatIgnoresPrototypeProperties-module-namespace-set-dep.mjs
@@ -1,0 +1,6 @@
+// Dependency for SetterThatIgnoresPrototypeProperties-module-namespace-set.mjs.
+// The exported names ensure the namespace reports writable own data
+// descriptors even though its [[Set]] internal method always returns false.
+
+export let stack = "original stack";
+export let constructor = "original constructor";

--- a/test262-extra/SetterThatIgnoresPrototypeProperties-module-namespace-set.mjs
+++ b/test262-extra/SetterThatIgnoresPrototypeProperties-module-namespace-set.mjs
@@ -1,0 +1,62 @@
+/*---
+description: >
+  SetterThatIgnoresPrototypeProperties honors a module namespace exotic
+  object's [[Set]] result when the receiver has an own property.
+info: |
+  SetterThatIgnoresPrototypeProperties ( thisValue, home, p, v )
+
+  3. Let desc be ? thisValue.[[GetOwnProperty]](p).
+  4. If desc is undefined, then
+    a. Perform ? CreateDataPropertyOrThrow(thisValue, p, v).
+  5. Else,
+    a. Perform ? Set(thisValue, p, v, true).
+
+  Module Namespace Exotic Objects [[Set]] ( P, V, Receiver )
+
+  1. Return false.
+esid: sec-SetterThatIgnoresPrototypeProperties
+features: [error-stack-accessor, iterator-helpers, Symbol.toStringTag]
+flags: [module]
+---*/
+
+import * as ns from "./SetterThatIgnoresPrototypeProperties-module-namespace-set-dep.mjs";
+
+var errorStackSetter = Object.getOwnPropertyDescriptor(Error.prototype, "stack").set;
+var iteratorConstructorSetter = Object.getOwnPropertyDescriptor(
+  Iterator.prototype,
+  "constructor"
+).set;
+var iteratorToStringTagSetter = Object.getOwnPropertyDescriptor(
+  Iterator.prototype,
+  Symbol.toStringTag
+).set;
+
+function assertTypeError(setter, value, label) {
+  var caught;
+  try {
+    setter.call(ns, value);
+  } catch (error) {
+    caught = error;
+  }
+  if (!(caught instanceof TypeError)) {
+    throw new Test262Error(label + ": expected TypeError, got " + caught);
+  }
+}
+
+assertTypeError(errorStackSetter, "updated stack", "Error.prototype.stack");
+assertTypeError(iteratorConstructorSetter, "updated constructor", "Iterator.prototype.constructor");
+assertTypeError(
+  iteratorToStringTagSetter,
+  "updated tag",
+  "Iterator.prototype[Symbol.toStringTag]"
+);
+
+if (ns.stack !== "original stack") {
+  throw new Test262Error("the exported stack binding was changed");
+}
+if (ns.constructor !== "original constructor") {
+  throw new Test262Error("the exported constructor binding was changed");
+}
+if (ns[Symbol.toStringTag] !== "Module") {
+  throw new Test262Error("the namespace toStringTag was changed");
+}


### PR DESCRIPTION
## Summary

- reject module namespace writes through the canonical `[[Set]]` entry point
- route `Error.prototype.stack`, `Iterator.prototype.constructor`, and `Iterator.prototype[Symbol.toStringTag]` existing-property writes through that entry point
- add a module-namespace regression covering all three setters

## Testing

- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py`
- focused custom regression: 1/1
- focused Error/Iterator test262: 78/78
- `TZ=UTC uv run python scripts/run-test262.py`: 99,568/99,568

Closes #185