### PR TITLE
feat(bytecode): compile numeric for and while loops

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,9 @@
 # JSSE Architecture Overview
 
-JSSE is a from-scratch JavaScript engine in Rust. The execution model is a direct AST-walking interpreter: source text is tokenized, parsed into an AST, and evaluated without a bytecode or JIT layer.
+JSSE is a from-scratch JavaScript engine in Rust. The default execution model is
+a direct AST-walking interpreter. An experimental `--bytecode` mode compiles
+eligible function Bodies to stack bytecode and conservatively falls back to the
+tree-walker for unsupported syntax.
 
 ## Pipeline
 
@@ -17,7 +20,7 @@ Source (.js file / -e string / REPL)
     src/ast.rs
         |
         v
-    src/interpreter/
+    src/interpreter/ -------- eligible function Body --------> bytecode VM
         |
         v
     stdout / exit code
@@ -68,7 +71,12 @@ The interpreter lives under `src/interpreter/` and is split across runtime subsy
 - `src/interpreter/types.rs`: runtime object, environment, and completion types
 - `src/interpreter/helpers.rs`: coercion, equality, JSON, date, and other shared helpers
 - `src/interpreter/gc.rs`: mark-and-sweep garbage collection
+- `src/interpreter/bytecode/`: opt-in compiler, Chunk format, and stack VM
 - `src/interpreter/builtins/`: built-in constructors, prototypes, and related runtime support
+
+The bytecode compiler has a whole-Body eligibility seam: compilation either
+produces a complete Chunk or marks that function object ineligible. It never
+mixes bytecode and AST evaluation within a single invocation.
 
 Key runtime responsibilities:
 

--- a/docs/specs/2026-07-20-bytecode-loop-slice-design.md
+++ b/docs/specs/2026-07-20-bytecode-loop-slice-design.md
@@ -1,0 +1,90 @@
+# Bytecode numeric-loop slice
+
+## Context
+
+Issue #67 already has an opt-in, function-body stack VM with a conservative
+eligibility membrane. It compiles literals, identifier reads and simple
+assignment, arithmetic and comparison expressions, conditionals, and `if`
+statements. It cannot compile variable declarations, update expressions, or
+loops, so the tight numeric loop that motivated the issue still falls back to
+the tree-walker.
+
+This slice makes that workload eligible without changing the default execution
+mode or weakening the whole-body fallback.
+
+## Approaches considered
+
+1. Extend the existing stack VM vertically. Add only the bindings, expressions,
+   and backward control flow needed for numeric `for` and `while` loops. This is
+   the selected approach because it reuses the reviewed compiler/VM seam and
+   can be validated against the tree-walker.
+2. Introduce indexed local slots before adding loops. This should ultimately
+   outperform name-based environment lookup, but it requires a new Environment
+   interface and compile-time binding analysis. It is a larger semantic change
+   and is deferred until loop dispatch itself is measurable.
+3. Compile every statement form and enable bytecode by default. This would make
+   issue #67 look complete sooner, but calls, lexical environments, abrupt
+   completions, and `try`/`finally` need substantially more VM machinery. The
+   risk is disproportionate to this slice.
+
+## Design
+
+The bytecode module remains a deep module with one external seam:
+`compile_body` either returns a complete `Chunk` or rejects the entire Body.
+`dispatch_body` continues to cache that outcome and selects either the VM or the
+tree-walker. There is no instruction-level fallback.
+
+The compiler records function-scoped `var` names as indices into the Chunk's
+existing name pool. Before dispatch, the VM creates any missing mutable `var`
+bindings with `undefined`. This follows FunctionDeclarationInstantiation: the
+binding exists before any initializer is evaluated, while each initializer is
+executed in source order. Only identifier patterns are eligible; destructuring
+and lexical declarations remain on the tree-walker.
+
+Simple identifier update expressions use one `UpdateName` instruction carrying
+the name, increment/decrement operation, and prefix/postfix mode. Its handler
+uses the interpreter's existing identifier-update semantics, preserving
+ToNumeric, BigInt, strict-mode, TDZ, const assignment, and returned-value rules.
+Non-logical compound assignments to identifiers lower to the existing
+load/binary-operation/store sequence. Logical assignments remain unsupported.
+
+`while` lowers to a condition header, a false exit, the body, and a backward
+jump. `for` lowers initializer, condition, false exit, body, update, and a
+backward jump in specification order. An absent condition emits no exit branch.
+Every backward jump performs the same GC safepoint that the tree-walker performs
+once per iteration. The compiler requires the operand stack to be empty at the
+backedge.
+
+This slice accepts expression initializers and `var` initializers. `let` and
+`const` loop heads remain ineligible because CreatePerIterationEnvironment is
+observable through closures. `break`, `continue`, labels, `do`/`while`, calls,
+member access, and other unsupported nodes also reject the entire Body.
+
+## Error handling and limits
+
+Backward and forward jumps continue to use signed 16-bit relative offsets. If
+a loop body does not fit, compilation returns `CompileError::Unsupported` and
+the Body is permanently cached as ineligible. Runtime JavaScript abrupt
+completions from name lookup, update, coercion, or assignment immediately leave
+the VM unchanged.
+
+## Validation
+
+- Compiler/VM tests cover var hoisting before initializers, multiple var
+  declarators, prefix/postfix increment/decrement (including BigInt through an
+  argument), `while`, `for`, absent loop clauses, and unsupported lexical loop
+  fallback.
+- End-to-end parity tests run each eligible function in tree-walker and bytecode
+  modes and assert that a Chunk actually executed.
+- A release-mode numeric-loop timing compares the two modes as performance
+  evidence, without making wall-clock timing a unit-test assertion.
+- Targeted test262 runs cover variable statements, update expressions, and
+  `for`/`while`, followed by the full suite in normal mode and the required Rust
+  quality gate.
+
+## Success criteria
+
+The function equivalent of the motivating loop,
+`for (var i = 0; i < n; i++) sum += i`, executes a bytecode Chunk, returns the
+same result as the tree-walker, retains a per-iteration GC safepoint, and does
+not introduce a test262 baseline regression.

