### PR TITLE
fix(runtime): distinguish symbol and string property keys

### DIFF
--- a/docs/specs/2026-07-20-symbol-property-key-discriminator-design.md
+++ b/docs/specs/2026-07-20-symbol-property-key-discriminator-design.md
@@ -1,0 +1,84 @@
+# Symbol Property-Key Discriminator
+
+## Problem
+
+ECMAScript property keys are disjoint String and Symbol values. Every String
+value is a valid property key, including strings whose text resembles a Symbol
+display value. JSSE instead stores Symbol keys as ordinary `JsPropertyKey`
+bytes such as `Symbol(Symbol.iterator)` or `Symbol(desc)#42` and identifies
+them with `starts_with("Symbol(")`. A real String key with that prefix is
+therefore misclassified, and a String that exactly matches an encoded Symbol
+can alias it in property storage.
+
+The fix must preserve exact UTF-16 String keys, keep Symbol identity distinct,
+and retain the allocation-sharing and borrowed-lookup properties of the current
+WTF-8-backed property map.
+
+## Approaches Considered
+
+1. Prefix the internal bytes of every Symbol key with a byte that canonical
+   WTF-8 never emits. This preserves the current key size, hashing, equality,
+   interning, and `Borrow<[u8]>` lookup seam. This is the selected approach.
+2. Add a String/Symbol enum or tag field to `JsPropertyKey`. This represents the
+   specification distinction directly, but a hash that includes the tag cannot
+   support the existing borrowed `[u8]` lookup contract, while a hash that
+   excludes it would violate Rust's `Borrow` requirements. It would also grow
+   every stored key.
+3. Store String and Symbol properties in separate maps. This is also explicit,
+   but duplicates ordering and lookup plumbing across ordinary, exotic, and
+   proxy paths and is disproportionate to this representation defect.
+
+## Design
+
+Reserve `0xFF` as the first byte of an internal Symbol property key. The
+canonical UTF-8/WTF-8 encoder used for ECMAScript Strings never emits that
+byte, so the two key domains cannot collide. `JsPropertyKey` remains a single
+`Arc<[u8]>`; equality, hashing, interning, and map lookup continue to operate on
+the complete stored bytes.
+
+Add representation-level constructors and predicates so callers never inspect
+the sigil directly:
+
+- `JsSymbol::to_property_key` produces a tagged `JsPropertyKey` rather than a
+  Rust `String`.
+- a well-known-Symbol constructor creates the same tagged representation for
+  engine bootstrap sites that do not yet have the runtime Symbol value;
+- `JsPropertyKey::is_symbol` classifies keys;
+- Symbol-to-value conversion reads only the tagged key's textual payload.
+
+`as_str` continues to mean "this complete key is ordinary UTF-8 text" and
+therefore returns `None` for Symbol keys. String conversion is valid only for
+String keys. Debug/display compatibility may show the textual Symbol payload,
+but that payload is never used for identity or classification.
+
+Replace all raw `starts_with("Symbol(")` classifiers with `is_symbol`, and
+replace all hard-coded symbol-key strings used for property access or
+definition with tagged keys. Human-facing function names such as
+`[Symbol.iterator]` remain ordinary text. The key interner seeds tagged
+well-known keys separately from ordinary String seeds.
+
+## Specification Semantics
+
+The Object type defines each property key as either a String or a Symbol and
+accepts every value of both types. `OrdinaryOwnPropertyKeys` emits array-index
+Strings, other Strings, and Symbols as three distinct groups.
+`EnumerableOwnProperties`, `GetOwnPropertyKeys`, and JSON serialization then
+select keys by that type distinction. The internal discriminator implements
+that distinction without exposing an engine encoding to ECMAScript code.
+
+## Validation
+
+Add representation unit tests proving that a Symbol key and an ordinary String
+containing the same display payload are unequal and classify differently. Add
+a `test262-extra` regression that keeps literal `Symbol(...)` String keys and
+real Symbol keys on the same object and checks:
+
+- bracket lookup, `in`, deletion, and descriptors;
+- `Object.keys`, names, symbols, `Reflect.ownKeys`, and key ordering;
+- `for-in`, `JSON.stringify`, `Object.assign`, and object spread;
+- proxy key forwarding;
+- both pure-ASCII and lone-surrogate String variants.
+
+Run the focused Object, Reflect, Proxy, Symbol, JSON, and for-in test262 areas,
+then the repository formatting, Clippy, release build/tests, and full test262
+gate. Update the README only if the full pass count changes.

