### PR TITLE
fix(node-compat): buffer split StringDecoder input

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -230,7 +230,9 @@ can similarly alias it to `node-buffer-module.js`. The selector exports the
 shared JS-only Buffer shim on JSSE and Node's native `node:buffer` module on the
 reference path. `node-util-module.js` provides the equivalent selector for the
 shared `util.format`/`util.inspect` implementation, while
-`node-string-decoder-module.js` supplies iconv-lite's buffered decoder seam.
+`node-string-decoder-module.js` supplies iconv-lite's buffered decoder seam,
+including UTF-8, UTF-16LE, base64, and base64url continuation state across
+`write()`/`end()` chunk boundaries.
 
 Full **chai** and **uvu** adapters remain deferred. Luxon settles the Jest seam
 concretely: `gen-luxon-entry.js` bundles the published `expect/build/matchers`

--- a/scripts/node-string-decoder-module.js
+++ b/scripts/node-string-decoder-module.js
@@ -1,18 +1,208 @@
 // CommonJS `string_decoder` selector for bundled library dependencies.
 //
 // iconv-lite's internal codec module imports StringDecoder even when qs only
-// selects a legacy DBCS codec. The JSSE fallback covers the ordinary buffered
-// write/end surface; Node retains its native implementation.
+// selects a legacy DBCS codec. The JSSE fallback covers the buffered write/end
+// surface; Node retains its native implementation.
+//
+// The buffered-state algorithm is derived from Node.js's MIT-licensed
+// lib/string_decoder.js:
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 if (typeof __host_write !== "undefined") {
+  function decoderKind(encoding) {
+    switch (String(encoding).toLowerCase()) {
+      case "utf8":
+      case "utf-8":
+        return "utf8";
+      case "ucs2":
+      case "ucs-2":
+      case "utf16le":
+      case "utf-16le":
+        return "utf16le";
+      case "base64":
+      case "base64url":
+        return "base64";
+      default:
+        return "stateless";
+    }
+  }
+
+  function copyBytes(source, target, targetStart, sourceStart, sourceEnd) {
+    for (var i = sourceStart; i < sourceEnd; i++) {
+      target[targetStart++] = source[i];
+    }
+  }
+
+  function utf8CheckByte(byte) {
+    if (byte <= 0x7f) return 0;
+    if (byte >> 5 === 0x06) return 2;
+    if (byte >> 4 === 0x0e) return 3;
+    if (byte >> 3 === 0x1e) return 4;
+    return byte >> 6 === 0x02 ? -1 : -2;
+  }
+
+  function utf8CheckIncomplete(decoder, bytes, start) {
+    var index = bytes.length - 1;
+    if (index < start) return 0;
+    var size = utf8CheckByte(bytes[index]);
+    if (size >= 0) {
+      if (size > 0) decoder._lastNeed = size - 1;
+      return size;
+    }
+    if (--index < start || size === -2) return 0;
+    size = utf8CheckByte(bytes[index]);
+    if (size >= 0) {
+      if (size > 0) decoder._lastNeed = size - 2;
+      return size;
+    }
+    if (--index < start || size === -2) return 0;
+    size = utf8CheckByte(bytes[index]);
+    if (size >= 0) {
+      if (size > 0) {
+        if (size === 2) size = 0;
+        else decoder._lastNeed = size - 3;
+      }
+      return size;
+    }
+    return 0;
+  }
+
+  function fillLastBytes(decoder, bytes) {
+    var targetStart = decoder._lastTotal - decoder._lastNeed;
+    if (decoder._lastNeed <= bytes.length) {
+      copyBytes(bytes, decoder._lastChar, targetStart, 0, decoder._lastNeed);
+      return decoder._lastChar
+        .subarray(0, decoder._lastTotal)
+        .toString(decoder.encoding);
+    }
+    copyBytes(bytes, decoder._lastChar, targetStart, 0, bytes.length);
+    decoder._lastNeed -= bytes.length;
+  }
+
+  function utf8Text(decoder, bytes, start) {
+    var total = utf8CheckIncomplete(decoder, bytes, start);
+    if (!decoder._lastNeed) return bytes.toString("utf8", start);
+    decoder._lastTotal = total;
+    var end = bytes.length - (total - decoder._lastNeed);
+    copyBytes(bytes, decoder._lastChar, 0, end, bytes.length);
+    return bytes.toString("utf8", start, end);
+  }
+
+  function utf16Text(decoder, bytes, start) {
+    if ((bytes.length - start) % 2 === 0) {
+      var out = bytes.toString(decoder.encoding, start);
+      if (out) {
+        var codeUnit = out.charCodeAt(out.length - 1);
+        if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+          decoder._lastNeed = 2;
+          decoder._lastTotal = 4;
+          decoder._lastChar[0] = bytes[bytes.length - 2];
+          decoder._lastChar[1] = bytes[bytes.length - 1];
+          return out.slice(0, -1);
+        }
+      }
+      return out;
+    }
+    decoder._lastNeed = 1;
+    decoder._lastTotal = 2;
+    decoder._lastChar[0] = bytes[bytes.length - 1];
+    return bytes.toString(decoder.encoding, start, bytes.length - 1);
+  }
+
+  function base64Text(decoder, bytes, start) {
+    var trailing = (bytes.length - start) % 3;
+    if (trailing === 0) return bytes.toString(decoder.encoding, start);
+    decoder._lastNeed = 3 - trailing;
+    decoder._lastTotal = 3;
+    if (trailing === 1) {
+      decoder._lastChar[0] = bytes[bytes.length - 1];
+    } else {
+      decoder._lastChar[0] = bytes[bytes.length - 2];
+      decoder._lastChar[1] = bytes[bytes.length - 1];
+    }
+    return bytes.toString(decoder.encoding, start, bytes.length - trailing);
+  }
+
+  function statefulText(decoder, bytes, start) {
+    if (decoder._kind === "utf8") return utf8Text(decoder, bytes, start);
+    if (decoder._kind === "utf16le") return utf16Text(decoder, bytes, start);
+    return base64Text(decoder, bytes, start);
+  }
+
   function StringDecoder(encoding) {
     this.encoding = encoding || "utf8";
+    this._kind = decoderKind(this.encoding);
+    if (this._kind !== "stateless") {
+      this._lastNeed = 0;
+      this._lastTotal = 0;
+      this._lastChar = globalThis.Buffer.alloc(
+        this._kind === "base64" ? 3 : 4
+      );
+    }
   }
