### PR TITLE
perf(gc): arena-allocate JavaScript objects

### DIFF
--- a/docs/specs/2026-07-20-object-arena-allocator-design.md
+++ b/docs/specs/2026-07-20-object-arena-allocator-design.md
@@ -1,0 +1,78 @@
+# Object arena allocator design
+
+## Goal
+
+Eliminate the system allocation and deallocation performed for every
+`Rc<RefCell<JsObjectData>>` while preserving the interpreter's existing object
+identity, `RefCell` borrow checks, GC slot reuse, and re-entrant builtin
+behaviour.
+
+ECMAScript specifies object behaviour and internal slots, but explicitly leaves
+their representation to the implementation. This change is therefore a storage
+optimization: `MakeBasicObject`, ordinary objects, and exotic objects retain
+the same observable semantics.
+
+## Considered approaches
+
+1. Store `Option<RefCell<JsObjectData>>` directly in the existing chunked
+   `ObjectArena`. This has the smallest per-object header, but the remaining
+   owned `Rc` handles deliberately span re-entrant `&mut Interpreter` calls.
+   Replacing them with raw pointers would be unsafe if GC frees and reuses a
+   slot while such a handle is live; replacing all of them with borrows requires
+   a broad evaluator rewrite.
+2. Use Rust's allocator-aware `Rc`. This preserves the API and lets an arena
+   supply the backing memory, but `Rc::new_in` and the allocator API remain
+   unstable on the project's stable toolchain.
+3. Use a narrow, object-specific reference-counted handle backed by a
+   per-interpreter fixed-block arena. This preserves the ownership behaviour of
+   the current `Rc`, confines unsafe code to one module, and replaces one system
+   allocation per object with one allocation per chunk. This is the selected
+   approach.
+
+## Design
+
+`ObjectHandle` is an eight-byte non-null pointer to an `ObjectAllocation`.
+`ObjectAllocation` contains a single-threaded strong count, a reference to its
+owning storage, and the existing `RefCell<JsObjectData>`. `Clone`, `Deref`, and
+`AsRef` provide the small API used by current call sites.
+
+`ObjectStorage` owns fixed-size chunks of uninitialized, correctly aligned
+`ObjectAllocation` slots and a free list. Allocation takes a free block or the
+next block in the current chunk, initializes it in place, and returns an
+`ObjectHandle`. Releasing the last handle drops `JsObjectData` and returns the
+block to the free list; backing chunks remain allocated until the interpreter
+and any temporarily escaped handles are gone.
+
+Logical GC slots and physical allocation blocks remain separate. GC may remove
+an object from its logical slot and reuse the numeric object id while a
+temporary handle to the old allocation exists. The old allocation is not
+reused until that handle is dropped, matching the current `Rc` behaviour and
+preventing ABA access to a newly allocated object.
+
+The storage is per interpreter. This avoids cross-interpreter lifetime coupling,
+global synchronization, and memory retention beyond the last related object
+handle.
+
+## Safety invariants
+
+- Chunk allocations never move, so every `ObjectHandle` pointer remains stable.
+- An initialized block is returned to the storage free list exactly once, after
+  its strong count reaches zero and its value has been dropped.
+- The embedded storage reference keeps all chunks alive until the last handle
+  backed by them is released.
+- Free-list blocks are uninitialized and are never dereferenced before the next
+  allocation writes a complete `ObjectAllocation`.
+- `ObjectHandle` remains single-threaded, like `Rc`, and `RefCell` continues to
+  enforce dynamic borrow rules.
+
+## Validation
+
+- Unit-test chunk growth, block reuse, and the case where GC frees a logical
+  slot while a cloned handle keeps its physical allocation alive.
+- Run formatting, clippy, release build, and release unit/integration tests.
+- Run object/proxy/collection test262 subsets because they exercise ordinary
+  allocation, re-entrancy, and owned handles, followed by the full suite.
+- Compare JetStream splay before and after when the local JetStream checkout is
+  available. At minimum, record arena allocation statistics in unit tests so
+  the one-chunk-per-many-objects property cannot regress silently.
+

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -6,14 +6,14 @@ use super::super::*;
 /// sibling of `string.rs`'s `this_string_value` / `this_js_string`: it
 /// concentrates the receiver brand-check that every `Map.prototype` method would
 /// otherwise open-code, returning the receiver's object id and cell, or a
