### PR TITLE
ci: enforce Conventional Commits (PR titles + commitlint)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: lts/*

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,26 @@
+# Lints commit messages against Conventional Commits on pushes to the default branch.
+# Direct pushes are what the PR-title check can't see; PRs are covered by lint-pr-title.yml.
+name: Lint commits
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: lts/*
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+      - name: Lint pushed commits
+        if: github.event.before != '0000000000000000000000000000000000000000'
+        run: npx commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --verbose

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,23 @@
+# Enforces that PR titles follow the Conventional Commits spec.
+# https://www.conventionalcommits.org/  |  https://github.com/amannn/action-semantic-pull-request
+name: Lint PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -27,3 +27,24 @@ rules:
       # tag can be pushed back to main. It uploads only the packaged binary and
       # checksums (no .git), so the token cannot leak via artifacts.
       - release.yml
+
+  # lint-pr-title.yml uses pull_request_target so the check runs with a real
+  # GITHUB_TOKEN even on PRs from forks. It never checks out the PR's ref and
+  # never executes anything the PR controls: amannn/action-semantic-pull-request
+  # only reads the PR title/body via the GitHub API and validates them against
+  # the Conventional Commits regex, with permissions scoped to
+  # `pull-requests: read`. There is no code-execution or exfiltration path for
+  # PR-controlled content to reach the elevated token.
+  dangerous-triggers:
+    ignore:
+      - lint-pr-title.yml
+
+  # commitlint.yml installs @commitlint/cli and @commitlint/config-conventional
+  # ad-hoc (pinned to major version @21) rather than via a project lockfile:
+  # this repo has no package.json/lockfile of its own (it's a Rust project),
+  # so there is nothing for these CI-only tools to lock against. The job only
+  # has `contents: read` and never pushes, so a compromised transitive
+  # dependency has no credentials to exfiltrate.
+  adhoc-packages:
+    ignore:
+      - commitlint.yml

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,5 @@
+/* Conventional Commits ruleset for commitlint.
+ * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};


### PR DESCRIPTION
Standardizes this repository on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

### Adds
- `.github/workflows/lint-pr-title.yml` — validates **PR titles** with [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request).
- `.github/workflows/commitlint.yml` — lints **commit messages** on pushes to `main` (covers direct pushes the PR-title check can't see).
- `commitlint.config.cjs` — the Conventional Commits ruleset (`.cjs` so it loads under `"type":"module"` too).

### Notes
- For the PR-title check to feed clean history, enable **Settings → Pull Requests → Allow squash merging** with *"Default to PR title for squash-merge commits"*.
- `commitlint.yml` only lints commits going forward — it does not fail on existing history.

_Part of a cross-repo standardization pass. Review and merge, or close if unwanted._