--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -3653,7 +3653,7 @@ impl Interpreter {
             self.get_object_cell_expect(array_id)
                 .borrow_mut()
                 .insert_property(
-                    "Symbol(Symbol.species)".to_string(),
+                    JsPropertyKey::well_known_symbol("species"),
                     PropertyDescriptor {
                         value: None,
                         writable: None,
@@ -3704,7 +3704,7 @@ impl Interpreter {
             self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_property(
-                    "Symbol(Symbol.unscopables)".to_string(),
+                    JsPropertyKey::well_known_symbol("unscopables"),
                     PropertyDescriptor::data(unscopables_val, false, false, true),
                 );
         }

--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -712,7 +712,7 @@ impl Interpreter {
         // @@toStringTag
         {
             let tag = JsValue::String(JsString::from_str("Atomics"));
-            let sym_key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let sym_key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor::data(tag, false, false, true);
             self.get_object_cell_expect(atomics_obj_id)
                 .borrow_mut()

--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -138,7 +138,7 @@ impl Interpreter {
         // @@toStringTag
         let tag_key = self
             .get_symbol_key("toStringTag")
-            .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
+            .unwrap_or_else(|| JsPropertyKey::well_known_symbol("toStringTag"));
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -69,7 +69,7 @@ impl Interpreter {
         self.get_object_cell_expect(map_iter_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("Map Iterator")),
                     false,
@@ -446,7 +446,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("Map")),
                     false,
@@ -585,7 +585,7 @@ impl Interpreter {
                 |_interp, this_val, _args| Completion::Normal(this_val.clone()),
             ));
             ctor_obj.borrow_mut().insert_property(
-                "Symbol(Symbol.species)".to_string(),
+                JsPropertyKey::well_known_symbol("species"),
                 PropertyDescriptor {
                     value: None,
                     writable: None,
@@ -757,7 +757,7 @@ impl Interpreter {
         self.get_object_cell_expect(set_iter_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("Set Iterator")),
                     false,
@@ -1503,7 +1503,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("Set")),
                     false,
@@ -1637,7 +1637,7 @@ impl Interpreter {
                 |_interp, this_val, _args| Completion::Normal(this_val.clone()),
             ));
             ctor_obj.borrow_mut().insert_property(
-                "Symbol(Symbol.species)".to_string(),
+                JsPropertyKey::well_known_symbol("species"),
                 PropertyDescriptor {
                     value: None,
                     writable: None,
@@ -1871,7 +1871,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("WeakMap")),
                     false,
@@ -2133,7 +2133,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("WeakSet")),
                     false,
@@ -2313,7 +2313,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .property_order
@@ -2537,7 +2537,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .property_order

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -1104,14 +1104,11 @@ impl Interpreter {
                 Completion::Throw(e)
             },
         ));
-        if let Some(sym_val) = self.get_global_var("Symbol")
-            && let JsValue::Object(sym_obj) = &sym_val
-        {
-            let tp_key = to_js_string(&self.get_property_on_id(sym_obj.id, "toPrimitive"));
+        if let Some(key) = self.get_symbol_key("toPrimitive") {
             self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_property(
-                    tp_key,
+                    key,
                     PropertyDescriptor::data(to_prim_fn, false, false, true),
                 );
         }

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -222,7 +222,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.Collator"))),
                     writable: Some(false),

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -5620,7 +5620,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.DateTimeFormat"))),
                     writable: Some(false),

--- a/src/interpreter/builtins/intl/displaynames.rs
+++ b/src/interpreter/builtins/intl/displaynames.rs
@@ -1082,7 +1082,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.DisplayNames"))),
                     writable: Some(false),

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -1151,7 +1151,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.DurationFormat"))),
                     writable: Some(false),

--- a/src/interpreter/builtins/intl/listformat.rs
+++ b/src/interpreter/builtins/intl/listformat.rs
@@ -116,7 +116,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.ListFormat"))),
                     writable: Some(false),

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -207,7 +207,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.Locale"))),
                     writable: Some(false),

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -20,7 +20,7 @@ impl Interpreter {
 
         // @@toStringTag = "Intl" (per spec 8.1.1)
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Intl"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -2967,7 +2967,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.NumberFormat"))),
                     writable: Some(false),

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -179,7 +179,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.PluralRules"))),
                     writable: Some(false),

--- a/src/interpreter/builtins/intl/relativetimeformat.rs
+++ b/src/interpreter/builtins/intl/relativetimeformat.rs
@@ -477,7 +477,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str(
                         "Intl.RelativeTimeFormat",

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -177,7 +177,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: Some(JsValue::String(JsString::from_str("Intl.Segmenter"))),
                     writable: Some(false),
@@ -553,7 +553,7 @@ impl Interpreter {
                     .get_object_cell_expect(segments_obj_id)
                     .borrow_mut()
                     .insert_property(
-                        "Symbol(Symbol.iterator)".to_string(),
+                        JsPropertyKey::well_known_symbol("iterator"),
                         PropertyDescriptor::data(iter_fn, true, false, true),
                     );
 

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -631,7 +631,7 @@ impl Interpreter {
                     }
                     let prop_key = tst_key_for_setter
                         .clone()
-                        .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
+                        .unwrap_or_else(|| JsPropertyKey::well_known_symbol("toStringTag"));
                     let has_own = if let Some(od) = interp.get_object_cell(this_id) {
                         od.borrow().properties.contains_key(&prop_key)
                     } else {
@@ -667,7 +667,7 @@ impl Interpreter {
             self.get_object_cell_expect(iter_proto_id)
                 .borrow_mut()
                 .insert_property(
-                    "Symbol(Symbol.toStringTag)".to_string(),
+                    JsPropertyKey::well_known_symbol("toStringTag"),
                     PropertyDescriptor {
                         value: None,
                         writable: None,
@@ -1217,7 +1217,7 @@ impl Interpreter {
         self.get_object_cell_expect(arr_iter_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("Array Iterator")),
                     false,
@@ -1311,7 +1311,7 @@ impl Interpreter {
         self.get_object_cell_expect(str_iter_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("String Iterator")),
                     false,
@@ -1485,7 +1485,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("Iterator Helper")),
                     false,
@@ -3823,7 +3823,7 @@ impl Interpreter {
         self.get_object_cell_expect(gen_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("Generator")),
                     false,
@@ -3870,7 +3870,7 @@ impl Interpreter {
         self.get_object_cell_expect(gf_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("GeneratorFunction")),
                     false,
@@ -4130,7 +4130,7 @@ impl Interpreter {
         self.get_object_cell_expect(gen_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("AsyncGenerator")),
                     false,
@@ -4162,7 +4162,7 @@ impl Interpreter {
         self.get_object_cell_expect(agf_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("AsyncGeneratorFunction")),
                     false,
@@ -4187,14 +4187,8 @@ impl Interpreter {
 }
 
 impl Interpreter {
-    pub(crate) fn get_symbol_iterator_key(&self) -> Option<String> {
-        self.get_global_var_ref("Symbol").and_then(|sv| {
-            if let JsValue::Object(so) = sv {
-                Some(to_js_string(&self.get_property_on_id(so.id, "iterator")))
-            } else {
-                None
-            }
-        })
+    pub(crate) fn get_symbol_iterator_key(&self) -> Option<JsPropertyKey> {
+        self.get_symbol_key("iterator")
     }
 
     pub(crate) fn create_iter_result_object(&mut self, value: JsValue, done: bool) -> JsValue {

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2534,7 +2534,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             self.get_object_cell_expect(math_obj_id)
                 .borrow_mut()
                 .property_order
@@ -3170,7 +3170,7 @@ impl Interpreter {
             self.get_object_cell_expect(af_proto_id)
                 .borrow_mut()
                 .insert_property(
-                    "Symbol(Symbol.toStringTag)".to_string(),
+                    JsPropertyKey::well_known_symbol("toStringTag"),
                     PropertyDescriptor::data(
                         JsValue::String(JsString::from_str("AsyncFunction")),
                         false,
@@ -3876,7 +3876,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             self.get_object_cell_expect(json_obj_id)
                 .borrow_mut()
                 .property_order
@@ -4330,7 +4330,7 @@ impl Interpreter {
                                 "Object"
                             };
                             // Step 15: Let tag be ? Get(O, @@toStringTag).
-                            let tag_key = "Symbol(Symbol.toStringTag)".to_string();
+                            let tag_key = JsPropertyKey::well_known_symbol("toStringTag");
                             let tag_result = interp.get_object_property(obj_ref.id, &tag_key, &o);
                             let tag = match tag_result {
                                 Completion::Normal(JsValue::String(s)) => s.to_string(),
@@ -5772,7 +5772,7 @@ impl Interpreter {
                                     names.push(JsValue::String(JsString::from_str(&i.to_string())));
                                 }
                                 for k in &property_order {
-                                    if k.starts_with("Symbol(") {
+                                    if k.is_symbol() {
                                         continue;
                                     }
                                     if let Ok(n) = k.parse::<u64>()
@@ -5802,7 +5802,7 @@ impl Interpreter {
                         let prop_keys: Vec<JsPropertyKey> = b
                             .property_order
                             .iter()
-                            .filter(|k| !k.starts_with("Symbol("))
+                            .filter(|k| !k.is_symbol())
                             .cloned()
                             .collect();
                         drop(b);
@@ -5900,11 +5900,11 @@ impl Interpreter {
                                 let mut sym_keys: Vec<JsPropertyKey> = b
                                     .property_order
                                     .iter()
-                                    .filter(|k| k.starts_with("Symbol("))
+                                    .filter(|k| k.is_symbol())
                                     .cloned()
                                     .collect();
                                 for k in b.properties.keys() {
-                                    if k.starts_with("Symbol(") && !sym_keys.contains(k) {
+                                    if k.is_symbol() && !sym_keys.contains(k) {
                                         sym_keys.push(k.clone());
                                     }
                                 }
@@ -6767,7 +6767,7 @@ impl Interpreter {
                         }
                     }
                     // Module namespace exotic: [[Delete]] — only for string keys (not symbols)
-                    if !key.starts_with("Symbol(") {
+                    if !key.is_symbol() {
                         let is_ns = obj.borrow().module_namespace().is_some();
                         if is_ns {
                             let export_names = obj
@@ -7088,7 +7088,7 @@ impl Interpreter {
                             let mut strings: Vec<(JsPropertyKey, usize)> = Vec::new();
                             let mut symbols: Vec<(JsPropertyKey, usize)> = Vec::new();
                             for (pos, k) in property_order.iter().enumerate() {
-                                if k.starts_with("Symbol(") {
+                                if k.is_symbol() {
                                     symbols.push((k.clone(), pos));
                                 } else if let Ok(n) = k.parse::<u64>()
                                     && n < 0xFFFFFFFF
@@ -7140,7 +7140,7 @@ impl Interpreter {
                         }
                     }
                     for (pos, k) in property_order.iter().enumerate() {
-                        if k.starts_with("Symbol(") {
+                        if k.is_symbol() {
                             symbols.push((k.clone(), pos));
                         } else if let Ok(n) = k.parse::<u64>()
                             && n < 0xFFFFFFFF
@@ -7656,7 +7656,7 @@ impl Interpreter {
                 get: None,
                 set: None,
             };
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             self.get_object_cell_expect(reflect_obj_id)
                 .borrow_mut()
                 .property_order
@@ -8149,7 +8149,7 @@ impl Interpreter {
         // ShadowRealm.prototype[Symbol.toStringTag] = "ShadowRealm"
         let to_string_tag_key = self
             .get_symbol_key("toStringTag")
-            .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
+            .unwrap_or_else(|| JsPropertyKey::well_known_symbol("toStringTag"));
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(

--- a/src/interpreter/builtins/number.rs
+++ b/src/interpreter/builtins/number.rs
@@ -348,53 +348,28 @@ impl Interpreter {
             }),
             false,
         ));
-        // Get the @@toPrimitive well-known symbol key
-        if let Some(sym_val) = self.get_global_var("Symbol")
-            && let JsValue::Object(sym_obj) = &sym_val
-        {
-            let to_prim_sym = self.get_property_on_id(sym_obj.id, "toPrimitive");
-            if let JsValue::Symbol(s) = &to_prim_sym {
-                let key = format!(
-                    "Symbol({})",
-                    s.description
-                        .as_ref()
-                        .map(|d| d.to_rust_string())
-                        .unwrap_or_default()
+        if let Some(key) = self.get_symbol_key("toPrimitive") {
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(to_prim_fn, false, false, true),
                 );
-                self.get_object_cell_expect(proto_id)
-                    .borrow_mut()
-                    .insert_property(
-                        key,
-                        PropertyDescriptor::data(to_prim_fn, false, false, true),
-                    );
-            }
         }
 
         // [Symbol.toStringTag] = "Symbol"
-        if let Some(sym_val) = self.get_global_var("Symbol")
-            && let JsValue::Object(sym_obj) = &sym_val
-        {
-            let tag_sym = self.get_property_on_id(sym_obj.id, "toStringTag");
-            if let JsValue::Symbol(s) = &tag_sym {
-                let key = format!(
-                    "Symbol({})",
-                    s.description
-                        .as_ref()
-                        .map(|d| d.to_rust_string())
-                        .unwrap_or_default()
+        if let Some(key) = self.get_symbol_key("toStringTag") {
+            self.get_object_cell_expect(proto_id)
+                .borrow_mut()
+                .insert_property(
+                    key,
+                    PropertyDescriptor::data(
+                        JsValue::String(JsString::from_str("Symbol")),
+                        false,
+                        false,
+                        true,
+                    ),
                 );
-                self.get_object_cell_expect(proto_id)
-                    .borrow_mut()
-                    .insert_property(
-                        key,
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str("Symbol")),
-                            false,
-                            false,
-                            true,
-                        ),
-                    );
-            }
         }
 
         // Set Symbol.prototype on the Symbol constructor

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -136,7 +136,11 @@ impl Interpreter {
         } else {
             return Ok(default_ctor.clone());
         };
-        let species = match self.get_object_property(ctor_id, "Symbol(Symbol.species)", &ctor) {
+        let species = match self.get_object_property(
+            ctor_id,
+            &JsPropertyKey::well_known_symbol("species"),
+            &ctor,
+        ) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(e),
             _ => return Ok(default_ctor.clone()),
@@ -384,7 +388,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(
                     JsValue::String(JsString::from_str("Promise")),
                     false,
@@ -480,7 +484,7 @@ impl Interpreter {
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
-                    "Symbol(Symbol.species)".to_string(),
+                    JsPropertyKey::well_known_symbol("species"),
                     PropertyDescriptor {
                         value: None,
                         writable: None,

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -7022,14 +7022,11 @@ fn regexp_exec_raw(
     Completion::Normal(result)
 }
 
-fn get_symbol_key(interp: &Interpreter, name: &str) -> Option<String> {
-    interp.get_global_var_ref("Symbol").and_then(|sv| {
-        if let JsValue::Object(so) = sv {
-            Some(to_js_string(&interp.get_property_on_id(so.id, name)))
-        } else {
-            None
-        }
-    })
+fn get_symbol_key(interp: &Interpreter, name: &str) -> Option<JsPropertyKey> {
+    interp
+        .well_known_symbols
+        .get(name)
+        .map(crate::types::JsSymbol::to_property_key)
 }
 
 impl Interpreter {
@@ -9339,7 +9336,7 @@ impl Interpreter {
                 |_interp, this_val, _args| Completion::Normal(this_val.clone()),
             ));
             obj.borrow_mut().insert_property(
-                "Symbol(Symbol.species)".to_string(),
+                JsPropertyKey::well_known_symbol("species"),
                 PropertyDescriptor {
                     value: None,
                     writable: None,
@@ -9580,7 +9577,7 @@ impl Interpreter {
         self.realm_mut().regexp_prototype = Some(regexp_proto_id);
     }
 
-    pub(crate) fn get_symbol_key(&self, name: &str) -> Option<String> {
+    pub(crate) fn get_symbol_key(&self, name: &str) -> Option<JsPropertyKey> {
         get_symbol_key(self, name)
     }
 }

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -1640,7 +1640,7 @@ impl Interpreter {
 
         // @@toStringTag
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.Duration"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -22,7 +22,7 @@ impl Interpreter {
 
         // @@toStringTag
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.Instant"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -1618,7 +1618,7 @@ impl Interpreter {
 
         // @@toStringTag = "Temporal"
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -9,7 +9,7 @@ impl Interpreter {
 
         // @@toStringTag = "Temporal.Now"
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.Now"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -14,7 +14,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainDate".to_string();
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.PlainDate"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -543,7 +543,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainDateTime".to_string();
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str(
                     "Temporal.PlainDateTime",

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -406,7 +406,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainMonthDay".to_string();
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str(
                     "Temporal.PlainMonthDay",

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -13,7 +13,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainTime".to_string();
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str("Temporal.PlainTime"))),
                 writable: Some(false),

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -394,7 +394,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Temporal.PlainYearMonth".to_string();
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str(
                     "Temporal.PlainYearMonth",

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -1805,7 +1805,7 @@ impl Interpreter {
 
         // @@toStringTag
         {
-            let key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor {
                 value: Some(JsValue::String(JsString::from_str(
                     "Temporal.ZonedDateTime",

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -884,7 +884,7 @@ impl Interpreter {
 
         // @@toStringTag
         let tag = JsValue::String(JsString::from_str("ArrayBuffer"));
-        let sym_key = "Symbol(Symbol.toStringTag)".to_string();
+        let sym_key = JsPropertyKey::well_known_symbol("toStringTag");
         self.get_object_cell_expect(ab_proto_id)
             .borrow_mut()
             .insert_property(sym_key, PropertyDescriptor::data(tag, false, false, true));
@@ -1029,7 +1029,7 @@ impl Interpreter {
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
-                    "Symbol(Symbol.species)".to_string(),
+                    JsPropertyKey::well_known_symbol("species"),
                     PropertyDescriptor {
                         value: None,
                         writable: None,
@@ -1383,7 +1383,7 @@ impl Interpreter {
         // @@toStringTag
         {
             let tag = JsValue::String(JsString::from_str("SharedArrayBuffer"));
-            let sym_key = crate::interpreter::key_intern::intern_key("Symbol(Symbol.toStringTag)");
+            let sym_key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
             let desc = PropertyDescriptor::data(tag, false, false, true);
             self.get_object_cell_expect(sab_proto_id)
                 .borrow_mut()
@@ -1511,7 +1511,7 @@ impl Interpreter {
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
-                    "Symbol(Symbol.species)".to_string(),
+                    JsPropertyKey::well_known_symbol("species"),
                     PropertyDescriptor {
                         value: None,
                         writable: None,
@@ -3136,7 +3136,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: None,
                     writable: None,
@@ -3177,7 +3177,7 @@ impl Interpreter {
             .insert_builtin("values".to_string(), values_fn.clone());
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
-            .insert_builtin("Symbol(Symbol.iterator)".to_string(), values_fn);
+            .insert_builtin(JsPropertyKey::well_known_symbol("iterator"), values_fn);
     }
 
     fn setup_ta_iterator_methods(&mut self, proto_id: u64) {
@@ -3733,7 +3733,11 @@ impl Interpreter {
 
                 // Step 4: Get @@iterator from raw source (before ToObject)
                 let using_iterator = if let JsValue::Object(ref o) = source {
-                    match interp.get_object_property(o.id, "Symbol(Symbol.iterator)", &source) {
+                    match interp.get_object_property(
+                        o.id,
+                        &JsPropertyKey::well_known_symbol("iterator"),
+                        &source,
+                    ) {
                         Completion::Normal(v)
                             if !matches!(v, JsValue::Undefined | JsValue::Null) =>
                         {
@@ -3759,8 +3763,11 @@ impl Interpreter {
                         }
                     };
                     if let JsValue::Object(ref wo) = wrapped {
-                        match interp.get_object_property(wo.id, "Symbol(Symbol.iterator)", &wrapped)
-                        {
+                        match interp.get_object_property(
+                            wo.id,
+                            &JsPropertyKey::well_known_symbol("iterator"),
+                            &wrapped,
+                        ) {
                             Completion::Normal(v)
                                 if !matches!(v, JsValue::Undefined | JsValue::Null) =>
                             {
@@ -4017,7 +4024,7 @@ impl Interpreter {
             && let Some(obj) = self.get_object_cell(o.id)
         {
             obj.borrow_mut().insert_property(
-                "Symbol(Symbol.species)".to_string(),
+                JsPropertyKey::well_known_symbol("species"),
                 PropertyDescriptor {
                     value: None,
                     writable: None,
@@ -5033,7 +5040,11 @@ impl Interpreter {
             && let Some(_obj) = self.get_object_cell(o.id)
         {
             // Step 5: Let usingIterator be ? GetMethod(object, @@iterator).
-            let iter_fn = match self.get_object_property(o.id, "Symbol(Symbol.iterator)", val) {
+            let iter_fn = match self.get_object_property(
+                o.id,
+                &JsPropertyKey::well_known_symbol("iterator"),
+                val,
+            ) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(Completion::Throw(e)),
                 _ => JsValue::Undefined,
@@ -5683,7 +5694,7 @@ impl Interpreter {
         self.get_object_cell_expect(dv_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor::data(tag, false, false, true),
             );
 

--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -22,10 +22,10 @@ impl Interpreter {
         self.env_get(&env, name)
     }
 
-    /// `&self` variant of `get_global_var` for read-only call sites that don't
-    /// have a `&mut Interpreter` (e.g. helpers like `get_symbol_iterator_key`).
-    /// Skips Proxy traps on the global object — sufficient for built-in name
-    /// lookups that should resolve via own properties.
+    /// Test-only `&self` variant of `get_global_var`.
+    /// Skips Proxy traps on the global object, which is sufficient for test
+    /// assertions that inspect the global object's own properties.
+    #[cfg(test)]
     pub(crate) fn get_global_var_ref(&self, name: &str) -> Option<JsValue> {
         let env = self.realm().global_env.borrow();
         if let Some(v) = env.get(name) {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -727,7 +727,7 @@ impl Interpreter {
                             }
                         }
                         // Module namespace exotic: [[Delete]] — only for string keys (not symbols)
-                        if !key.starts_with("Symbol(") {
+                        if !key.is_symbol() {
                             let ns_info = obj
                                 .borrow()
                                 .module_namespace()
@@ -1594,8 +1594,8 @@ impl Interpreter {
             JsValue::Object(o) => {
                 // §7.1.1 Step 2-3: Check @@toPrimitive
                 let exotic_to_prim = {
-                    let key = "Symbol(Symbol.toPrimitive)";
-                    match self.get_object_property(o.id, key, val) {
+                    let key = JsPropertyKey::well_known_symbol("toPrimitive");
+                    match self.get_object_property(o.id, &key, val) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Err(e),
                         _ => JsValue::Undefined,

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -139,11 +139,11 @@ impl Interpreter {
         }
         match val {
             JsValue::String(s) => Ok(JsPropertyKey::from_js_string(s)),
-            JsValue::Symbol(s) => Ok(JsPropertyKey::from(s.to_property_key())),
+            JsValue::Symbol(s) => Ok(s.to_property_key()),
             JsValue::Object(_) => {
                 let prim = self.to_primitive(val, "string")?;
                 if let JsValue::Symbol(s) = &prim {
-                    return Ok(JsPropertyKey::from(s.to_property_key()));
+                    return Ok(s.to_property_key());
                 }
                 match prim {
                     JsValue::String(s) => Ok(JsPropertyKey::from_js_string(&s)),

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -114,10 +114,7 @@ impl Interpreter {
         obj_id: u64,
         key: &K,
     ) -> Result<(), JsValue> {
-        if key
-            .as_property_key_str()
-            .is_some_and(|key| key.starts_with("Symbol("))
-        {
+        if key.to_js_property_key().is_symbol() {
             return Ok(());
         }
         let ns_data = if let Some(obj) = self.get_object_cell(obj_id) {
@@ -177,8 +174,8 @@ impl Interpreter {
         key: &K,
         deferred: bool,
     ) -> bool {
-        key.as_property_key_str()
-            .is_some_and(|key| key.starts_with("Symbol(") || (deferred && key == "then"))
+        let key = key.to_js_property_key();
+        key.is_symbol() || (deferred && key.eq_str("then"))
     }
 
     /// Trigger evaluation of a deferred module namespace when a non-symbol-like key is accessed.
@@ -275,8 +272,8 @@ impl Interpreter {
     ) -> Result<bool, JsValue> {
         let unscopables_val = {
             let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
-            let key = "Symbol(Symbol.unscopables)";
-            match self.get_object_property(obj_id, key, &this_val) {
+            let key = JsPropertyKey::well_known_symbol("unscopables");
+            match self.get_object_property(obj_id, &key, &this_val) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
                 _ => JsValue::Undefined,

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -129,7 +129,7 @@ pub(crate) fn js_value_to_code_units(val: &JsValue) -> Vec<u16> {
 pub(crate) fn to_property_key_string(val: &JsValue) -> JsPropertyKey {
     match val {
         JsValue::String(s) => JsPropertyKey::from_js_string(s),
-        JsValue::Symbol(s) => JsPropertyKey::from(s.to_property_key()),
+        JsValue::Symbol(s) => s.to_property_key(),
         _ => JsPropertyKey::from(format!("{val}")),
     }
 }
@@ -408,7 +408,7 @@ pub(crate) fn enumerable_own_keys(
                 if is_string_wrapper && k.eq_str("length") {
                     return false;
                 }
-                !k.starts_with("Symbol(")
+                !k.is_symbol()
                     && b.properties
                         .get(k)
                         .is_some_and(|d| d.enumerable != Some(false))

--- a/src/interpreter/key_intern.rs
+++ b/src/interpreter/key_intern.rs
@@ -4,7 +4,7 @@
 //! and once in `JsObjectData.property_order`. Both copies used to be owned
 //! `String`s, so every property cost two heap allocations of the same bytes.
 //!
-//! This module interns ordinary and symbol-encoded keys into a process-thread
+//! This module interns ordinary and tagged Symbol keys into a process-thread
 //! cache of `JsPropertyKey`. The storage layer (`PropertyMap` + `property_order`)
 //! holds `JsPropertyKey` rather than `String`, so the two stored copies share one
 //! allocation and "cloning" a key is a refcount bump.
@@ -54,10 +54,9 @@ const SEED_KEYS: &[&str] = &[
     "enumerable",
     "configurable",
     "writable",
-    "Symbol(Symbol.iterator)",
-    "Symbol(Symbol.toPrimitive)",
-    "Symbol(Symbol.toStringTag)",
 ];
+
+const SEED_SYMBOL_KEYS: &[&str] = &["iterator", "toPrimitive", "toStringTag"];
 
 impl KeyCache {
     fn new() -> Self {
@@ -65,6 +64,10 @@ impl KeyCache {
         for &s in SEED_KEYS {
             let key = JsPropertyKey::from_str(s);
             map.insert(Box::from(s.as_bytes()), key);
+        }
+        for &name in SEED_SYMBOL_KEYS {
+            let key = JsPropertyKey::well_known_symbol(name);
+            map.insert(Box::from(key.as_bytes()), key);
         }
         Self { map }
     }
@@ -99,7 +102,7 @@ fn is_canonical_array_index(s: &str) -> bool {
 
 /// Intern a property key into shared WTF-8 storage.
 ///
-/// Ordinary names and symbol-encoded keys (`"Symbol(...)#id"`) are cached so
+/// Ordinary names and tagged Symbol keys are cached so
 /// repeated uses share one allocation. Canonical array-index strings are NOT
 /// cached (see the integer-index gate in the module docs) — a fresh key
 /// is returned so the cache never accumulates unbounded numeric keys.
@@ -117,6 +120,11 @@ pub(crate) fn intern_js_key(key: JsPropertyKey) -> JsPropertyKey {
         return key;
     }
     KEY_CACHE.with(|c| c.borrow_mut().intern(key))
+}
+
+#[inline]
+pub(crate) fn intern_well_known_symbol(name: &str) -> JsPropertyKey {
+    intern_js_key(JsPropertyKey::well_known_symbol(name))
 }
 
 #[cfg(test)]
@@ -143,13 +151,17 @@ mod tests {
 
     #[test]
     fn symbol_keys_are_interned_and_preserved() {
-        let key = "Symbol(desc)#42";
-        let a = intern_key(key);
-        let b = intern_key(key);
-        assert!(a.shares_storage_with(&b), "symbol-encoded keys must intern");
+        let symbol = crate::types::JsSymbol {
+            id: 42,
+            description: Some(crate::types::JsString::from_str("desc")),
+        };
+        let a = intern_js_key(symbol.to_property_key());
+        let b = intern_js_key(symbol.to_property_key());
+        assert!(a.shares_storage_with(&b), "Symbol keys must intern");
         // Byte content must be preserved exactly for symbol_key_to_jsvalue.
-        assert!(a.eq_str(key));
-        assert!(a.starts_with("Symbol("));
+        assert_eq!(a.symbol_encoding(), Some("Symbol(desc)#42"));
+        assert!(a.is_symbol());
+        assert_ne!(a, intern_key("Symbol(desc)#42"));
     }
 
     #[test]

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -99,7 +99,7 @@ pub struct Interpreter {
     pub(crate) active_array_joins: Vec<u64>,
     pub(crate) generator_inline_iters: FxHashMap<u64, Vec<JsValue>>,
     pub(crate) scheduler: scheduler::JobScheduler,
-    cached_has_instance_key: Option<String>,
+    cached_has_instance_key: Option<JsPropertyKey>,
     module_registry: HashMap<(usize, PathBuf), Rc<RefCell<LoadedModule>>>,
     synthetic_module_registry: HashMap<(PathBuf, ImportModuleType), Rc<RefCell<LoadedModule>>>,
     current_module_path: Option<PathBuf>,
@@ -818,7 +818,7 @@ impl Interpreter {
         self.get_object_cell_expect(ams_proto_id)
             .borrow_mut()
             .insert_property(
-                "Symbol(Symbol.toStringTag)".to_string(),
+                JsPropertyKey::well_known_symbol("toStringTag"),
                 PropertyDescriptor {
                     value: None,
                     writable: None,
@@ -1672,28 +1672,22 @@ impl Interpreter {
         result
     }
 
-    /// Convert a symbol property key string (e.g. "Symbol(Symbol.toStringTag)" or "Symbol(desc)#42")
-    /// back to a JsValue::Symbol.
+    /// Convert an internal property key back to its ECMAScript String or Symbol value.
     pub(crate) fn symbol_key_to_jsvalue<K: PropertyKeyLike + ?Sized>(
         &mut self,
         property_key: &K,
     ) -> JsValue {
         let exact_key = property_key.to_js_property_key();
-        let Some(key) = exact_key.as_str() else {
+        let Some(key) = exact_key.symbol_encoding() else {
             return JsValue::String(exact_key.to_js_string());
         };
-        // Well-known symbols: "Symbol(Symbol.xyz)" — look up from Symbol constructor
+        // Well-known symbols: "Symbol(Symbol.xyz)" — recover the intrinsic Symbol value.
         if key.starts_with("Symbol(Symbol.") && key.ends_with(')') && !key.contains('#') {
             // Extract the well-known name (e.g. "toStringTag" from "Symbol(Symbol.toStringTag)")
             let inner = &key[7..key.len() - 1]; // "Symbol.toStringTag"
             let name = &inner[7..]; // "toStringTag"
-            if let Some(sym_val) = self.get_global_var("Symbol")
-                && let JsValue::Object(so) = sym_val
-            {
-                let val = self.get_property_on_id(so.id, name);
-                if let JsValue::Symbol(s) = val {
-                    return JsValue::Symbol(s);
-                }
+            if let Some(symbol) = self.well_known_symbols.get(name) {
+                return JsValue::Symbol(symbol.clone());
             }
         }
         // User symbols with id: "Symbol(desc)#id" or "Symbol()#id"
@@ -4401,7 +4395,7 @@ impl Interpreter {
         // writable=false, enumerable=false, configurable=false
         let sym_key = self
             .get_symbol_key("toStringTag")
-            .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
+            .unwrap_or_else(|| JsPropertyKey::well_known_symbol("toStringTag"));
         self.get_object_cell_expect(obj_id)
             .borrow_mut()
             .insert_property(
@@ -4477,7 +4471,7 @@ impl Interpreter {
 
         let sym_key = self
             .get_symbol_key("toStringTag")
-            .unwrap_or_else(|| "Symbol(Symbol.toStringTag)".to_string());
+            .unwrap_or_else(|| JsPropertyKey::well_known_symbol("toStringTag"));
         self.get_object_cell_expect(obj_id)
             .borrow_mut()
             .insert_property(

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -185,9 +185,7 @@ impl Interpreter {
             if let Some(ns_data) = ns_data {
                 // Deferred namespace: IsSymbolLikeNamespaceKey check
                 if ns_data.deferred
-                    && !key
-                        .as_property_key_str()
-                        .is_some_and(|key| Self::is_symbol_like_namespace_key(key, true))
+                    && !Self::is_symbol_like_namespace_key(key, true)
                     && let Err(e) = self.ensure_deferred_namespace_evaluation(obj_id)
                 {
                     return Completion::Throw(e);
@@ -294,11 +292,7 @@ impl Interpreter {
                     .module_namespace()
                     .as_ref()
                     .is_some_and(|ns| ns.deferred);
-                if is_deferred_ns
-                    && !key
-                        .as_property_key_str()
-                        .is_some_and(|key| Self::is_symbol_like_namespace_key(key, true))
-                {
+                if is_deferred_ns && !Self::is_symbol_like_namespace_key(key, true) {
                     self.ensure_deferred_namespace_evaluation(obj_id)?;
                 }
             }
@@ -1555,7 +1549,7 @@ impl Interpreter {
             }
 
             for k in &b.property_order {
-                if k.starts_with("Symbol(") {
+                if k.is_symbol() {
                     sym_keys.push(k.clone());
                 } else if let Ok(n) = k.parse::<u64>() {
                     if k.eq_str(&n.to_string()) {
@@ -1608,9 +1602,6 @@ impl Interpreter {
             for key in &own_keys {
                 if let JsValue::String(s) = key {
                     let key_str = JsPropertyKey::from_js_string(s);
-                    if key_str.starts_with("Symbol(") {
-                        continue;
-                    }
                     if seen.contains(&key_str) {
                         continue;
                     }

--- a/src/interpreter/property_map.rs
+++ b/src/interpreter/property_map.rs
@@ -313,22 +313,24 @@ mod tests {
     }
 
     #[test]
-    fn keys_includes_symbols_in_both_modes() {
+    fn keys_keep_symbol_and_symbol_like_string_distinct_in_both_modes() {
         let mut m = PropertyMap::new();
-        m.insert(key("Symbol(foo)"), desc(1.0));
-        m.insert(key("plain"), desc(2.0));
+        let symbol = JsPropertyKey::well_known_symbol("iterator");
+        let text = key("Symbol(Symbol.iterator)");
+        m.insert(symbol.clone(), desc(1.0));
+        m.insert(text.clone(), desc(2.0));
         let keys: Vec<&JsPropertyKey> = m.keys().collect();
-        assert!(keys.iter().any(|k| k.eq_str("Symbol(foo)")));
-        assert!(keys.iter().any(|k| k.eq_str("plain")));
+        assert!(keys.contains(&&symbol));
+        assert!(keys.contains(&&text));
+        assert_eq!(num(m.get(&symbol).expect("Symbol key present")), 1.0);
+        assert_eq!(num(m.get(&text).expect("String key present")), 2.0);
         for i in 0..INLINE_CAP {
             m.insert(key(format!("k{i}")), desc(i as f64));
         }
         assert!(!is_inline(&m));
         let keys: Vec<&JsPropertyKey> = m.keys().collect();
-        assert!(
-            keys.iter().any(|k| k.eq_str("Symbol(foo)")),
-            "Symbol key lost on spill"
-        );
+        assert!(keys.contains(&&symbol), "Symbol key lost on spill");
+        assert!(keys.contains(&&text), "String key lost on spill");
     }
 
     #[test]

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -2146,7 +2146,6 @@ impl JsObjectData {
         // Module namespace exotic: §10.4.6.4 [[GetOwnProperty]]
         if let Some(key_str) = key.as_property_key_str()
             && let Some(ns_data) = self.module_namespace()
-            && !key_str.starts_with("Symbol(")
         {
             if ns_data.export_names.contains(&key_str.to_string()) {
                 let val = if let Some(binding_name) = ns_data.export_to_binding.get(key_str) {
@@ -2253,7 +2252,6 @@ impl JsObjectData {
         // Module namespace exotic: [[HasProperty]] checks export list
         if let Some(key_str) = key.as_property_key_str()
             && let Some(ns_data) = self.module_namespace()
-            && !key_str.starts_with("Symbol(")
         {
             return ns_data.export_names.contains(&key_str.to_string());
         }
@@ -3135,7 +3133,7 @@ impl JsObjectData {
         }
 
         for k in &self.property_order {
-            if k.starts_with("Symbol(") {
+            if k.is_symbol() {
                 continue;
             }
             if let Some(desc) = self.properties.get(k) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -84,11 +84,15 @@ impl fmt::Display for JsString {
 /// String keys are stored as canonical WTF-8: well-formed UTF-16 has its usual
 /// UTF-8 encoding, while lone surrogates use the corresponding three-byte
 /// WTF-8 sequence. This makes ordinary Rust `str` keys directly borrowable as
-/// bytes while retaining every possible ECMAScript String value.
+/// bytes while retaining every possible ECMAScript String value. Symbol keys
+/// carry a leading byte that canonical WTF-8 can never produce, keeping their
+/// identity disjoint from every possible String key.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct JsPropertyKey {
     bytes: Arc<[u8]>,
 }
+
+const SYMBOL_PROPERTY_KEY_SIGIL: u8 = 0xFF;
 
 pub enum JsPropertyKeyParseError<E> {
     IllFormedUtf16,
@@ -140,20 +144,41 @@ impl JsPropertyKey {
         }
     }
 
+    fn from_symbol_encoding(encoding: String) -> Self {
+        let mut bytes = Vec::with_capacity(encoding.len() + 1);
+        bytes.push(SYMBOL_PROPERTY_KEY_SIGIL);
+        bytes.extend_from_slice(encoding.as_bytes());
+        Self {
+            bytes: Arc::from(bytes),
+        }
+    }
+
+    pub(crate) fn well_known_symbol(name: &str) -> Self {
+        Self::from_symbol_encoding(format!("Symbol(Symbol.{name})"))
+    }
+
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }
 
     pub fn as_str(&self) -> Option<&str> {
+        if self.is_symbol() {
+            return None;
+        }
         std::str::from_utf8(&self.bytes).ok()
+    }
+
+    pub fn is_symbol(&self) -> bool {
+        self.bytes.first() == Some(&SYMBOL_PROPERTY_KEY_SIGIL)
+    }
+
+    pub(crate) fn symbol_encoding(&self) -> Option<&str> {
+        self.is_symbol()
+            .then(|| std::str::from_utf8(&self.bytes[1..]).expect("Symbol encoding is UTF-8"))
     }
 
     pub fn eq_str(&self, other: &str) -> bool {
         self.bytes.as_ref() == other.as_bytes()
-    }
-
-    pub fn starts_with(&self, prefix: &str) -> bool {
-        self.bytes.starts_with(prefix.as_bytes())
     }
 
     pub fn parse<T: FromStr>(&self) -> Result<T, JsPropertyKeyParseError<T::Err>> {
@@ -169,31 +194,36 @@ impl JsPropertyKey {
     }
 
     pub fn to_js_string(&self) -> JsString {
-        let mut units = Vec::with_capacity(self.bytes.len());
+        let bytes = if self.is_symbol() {
+            &self.bytes[1..]
+        } else {
+            &self.bytes
+        };
+        let mut units = Vec::with_capacity(bytes.len());
         let mut i = 0;
-        while i < self.bytes.len() {
-            let first = self.bytes[i];
+        while i < bytes.len() {
+            let first = bytes[i];
             if first < 0x80 {
                 units.push(first as u16);
                 i += 1;
             } else if first < 0xE0 {
-                debug_assert!(i + 1 < self.bytes.len());
-                let code_point = ((first as u32 & 0x1F) << 6) | (self.bytes[i + 1] as u32 & 0x3F);
+                debug_assert!(i + 1 < bytes.len());
+                let code_point = ((first as u32 & 0x1F) << 6) | (bytes[i + 1] as u32 & 0x3F);
                 units.push(code_point as u16);
                 i += 2;
             } else if first < 0xF0 {
-                debug_assert!(i + 2 < self.bytes.len());
+                debug_assert!(i + 2 < bytes.len());
                 let code_point = ((first as u32 & 0x0F) << 12)
-                    | ((self.bytes[i + 1] as u32 & 0x3F) << 6)
-                    | (self.bytes[i + 2] as u32 & 0x3F);
+                    | ((bytes[i + 1] as u32 & 0x3F) << 6)
+                    | (bytes[i + 2] as u32 & 0x3F);
                 units.push(code_point as u16);
                 i += 3;
             } else {
-                debug_assert!(i + 3 < self.bytes.len());
+                debug_assert!(i + 3 < bytes.len());
                 let code_point = ((first as u32 & 0x07) << 18)
-                    | ((self.bytes[i + 1] as u32 & 0x3F) << 12)
-                    | ((self.bytes[i + 2] as u32 & 0x3F) << 6)
-                    | (self.bytes[i + 3] as u32 & 0x3F);
+                    | ((bytes[i + 1] as u32 & 0x3F) << 12)
+                    | ((bytes[i + 2] as u32 & 0x3F) << 6)
+                    | (bytes[i + 3] as u32 & 0x3F);
                 let offset = code_point - 0x10000;
                 units.push((0xD800 + (offset >> 10)) as u16);
                 units.push((0xDC00 + (offset & 0x3FF)) as u16);
@@ -309,18 +339,19 @@ pub struct JsSymbol {
 }
 
 impl JsSymbol {
-    /// Convert to the internal property key string.
+    /// Convert to the internal Symbol-valued property key.
     /// Well-known symbols (description starts with "Symbol.") use a stable format
-    /// without id, so hardcoded lookups like "Symbol(Symbol.iterator)" still work.
+    /// without id, so bootstrap lookups can construct the same key directly.
     /// User-created symbols include the unique id to avoid collisions.
-    pub fn to_property_key(&self) -> String {
-        match &self.description {
+    pub fn to_property_key(&self) -> JsPropertyKey {
+        let encoding = match &self.description {
             Some(desc) if desc.to_string().starts_with("Symbol.") => {
                 format!("Symbol({})", desc)
             }
             Some(desc) => format!("Symbol({})#{}", desc, self.id),
             None => format!("Symbol()#{}", self.id),
-        }
+        };
+        JsPropertyKey::from_symbol_encoding(encoding)
     }
 }
 
@@ -977,6 +1008,39 @@ mod tests {
         assert_ne!(replacement, high);
         assert_ne!(replacement, low);
         assert_ne!(high, low);
+    }
+
+    #[test]
+    fn symbol_property_keys_do_not_collide_with_display_text() {
+        let symbol = JsSymbol {
+            id: 7,
+            description: Some(JsString::from_str("x")),
+        }
+        .to_property_key();
+        let text = JsPropertyKey::from_str("Symbol(x)#7");
+
+        assert!(symbol.is_symbol());
+        assert!(!text.is_symbol());
+        assert_ne!(symbol, text);
+        assert_eq!(symbol.symbol_encoding(), Some("Symbol(x)#7"));
+        assert_eq!(symbol.to_string(), "Symbol(x)#7");
+    }
+
+    #[test]
+    fn well_known_symbol_property_keys_are_tagged() {
+        let constructed = JsPropertyKey::well_known_symbol("iterator");
+        let symbol = JsSymbol {
+            id: 1,
+            description: Some(JsString::from_str("Symbol.iterator")),
+        }
+        .to_property_key();
+
+        assert_eq!(constructed, symbol);
+        assert!(constructed.is_symbol());
+        assert_ne!(
+            constructed,
+            JsPropertyKey::from_str("Symbol(Symbol.iterator)")
+        );
     }
 
     // ----- JsValue method surface (issue #69 NaN-box migration) -------------

--- a/test262-extra/symbol-like-string-property-keys.js
+++ b/test262-extra/symbol-like-string-property-keys.js
@@ -1,0 +1,130 @@
+// ECMAScript property keys are either Strings or Symbols, and every String is
+// a valid property key. A String that resembles a Symbol's display text must
+// remain distinct from the Symbol itself through storage and enumeration.
+// Spec: sec-object-type, sec-ordinaryownpropertykeys,
+//       sec-enumerableownproperties, sec-getownpropertykeys,
+//       sec-serializejsonobject.
+
+function Test262Error(message) {
+  this.message = message || "";
+}
+Test262Error.prototype.toString = function () {
+  return "Test262Error: " + this.message;
+};
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Test262Error(message);
+  }
+}
+
+function assertSame(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Test262Error(message + ": expected " + expected + ", got " + actual);
+  }
+}
+
+function assertKeys(actual, expected, message) {
+  assertSame(actual.length, expected.length, message + " length");
+  for (var i = 0; i < expected.length; i++) {
+    assertSame(actual[i], expected[i], message + " key " + i);
+  }
+}
+
+var wellKnownText = "Symbol(Symbol.iterator)";
+var asciiText = "Symbol(x)";
+var surrogateText = "Symbol(\uD834";
+var customSymbol = Symbol("x");
+
+var value = {};
+value[wellKnownText] = "well-known text";
+value[Symbol.iterator] = "well-known symbol";
+value[asciiText] = "ascii text";
+value[surrogateText] = "surrogate text";
+value[customSymbol] = "custom symbol";
+
+// The exact text formerly used for JSSE's internal well-known Symbol encoding
+// must coexist with the actual well-known Symbol key.
+assertSame(value[wellKnownText], "well-known text", "well-known text lookup");
+assertSame(value[Symbol.iterator], "well-known symbol", "well-known Symbol lookup");
+assertSame(value[asciiText], "ascii text", "ASCII text lookup");
+assertSame(value[surrogateText], "surrogate text", "surrogate text lookup");
+assertSame(value[customSymbol], "custom symbol", "custom Symbol lookup");
+assert(wellKnownText in value, "well-known text missing from HasProperty");
+assert(Symbol.iterator in value, "well-known Symbol missing from HasProperty");
+
+var names = Object.getOwnPropertyNames(value);
+assertKeys(names, [wellKnownText, asciiText, surrogateText], "own property names");
+
+var symbols = Object.getOwnPropertySymbols(value);
+assertKeys(symbols, [Symbol.iterator, customSymbol], "own property symbols");
+
+assertKeys(Object.keys(value), names, "Object.keys");
+assertKeys(Reflect.ownKeys(value), names.concat(symbols), "Reflect.ownKeys");
+
+var iterated = [];
+for (var key in value) {
+  iterated.push(key);
+}
+assertKeys(iterated, names, "for-in");
+
+assertSame(
+  Object.getOwnPropertyDescriptor(value, wellKnownText).value,
+  "well-known text",
+  "string descriptor"
+);
+assertSame(
+  Object.getOwnPropertyDescriptor(value, Symbol.iterator).value,
+  "well-known symbol",
+  "Symbol descriptor"
+);
+
+var jsonValue = JSON.parse(JSON.stringify(value));
+assertKeys(Object.keys(jsonValue), names, "JSON keys");
+assertSame(jsonValue[wellKnownText], "well-known text", "JSON well-known text");
+assertSame(jsonValue[asciiText], "ascii text", "JSON ASCII text");
+assertSame(jsonValue[surrogateText], "surrogate text", "JSON surrogate text");
+
+var assigned = Object.assign({}, value);
+assertKeys(Reflect.ownKeys(assigned), names.concat(symbols), "Object.assign keys");
+assertSame(assigned[wellKnownText], "well-known text", "Object.assign text");
+assertSame(assigned[Symbol.iterator], "well-known symbol", "Object.assign Symbol");
+
+var spread = { ...value };
+assertKeys(Reflect.ownKeys(spread), names.concat(symbols), "object spread keys");
+
+var trapKeys = [];
+var proxy = new Proxy(value, {
+  get: function (target, key, receiver) {
+    trapKeys.push(key);
+    return Reflect.get(target, key, receiver);
+  }
+});
+assertSame(proxy[wellKnownText], "well-known text", "proxy text result");
+assertSame(proxy[Symbol.iterator], "well-known symbol", "proxy Symbol result");
+assertSame(trapKeys[0], wellKnownText, "proxy received String key");
+assertSame(trapKeys[1], Symbol.iterator, "proxy received Symbol key");
+
+var ownKeysProxy = new Proxy({}, {
+  ownKeys: function () {
+    return [wellKnownText, Symbol.iterator, asciiText, surrogateText, customSymbol];
+  },
+  getOwnPropertyDescriptor: function () {
+    return { configurable: true, enumerable: true, value: 1 };
+  }
+});
+assertKeys(
+  Reflect.ownKeys(ownKeysProxy),
+  [wellKnownText, Symbol.iterator, asciiText, surrogateText, customSymbol],
+  "proxy ownKeys"
+);
+assertKeys(
+  Object.keys(ownKeysProxy),
+  [wellKnownText, asciiText, surrogateText],
+  "proxy enumerable String keys"
+);
+
+assert(delete value[wellKnownText], "delete text key");
+assertSame(value[Symbol.iterator], "well-known symbol", "delete text retained Symbol");
+assert(delete value[Symbol.iterator], "delete Symbol key");
+assertSame(value[asciiText], "ascii text", "delete Symbol retained text");


### PR DESCRIPTION
## Summary

- tag internal Symbol property keys with a byte canonical WTF-8 String keys cannot contain
- migrate symbol classification, well-known Symbol lookup, interning, and built-in property definitions to the tagged representation
- add regression coverage for exact well-known-Symbol display text, ASCII `Symbol(` keys, lone-surrogate keys, enumeration, JSON, copying, proxies, and deletion

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release` (307 unit tests + smoke oracle)
- `uv run python scripts/run-custom-tests.py` (8/8)
- new regression on JSSE and Node
- targeted property-key test262 matrix (910/910)
- former full-suite regression surface (412/412 under the repository CI-default `TZ=UTC`)
- full test262 (99,568/99,568, zero regressions under `TZ=UTC`)

`test262-pass.txt` remains unchanged per feature-branch policy. README already reports 99,568/99,568.

Closes #333