-/// TypeError completion naming the method. The cell is an owned `Rc` (via
+/// TypeError completion naming the method. The cell is an owned handle (via
 /// `get_object`) so callers may re-enter the interpreter — e.g. `forEach`
 /// invoking a callback — while holding it.
 fn this_map(
     interp: &mut Interpreter,
     this: &JsValue,
     method: &str,
-) -> Result<(u64, Rc<RefCell<JsObjectData>>), Completion> {
+) -> Result<(u64, ObjectHandle), Completion> {
     if let JsValue::Object(o) = this
         && let Some(obj) = interp.get_object(o.id)
         && {
@@ -35,7 +35,7 @@ fn this_set(
     interp: &mut Interpreter,
     this: &JsValue,
     method: &str,
-) -> Result<(u64, Rc<RefCell<JsObjectData>>), Completion> {
+) -> Result<(u64, ObjectHandle), Completion> {
     if let JsValue::Object(o) = this
         && let Some(obj) = interp.get_object(o.id)
         && {

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -511,7 +511,7 @@ impl Interpreter {
     /// caller's slow path re-records it.
     fn ic_probe_prop_kind<K: PropertyKeyLike + ?Sized>(
         &self,
-        obj_rc: &Rc<RefCell<JsObjectData>>,
+        obj_rc: &ObjectHandle,
         key: &K,
         kind: crate::interpreter::ic::PropIcKind,
     ) -> Option<JsValue> {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod ic;
 pub(crate) mod ic_store;
 pub(crate) mod key_intern;
 mod object_arena;
+pub(crate) use object_arena::ObjectHandle;
 mod property;
 mod property_map;
 pub(crate) use property_map::PropertyMap;
@@ -1435,14 +1436,15 @@ impl Interpreter {
         getter
     }
 
-    /// Get a fresh `Rc::clone` of the slot's `Rc<RefCell<…>>` if live.
+    /// Get a fresh owned clone of the slot's object handle if live.
     /// New callers should prefer `get_object_cell` / `get_object_cell_expect`
-    /// (returns `&RefCell<…>`) to avoid the per-call `Rc::clone`; this
+    /// (returns `&RefCell<…>`) to avoid the per-call handle refcount change; this
     /// function remains for the (large) set of legacy callers that
     /// pattern-match `if let Some(obj) = interp.get_object(id) { obj.borrow*() }`
     /// and need a value-type binding outliving any inner `&mut self`
     /// callback (proxy traps, getter dispatch, error allocation).
-    pub(crate) fn get_object(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
+    #[inline(always)]
+    pub(crate) fn get_object(&self, id: u64) -> Option<ObjectHandle> {
         self.objects.get(id)
     }
 

--- a/src/interpreter/object_arena.rs
+++ b/src/interpreter/object_arena.rs
@@ -1,27 +1,189 @@
-//! Chunked arena for `JsObjectData` slots.
+//! Chunked arena for `JsObjectData`.
 //!
-//! Replaces the prior `Vec<Option<Rc<RefCell<JsObjectData>>>>` slab with
-//! `Vec<Box<[Option<Rc<RefCell<JsObjectData>>>; CHUNK_SIZE]>>`. Per-slot
-//! `Rc<RefCell<…>>` storage is preserved (PR 2b.1) so existing call sites
-//! keep their `Rc<RefCell<JsObjectData>>` API. The chunked layout makes
-//! slot addresses stable across `Vec` growth, paving the way for a future
-//! PR 2b.2 that drops the per-slot `Rc` and yields `&RefCell<JsObjectData>`
-//! borrows directly.
+//! Logical object ids live in chunked slots, while their `JsObjectData`
+//! allocations come from a second fixed-block arena. [`ObjectHandle`] keeps
+//! the ownership and re-entrancy behaviour of the old
+//! `Rc<RefCell<JsObjectData>>` representation without asking the system
+//! allocator for every object. Logical ids may be reused as soon as GC clears
+//! a slot; physical blocks are reused only after the last temporary handle to
+//! the old object is dropped.
 
 use super::types::JsObjectData;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::mem::MaybeUninit;
+use std::ops::Deref;
+use std::ptr::{self, NonNull};
 use std::rc::Rc;
 
 pub(crate) const CHUNK_SIZE: usize = 1024;
 
-type Slot = Option<Rc<RefCell<JsObjectData>>>;
+type Slot = Option<ObjectHandle>;
 type Chunk = Box<[Slot; CHUNK_SIZE]>;
+
+/// Owned pointer to arena-allocated object data.
+///
+/// This intentionally exposes only the subset of `Rc` used for JS objects:
+/// clone an owned handle and dereference it to the existing `RefCell` API.
+/// The pointer is stable because [`ObjectStorage`] never moves its chunks.
+pub(crate) struct ObjectHandle {
+    allocation: NonNull<ObjectAllocation>,
+}
+
+impl ObjectHandle {
+    fn new(storage: &Rc<ObjectStorage>, data: JsObjectData) -> Self {
+        let allocation = storage.take_block();
+        // SAFETY: `take_block` returns an aligned, currently uninitialized
+        // block owned by `storage`. No handle can reference it until this
+        // complete value has been written.
+        unsafe {
+            allocation.as_ptr().write(ObjectAllocation {
+                strong: Cell::new(1),
+                storage: Rc::clone(storage),
+                value: RefCell::new(data),
+            });
+        }
+        Self { allocation }
+    }
+
+    #[cold]
+    #[inline(never)]
+    unsafe fn drop_slow(allocation: NonNull<ObjectAllocation>) {
+        // SAFETY: the caller established that this is the unique final handle.
+        let allocation_ref = unsafe { allocation.as_ref() };
+        let allocation_ptr = allocation.as_ptr();
+        // Keep the storage alive while removing its reference from the block.
+        let storage = Rc::clone(&allocation_ref.storage);
+        // SAFETY: drop each non-trivial field exactly once, then return the
+        // now-uninitialized block to its owner.
+        unsafe {
+            ptr::drop_in_place(ptr::addr_of_mut!((*allocation_ptr).value));
+            ptr::drop_in_place(ptr::addr_of_mut!((*allocation_ptr).storage));
+        }
+        storage.return_block(allocation);
+    }
+}
+
+impl Clone for ObjectHandle {
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        // SAFETY: every live handle contributes one to `strong`, which keeps
+        // this initialized allocation and its storage alive.
+        let allocation = unsafe { self.allocation.as_ref() };
+        let strong = allocation
+            .strong
+            .get()
+            .checked_add(1)
+            .expect("ObjectHandle strong count overflow");
+        allocation.strong.set(strong);
+        Self {
+            allocation: self.allocation,
+        }
+    }
+}
+
+impl Deref for ObjectHandle {
+    type Target = RefCell<JsObjectData>;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: a live handle keeps the allocation initialized and the
+        // embedded storage reference keeps its backing chunk allocated.
+        &unsafe { self.allocation.as_ref() }.value
+    }
+}
+
+impl AsRef<RefCell<JsObjectData>> for ObjectHandle {
+    #[inline(always)]
+    fn as_ref(&self) -> &RefCell<JsObjectData> {
+        self
+    }
+}
+
+impl Drop for ObjectHandle {
+    #[inline(always)]
+    fn drop(&mut self) {
+        // SAFETY: `self` owns one strong reference, so the allocation is live.
+        let allocation = unsafe { self.allocation.as_ref() };
+        let strong = allocation.strong.get();
+        debug_assert!(strong > 0, "ObjectHandle strong count underflow");
+        if strong > 1 {
+            allocation.strong.set(strong - 1);
+            return;
+        }
+
+        // SAFETY: `strong == 1`, so this is the unique final handle.
+        unsafe { Self::drop_slow(self.allocation) };
+    }
+}
+
+struct ObjectAllocation {
+    strong: Cell<usize>,
+    storage: Rc<ObjectStorage>,
+    value: RefCell<JsObjectData>,
+}
+
+/// Physical backing store for [`ObjectAllocation`] blocks.
+///
+/// Chunks contain `MaybeUninit` so dropping the storage never double-drops
+/// blocks already finalized by `ObjectHandle::drop`.
+struct ObjectStorage {
+    state: RefCell<ObjectStorageState>,
+    recycle_blocks: Cell<bool>,
+}
+
+struct ObjectStorageState {
+    chunks: Vec<Box<[MaybeUninit<ObjectAllocation>]>>,
+    free_list: Vec<NonNull<ObjectAllocation>>,
+    next_block: usize,
+}
+
+impl ObjectStorage {
+    fn new() -> Self {
+        Self {
+            state: RefCell::new(ObjectStorageState {
+                chunks: Vec::new(),
+                free_list: Vec::new(),
+                next_block: 0,
+            }),
+            recycle_blocks: Cell::new(true),
+        }
+    }
+
+    fn take_block(&self) -> NonNull<ObjectAllocation> {
+        let mut state = self.state.borrow_mut();
+        if let Some(block) = state.free_list.pop() {
+            return block;
+        }
+        if state.next_block == state.chunks.len() * CHUNK_SIZE {
+            Self::grow_one_chunk(&mut state);
+        }
+        let block_idx = state.next_block;
+        state.next_block += 1;
+        let chunk_idx = block_idx / CHUNK_SIZE;
+        let slot_idx = block_idx % CHUNK_SIZE;
+        NonNull::from(&mut state.chunks[chunk_idx][slot_idx]).cast()
+    }
+
+    fn return_block(&self, block: NonNull<ObjectAllocation>) {
+        if self.recycle_blocks.get() {
+            self.state.borrow_mut().free_list.push(block);
+        }
+    }
+
+    fn grow_one_chunk(state: &mut ObjectStorageState) {
+        let chunk: Vec<MaybeUninit<ObjectAllocation>> = std::iter::repeat_with(MaybeUninit::uninit)
+            .take(CHUNK_SIZE)
+            .collect();
+        state.chunks.push(chunk.into_boxed_slice());
+    }
+}
 
 pub(crate) struct ObjectArena {
     chunks: Vec<Chunk>,
     free_list: Vec<u64>,
     next_slot: u64,
     live_count: usize,
+    storage: Rc<ObjectStorage>,
 }
 
 impl ObjectArena {
@@ -31,13 +193,14 @@ impl ObjectArena {
             free_list: Vec::new(),
             next_slot: 0,
             live_count: 0,
+            storage: Rc::new(ObjectStorage::new()),
         }
     }
 
-    /// Allocate a slot for `data`. Writes `data.id = Some(id)` before wrapping
-    /// in `Rc<RefCell<>>`. Returns `(id, was_reuse)` so callers can adjust GC
-    /// pressure accounting (a reused slot is cheaper than a fresh chunk
-    /// growth).
+    /// Allocate a slot for `data`. Writes `data.id = Some(id)` before placing
+    /// it in the physical arena. Returns `(id, was_reuse)` so callers can
+    /// adjust GC pressure accounting (a reused logical slot is cheaper than a
+    /// fresh chunk growth).
     pub(crate) fn alloc(&mut self, mut data: JsObjectData) -> (u64, bool) {
         let (id, was_reuse) = if let Some(idx) = self.free_list.pop() {
             (idx, true)
@@ -50,16 +213,17 @@ impl ObjectArena {
             (idx, false)
         };
         data.id = Some(id);
-        let rc = Rc::new(RefCell::new(data));
-        self.set_slot(id, Some(rc));
+        let handle = ObjectHandle::new(&self.storage, data);
+        self.set_slot(id, Some(handle));
         self.live_count += 1;
         (id, was_reuse)
     }
 
-    /// Return a fresh `Rc::clone` of the slot's `Rc<RefCell<…>>` if live.
-    /// Used by the legacy `Interpreter::get_object` API; new callers should
-    /// use `get_cell` / `get_cell_expect` instead.
-    pub(crate) fn get(&self, id: u64) -> Option<Rc<RefCell<JsObjectData>>> {
+    /// Return an owned clone of the slot's handle if live. Used by the legacy
+    /// `Interpreter::get_object` API; new callers should use `get_cell` /
+    /// `get_cell_expect` instead.
+    #[inline(always)]
+    pub(crate) fn get(&self, id: u64) -> Option<ObjectHandle> {
         self.slot_at(id).and_then(|s| s.clone())
     }
 
@@ -69,7 +233,7 @@ impl ObjectArena {
     #[allow(dead_code)] // get_cell isn't yet hot; get_cell_expect is
     pub(crate) fn get_cell(&self, id: u64) -> Option<&RefCell<JsObjectData>> {
         self.slot_at(id)
-            .and_then(|s| s.as_ref().map(|rc| rc.as_ref()))
+            .and_then(|s| s.as_ref().map(ObjectHandle::as_ref))
     }
 
     /// Like `get_cell`, but panics for dead ids.
@@ -100,9 +264,8 @@ impl ObjectArena {
         (self.chunks.len() * CHUNK_SIZE) as u64
     }
 
-    /// Direct slot inspection — returns `&Slot` for the underlying
-    /// `Option<Rc<…>>`. Used by sweep to test `is_some()` and to access
-    /// the inner `Rc` without cloning.
+    /// Direct slot inspection. Used by sweep to test `is_some()` without
+    /// cloning the underlying handle.
     pub(crate) fn slot_at(&self, id: u64) -> Option<&Slot> {
         let (chunk_idx, slot_idx) = Self::split(id);
         self.chunks.get(chunk_idx).map(|c| &c[slot_idx])
@@ -125,6 +288,26 @@ impl ObjectArena {
             .try_into()
             .unwrap_or_else(|_| panic!("ObjectArena: chunk size {CHUNK_SIZE} mismatch"));
         self.chunks.push(array);
+    }
+
+    #[cfg(test)]
+    fn storage_stats(&self) -> (usize, usize, usize) {
+        let storage = self.storage.state.borrow();
+        (
+            storage.chunks.len(),
+            storage.next_block,
+            storage.free_list.len(),
+        )
+    }
+}
+
+impl Drop for ObjectArena {
+    fn drop(&mut self) {
+        // No future allocation can reuse blocks after the arena starts
+        // dropping. Avoid filling a free list while its live slots are torn
+        // down; escaped handles still keep the backing chunks alive until they
+        // are released.
+        self.storage.recycle_blocks.set(false);
     }
 }
 
@@ -171,5 +354,67 @@ mod tests {
         let (fresh, was_reuse) = arena.alloc(JsObjectData::new());
         assert_eq!(fresh, second + 1);
         assert!(!was_reuse);
+    }
+
+    #[test]
+    fn object_payloads_are_allocated_in_chunks() {
+        let mut arena = ObjectArena::new();
+
+        for _ in 0..CHUNK_SIZE {
+            arena.alloc(JsObjectData::new());
+        }
+        assert_eq!(arena.storage_stats(), (1, CHUNK_SIZE, 0));
+
+        arena.alloc(JsObjectData::new());
+        assert_eq!(arena.storage_stats(), (2, CHUNK_SIZE + 1, 0));
+        assert_eq!(
+            std::mem::size_of::<ObjectHandle>(),
+            std::mem::size_of::<usize>()
+        );
+    }
+
+    #[test]
+    fn released_payload_blocks_are_reused() {
+        let mut arena = ObjectArena::new();
+        let (id, _) = arena.alloc(JsObjectData::new());
+        assert_eq!(arena.storage_stats(), (1, 1, 0));
+
+        arena.free(id);
+        assert_eq!(arena.storage_stats(), (1, 1, 1));
+
+        arena.alloc(JsObjectData::new());
+        assert_eq!(arena.storage_stats(), (1, 1, 0));
+    }
+
+    #[test]
+    fn cloned_handle_delays_physical_reuse_after_logical_free() {
+        let mut arena = ObjectArena::new();
+        let (id, _) = arena.alloc(JsObjectData::new());
+        let pinned = arena.get(id).unwrap();
+
+        arena.free(id);
+        assert_eq!(arena.storage_stats(), (1, 1, 0));
+
+        let (reused_id, was_reuse) = arena.alloc(JsObjectData::new());
+        assert_eq!(reused_id, id);
+        assert!(was_reuse);
+        assert_eq!(arena.storage_stats(), (1, 2, 0));
+
+        drop(pinned);
+        assert_eq!(arena.storage_stats(), (1, 2, 1));
+    }
+
+    #[test]
+    fn cloned_handle_keeps_storage_alive_after_arena_drop() {
+        let (id, pinned, storage) = {
+            let mut arena = ObjectArena::new();
+            let (id, _) = arena.alloc(JsObjectData::new());
+            (id, arena.get(id).unwrap(), Rc::clone(&arena.storage))
+        };
+
+        assert!(!storage.recycle_blocks.get());
+        assert_eq!(pinned.borrow().id, Some(id));
+        drop(pinned);
+        assert!(storage.state.borrow().free_list.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- replace one `Rc<RefCell<JsObjectData>>` system allocation per JavaScript object with 1,024-slot fixed-block arena chunks
- preserve owned/re-entrant object access through an eight-byte object-specific handle
- keep logical GC slot reuse separate from physical block reuse so escaped handles safely pin old payloads
- document the design and cover chunk growth, block reuse, delayed reuse, teardown lifetime, and handle size with unit tests

## Performance

A deterministic reduced JetStream Splay workload (1,000 initial nodes, depth-5 payloads, 5 x 80 mutations), pinned to one CPU for three paired runs, showed:

- median task-clock: 2.373 s -> 2.135 s (-10.0%)
- median cycles: 7.385B -> 6.738B (-8.8%)
- median cache misses: 133.1M -> 100.8M (-24.2%)

Process-scoped `perf stat` counters were used because the shared worker was under unrelated concurrent load.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo build --release`
- `cargo test --release` (313 unit tests + smoke oracle)
- `uv run python scripts/run-custom-tests.py` (8/8)
- targeted Object/Proxy/Map/Set test262 (8,578/8,578)
- full test262 (99,546/99,568); all 22 reported baseline regressions are in an unrelated Intl/Temporal cluster and the same sampled scenarios fail on an untouched `origin/main` release binary
- Valgrind allocation/GC churn check with no definite leaks or errors

The README baseline was not changed because this representation-only optimization has no semantic pass-count movement; the full-suite difference is existing baseline drift on `main`.

Closes #66