--- a/src/interpreter/bytecode/chunk.rs
+++ b/src/interpreter/bytecode/chunk.rs
@@ -21,5 +21,7 @@ pub(crate) struct Chunk {
     pub(crate) code: Vec<u8>,
     pub(crate) constants: Vec<Constant>,
     pub(crate) names: Vec<Rc<str>>,
+    pub(crate) var_names: Vec<u16>,
     pub(crate) max_stack: u16,
+    pub(crate) max_refs: u16,
 }

--- a/src/interpreter/bytecode/compiler.rs
+++ b/src/interpreter/bytecode/compiler.rs
@@ -1,6 +1,9 @@
 use super::chunk::{Chunk, Constant};
 use super::op::Op;
-use crate::ast::{AssignOp, BinaryOp, Expression, Literal, LogicalOp, Statement, UnaryOp};
+use crate::ast::{
+    AssignOp, BinaryOp, Expression, ForInit, Literal, LogicalOp, Pattern, Statement, UnaryOp,
+    UpdateOp, VarKind, VariableDeclaration,
+};
 
 #[derive(Debug)]
 pub(crate) enum CompileError {
@@ -16,8 +19,11 @@ struct Compiler {
     code: Vec<u8>,
     constants: Vec<Constant>,
     names: Vec<std::rc::Rc<str>>,
+    var_names: Vec<u16>,
     current_stack: u16,
     max_stack: u16,
+    current_refs: u16,
+    max_refs: u16,
     /// Highest byte offset targeted by any patched forward jump. When this
     /// equals the final code length, some branch falls through to the very end
     /// of the chunk, so `finish` must append a trailing `ReturnUndefined` even
@@ -33,8 +39,11 @@ impl Compiler {
             code: Vec::new(),
             constants: Vec::new(),
             names: Vec::new(),
+            var_names: Vec::new(),
             current_stack: 0,
             max_stack: 0,
+            current_refs: 0,
+            max_refs: 0,
             max_jump_target: 0,
         }
     }
@@ -80,6 +89,17 @@ impl Compiler {
         patch
     }
 
+    fn emit_jump_to(&mut self, op: Op, target: usize) -> Result<(), CompileError> {
+        self.emit(op);
+        let from = self.code.len() + 2;
+        let delta = target as isize - from as isize;
+        if !(i16::MIN as isize..=i16::MAX as isize).contains(&delta) {
+            return Err(CompileError::Unsupported("jump offset overflow"));
+        }
+        self.emit_u16(delta as i16 as u16);
+        Ok(())
+    }
+
     fn patch_jump(&mut self, patch: usize) -> Result<(), CompileError> {
         // Offset is from the byte AFTER the 2-byte operand to the current code length.
         let from = patch + 2;
@@ -105,6 +125,84 @@ impl Compiler {
     fn pop_n(&mut self, n: u16) {
         debug_assert!(self.current_stack >= n, "stack underflow during compile");
         self.current_stack -= n;
+    }
+
+    fn push_ref(&mut self) {
+        self.current_refs += 1;
+        self.max_refs = self.max_refs.max(self.current_refs);
+    }
+
+    fn pop_ref(&mut self) {
+        debug_assert!(
+            self.current_refs > 0,
+            "reference stack underflow during compile"
+        );
+        self.current_refs -= 1;
+    }
+
+    fn emit_resolve_name(&mut self, name_idx: u16) {
+        self.emit(Op::ResolveName);
+        self.emit_u16(name_idx);
+        self.push_ref();
+    }
+
+    fn emit_store_resolved_name(&mut self, name_idx: u16) {
+        self.emit(Op::StoreResolvedName);
+        self.emit_u16(name_idx);
+        self.pop_ref();
+    }
+
+    fn add_var_name(&mut self, name: &str) -> Result<u16, CompileError> {
+        let idx = self.add_name(name)?;
+        if !self.var_names.contains(&idx) {
+            self.var_names.push(idx);
+        }
+        Ok(idx)
+    }
+
+    fn binary_op(op: BinaryOp) -> Result<Op, CompileError> {
+        match op {
+            BinaryOp::Add => Ok(Op::Add),
+            BinaryOp::Sub => Ok(Op::Sub),
+            BinaryOp::Mul => Ok(Op::Mul),
+            BinaryOp::Div => Ok(Op::Div),
+            BinaryOp::Mod => Ok(Op::Mod),
+            BinaryOp::Exp => Ok(Op::Pow),
+            BinaryOp::Eq => Ok(Op::Eq),
+            BinaryOp::NotEq => Ok(Op::NotEq),
+            BinaryOp::StrictEq => Ok(Op::StrictEq),
+            BinaryOp::StrictNotEq => Ok(Op::StrictNotEq),
+            BinaryOp::Lt => Ok(Op::Lt),
+            BinaryOp::Gt => Ok(Op::Gt),
+            BinaryOp::LtEq => Ok(Op::LtEq),
+            BinaryOp::GtEq => Ok(Op::GtEq),
+            BinaryOp::BitAnd => Ok(Op::BitAnd),
+            BinaryOp::BitOr => Ok(Op::BitOr),
+            BinaryOp::BitXor => Ok(Op::BitXor),
+            BinaryOp::LShift => Ok(Op::Shl),
+            BinaryOp::RShift => Ok(Op::Shr),
+            BinaryOp::URShift => Ok(Op::UShr),
+            _ => Err(CompileError::Unsupported("binary op")),
+        }
+    }
+
+    fn compound_binary_op(op: AssignOp) -> Result<Op, CompileError> {
+        let binary = match op {
+            AssignOp::AddAssign => BinaryOp::Add,
+            AssignOp::SubAssign => BinaryOp::Sub,
+            AssignOp::MulAssign => BinaryOp::Mul,
+            AssignOp::DivAssign => BinaryOp::Div,
+            AssignOp::ModAssign => BinaryOp::Mod,
+            AssignOp::ExpAssign => BinaryOp::Exp,
+            AssignOp::LShiftAssign => BinaryOp::LShift,
+            AssignOp::RShiftAssign => BinaryOp::RShift,
+            AssignOp::URShiftAssign => BinaryOp::URShift,
+            AssignOp::BitAndAssign => BinaryOp::BitAnd,
+            AssignOp::BitOrAssign => BinaryOp::BitOr,
+            AssignOp::BitXorAssign => BinaryOp::BitXor,
+            _ => return Err(CompileError::Unsupported("assignment op")),
+        };
+        Self::binary_op(binary)
     }
 
     fn compile_expr(&mut self, expr: &Expression) -> Result<(), CompileError> {
@@ -143,15 +241,41 @@ impl Compiler {
                 }
                 Ok(())
             }
-            Expression::Assign(AssignOp::Assign, target, value) => {
+            Expression::Assign(op, target, value) => {
                 let Expression::Identifier(name) = target.as_ref() else {
                     return Err(CompileError::Unsupported("assign target"));
                 };
                 let idx = self.add_name(name)?;
-                self.compile_expr(value)?;
-                self.emit(Op::StoreName);
+                self.emit_resolve_name(idx);
+                if *op == AssignOp::Assign {
+                    self.compile_expr(value)?;
+                } else {
+                    self.emit(Op::LoadResolvedName);
+                    self.emit_u16(idx);
+                    self.push_n(1);
+                    self.compile_expr(value)?;
+                    self.emit(Self::compound_binary_op(*op)?);
+                    self.pop_n(2);
+                    self.push_n(1);
+                }
+                self.emit_store_resolved_name(idx);
+                Ok(())
+            }
+            Expression::Update(op, prefix, target) => {
+                let Expression::Identifier(name) = target.as_ref() else {
+                    return Err(CompileError::Unsupported("update target"));
+                };
+                let idx = self.add_name(name)?;
+                self.emit(Op::UpdateName);
                 self.emit_u16(idx);
-                // Stack height unchanged: value remains on stack.
+                let mode = match (op, prefix) {
+                    (UpdateOp::Increment, false) => 0,
+                    (UpdateOp::Increment, true) => 1,
+                    (UpdateOp::Decrement, false) => 2,
+                    (UpdateOp::Decrement, true) => 3,
+                };
+                self.code.push(mode);
+                self.push_n(1);
                 Ok(())
             }
             Expression::Logical(op, lhs, rhs) => {
@@ -198,36 +322,33 @@ impl Compiler {
             Expression::Binary(op, lhs, rhs) => {
                 self.compile_expr(lhs)?;
                 self.compile_expr(rhs)?;
-                let bytecode_op = match op {
-                    BinaryOp::Add => Op::Add,
-                    BinaryOp::Sub => Op::Sub,
-                    BinaryOp::Mul => Op::Mul,
-                    BinaryOp::Div => Op::Div,
-                    BinaryOp::Mod => Op::Mod,
-                    BinaryOp::Exp => Op::Pow,
-                    BinaryOp::Eq => Op::Eq,
-                    BinaryOp::NotEq => Op::NotEq,
-                    BinaryOp::StrictEq => Op::StrictEq,
-                    BinaryOp::StrictNotEq => Op::StrictNotEq,
-                    BinaryOp::Lt => Op::Lt,
-                    BinaryOp::Gt => Op::Gt,
-                    BinaryOp::LtEq => Op::LtEq,
-                    BinaryOp::GtEq => Op::GtEq,
-                    BinaryOp::BitAnd => Op::BitAnd,
-                    BinaryOp::BitOr => Op::BitOr,
-                    BinaryOp::BitXor => Op::BitXor,
-                    BinaryOp::LShift => Op::Shl,
-                    BinaryOp::RShift => Op::Shr,
-                    BinaryOp::URShift => Op::UShr,
-                    _ => return Err(CompileError::Unsupported("binary op")),
-                };
-                self.emit(bytecode_op);
+                self.emit(Self::binary_op(*op)?);
                 self.pop_n(2);
                 self.push_n(1);
                 Ok(())
             }
             _ => Err(CompileError::Unsupported("expression")),
         }
+    }
+
+    fn compile_var_declaration(&mut self, decl: &VariableDeclaration) -> Result<(), CompileError> {
+        if decl.kind != VarKind::Var {
+            return Err(CompileError::Unsupported("lexical declaration"));
+        }
+        for declarator in &decl.declarations {
+            let Pattern::Identifier(name) = &declarator.pattern else {
+                return Err(CompileError::Unsupported("var binding pattern"));
+            };
+            let idx = self.add_var_name(name)?;
+            if let Some(init) = &declarator.init {
+                self.emit_resolve_name(idx);
+                self.compile_expr(init)?;
+                self.emit_store_resolved_name(idx);
+                self.emit(Op::Pop);
+                self.pop_n(1);
+            }
+        }
+        Ok(())
     }
 
     fn compile_literal(&mut self, lit: &Literal) -> Result<(), CompileError> {
@@ -284,6 +405,7 @@ impl Compiler {
                 }
                 Ok(())
             }
+            Statement::Variable(decl) => self.compile_var_declaration(decl),
             Statement::If(if_stmt) => {
                 // Lowering (mirrors `Conditional`'s JumpIfFalse discipline):
                 //   <test>
@@ -306,6 +428,51 @@ impl Compiler {
                     self.patch_jump(end_target)?;
                 } else {
                     self.patch_jump(else_target)?;
+                }
+                Ok(())
+            }
+            Statement::While(while_stmt) => {
+                let loop_start = self.code.len();
+                self.compile_expr(&while_stmt.test)?;
+                self.pop_n(1);
+                let exit = self.emit_jump(Op::JumpIfFalse);
+                self.compile_statement(&while_stmt.body)?;
+                debug_assert_eq!(self.current_stack, 0);
+                debug_assert_eq!(self.current_refs, 0);
+                self.emit_jump_to(Op::Jump, loop_start)?;
+                self.patch_jump(exit)?;
+                Ok(())
+            }
+            Statement::For(for_stmt) => {
+                if let Some(init) = &for_stmt.init {
+                    match init {
+                        ForInit::Variable(decl) => self.compile_var_declaration(decl)?,
+                        ForInit::Expression(expr) => {
+                            self.compile_expr(expr)?;
+                            self.emit(Op::Pop);
+                            self.pop_n(1);
+                        }
+                    }
+                }
+                let loop_start = self.code.len();
+                let exit = if let Some(test) = &for_stmt.test {
+                    self.compile_expr(test)?;
+                    self.pop_n(1);
+                    Some(self.emit_jump(Op::JumpIfFalse))
+                } else {
+                    None
+                };
+                self.compile_statement(&for_stmt.body)?;
+                if let Some(update) = &for_stmt.update {
+                    self.compile_expr(update)?;
+                    self.emit(Op::Pop);
+                    self.pop_n(1);
+                }
+                debug_assert_eq!(self.current_stack, 0);
+                debug_assert_eq!(self.current_refs, 0);
+                self.emit_jump_to(Op::Jump, loop_start)?;
+                if let Some(exit) = exit {
+                    self.patch_jump(exit)?;
                 }
                 Ok(())
             }
@@ -336,7 +503,9 @@ impl Compiler {
             code: self.code,
             constants: self.constants,
             names: self.names,
+            var_names: self.var_names,
             max_stack: self.max_stack,
+            max_refs: self.max_refs,
         }
     }
 }

--- a/src/interpreter/bytecode/op.rs
+++ b/src/interpreter/bytecode/op.rs
@@ -40,7 +40,10 @@ pub(crate) enum Op {
     JumpIfFalsyKeep = 36,
     JumpIfNotNullishKeep = 37,
     LoadName = 38,
-    StoreName = 39,
+    ResolveName = 39,
+    LoadResolvedName = 40,
+    StoreResolvedName = 41,
+    UpdateName = 42,
 }
 
 impl Op {
@@ -85,7 +88,10 @@ impl Op {
             36 => Some(Op::JumpIfFalsyKeep),
             37 => Some(Op::JumpIfNotNullishKeep),
             38 => Some(Op::LoadName),
-            39 => Some(Op::StoreName),
+            39 => Some(Op::ResolveName),
+            40 => Some(Op::LoadResolvedName),
+            41 => Some(Op::StoreResolvedName),
+            42 => Some(Op::UpdateName),
             _ => None,
         }
     }

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -791,6 +791,26 @@ fn nested_for_and_while_loops_take_bytecode_path() {
 }
 
 #[test]
+fn while_loop_htmldda_truthiness_matches_tree_walker() {
+    // $262.IsHTMLDDA carries the [[IsHTMLDDA]] slot (Annex B.3.6) and must
+    // coerce to false despite being an object, matching document.all. `h` is
+    // declared outside the compiled function (member access on `$262` isn't
+    // itself compilable) and read as a captured identifier in the loop test.
+    assert_parity_number(
+        "var h = $262.IsHTMLDDA; var __r = (function(){ var i = 0; while (h) { i++; if (i > 2) return 99; } return 1; })();",
+        1.0,
+    );
+}
+
+#[test]
+fn for_loop_htmldda_truthiness_matches_tree_walker() {
+    assert_parity_number(
+        "var h = $262.IsHTMLDDA; var __r = (function(){ var i = 0; for (; h; ) { i++; if (i > 2) return 99; } return 1; })();",
+        1.0,
+    );
+}
+
+#[test]
 fn lexical_for_loop_falls_back_to_tree_walker() {
     let source = "var __r = (function(){ var sum = 0; for (let i = 0; i < 3; i++) sum += i; return sum; })();";
     let (value, count) = eval_with_mode(source, true);

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -62,11 +62,10 @@ fn end_to_end_addition_return_takes_bytecode_path() {
 }
 
 #[test]
-fn end_to_end_ineligible_function_falls_back_to_ast() {
-    // var declarations + identifier reads aren't compilable yet → must bail to AST
+fn end_to_end_var_declaration_takes_bytecode_path() {
     let source = "var __r = (function(){ var x = 7; return x; })();";
     let (v, count) = eval_with_mode(source, true);
-    assert_eq!(count, 0, "ineligible function must NOT use bytecode path");
+    assert!(count >= 1, "bytecode mode must execute the var body");
     assert!(matches!(v, JsValue::Number(n) if n == 7.0));
 }
 
@@ -99,7 +98,9 @@ fn load_const_and_return_yields_number_completion() {
         code: vec![Op::LoadConst as u8, 0, 0, Op::Return as u8],
         constants: vec![Constant::Number(42.0)],
         names: vec![],
+        var_names: vec![],
         max_stack: 1,
+        max_refs: 0,
     };
     match run(chunk) {
         Completion::Return(JsValue::Number(n)) => assert_eq!(n, 42.0),
@@ -113,7 +114,9 @@ fn return_undefined_completes_with_undefined() {
         code: vec![Op::ReturnUndefined as u8],
         constants: vec![],
         names: vec![],
+        var_names: vec![],
         max_stack: 0,
+        max_refs: 0,
     };
     match run(chunk) {
         Completion::Return(JsValue::Undefined) => {}
@@ -137,7 +140,9 @@ fn add_two_numbers_via_eval_binary() {
         ],
         constants: vec![Constant::Number(2.0), Constant::Number(3.0)],
         names: vec![],
+        var_names: vec![],
         max_stack: 2,
+        max_refs: 0,
     };
     match run(chunk) {
         Completion::Return(JsValue::Number(n)) => assert_eq!(n, 5.0),
@@ -442,7 +447,9 @@ fn add_string_and_number_falls_through_to_string_concat() {
         ],
         constants: vec![Constant::String("x".into()), Constant::Number(1.0)],
         names: vec![],
+        var_names: vec![],
         max_stack: 2,
+        max_refs: 0,
     };
     match run(chunk) {
         Completion::Return(JsValue::String(s)) => assert_eq!(s.to_string(), "x1"),
@@ -468,10 +475,8 @@ fn assert_parity_number(source: &str, expected: f64) {
     }
 }
 
-// NOTE: `var`/`let` declarations are not yet compilable, so a body that
-// contains one bails the WHOLE body to the tree-walker. To exercise the
-// bytecode path these tests use a parameter for input plus `return` in the
-// branches — both of which the compiler supports.
+// NOTE: lexical declarations are not yet compilable, so a body containing one
+// still bails the WHOLE body to the tree-walker.
 
 #[test]
 fn if_true_takes_consequent_branch() {
@@ -674,10 +679,129 @@ fn load_undefined_then_return_completes_with_undefined() {
         code: vec![Op::LoadUndefined as u8, Op::Return as u8],
         constants: vec![],
         names: vec![],
+        var_names: vec![],
         max_stack: 1,
+        max_refs: 0,
     };
     match run(chunk) {
         Completion::Return(JsValue::Undefined) => {}
         other => panic!("expected Return(Undefined), got {other:?}"),
     }
+}
+
+// ----- var declarations, updates, compound assignment, and loops -----
+
+#[test]
+fn var_bindings_are_hoisted_before_initializers() {
+    let source = "var __r = (function(){ var before = x; var x = 7; return before; })();";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(bytecode_count >= 1, "bytecode path must run");
+    assert!(matches!(ast, JsValue::Undefined));
+    assert!(matches!(bytecode, JsValue::Undefined));
+}
+
+#[test]
+fn multiple_var_initializers_run_in_source_order() {
+    assert_parity_number(
+        "var __r = (function(){ var a = 1, b = a + 2; return b; })();",
+        3.0,
+    );
+}
+
+#[test]
+fn prefix_and_postfix_updates_preserve_result_value() {
+    assert_parity_number(
+        "var __r = (function(){ var x = 1; var old = x++; var now = ++x; return old * 100 + now * 10 + x; })();",
+        133.0,
+    );
+    assert_parity_number(
+        "var __r = (function(){ var x = 3; return x-- * 10 + --x; })();",
+        31.0,
+    );
+}
+
+#[test]
+fn identifier_update_preserves_bigint_semantics() {
+    let source = "var __r = (function(x){ x++; return x; })(1n);";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(bytecode_count >= 1, "bytecode path must run");
+    match (ast, bytecode) {
+        (JsValue::BigInt(a), JsValue::BigInt(b)) => {
+            assert_eq!(a.value.to_string(), "2");
+            assert_eq!(b.value.to_string(), "2");
+        }
+        other => panic!("expected matching BigInt results, got {other:?}"),
+    }
+}
+
+#[test]
+fn compound_assignment_preserves_captured_identifier_reference() {
+    let source = "\
+        var obj = { get x(){ delete this.x; return 2; } }; \
+        var f; \
+        with (obj) { f = function(){ x += 3; return 0; }; } \
+        f(); \
+        var __r = Object.prototype.hasOwnProperty.call(obj, 'x') ? obj.x : -1;";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(bytecode_count >= 1, "nested function must use bytecode");
+    assert!(matches!(ast, JsValue::Number(n) if n == 5.0));
+    assert!(matches!(bytecode, JsValue::Number(n) if n == 5.0));
+}
+
+#[test]
+fn numeric_for_loop_takes_bytecode_path() {
+    assert_parity_number(
+        "var __r = (function(n){ var sum = 0; for (var i = 0; i < n; i++) { sum += i; } return sum; })(10);",
+        45.0,
+    );
+}
+
+#[test]
+fn while_loop_takes_bytecode_path() {
+    assert_parity_number(
+        "var __r = (function(n){ var sum = 0; while (n > 0) { sum += n; n--; } return sum; })(10);",
+        55.0,
+    );
+}
+
+#[test]
+fn for_loop_optional_clauses_preserve_order() {
+    assert_parity_number(
+        "var __r = (function(i){ for (; i < 3; i++) {} return i; })(0);",
+        3.0,
+    );
+    assert_parity_number(
+        "var __r = (function(){ for (var i = 0; i < 3;) { i++; } return i; })();",
+        3.0,
+    );
+}
+
+#[test]
+fn nested_for_and_while_loops_take_bytecode_path() {
+    assert_parity_number(
+        "var __r = (function(){ var n = 0; for (var i = 0; i < 3; i++) { var j = 0; while (j < 2) { n += i; j++; } } return n; })();",
+        6.0,
+    );
+}
+
+#[test]
+fn lexical_for_loop_falls_back_to_tree_walker() {
+    let source = "var __r = (function(){ var sum = 0; for (let i = 0; i < 3; i++) sum += i; return sum; })();";
+    let (value, count) = eval_with_mode(source, true);
+    assert_eq!(count, 0, "lexical loop must remain ineligible");
+    assert!(matches!(value, JsValue::Number(n) if n == 3.0));
+}
+
+#[test]
+fn loop_with_break_falls_back_to_tree_walker() {
+    let source = "var __r = (function(){ var i = 0; while (true) { i++; break; } return i; })();";
+    let (value, count) = eval_with_mode(source, true);
+    assert_eq!(count, 0, "break lowering is not part of this slice");
+    assert!(matches!(value, JsValue::Number(n) if n == 1.0));
 }

--- a/src/interpreter/bytecode/vm.rs
+++ b/src/interpreter/bytecode/vm.rs
@@ -1,8 +1,9 @@
 use super::chunk::Chunk;
 use super::op::Op;
-use crate::ast::{BinaryOp, UnaryOp};
+use crate::ast::{BinaryOp, UnaryOp, UpdateOp};
+use crate::interpreter::eval::IdentifierRef;
 use crate::interpreter::helpers::to_boolean;
-use crate::interpreter::types::Completion;
+use crate::interpreter::types::{BindingKind, Completion, Environment};
 use crate::interpreter::{EnvRef, Interpreter};
 use crate::types::JsValue;
 
@@ -12,6 +13,12 @@ fn decode_i16(chunk: &Chunk, pc: usize) -> i16 {
     ((hi << 8) | lo) as i16
 }
 
+fn decode_u16(chunk: &Chunk, pc: usize) -> u16 {
+    let lo = chunk.code[pc] as u16;
+    let hi = chunk.code[pc + 1] as u16;
+    (hi << 8) | lo
+}
+
 pub(crate) fn run_chunk(
     interp: &mut Interpreter,
     chunk: &Chunk,
@@ -19,7 +26,15 @@ pub(crate) fn run_chunk(
     _this: JsValue,
 ) -> Completion {
     interp.bytecode_chunks_executed += 1;
+    let var_scope = Environment::find_var_scope(env);
+    for &name_idx in &chunk.var_names {
+        let name = &chunk.names[name_idx as usize];
+        if !var_scope.borrow().bindings.contains_key(name.as_ref()) {
+            var_scope.borrow_mut().declare(name, BindingKind::Var);
+        }
+    }
     let mut stack: Vec<JsValue> = Vec::with_capacity(chunk.max_stack as usize);
+    let mut refs: Vec<IdentifierRef> = Vec::with_capacity(chunk.max_refs as usize);
     let mut pc: usize = 0;
     loop {
         let op_byte = chunk.code[pc];
@@ -27,18 +42,14 @@ pub(crate) fn run_chunk(
         pc += 1;
         match op {
             Op::LoadConst => {
-                let lo = chunk.code[pc] as u16;
-                let hi = chunk.code[pc + 1] as u16;
+                let idx = decode_u16(chunk, pc);
                 pc += 2;
-                let idx = (hi << 8) | lo;
                 let v = chunk.constants[idx as usize].to_value();
                 stack.push(v);
             }
             Op::LoadName => {
-                let lo = chunk.code[pc] as u16;
-                let hi = chunk.code[pc + 1] as u16;
+                let idx = decode_u16(chunk, pc);
                 pc += 2;
-                let idx = (hi << 8) | lo;
                 let name = chunk.names[idx as usize].clone();
                 let strict = env.borrow().strict;
                 match interp.resolve_identifier(&name, env, strict) {
@@ -46,21 +57,57 @@ pub(crate) fn run_chunk(
                     abrupt => return abrupt,
                 }
             }
-            Op::StoreName => {
-                // Stack on entry: [..., value]
-                // Stack on exit:  [..., value]   (assignment leaves value on stack)
-                let lo = chunk.code[pc] as u16;
-                let hi = chunk.code[pc + 1] as u16;
+            Op::ResolveName => {
+                let idx = decode_u16(chunk, pc);
                 pc += 2;
-                let idx = (hi << 8) | lo;
-                let name = chunk.names[idx as usize].clone();
-                let value = stack.last().expect("stack underflow on StoreName").clone();
-                let id_ref = match interp.resolve_identifier_ref(&name, env) {
-                    Ok(r) => r,
+                let name = &chunk.names[idx as usize];
+                match interp.resolve_identifier_ref(name, env) {
+                    Ok(id_ref) => refs.push(id_ref),
                     Err(e) => return Completion::Throw(e),
-                };
-                if let Completion::Throw(e) = interp.put_value_by_ref(&name, value, &id_ref, env) {
+                }
+            }
+            Op::LoadResolvedName => {
+                let idx = decode_u16(chunk, pc);
+                pc += 2;
+                let name = &chunk.names[idx as usize];
+                let id_ref = refs
+                    .last()
+                    .expect("reference stack underflow on LoadResolvedName");
+                match interp.get_identifier_value_by_ref(name, id_ref, env) {
+                    Completion::Normal(value) => stack.push(value),
+                    abrupt => return abrupt,
+                }
+            }
+            Op::StoreResolvedName => {
+                let idx = decode_u16(chunk, pc);
+                pc += 2;
+                let name = &chunk.names[idx as usize];
+                let id_ref = refs
+                    .pop()
+                    .expect("reference stack underflow on StoreResolvedName");
+                let value = stack
+                    .last()
+                    .expect("stack underflow on StoreResolvedName")
+                    .clone();
+                if let Completion::Throw(e) = interp.put_value_by_ref(name, value, &id_ref, env) {
                     return Completion::Throw(e);
+                }
+            }
+            Op::UpdateName => {
+                let idx = decode_u16(chunk, pc);
+                let mode = chunk.code[pc + 2];
+                pc += 3;
+                let (op, prefix) = match mode {
+                    0 => (UpdateOp::Increment, false),
+                    1 => (UpdateOp::Increment, true),
+                    2 => (UpdateOp::Decrement, false),
+                    3 => (UpdateOp::Decrement, true),
+                    _ => panic!("invalid UpdateName mode"),
+                };
+                let name = &chunk.names[idx as usize];
+                match interp.eval_identifier_update(op, prefix, name, env) {
+                    Completion::Normal(value) => stack.push(value),
+                    abrupt => return abrupt,
                 }
             }
             Op::LoadUndefined => {
@@ -151,6 +198,11 @@ pub(crate) fn run_chunk(
             }
             Op::Jump => {
                 let offset = decode_i16(chunk, pc) as i32;
+                if offset < 0 {
+                    debug_assert!(stack.is_empty(), "operand stack live at loop backedge");
+                    debug_assert!(refs.is_empty(), "reference stack live at loop backedge");
+                    interp.gc_safepoint();
+                }
                 pc = (pc as i32 + 2 + offset) as usize;
             }
             Op::JumpIfFalse => {

--- a/src/interpreter/bytecode/vm.rs
+++ b/src/interpreter/bytecode/vm.rs
@@ -2,7 +2,6 @@ use super::chunk::Chunk;
 use super::op::Op;
 use crate::ast::{BinaryOp, UnaryOp, UpdateOp};
 use crate::interpreter::eval::IdentifierRef;
-use crate::interpreter::helpers::to_boolean;
 use crate::interpreter::types::{BindingKind, Completion, Environment};
 use crate::interpreter::{EnvRef, Interpreter};
 use crate::types::JsValue;
@@ -209,7 +208,7 @@ pub(crate) fn run_chunk(
                 let offset = decode_i16(chunk, pc) as i32;
                 pc += 2;
                 let v = stack.pop().expect("stack underflow on JumpIfFalse");
-                if !to_boolean(&v) {
+                if !interp.to_boolean_val(&v) {
                     pc = (pc as i32 + offset) as usize;
                 }
             }
@@ -217,7 +216,7 @@ pub(crate) fn run_chunk(
                 let offset = decode_i16(chunk, pc) as i32;
                 pc += 2;
                 let v = stack.pop().expect("stack underflow on JumpIfTrue");
-                if to_boolean(&v) {
+                if interp.to_boolean_val(&v) {
                     pc = (pc as i32 + offset) as usize;
                 }
             }
@@ -225,7 +224,7 @@ pub(crate) fn run_chunk(
                 let offset = decode_i16(chunk, pc) as i32;
                 pc += 2;
                 let v = stack.last().expect("stack underflow on JumpIfTruthyKeep");
-                if to_boolean(v) {
+                if interp.to_boolean_val(v) {
                     pc = (pc as i32 + offset) as usize;
                 }
             }
@@ -233,7 +232,7 @@ pub(crate) fn run_chunk(
                 let offset = decode_i16(chunk, pc) as i32;
                 pc += 2;
                 let v = stack.last().expect("stack underflow on JumpIfFalsyKeep");
-                if !to_boolean(v) {
+                if !interp.to_boolean_val(v) {
                     pc = (pc as i32 + offset) as usize;
                 }
             }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2497,6 +2497,102 @@ impl Interpreter {
         }
     }
 
+    pub(super) fn get_identifier_value_by_ref(
+        &mut self,
+        name: &str,
+        id_ref: &IdentifierRef,
+        env: &EnvRef,
+    ) -> Completion {
+        let strict = env.borrow().strict;
+        match id_ref {
+            IdentifierRef::WithObject(obj_id) => self.with_get_binding_value(*obj_id, name, strict),
+            IdentifierRef::Unresolvable => {
+                Completion::Throw(self.create_reference_error(&format!("{name} is not defined")))
+            }
+            IdentifierRef::SpecificEnv(specific_env) => {
+                let (indirect, has_binding) = {
+                    let specific = specific_env.borrow();
+                    (
+                        specific.resolve_indirect_binding(name),
+                        specific.bindings.contains_key(name),
+                    )
+                };
+                if let Some(resolved) = indirect {
+                    match resolved {
+                        Some(value) => Completion::Normal(value),
+                        None => Completion::Throw(self.create_reference_error(&format!(
+                            "Cannot access '{name}' before initialization"
+                        ))),
+                    }
+                } else if has_binding {
+                    match self.env_get(specific_env, name) {
+                        Some(value) => Completion::Normal(value),
+                        None => Completion::Throw(self.create_reference_error(&format!(
+                            "Cannot access '{name}' before initialization"
+                        ))),
+                    }
+                } else if let Some(result) = self.resolve_global_getter(name, specific_env) {
+                    result
+                } else {
+                    Completion::Throw(
+                        self.create_reference_error(&format!("{name} is not defined")),
+                    )
+                }
+            }
+        }
+    }
+
+    pub(super) fn eval_identifier_update(
+        &mut self,
+        op: UpdateOp,
+        prefix: bool,
+        name: &str,
+        env: &EnvRef,
+    ) -> Completion {
+        // Fast path: identifier is a Number in the local scope chain (no with/module)
+        {
+            let env_borrow = env.borrow();
+            if env_borrow.with_object.is_none()
+                && let Some(binding) = env_borrow.bindings.get(name)
+                && binding.initialized
+                && binding.kind != BindingKind::Const
+                && binding.kind != BindingKind::FunctionName
+                && binding.kind != BindingKind::ImmutableValue
+                && let JsValue::Number(n) = &binding.value
+            {
+                let old_num = *n;
+                let new_num = match op {
+                    UpdateOp::Increment => old_num + 1.0,
+                    UpdateOp::Decrement => old_num - 1.0,
+                };
+                let new_val = JsValue::Number(new_num);
+                drop(env_borrow);
+                if let Err(e) = self.env_set(env, name, new_val) {
+                    return Completion::Throw(e);
+                }
+                return Completion::Normal(JsValue::Number(if prefix { new_num } else { old_num }));
+            }
+        }
+
+        let id_ref = match self.resolve_identifier_ref(name, env) {
+            Ok(r) => r,
+            Err(e) => return Completion::Throw(e),
+        };
+        let raw_val = match self.get_identifier_value_by_ref(name, &id_ref, env) {
+            Completion::Normal(v) => v,
+            other => return other,
+        };
+        let (old_val, new_val) = match self.apply_update_numeric(&raw_val, op) {
+            Ok(pair) => pair,
+            Err(e) => return Completion::Throw(e),
+        };
+        match self.put_value_by_ref(name, new_val.clone(), &id_ref, env) {
+            Completion::Normal(_) => {}
+            other => return other,
+        }
+        Completion::Normal(if prefix { new_val } else { old_val })
+    }
+
     fn eval_update(
         &mut self,
         op: UpdateOp,
@@ -2505,79 +2601,7 @@ impl Interpreter {
         env: &EnvRef,
     ) -> Completion {
         if let Expression::Identifier(name) = arg {
-            // Fast path: identifier is a Number in the local scope chain (no with/module)
-            {
-                let env_borrow = env.borrow();
-                if env_borrow.with_object.is_none()
-                    && let Some(binding) = env_borrow.bindings.get(name)
-                    && binding.initialized
-                    && binding.kind != BindingKind::Const
-                    && binding.kind != BindingKind::FunctionName
-                    && binding.kind != BindingKind::ImmutableValue
-                    && let JsValue::Number(n) = &binding.value
-                {
-                    let old_num = *n;
-                    let new_num = match op {
-                        UpdateOp::Increment => old_num + 1.0,
-                        UpdateOp::Decrement => old_num - 1.0,
-                    };
-                    let new_val = JsValue::Number(new_num);
-                    drop(env_borrow);
-                    if let Err(e) = self.env_set(env, name, new_val) {
-                        return Completion::Throw(e);
-                    }
-                    return Completion::Normal(JsValue::Number(if prefix {
-                        new_num
-                    } else {
-                        old_num
-                    }));
-                }
-            }
-
-            let strict = env.borrow().strict;
-            let id_ref = match self.resolve_identifier_ref(name, env) {
-                Ok(r) => r,
-                Err(e) => return Completion::Throw(e),
-            };
-            let raw_val = match &id_ref {
-                IdentifierRef::WithObject(obj_id) => {
-                    match self.with_get_binding_value(*obj_id, name, strict) {
-                        Completion::Normal(v) => v,
-                        other => return other,
-                    }
-                }
-                IdentifierRef::Unresolvable => {
-                    return Completion::Throw(
-                        self.create_reference_error(&format!("{name} is not defined")),
-                    );
-                }
-                IdentifierRef::SpecificEnv(_) => {
-                    if let Some(result) = self.resolve_global_getter(name, env) {
-                        match result {
-                            Completion::Normal(v) => v,
-                            other => return other,
-                        }
-                    } else {
-                        match self.env_get(env, name) {
-                            Some(v) => v,
-                            None => {
-                                let err =
-                                    self.create_reference_error(&format!("{name} is not defined"));
-                                return Completion::Throw(err);
-                            }
-                        }
-                    }
-                }
-            };
-            let (old_val, new_val) = match self.apply_update_numeric(&raw_val, op) {
-                Ok(pair) => pair,
-                Err(e) => return Completion::Throw(e),
-            };
-            match self.put_value_by_ref(name, new_val.clone(), &id_ref, env) {
-                Completion::Normal(_) => {}
-                other => return other,
-            }
-            Completion::Normal(if prefix { new_val } else { old_val })
+            self.eval_identifier_update(op, prefix, name, env)
         } else if let Expression::Member(obj_expr, prop, _) = arg {
             // §13.3.7.1: super[expr]++ — special evaluation order
             if matches!(obj_expr.as_ref(), Expression::Super)


### PR DESCRIPTION
## Summary

- compile function-scoped `var`, captured identifier assignment/update, and basic `for`/`while` loops in the opt-in stack VM
- preserve assignment reference timing and run a GC safepoint at each bytecode backedge
- retain whole-body fallback for lexical loops, `break`/`continue`, and unsupported syntax

## Performance

- empty 1M loop: 247.2 ms AST vs 105.2 ms bytecode (2.35x faster)
- summing 1M loop: 382.8 ms AST vs 259.4 ms bytecode (1.48x faster)

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (320 unit tests plus smoke oracle)
- `./scripts/lint.sh`
- custom tests: 8/8
- targeted bytecode test262: 3,021/3,021
- full default test262: 99,546/99,568; the 22 failures are pre-existing Intl locale-data cases and reproduce with bytecode disabled
- full bytecode test262: same 22 Intl failures plus 12 shared-host timeout artifacts; every timeout passed in isolated bytecode reruns

Closes #67