### PR TITLE
refactor(gc): root member-assignment base via gc_root_value helper

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -3156,9 +3156,7 @@ impl Interpreter {
                 // `obj_val` otherwise exists only as a Rust local, invisible to
                 // the tracing collector.
                 let gc_frame = self.gc_root_frame();
-                if let JsValue::Object(o) = &obj_val {
-                    self.gc_temp_roots.push(o.id);
-                }
+                self.gc_root_value(&obj_val);
                 let result = (|| {
                     if let MemberProperty::Private(name) = prop {
                         let branded = self.resolve_private_name(name, env);


### PR DESCRIPTION
## Summary

- Converts the member-assignment base rooting site (`src/interpreter/eval.rs`) from the inline `if let JsValue::Object(o) = &obj_val { self.gc_temp_roots.push(o.id); }` to the `self.gc_root_value(&obj_val)` helper.
- This is a **verified behavioral no-op**: `gc_root_value` is defined as exactly `if let JsValue::Object(o) = val { self.gc_temp_roots.push(o.id); }`. The change reconciles the last array-literal / member-assignment GC-rooting divergence left by #278 — the array-literal site already uses the helper.
- Standardizes on the helper as the mutation boundary so ordinary callers don't touch `gc_temp_roots` directly, giving a single place for future validation/tracing and easier auditing (grep `gc_root_value`).

This is the option (b) resolution from #290 (the issue's own "reconcile only the named site" path). The dual-push and raw-id inline sites are intentionally left alone — they encode extra lifetime bookkeeping and are not `gc_root_value`-equivalent. A broader mechanical sweep of the other trivially-equivalent inline sites and the larger GC-ergonomics redesign are tracked separately.

Closes #290

## Test plan

- [x] `cargo build --release` — clean
- [x] `./scripts/lint.sh` (rustfmt + clippy) — clean
- [x] 6 GC regression tests (3 files × default+strict) — 6/6 pass:
  - `test262-extra/Array-literal-spread-gc-rooting.js`
  - `test262-extra/GC-literal-partial-rooting.js`
  - `test262-extra/GC-member-assignment-base-rooting.js`

Since the change is a verified behavioral no-op, the targeted GC regression tests are the discriminator; a full test262 run is optional insurance.