### PR TITLE
fix(node-shim): align TextDecoder encoding labels

### DIFF
--- a/scripts/node-buffer-shim.js
+++ b/scripts/node-buffer-shim.js
@@ -45,27 +45,45 @@
     }
   }
 
-  // TextDecoder follows the Encoding Standard's label table rather than
-  // Buffer's encoding vocabulary. Keep this separate so accepting utf-16be
-  // here does not make Buffer.isEncoding("utf-16be") incorrectly return true.
+  // TextDecoder uses Encoding Standard labels for the decoder families below;
+  // Buffer has a different vocabulary. Keep normalization separate so
+  // accepting utf-16be does not make Buffer.isEncoding("utf-16be") return true.
   function normalizeTextDecoderEncoding(label) {
     switch (String(label).trim().toLowerCase()) {
-      case "utf8":
+      case "unicode-1-1-utf-8":
+      case "unicode11utf8":
+      case "unicode20utf8":
       case "utf-8":
+      case "utf8":
+      case "x-unicode20utf8":
         return "utf8";
+      case "ansi_x3.4-1968":
       case "ascii":
-      case "binary":
+      case "cp1252":
+      case "cp819":
+      case "csisolatin1":
+      case "ibm819":
       case "iso-8859-1":
+      case "iso-ir-100":
+      case "iso8859-1":
+      case "iso88591":
+      case "iso_8859-1":
+      case "iso_8859-1:1987":
+      case "l1":
       case "latin1":
       case "us-ascii":
       case "windows-1252":
+      case "x-cp1252":
         return "windows1252";
-      case "ucs2":
+      case "csunicode":
+      case "iso-10646-ucs-2":
       case "ucs-2":
-      case "utf16le":
+      case "unicode":
+      case "unicodefeff":
+      case "utf-16":
       case "utf-16le":
         return "utf16le";
-      case "utf16be":
+      case "unicodefffe":
       case "utf-16be":
         return "utf16be";
       default:

--- a/scripts/shim-fixtures/text-decoder-labels.fixture.js
+++ b/scripts/shim-fixtures/text-decoder-labels.fixture.js
@@ -1,0 +1,83 @@
+// Self-verifying TextDecoder label fixture for scripts/node-buffer-shim.js.
+//
+// The Encoding Standard has a different label table from Node's Buffer API.
+// Run through run-shim-fixtures.sh, these assertions compare the shim on jsse
+// with Node's native TextDecoder.
+
+(function () {
+  "use strict";
+
+  var passed = 0;
+  var failed = 0;
+
+  function fail(msg) {
+    failed++;
+    console.log("FAIL: " + msg);
+  }
+
+  function eq(actual, expected, msg) {
+    if (actual === expected) {
+      passed++;
+    } else {
+      fail(msg + " — expected " + expected + ", got " + actual);
+    }
+  }
+
+  function throwsRangeError(fn, msg) {
+    try {
+      fn();
+      fail(msg + " — expected a RangeError");
+    } catch (e) {
+      if (e instanceof RangeError) {
+        passed++;
+      } else {
+        fail(msg + " — expected a RangeError, got " + e.name);
+      }
+    }
+  }
+
+  ["utf16le", "ucs2", "utf16be", "binary"].forEach(function (label) {
+    throwsRangeError(function () {
+      new TextDecoder(label);
+    }, "TextDecoder rejects Buffer-only label " + label);
+  });
+
+  [
+    ["unicode-1-1-utf-8", "utf-8"],
+    ["unicode11utf8", "utf-8"],
+    ["unicode20utf8", "utf-8"],
+    ["utf8", "utf-8"],
+    ["x-unicode20utf8", "utf-8"],
+    ["ansi_x3.4-1968", "windows-1252"],
+    ["cp1252", "windows-1252"],
+    ["cp819", "windows-1252"],
+    ["csisolatin1", "windows-1252"],
+    ["ibm819", "windows-1252"],
+    ["iso-ir-100", "windows-1252"],
+    ["iso8859-1", "windows-1252"],
+    ["iso88591", "windows-1252"],
+    ["iso_8859-1", "windows-1252"],
+    ["iso_8859-1:1987", "windows-1252"],
+    ["l1", "windows-1252"],
+    ["x-cp1252", "windows-1252"],
+    ["csunicode", "utf-16le"],
+    ["iso-10646-ucs-2", "utf-16le"],
+    ["ucs-2", "utf-16le"],
+    ["unicode", "utf-16le"],
+    ["unicodefeff", "utf-16le"],
+    ["utf-16", "utf-16le"],
+    ["unicodefffe", "utf-16be"],
+  ].forEach(function (entry) {
+    eq(
+      new TextDecoder(entry[0]).encoding,
+      entry[1],
+      "TextDecoder canonicalizes standard label " + entry[0]
+    );
+  });
+
+  var total = passed + failed;
+  console.log("SHIM-FIXTURE: " + passed + " of " + total + " assertions passed");
+  if (failed > 0) {
+    throw new Error(failed + " assertion(s) failed");
+  }
+})();


### PR DESCRIPTION
## Summary

- reject Buffer-only TextDecoder labels that Node and browsers reject
- accept the WHATWG aliases for the decoder families already implemented by the shim
- add a dedicated fixture cross-checked against native Node

## Testing

- `./scripts/run-shim-fixtures.sh` (266 Buffer assertions and 28 label assertions pass on both jsse and Node)
- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (305 unit tests and smoke oracle pass)
- `uv run python scripts/run-test262.py` (completed 99,568 scenarios; 99,546 passed, with 22 unrelated pre-existing Intl/Temporal baseline failures and 323 new passes; engine and dependency inputs are identical to origin/main)

Closes #339