### PR TITLE
fix: preserve binary operands across garbage collection

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -419,16 +419,21 @@ impl Interpreter {
                 // operator. Either phase can run user code and reach a GC
                 // safepoint, so keep object operands rooted until the operation
                 // has completed.
-                let gc_frame = self.gc_root_frame();
                 self.gc_root_value(&lval);
                 let rval = match self.eval_expr(right, env) {
                     Completion::Normal(v) => v,
                     other => {
-                        self.gc_unroot_frame(gc_frame);
+                        self.gc_unroot_value(&lval);
                         return other;
                     }
                 };
                 self.gc_root_value(&rval);
+                // The fast string-concat arm below moves lval/rval, so snapshot
+                // the object operands now for a targeted unroot afterwards. Only
+                // objects are ever rooted, and that arm runs only for primitives,
+                // so these are cheap handle copies or None.
+                let lroot = matches!(&lval, JsValue::Object(_)).then(|| lval.clone());
+                let rroot = matches!(&rval, JsValue::Object(_)).then(|| rval.clone());
                 let result = if *op == BinaryOp::Instanceof {
                     self.eval_instanceof(&lval, &rval)
                 // Fast path for string + on owned primitive values:
@@ -456,7 +461,16 @@ impl Interpreter {
                 } else {
                     self.eval_binary(*op, &lval, &rval)
                 };
-                self.gc_unroot_frame(gc_frame);
+                // Unroot only the operands we rooted (mirrors call_function_inner)
+                // so a persistent root a native builtin left alive during rval
+                // evaluation or operator coercion — e.g. Atomics.waitAsync or
+                // $262.agent.getReportAsync — is not dropped by a bulk truncate.
+                if let Some(ref r) = rroot {
+                    self.gc_unroot_value(r);
+                }
+                if let Some(ref l) = lroot {
+                    self.gc_unroot_value(l);
+                }
                 result
             }
             Expression::Logical(op, left, right) => self.eval_logical(*op, left, right, env),

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -414,36 +414,50 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
+                // EvaluateStringOrNumericBinaryExpression retains lVal while
+                // evaluating rVal, then retains both values while applying the
+                // operator. Either phase can run user code and reach a GC
+                // safepoint, so keep object operands rooted until the operation
+                // has completed.
+                let gc_frame = self.gc_root_frame();
+                self.gc_root_value(&lval);
                 let rval = match self.eval_expr(right, env) {
                     Completion::Normal(v) => v,
-                    other => return other,
+                    other => {
+                        self.gc_unroot_frame(gc_frame);
+                        return other;
+                    }
                 };
-                if *op == BinaryOp::Instanceof {
-                    return self.eval_instanceof(&lval, &rval);
-                }
+                self.gc_root_value(&rval);
+                let result = if *op == BinaryOp::Instanceof {
+                    self.eval_instanceof(&lval, &rval)
                 // Fast path for string + on owned primitive values:
                 // skip eval_binary → to_primitive → js_value_to_code_units clone chain.
-                if *op == BinaryOp::Add
+                } else if *op == BinaryOp::Add
                     && !matches!(&lval, JsValue::Object(_))
                     && !matches!(&rval, JsValue::Object(_))
                     && (matches!(&lval, JsValue::String(_)) || matches!(&rval, JsValue::String(_)))
                 {
                     if matches!(&lval, JsValue::Symbol(_)) || matches!(&rval, JsValue::Symbol(_)) {
-                        return Completion::Throw(
+                        Completion::Throw(
                             self.create_type_error("Cannot convert a Symbol value to a string"),
-                        );
+                        )
+                    } else {
+                        let mut code_units = match lval {
+                            JsValue::String(s) => s.into_vec(),
+                            ref other => js_value_to_code_units(other),
+                        };
+                        match rval {
+                            JsValue::String(s) => code_units.extend_from_slice(&s.code_units),
+                            ref other => code_units.extend(js_value_to_code_units(other)),
+                        };
+                        Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
                     }
-                    let mut code_units = match lval {
-                        JsValue::String(s) => s.into_vec(),
-                        ref other => js_value_to_code_units(other),
-                    };
-                    match rval {
-                        JsValue::String(s) => code_units.extend_from_slice(&s.code_units),
-                        ref other => code_units.extend(js_value_to_code_units(other)),
-                    };
-                    return Completion::Normal(JsValue::String(JsString::from_vec(code_units)));
-                }
-                self.eval_binary(*op, &lval, &rval)
+                } else {
+                    self.eval_binary(*op, &lval, &rval)
+                };
+                self.gc_unroot_frame(gc_frame);
+                result
             }
             Expression::Logical(op, left, right) => self.eval_logical(*op, left, right, env),
             Expression::Update(op, prefix, arg) => self.eval_update(*op, *prefix, arg, env),

--- a/test262-extra/Binary-expression-gc-rooting.js
+++ b/test262-extra/Binary-expression-gc-rooting.js
@@ -1,0 +1,55 @@
+/*---
+description: >
+  Evaluated binary-expression operands remain reachable while later evaluation
+  and coercion trigger garbage collection.
+esid: sec-evaluatestringornumericbinaryexpression
+info: |
+  EvaluateStringOrNumericBinaryExpression retains lVal while it evaluates rVal,
+  then passes both values to ApplyStringOrNumericBinaryOperator. For addition,
+  that operation coerces lVal before rVal. An implementation must therefore
+  keep both object operands reachable until their respective ToPrimitive calls
+  complete, even when user code triggers garbage collection between those
+  specification steps.
+---*/
+
+function leftOperand() {
+  return {
+    valueOf: function () {
+      return 41;
+    },
+  };
+}
+
+function collectAndReturnOne() {
+  $262.gc();
+  return 1;
+}
+
+assert.sameValue(
+  leftOperand() + collectAndReturnOne(),
+  42,
+  "lVal survives evaluation of rVal"
+);
+
+function coercingLeftOperand() {
+  return {
+    valueOf: function () {
+      $262.gc();
+      return 1;
+    },
+  };
+}
+
+function rightOperand() {
+  return {
+    valueOf: function () {
+      return 41;
+    },
+  };
+}
+
+assert.sameValue(
+  coercingLeftOperand() + rightOperand(),
+  42,
+  "rVal survives ToPrimitive(lVal)"
+);


### PR DESCRIPTION
## Summary

- root evaluated binary operands while right-hand evaluation and operator coercion can run user code and trigger garbage collection
- prevent arena slot reuse from turning a live temporary operand into an object that cannot be converted to a primitive
- add normal/strict GC regressions for both left-operand and right-operand lifetime windows

## Validation

- cargo fmt --check
- cargo clippy and ./scripts/lint.sh (warnings denied)
- cargo build --release
- cargo test --release (294 unit tests plus smoke oracle)
- targeted binary-expression test262: 360/360
- new regression: 2/2
- custom tests: 7/7
- full test262: 99,546/99,568; the same 22 environment-sensitive Intl402 mismatches reproduce on the untouched main binary, with 323 beyond-baseline passes
- Moment 2.30.1: 3,871 tests, 162,849 assertions, 0 failures; the original 198 coercion deaths are eliminated. The remaining 19-assertion Node count delta is Moment's no-DST fallback and belongs to existing #263.

Closes #311