+
   StringDecoder.prototype.write = function (buffer) {
-    return globalThis.Buffer.from(buffer).toString(this.encoding);
+    var bytes = globalThis.Buffer.from(buffer);
+    if (this._kind === "stateless") return bytes.toString(this.encoding);
+    if (bytes.length === 0) return "";
+
+    if (this._kind === "utf8") {
+      if (this._lastNeed) {
+        var buffered = this._lastTotal - this._lastNeed;
+        var combined = globalThis.Buffer.alloc(buffered + bytes.length);
+        copyBytes(this._lastChar, combined, 0, 0, buffered);
+        copyBytes(bytes, combined, buffered, 0, bytes.length);
+        bytes = combined;
+        this._lastNeed = 0;
+      }
+      return utf8Text(this, bytes, 0);
+    }
+
+    var out;
+    var start;
+    if (this._lastNeed) {
+      out = fillLastBytes(this, bytes);
+      if (out === undefined) return "";
+      start = this._lastNeed;
+      this._lastNeed = 0;
+    } else {
+      start = 0;
+    }
+    if (start < bytes.length) {
+      var rest = statefulText(this, bytes, start);
+      return out ? out + rest : rest;
+    }
+    return out || "";
   };
+
   StringDecoder.prototype.end = function (buffer) {
-    return buffer === undefined ? "" : this.write(buffer);
+    var out = buffer === undefined ? "" : this.write(buffer);
+    if (this._kind === "stateless" || !this._lastNeed) return out;
+    out += this._lastChar
+      .subarray(0, this._lastTotal - this._lastNeed)
+      .toString(this.encoding);
+    this._lastNeed = 0;
+    this._lastTotal = 0;
+    return out;
   };
   module.exports = { StringDecoder: StringDecoder };
 } else {

--- a/scripts/run-shim-fixtures.sh
+++ b/scripts/run-shim-fixtures.sh
@@ -5,10 +5,10 @@
 #   ./scripts/run-shim-fixtures.sh [--node] [--no-cross-check]
 #
 # Each fixture in scripts/shim-fixtures/*.fixture.js is a self-verifying test
-# for the shared shims (node-shim.js + node-buffer-shim.js). The runner
-# prepends both shims to the fixture and runs the result on:
-#   - jsse (release) — the shims define Buffer/TextEncoder/TextDecoder
-#   - Node           — the shims are inert; the fixture exercises native APIs
+# for the shared shims and selector modules. The runner prepends the shims and
+# string_decoder selector to the fixture and runs the result on:
+#   - jsse (release) — the shims define the Node-compatible APIs
+#   - Node           — the selectors expose native APIs as the oracle
 # A fixture passes iff the engine exits 0. By default the two engines must also
 # report the same "N of N assertions passed" count, so a fixture silently
 # skipping checks on jsse cannot masquerade as a pass.
@@ -24,6 +24,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FIXTURE_DIR="$SCRIPT_DIR/shim-fixtures"
 JSSE="$PROJECT_DIR/target/release/jsse"
 SHIMS=("$SCRIPT_DIR/node-shim.js" "$SCRIPT_DIR/node-buffer-shim.js")
+STRING_DECODER="$SCRIPT_DIR/node-string-decoder-module.js"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -45,12 +46,13 @@ fi
 # Parse "SHIM-FIXTURE: X of Y assertions passed"; echoes the count or empty.
 parse_count() { grep -oE 'SHIM-FIXTURE: [0-9]+ of [0-9]+' "$1" | tail -1 | grep -oE '[0-9]+ of' | grep -oE '^[0-9]+' || true; }
 
-# <engine> <fixture-bundle> <label> → returns 0 on pass, sets COUNT
+# <fixture-bundle> <label> <engine> [args...] → returns 0 on pass, sets COUNT
 COUNT=""
 run_one() {
-    local engine="$1" bundle="$2" label="$3"
+    local bundle="$1" label="$2"
+    shift 2
     local out="$WORK/out-$label.txt" rc=0
-    "$engine" "$bundle" > "$out" 2>&1 || rc=$?
+    "$@" "$bundle" > "$out" 2>&1 || rc=$?
     cat "$out"
     COUNT="$(parse_count "$out")"
     if [ "$rc" -ne 0 ]; then
@@ -78,24 +80,28 @@ fi
 FAIL=0
 for fixture in "${FIXTURES[@]}"; do
     name="$(basename "$fixture")"
-    bundle="$WORK/bundle-$name"
-    cat "${SHIMS[@]}" "$fixture" > "$bundle"
+    bundle="$WORK/bundle-$name.cjs"
+    {
+        cat "${SHIMS[@]}"
+        echo 'var module = { exports: {} };'
+        cat "$STRING_DECODER" "$fixture"
+    } > "$bundle"
     echo "========================================"
     echo "  Fixture: $name"
     echo "========================================"
 
     if [ "$NODE_ONLY" -eq 1 ]; then
-        run_one node "$bundle" node || FAIL=1
+        run_one "$bundle" node node || FAIL=1
         continue
     fi
 
     JSSE_COUNT=""
-    run_one "$JSSE" "$bundle" jsse && JSSE_COUNT="$COUNT" || FAIL=1
+    run_one "$bundle" jsse "$JSSE" --node && JSSE_COUNT="$COUNT" || FAIL=1
 
     if [ "$CROSS_CHECK" -eq 1 ]; then
         if command -v node >/dev/null 2>&1; then
             NODE_COUNT=""
-            run_one node "$bundle" node && NODE_COUNT="$COUNT" || FAIL=1
+            run_one "$bundle" node node && NODE_COUNT="$COUNT" || FAIL=1
             if [ -n "$JSSE_COUNT" ] && [ "$JSSE_COUNT" != "$NODE_COUNT" ]; then
                 echo "  MISMATCH: jsse ran $JSSE_COUNT assertions, Node ran $NODE_COUNT" >&2
                 FAIL=1

--- a/scripts/shim-fixtures/string-decoder.fixture.js
+++ b/scripts/shim-fixtures/string-decoder.fixture.js
@@ -1,0 +1,149 @@
+// Self-verifying fixture for scripts/node-string-decoder-module.js.
+//
+// The runner loads the JSSE selector into `module.exports`; under Node the same
+// selector exposes the native node:string_decoder implementation as the oracle.
+
+(function () {
+  "use strict";
+
+  var StringDecoder = module.exports.StringDecoder;
+  var passed = 0;
+  var failed = 0;
+
+  function fail(msg) {
+    failed++;
+    console.log("FAIL: " + msg);
+  }
+
+  function eq(actual, expected, msg) {
+    if (actual === expected) {
+      passed++;
+    } else {
+      fail(
+        msg +
+          " — expected " +
+          JSON.stringify(expected) +
+          ", got " +
+          JSON.stringify(actual)
+      );
+    }
+  }
+
+  var utf8 = new StringDecoder("utf8");
+  eq(utf8.write(Buffer.from([0xe2])), "", "utf8 buffers partial lead");
+  eq(
+    utf8.write(Buffer.from([0x82, 0xac])),
+    "€",
+    "utf8 completes across writes"
+  );
+  eq(utf8.end(), "", "utf8 end after complete input");
+
+  var emoji = new StringDecoder("utf-8");
+  eq(
+    emoji.write(Buffer.from([0xf0, 0x9f])),
+    "",
+    "utf8 buffers multi-byte prefix"
+  );
+  eq(
+    emoji.end(Buffer.from([0x98, 0x80])),
+    "😀",
+    "end buffer completes utf8 character"
+  );
+
+  var truncated = new StringDecoder("utf8");
+  eq(
+    truncated.write(Buffer.from([0xe2])),
+    "",
+    "utf8 holds truncated input until end"
+  );
+  eq(truncated.end(), "�", "utf8 end flushes incomplete input");
+  eq(truncated.write(Buffer.from("A")), "A", "utf8 decoder is reusable after end");
+
+  var invalid = new StringDecoder("utf8");
+  eq(
+    invalid.write(Buffer.from([0xf4, 0xa9])),
+    "",
+    "utf8 defers an invalid structural prefix"
+  );
+  eq(
+    invalid.end(Buffer.from([0x8c, 0x76])),
+    "���v",
+    "utf8 finalizes deferred invalid bytes together"
+  );
+
+  var bom = new StringDecoder("utf8");
+  eq(bom.write(Buffer.from([0xef])), "", "utf8 buffers split BOM");
+  eq(
+    bom.end(Buffer.from([0xbb, 0xbf, 0x41])),
+    "﻿A",
+    "StringDecoder preserves UTF-8 BOM"
+  );
+
+  var utf16 = new StringDecoder("ucs2");
+  eq(
+    utf16.write(Buffer.from([0x41])),
+    "",
+    "utf16 buffers odd trailing byte"
+  );
+  eq(
+    utf16.write(Buffer.from([0x00])),
+    "A",
+    "utf16 completes code unit across writes"
+  );
+  eq(
+    utf16.write(Buffer.from([0x3d, 0xd8])),
+    "",
+    "utf16 buffers trailing high surrogate"
+  );
+  eq(
+    utf16.end(Buffer.from([0x00, 0xde])),
+    "😀",
+    "utf16 completes surrogate pair across writes"
+  );
+
+  var utf16Trailing = new StringDecoder("utf16le");
+  utf16Trailing.write(Buffer.from([0x41]));
+  eq(
+    utf16Trailing.end(),
+    "",
+    "utf16 end drops an unmatched trailing byte"
+  );
+  var utf16Surrogate = new StringDecoder("utf16le");
+  utf16Surrogate.write(Buffer.from([0x3d, 0xd8]));
+  eq(
+    utf16Surrogate.end(),
+    "\ud83d",
+    "utf16 end preserves unmatched high surrogate"
+  );
+
+  var base64 = new StringDecoder("base64");
+  eq(base64.write(Buffer.from([0x61])), "", "base64 buffers incomplete group");
+  eq(
+    base64.write(Buffer.from([0x62, 0x63])),
+    "YWJj",
+    "base64 completes group across writes"
+  );
+  eq(
+    base64.end(Buffer.from([0x64, 0x65])),
+    "ZGU=",
+    "base64 end flushes partial group"
+  );
+
+  var base64url = new StringDecoder("base64url");
+  eq(
+    base64url.write(Buffer.from([0xfb])),
+    "",
+    "base64url buffers incomplete group"
+  );
+  eq(
+    base64url.end(Buffer.from([0xff, 0xbf])),
+    "-_-_",
+    "base64url completes group at end"
+  );
+
+  var total = passed + failed;
+  console.log("SHIM-FIXTURE: " + passed + " of " + total + " assertions passed");
+  if (failed > 0) {
+    throw new Error(failed + " assertion(s) failed");
+  }
+})();


### PR DESCRIPTION
## Summary

- retain incomplete UTF-8 and UTF-16LE characters across `StringDecoder.write()` calls
- buffer base64/base64url groups and flush pending input from `end()` with reusable decoder state
- cross-check a dedicated selector fixture against native `node:string_decoder`

## Validation

- `./scripts/run-shim-fixtures.sh` (JSSE and Node: 23/23 StringDecoder assertions; 266/266 existing shim assertions)
- deterministic native differential probe: 27,000 randomized chunkings matched
- `./scripts/run-library-tests.sh qs` (1,013/1,013 on JSSE and Node)
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- targeted TypedArray set/subarray test262: 354/354
- `TZ=UTC uv run python scripts/run-test262.py`: 99,568/99,568, zero regressions

The initial Europe/Berlin full-suite run exposed 22 timezone-dependent Intl baseline failures; representative cases and the complete rerun pass under the baseline UTC environment, as documented on #335.

Closes #335