### PR TITLE
fix(harness): distinguish sparse holes in tape deepEqual

### DIFF
--- a/scripts/harness-fixtures/qunit.fixture.js
+++ b/scripts/harness-fixtures/qunit.fixture.js
@@ -8,7 +8,7 @@
 // tests, expect() planning, raises, and — via one deliberately failing
 // assertion — that failures are detected and counted (not just passes).
 //
-// Expected summary: PASS: 23  FAIL: 1  TOTAL: 24
+// Expected summary: PASS: 24  FAIL: 1  TOTAL: 25
 
 QUnit.module("primitives");
 QUnit.test("equality asserts", function (assert) {
@@ -23,8 +23,9 @@ QUnit.test("equality asserts", function (assert) {
 
 QUnit.module("deepEqual");
 QUnit.test("structural equality edge cases", function (assert) {
-  assert.expect(8);
+  assert.expect(9);
   assert.deepEqual({ a: [1, 2], b: { c: 3 } }, { a: [1, 2], b: { c: 3 } }, "nested");
+  assert.deepEqual([, "x"], [undefined, "x"], "QUnit ignores sparse hole ownership");
   assert.deepEqual([NaN], [NaN], "NaN equals NaN structurally");
   assert.deepEqual(new Date(0), new Date(0), "Date by value");
   assert.deepEqual(/x/gi, /x/gi, "RegExp by source+flags");

--- a/scripts/harness-fixtures/tape.fixture.js
+++ b/scripts/harness-fixtures/tape.fixture.js
@@ -1,10 +1,18 @@
 // Self-test for the tape assertion-object adapter. The shared harness is inert
 // on Node, so run-harness-selftest.sh validates this fixture on JSSE alone.
 //
-// Expected summary: PASS: 16  FAIL: 0  TOTAL: 16
+// Expected summary: PASS: 17  FAIL: 0  TOTAL: 17
 
 var tape = globalThis.__tape;
 var restored = { value: true };
+var nonEnumerableHole = [];
+Object.defineProperty(nonEnumerableHole, 0, {
+  value: undefined,
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+nonEnumerableHole[1] = "x";
 
 tape("tape adapter", function (t) {
   t.equal(1, 1, "strict equality");
@@ -16,6 +24,11 @@ tape("tape adapter", function (t) {
     { a: [, "x"] },
     { a: [undefined, "x"] },
     "nested sparse hole is not undefined"
+  );
+  t.deepEqual(
+    [, "x"],
+    nonEnumerableHole,
+    "sparse hole equals non-enumerable own undefined"
   );
   t.ok(true, "truthy");
   t.notOk(false, "falsy");

--- a/scripts/harness-fixtures/tape.fixture.js
+++ b/scripts/harness-fixtures/tape.fixture.js
@@ -1,7 +1,7 @@
 // Self-test for the tape assertion-object adapter. The shared harness is inert
 // on Node, so run-harness-selftest.sh validates this fixture on JSSE alone.
 //
-// Expected summary: PASS: 13  FAIL: 0  TOTAL: 13
+// Expected summary: PASS: 16  FAIL: 0  TOTAL: 16
 
 var tape = globalThis.__tape;
 var restored = { value: true };
@@ -10,6 +10,13 @@ tape("tape adapter", function (t) {
   t.equal(1, 1, "strict equality");
   t.notEqual(1, "1", "strict inequality");
   t.deepEqual({ a: [1, NaN] }, { a: [1, NaN] }, "deep equality");
+  t.deepEqual([, "x"], [, "x"], "matching sparse array holes");
+  t.notDeepEqual([, "x"], [undefined, "x"], "sparse hole is not undefined");
+  t.notDeepEqual(
+    { a: [, "x"] },
+    { a: [undefined, "x"] },
+    "nested sparse hole is not undefined"
+  );
   t.ok(true, "truthy");
   t.notOk(false, "falsy");
 

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -273,10 +273,10 @@
   }
 
   // ==========================================================================
-  // objectType + equiv — ported verbatim from qunitjs 2.4.1 (qunit/qunit.js),
-  // the deepEqual engine. Hand-rolling structural equality is a known trap
-  // (NaN, Date, RegExp, Map/Set, cyclic, null-proto objects), so we keep QUnit's
-  // own implementation to match its semantics exactly.
+  // objectType + createEquiv — based on qunitjs 2.4.1 (qunit/qunit.js), the
+  // deepEqual engine. QUnit uses the original behavior; tape additionally
+  // compares array-index ownership because its deep-equal treats a sparse hole
+  // and an own property containing undefined as different values.
   // ==========================================================================
   function objectType(obj) {
     if (typeof obj === "undefined") return "undefined";
@@ -301,7 +301,7 @@
     }
   }
 
-  var equiv = (function () {
+  function createEquiv(compareArrayOwnership) {
     var pairs = [];
     var getProto =
       Object.getPrototypeOf ||
@@ -379,6 +379,13 @@
         len = a.length;
         if (len !== b.length) return false;
         for (i = 0; i < len; i++) {
+          if (
+            compareArrayOwnership &&
+            Object.prototype.hasOwnProperty.call(a, i) !==
+              Object.prototype.hasOwnProperty.call(b, i)
+          ) {
+            return false;
+          }
           if (!breadthFirstCompareChild(a[i], b[i])) return false;
         }
         return true;
@@ -471,7 +478,10 @@
       pairs.length = 0;
       return result;
     };
-  })();
+  }
+
+  var equiv = createEquiv(false);
+  var tapeEquiv = createEquiv(true);
 
   // A compact value renderer for failure diagnostics (not Node's util.inspect).
   function dump(v) {
@@ -1578,7 +1588,7 @@
         },
         deepEqual: function (actual, expected, message, extra) {
           assert(
-            equiv(actual, expected),
+            tapeEquiv(actual, expected),
             message || "should be deeply equivalent",
             actual,
             expected,
@@ -1587,7 +1597,7 @@
         },
         notDeepEqual: function (actual, expected, message, extra) {
           assert(
-            !equiv(actual, expected),
+            !tapeEquiv(actual, expected),
             message || "should not be deeply equivalent",
             actual,
             expected,

--- a/scripts/node-test-harness.js
+++ b/scripts/node-test-harness.js
@@ -275,8 +275,9 @@
   // ==========================================================================
   // objectType + createEquiv — based on qunitjs 2.4.1 (qunit/qunit.js), the
   // deepEqual engine. QUnit uses the original behavior; tape additionally
-  // compares array-index ownership because its deep-equal treats a sparse hole
-  // and an own property containing undefined as different values.
+  // compares array-index enumerability (matching its deep-equal's Object.keys
+  // semantics) because a sparse hole and an enumerable own undefined are
+  // different values, while a non-enumerable own undefined is not.
   // ==========================================================================
   function objectType(obj) {
     if (typeof obj === "undefined") return "undefined";
@@ -381,8 +382,8 @@
         for (i = 0; i < len; i++) {
           if (
             compareArrayOwnership &&
-            Object.prototype.hasOwnProperty.call(a, i) !==
-              Object.prototype.hasOwnProperty.call(b, i)
+            Object.prototype.propertyIsEnumerable.call(a, i) !==
+              Object.prototype.propertyIsEnumerable.call(b, i)
           ) {
             return false;
           }


### PR DESCRIPTION
## Summary

- derive separate QUnit and tape comparers from the existing cycle-aware equality implementation
- make only the tape variant compare indexed own-property presence, distinguishing holes from explicit `undefined`
- cover matching holes, direct and nested mismatches, and unchanged QUnit semantics in harness fixtures

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (305 unit tests + smoke oracle)
- `./scripts/lint.sh`
- `uv run python scripts/run-custom-tests.py` (8/8)
- `./scripts/run-harness-selftest.sh --no-build`
- `./scripts/run-library-tests.sh qs` (1,013/1,013, Node cross-check)
- `./scripts/run-library-tests.sh lodash` (6,794/6,794, Node cross-check)
- targeted array-expression test262 (104/104)
- full test262 completed at 99,546/99,568; it reported 22 pre-existing Intl-only baseline regressions and 323 unrelated new passes. The failures reproduce in isolation, while `src/`, Cargo files, `test262-pass.txt`, and `README.md` have no diff from `origin/main`; this PR changes only the JS harness and fixtures.

Closes #334