### PR TITLE
perf(interpreter): pool function call environments

### DIFF
--- a/docs/specs/2026-07-20-function-call-environment-pooling-design.md
+++ b/docs/specs/2026-07-20-function-call-environment-pooling-design.md
@@ -1,0 +1,75 @@
+# Function-call environment pooling design
+
+## Goal
+
+Reduce the fixed cost of ordinary ECMAScript calls, especially mandreel-style
+sloppy functions with one identifier parameter, without changing observable
+environment, parameter, closure, or `arguments` semantics.
+
+## Specification constraints
+
+`PrepareForOrdinaryCall` creates a new Function Environment Record for each
+activation, and `FunctionDeclarationInstantiation` creates and initializes the
+parameter bindings in that record. A simple parameter list contains only
+identifier bindings. Sloppy functions with simple parameters receive a mapped
+arguments object whose indexed properties remain linked to those bindings.
+Escaped closures and suspended generators retain their activation records after
+the call stack has moved on.
+
+JSSE can therefore reuse an environment's Rust allocation only when no
+observable object retains that activation. Reuse must reset every Environment
+field, detach the old parent, and clear all bindings before the environment is
+placed on a free list.
+
+## Design
+
+Add a small bounded free list of function-scope `EnvRef`s to `Interpreter`.
+Ordinary synchronous calls acquire their function environment from this list,
+reset it with the new parent, and reserve enough binding capacity for the known
+parameters plus `this` and `arguments`. On return, the environment is recycled
+only when `Rc::strong_count` proves that the call owns the sole remaining
+reference. A closure, mapped arguments object, nested body environment, or any
+other escape adds an owner and automatically prevents recycling. Generators and
+async functions keep their existing allocation path because their environments
+are intentionally retained for later execution.
+
+For sloppy functions whose syntax cannot reference `arguments`, retain the
+Annex-B-compatible `Function.prototype.arguments` behavior without eagerly
+building an arguments object. The active `CallFrame` stores the original first
+argument inline and any remaining arguments in a vector, plus the function
+environment. The getter materializes the mapped object on first access, caches
+it in the frame for stable identity, and returns it. The GC root walk traces
+deferred argument values. Zero- and one-argument calls perform no heap
+allocation for this payload.
+
+For a cached simple parameter list, bind parameters directly into the function
+environment's map as initialized mutable bindings. Non-simple parameters retain
+the existing `bind_pattern` path, including rest arrays, destructuring, default
+expressions, and abrupt completion handling. All function kinds use the shared
+binding helper, while only ordinary synchronous calls participate in pooling.
+
+The pool is bounded to avoid retaining storage proportional to pathological
+recursion depth. Environments are cleared before pooling so the free list never
+acts as a GC root for values or outer environments.
+
+## Alternatives considered
+
+Direct binding and pre-sizing alone have the smallest change surface, but leave
+the `Rc<RefCell<Environment>>` and sloppy arguments allocations on every hot
+call. Pooling with the existing eager arguments object is safe but ineffective
+for the motivating sloppy-function workload because the mapped arguments
+object retains the environment. Static escape analysis could avoid the runtime
+strong-count check, but correctly classifying closures, direct eval, and
+indirect observation would add substantially more complexity than the bounded
+dynamic ownership check.
+
+## Verification
+
+- Add focused custom coverage for simple and duplicate parameter binding,
+  closure escape across subsequent calls, mapped `arguments`, and lazy
+  `Function.prototype.arguments` identity and aliasing.
+- Run the test262 function-code and arguments-object areas, then the full suite
+  against the `origin/main` pass baseline.
+- Compare repeated release-mode timings of a one-parameter sloppy function call
+  loop before and after the change.
+- Run formatting, Clippy, release build, and release tests before publishing.

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2954,7 +2954,7 @@ impl Interpreter {
                                 for i in (0..interp.call_stack_frames.len()).rev() {
                                     if interp.call_stack_frames[i].func_obj_id == this_id {
                                         return Completion::Normal(
-                                            interp.call_stack_frames[i].arguments_obj.clone(),
+                                            interp.materialize_call_frame_arguments(i),
                                         );
                                     }
                                 }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -12465,6 +12465,45 @@ impl Interpreter {
         Completion::Normal(promise)
     }
 
+    fn bind_function_parameters(
+        &mut self,
+        params: &[Pattern],
+        args: &[JsValue],
+        func_env: &EnvRef,
+        has_simple_params: bool,
+    ) -> Result<(), JsValue> {
+        if has_simple_params {
+            let mut env = func_env.borrow_mut();
+            for (index, param) in params.iter().enumerate() {
+                let Pattern::Identifier(name) = param else {
+                    unreachable!("simple parameter metadata must match the parameter list");
+                };
+                env.bindings.insert(
+                    name.clone(),
+                    Binding {
+                        value: args.get(index).cloned().unwrap_or(JsValue::Undefined),
+                        kind: BindingKind::Var,
+                        initialized: true,
+                        deletable: false,
+                    },
+                );
+            }
+            return Ok(());
+        }
+
+        for (index, param) in params.iter().enumerate() {
+            if let Pattern::Rest(inner) = param {
+                let rest = args.get(index..).unwrap_or(&[]).to_vec();
+                let rest_array = self.create_array(rest);
+                self.bind_pattern(inner, rest_array, BindingKind::Var, func_env)?;
+                break;
+            }
+            let value = args.get(index).cloned().unwrap_or(JsValue::Undefined);
+            self.bind_pattern(param, value, BindingKind::Var, func_env)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn call_function(
         &mut self,
         func_val: &JsValue,
@@ -12738,7 +12777,10 @@ impl Interpreter {
                         }
                         if is_async && is_generator {
                             // Create persistent function environment
-                            let func_env = Environment::new_function_scope(Some(closure.clone()));
+                            let func_env = Environment::new_function_scope_with_capacity(
+                                Some(closure.clone()),
+                                params.len().saturating_add(2),
+                            );
                             func_env.borrow_mut().strict = is_strict;
                             func_env.borrow_mut().bindings.insert(
                                 "this".to_string(),
@@ -12788,28 +12830,14 @@ impl Interpreter {
                                 func_env.borrow_mut().has_parameter_expressions = true;
                             }
                             // §14.5.10 step 1: FunctionDeclarationInstantiation (bind params)
-                            for (i, param) in params.iter().enumerate() {
-                                if let Pattern::Rest(inner) = param {
-                                    let rest: Vec<JsValue> = args.get(i..).unwrap_or(&[]).to_vec();
-                                    let rest_arr = self.create_array(rest);
-                                    if let Err(e) = self.bind_pattern(
-                                        inner,
-                                        rest_arr,
-                                        BindingKind::Var,
-                                        &func_env,
-                                    ) {
-                                        self.current_realm_id = caller_realm;
-                                        return Completion::Throw(e);
-                                    }
-                                    break;
-                                }
-                                let val = args.get(i).cloned().unwrap_or(JsValue::Undefined);
-                                if let Err(e) =
-                                    self.bind_pattern(param, val, BindingKind::Var, &func_env)
-                                {
-                                    self.current_realm_id = caller_realm;
-                                    return Completion::Throw(e);
-                                }
+                            if let Err(error) = self.bind_function_parameters(
+                                &params,
+                                args,
+                                &func_env,
+                                is_simple_ag,
+                            ) {
+                                self.current_realm_id = caller_realm;
+                                return Completion::Throw(error);
                             }
                             // §14.5.10 step 2: OrdinaryCreateFromConstructor AFTER decl inst
                             let gen_obj_id = self.create_object_id();
@@ -12917,7 +12945,10 @@ impl Interpreter {
                         }
                         if is_generator {
                             // Create persistent function environment
-                            let func_env = Environment::new_function_scope(Some(closure.clone()));
+                            let func_env = Environment::new_function_scope_with_capacity(
+                                Some(closure.clone()),
+                                params.len().saturating_add(2),
+                            );
                             let closure_strict = closure.borrow().strict;
                             func_env.borrow_mut().strict = is_strict;
                             // §10.2.1.2 OrdinaryCallBindThis: sloppy mode this coercion
@@ -12987,28 +13018,11 @@ impl Interpreter {
                                 func_env.borrow_mut().has_parameter_expressions = true;
                             }
                             // §14.4.10 step 1: FunctionDeclarationInstantiation (bind params)
-                            for (i, param) in params.iter().enumerate() {
-                                if let Pattern::Rest(inner) = param {
-                                    let rest: Vec<JsValue> = args.get(i..).unwrap_or(&[]).to_vec();
-                                    let rest_arr = self.create_array(rest);
-                                    if let Err(e) = self.bind_pattern(
-                                        inner,
-                                        rest_arr,
-                                        BindingKind::Var,
-                                        &func_env,
-                                    ) {
-                                        self.current_realm_id = caller_realm;
-                                        return Completion::Throw(e);
-                                    }
-                                    break;
-                                }
-                                let val = args.get(i).cloned().unwrap_or(JsValue::Undefined);
-                                if let Err(e) =
-                                    self.bind_pattern(param, val, BindingKind::Var, &func_env)
-                                {
-                                    self.current_realm_id = caller_realm;
-                                    return Completion::Throw(e);
-                                }
+                            if let Err(error) =
+                                self.bind_function_parameters(&params, args, &func_env, is_simple_g)
+                            {
+                                self.current_realm_id = caller_realm;
+                                return Completion::Throw(error);
                             }
                             // §14.4.10 step 2: OrdinaryCreateFromConstructor AFTER decl inst
                             let gen_obj_id = self.create_object_id();
@@ -13115,12 +13129,13 @@ impl Interpreter {
                             }));
                         }
                         let closure_strict = closure.borrow().strict;
-                        let func_env = Environment::new_function_scope(Some(closure));
+                        let func_env = self
+                            .acquire_function_environment(closure, params.len().saturating_add(2));
                         if is_arrow {
                             func_env.borrow_mut().is_arrow_scope = true;
                         }
                         let is_simple = has_simple_params;
-                        let mut call_frame_args = JsValue::Null;
+                        let mut call_frame_arguments = CallFrameArguments::None;
                         if !is_arrow {
                             if self.constructing_derived {
                                 // Derived constructor: this is in TDZ until super() is called
@@ -13165,12 +13180,7 @@ impl Interpreter {
                                 );
                             }
                             let env_strict = func_env.borrow().strict;
-                            // Sloppy non-arrow functions need a real arguments object even
-                            // when the body doesn't reference it, because Annex B
-                            // `Function.prototype.arguments` (§B.3.7) observes the active
-                            // call frame's arguments_obj.
-                            let needs_args = uses_arguments || (!is_strict && !env_strict);
-                            if needs_args {
+                            if uses_arguments {
                                 let use_mapped = is_simple && !is_strict && !env_strict;
                                 let param_names: Vec<String> = if use_mapped {
                                     params
@@ -13194,7 +13204,8 @@ impl Interpreter {
                                     mapped_env,
                                     &param_names,
                                 );
-                                call_frame_args = arguments_obj.clone();
+                                call_frame_arguments =
+                                    CallFrameArguments::Materialized(arguments_obj.clone());
                                 func_env.borrow_mut().declare("arguments", BindingKind::Var);
                                 let _ = self.env_set(&func_env, "arguments", arguments_obj);
                                 if is_strict || !is_simple {
@@ -13202,6 +13213,13 @@ impl Interpreter {
                                 }
                             } else {
                                 func_env.borrow_mut().declare("arguments", BindingKind::Var);
+                                if !is_strict && !env_strict {
+                                    call_frame_arguments = CallFrameArguments::Deferred {
+                                        args: DeferredCallArguments::new(args),
+                                        func_env: func_env.clone(),
+                                        mapped: is_simple,
+                                    };
+                                }
                             }
                         }
                         // For arrows with non-simple params and "arguments" parameter,
@@ -13218,25 +13236,12 @@ impl Interpreter {
                             func_env.borrow_mut().has_parameter_expressions = true;
                         }
                         // Bind parameters (after this so default exprs can access this)
-                        for (i, param) in params.iter().enumerate() {
-                            if let Pattern::Rest(inner) = param {
-                                let rest: Vec<JsValue> = args.get(i..).unwrap_or(&[]).to_vec();
-                                let rest_arr = self.create_array(rest);
-                                if let Err(e) =
-                                    self.bind_pattern(inner, rest_arr, BindingKind::Var, &func_env)
-                                {
-                                    self.current_realm_id = caller_realm;
-                                    return Completion::Throw(e);
-                                }
-                                break;
-                            }
-                            let val = args.get(i).cloned().unwrap_or(JsValue::Undefined);
-                            if let Err(e) =
-                                self.bind_pattern(param, val, BindingKind::Var, &func_env)
-                            {
-                                self.current_realm_id = caller_realm;
-                                return Completion::Throw(e);
-                            }
+                        if let Err(error) =
+                            self.bind_function_parameters(&params, args, &func_env, is_simple)
+                        {
+                            self.current_realm_id = caller_realm;
+                            self.recycle_function_environment(func_env);
+                            return Completion::Throw(error);
                         }
                         let exec_env = if !is_simple {
                             let body_env = Environment::new_function_scope(Some(func_env.clone()));
@@ -13263,7 +13268,7 @@ impl Interpreter {
                         exec_env.borrow_mut().strict = is_strict;
                         self.call_stack_frames.push(CallFrame {
                             func_obj_id: o.id,
-                            arguments_obj: call_frame_args,
+                            arguments: call_frame_arguments,
                             is_eval: false,
                         });
                         self.call_stack_envs.push(exec_env.clone());
@@ -13279,6 +13284,8 @@ impl Interpreter {
                         let result = self.dispose_resources(&exec_env, result);
                         self.last_call_this_value = func_env.borrow().get("this");
                         self.current_realm_id = caller_realm;
+                        drop(exec_env);
+                        self.recycle_function_environment(func_env);
                         match result {
                             Completion::Return(v) => {
                                 self.last_call_had_explicit_return = true;
@@ -13720,7 +13727,7 @@ impl Interpreter {
         // Execute statements in lex_env
         self.call_stack_frames.push(CallFrame {
             func_obj_id: 0,
-            arguments_obj: JsValue::Null,
+            arguments: CallFrameArguments::None,
             is_eval: true,
         });
         self.call_stack_envs.push(lex_env.clone());
@@ -15711,7 +15718,10 @@ impl Interpreter {
         self.gc_root_value(&reject_fn);
 
         let closure_strict = closure.borrow().strict;
-        let func_env = Environment::new_function_scope(Some(closure));
+        let func_env = Environment::new_function_scope_with_capacity(
+            Some(closure),
+            params.len().saturating_add(2),
+        );
         if is_arrow {
             func_env.borrow_mut().is_arrow_scope = true;
         }
@@ -15786,34 +15796,18 @@ impl Interpreter {
                 func_env.borrow_mut().has_parameter_expressions = true;
             }
         }
-        for (i, param) in params.iter().enumerate() {
-            if let Pattern::Rest(inner) = param {
-                let rest: Vec<JsValue> = args.get(i..).unwrap_or(&[]).to_vec();
-                let rest_arr = self.create_array(rest);
-                if let Err(e) = self.bind_pattern(inner, rest_arr, BindingKind::Var, &func_env) {
-                    let _ = self.call_function(&reject_fn, &JsValue::Undefined, &[e]);
-                    self.drain_microtasks();
-                    self.gc_unroot_frame(gc_frame);
-                    // A default-param expression may have called `__host_exit`
-                    // (issue #229): return abrupt so the caller unwinds.
-                    if self.pending_exit.is_some() {
-                        return Completion::Throw(JsValue::Undefined);
-                    }
-                    return Completion::Normal(promise);
-                }
-                break;
+        if let Err(error) =
+            self.bind_function_parameters(params, args, &func_env, has_simple_params)
+        {
+            let _ = self.call_function(&reject_fn, &JsValue::Undefined, &[error]);
+            self.drain_microtasks();
+            self.gc_unroot_frame(gc_frame);
+            // A default-param expression may have called `__host_exit`
+            // (issue #229): return abrupt so the caller unwinds.
+            if self.pending_exit.is_some() {
+                return Completion::Throw(JsValue::Undefined);
             }
-            let val = args.get(i).cloned().unwrap_or(JsValue::Undefined);
-            if let Err(e) = self.bind_pattern(param, val, BindingKind::Var, &func_env) {
-                let _ = self.call_function(&reject_fn, &JsValue::Undefined, &[e]);
-                self.drain_microtasks();
-                self.gc_unroot_frame(gc_frame);
-                // See above: a default-param `__host_exit` must unwind abruptly.
-                if self.pending_exit.is_some() {
-                    return Completion::Throw(JsValue::Undefined);
-                }
-                return Completion::Normal(promise);
-            }
+            return Completion::Normal(promise);
         }
 
         func_env.borrow_mut().strict = is_strict;

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -217,7 +217,18 @@ impl Interpreter {
             if frame.func_obj_id != 0 {
                 worklist.push(frame.func_obj_id);
             }
-            Self::collect_value_roots(&frame.arguments_obj, &mut worklist);
+            match &frame.arguments {
+                CallFrameArguments::None => {}
+                CallFrameArguments::Materialized(arguments) => {
+                    Self::collect_value_roots(arguments, &mut worklist);
+                }
+                CallFrameArguments::Deferred { args, func_env, .. } => {
+                    for argument in args.values() {
+                        Self::collect_value_roots(argument, &mut worklist);
+                    }
+                    Self::collect_env_roots(func_env, &mut worklist, &mut seen_envs);
+                }
+            }
         }
         // Temporary roots (iterators, etc.)
         worklist.extend_from_slice(&self.gc_temp_roots);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -108,6 +108,7 @@ pub struct Interpreter {
     last_call_this_value: Option<JsValue>,
     constructing_derived: bool,
     calling_as_construct: bool,
+    function_env_pool: Vec<EnvRef>,
     pub(crate) call_stack_envs: Vec<EnvRef>,
     pub(crate) call_stack_frames: Vec<CallFrame>,
     pub(crate) gc_temp_roots: Vec<u64>,
@@ -247,9 +248,44 @@ pub(crate) const CALL_DEPTH_REARM_LIMIT: usize = 3_000;
 /// leaving ample headroom for the error object's own construction.
 pub(crate) const EVAL_DEPTH_LIMIT: usize = 50_000;
 
+const MAX_POOLED_FUNCTION_ENVIRONMENTS: usize = 256;
+const MAX_POOLED_FUNCTION_BINDING_CAPACITY: usize = 256;
+
+pub(crate) struct DeferredCallArguments {
+    first: Option<JsValue>,
+    rest: Vec<JsValue>,
+}
+
+impl DeferredCallArguments {
+    pub(crate) fn new(args: &[JsValue]) -> Self {
+        Self {
+            first: args.first().cloned(),
+            rest: args.get(1..).unwrap_or(&[]).to_vec(),
+        }
+    }
+
+    pub(crate) fn values(&self) -> impl Iterator<Item = &JsValue> {
+        self.first.iter().chain(self.rest.iter())
+    }
+
+    fn to_vec(&self) -> Vec<JsValue> {
+        self.values().cloned().collect()
+    }
+}
+
+pub(crate) enum CallFrameArguments {
+    None,
+    Materialized(JsValue),
+    Deferred {
+        args: DeferredCallArguments,
+        func_env: EnvRef,
+        mapped: bool,
+    },
+}
+
 pub(crate) struct CallFrame {
     pub func_obj_id: u64,
-    pub arguments_obj: JsValue,
+    pub arguments: CallFrameArguments,
     pub is_eval: bool,
 }
 
@@ -346,6 +382,7 @@ impl Interpreter {
             last_call_this_value: None,
             constructing_derived: false,
             calling_as_construct: false,
+            function_env_pool: Vec::new(),
             call_stack_envs: Vec::new(),
             call_stack_frames: Vec::new(),
             gc_temp_roots: Vec::new(),
@@ -1549,6 +1586,78 @@ impl Interpreter {
                 ),
             );
         }
+    }
+
+    pub(crate) fn acquire_function_environment(
+        &mut self,
+        parent: EnvRef,
+        binding_capacity: usize,
+    ) -> EnvRef {
+        if let Some(env) = self.function_env_pool.pop() {
+            debug_assert_eq!(Rc::strong_count(&env), 1);
+            env.borrow_mut()
+                .reset_function_scope(Some(parent), binding_capacity);
+            env
+        } else {
+            Environment::new_function_scope_with_capacity(Some(parent), binding_capacity)
+        }
+    }
+
+    pub(crate) fn recycle_function_environment(&mut self, env: EnvRef) {
+        if self.function_env_pool.len() >= MAX_POOLED_FUNCTION_ENVIRONMENTS
+            || Rc::strong_count(&env) != 1
+            || env.borrow().bindings.capacity() > MAX_POOLED_FUNCTION_BINDING_CAPACITY
+        {
+            return;
+        }
+        env.borrow_mut().reset_function_scope(None, 0);
+        self.function_env_pool.push(env);
+    }
+
+    pub(crate) fn materialize_call_frame_arguments(&mut self, frame_index: usize) -> JsValue {
+        let frame = &self.call_stack_frames[frame_index];
+        let (args, func_env, mapped, func_obj_id) = match &frame.arguments {
+            CallFrameArguments::None => return JsValue::Null,
+            CallFrameArguments::Materialized(arguments) => return arguments.clone(),
+            CallFrameArguments::Deferred {
+                args,
+                func_env,
+                mapped,
+            } => (args.to_vec(), func_env.clone(), *mapped, frame.func_obj_id),
+        };
+
+        let param_names = if mapped {
+            self.get_object_cell(func_obj_id)
+                .and_then(|obj| {
+                    let obj = obj.borrow();
+                    match &obj.callable {
+                        Some(JsFunction::User { params, .. }) => Some(
+                            params
+                                .iter()
+                                .filter_map(|param| match param {
+                                    Pattern::Identifier(name) => Some(name.clone()),
+                                    _ => None,
+                                })
+                                .collect(),
+                        ),
+                        _ => None,
+                    }
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let callee = JsValue::Object(crate::types::JsObject { id: func_obj_id });
+        let arguments = self.create_arguments_object(
+            &args,
+            callee,
+            false,
+            mapped.then_some(&func_env),
+            &param_names,
+        );
+        self.call_stack_frames[frame_index].arguments =
+            CallFrameArguments::Materialized(arguments.clone());
+        arguments
     }
 
     fn create_arguments_object(

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -89,6 +89,61 @@ fn write_case_file(dir: &Path, name: &str, source: &str) -> PathBuf {
 }
 
 #[test]
+fn function_environment_pool_reuses_and_resets_unescaped_storage() {
+    let mut interp = Interpreter::new();
+    let first_parent = Environment::new(None);
+    let env = interp.acquire_function_environment(first_parent, 3);
+    let allocation = Rc::as_ptr(&env);
+    {
+        let mut env = env.borrow_mut();
+        env.declare("stale", BindingKind::Var);
+        env.is_arrow_scope = true;
+        env.arguments_immutable = true;
+    }
+
+    interp.recycle_function_environment(env);
+    assert_eq!(interp.function_env_pool.len(), 1);
+
+    let second_parent = Environment::new(None);
+    let reused = interp.acquire_function_environment(second_parent.clone(), 2);
+    assert_eq!(Rc::as_ptr(&reused), allocation);
+    let reused_env = reused.borrow();
+    assert!(reused_env.bindings.is_empty());
+    assert!(!reused_env.is_arrow_scope);
+    assert!(!reused_env.arguments_immutable);
+    assert!(Rc::ptr_eq(
+        reused_env.parent.as_ref().expect("new parent"),
+        &second_parent
+    ));
+}
+
+#[test]
+fn function_environment_pool_rejects_escaped_storage() {
+    let mut interp = Interpreter::new();
+    let env = interp.acquire_function_environment(Environment::new(None), 1);
+    env.borrow_mut().declare("captured", BindingKind::Var);
+    let escaped = env.clone();
+
+    interp.recycle_function_environment(env);
+
+    assert!(interp.function_env_pool.is_empty());
+    assert!(escaped.borrow().bindings.contains_key("captured"));
+}
+
+#[test]
+fn ordinary_calls_return_non_escaping_activations_to_the_pool() {
+    let interp = run_script(
+        r#"
+        function addOne(value) { return value + 1; }
+        var result = addOne(addOne(0));
+        if (result !== 2) throw new Error("unexpected result");
+        "#,
+    );
+
+    assert!(!interp.function_env_pool.is_empty());
+}
+
+#[test]
 fn define_method_installs_a_correctly_shaped_builtin() {
     let mut interp = Interpreter::new();
     let target_id = interp.create_object_id();

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -779,9 +779,16 @@ impl Environment {
     }
 
     pub fn new_function_scope(parent: Option<EnvRef>) -> EnvRef {
+        Self::new_function_scope_with_capacity(parent, 0)
+    }
+
+    pub fn new_function_scope_with_capacity(
+        parent: Option<EnvRef>,
+        binding_capacity: usize,
+    ) -> EnvRef {
         let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
         Rc::new(RefCell::new(Environment {
-            bindings: HashMap::new(),
+            bindings: HashMap::with_capacity(binding_capacity),
             parent,
             strict,
             is_function_scope: true,
@@ -800,6 +807,29 @@ impl Environment {
             indirect_bindings: None,
             module_path: None,
         }))
+    }
+
+    pub(crate) fn reset_function_scope(&mut self, parent: Option<EnvRef>, binding_capacity: usize) {
+        let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
+        self.bindings.clear();
+        self.bindings.reserve(binding_capacity);
+        self.parent = parent;
+        self.strict = strict;
+        self.is_function_scope = true;
+        self.is_arrow_scope = false;
+        self.with_object = None;
+        self.dispose_stack = None;
+        self.global_object_id = None;
+        self.annexb_function_names = None;
+        self.class_private_names = None;
+        self.is_field_initializer = false;
+        self.arguments_immutable = false;
+        self.has_parameter_expressions = false;
+        self.has_simple_params = true;
+        self.is_simple_catch_scope = false;
+        self.is_derived_constructor_scope = false;
+        self.indirect_bindings = None;
+        self.module_path = None;
     }
 
     pub fn find_module_path(env: &EnvRef) -> Option<std::path::PathBuf> {

--- a/test262-extra/function-call-environment-reuse.js
+++ b/test262-extra/function-call-environment-reuse.js
@@ -1,0 +1,68 @@
+/*---
+description: Function-call storage optimizations preserve activation and arguments semantics
+info: |
+  10.2.1.3 OrdinaryCallEvaluateBody
+  10.2.11 FunctionDeclarationInstantiation
+  10.4.4 Arguments Exotic Objects
+
+  A fresh Function Environment Record is observed for every activation even
+  when an implementation reuses backing storage. Simple identifier parameters
+  are initialized in source order, escaped closures retain their activation,
+  and a sloppy mapped arguments object remains linked to parameter bindings.
+esid: sec-functiondeclarationinstantiation
+flags: [noStrict]
+---*/
+
+function duplicate(a, a) {
+  return a;
+}
+assert.sameValue(duplicate(1, 2), 2, "the last duplicate parameter wins");
+
+function missing(a, b, c) {
+  return [a, b, c];
+}
+var missingResult = missing(1);
+assert.sameValue(missingResult[0], 1);
+assert.sameValue(missingResult[1], undefined);
+assert.sameValue(missingResult[2], undefined);
+
+function makeClosure(value) {
+  return function () {
+    return value;
+  };
+}
+var firstClosure = makeClosure("first");
+for (var i = 0; i < 1000; i++) {
+  makeClosure(i);
+}
+var lastClosure = makeClosure("last");
+assert.sameValue(firstClosure(), "first", "an escaped activation is not reused");
+assert.sameValue(lastClosure(), "last", "later activations remain distinct");
+
+function observeMapped(a, b) {
+  a = 7;
+  var first = observeMapped.arguments;
+  var second = observeMapped.arguments;
+  assert.sameValue(first, second, "the lazily observed object has stable identity");
+  assert.sameValue(first[0], 7, "parameter writes are visible through the map");
+  first[1] = 9;
+  return b;
+}
+assert.sameValue(observeMapped(1, 2), 9, "mapped writes update the parameter");
+assert.sameValue(observeMapped.arguments, null, "inactive functions expose no arguments");
+
+function observeUnmapped(a = 1) {
+  a = 8;
+  return observeUnmapped.arguments[0];
+}
+assert.sameValue(observeUnmapped(3), 3, "non-simple parameters use an unmapped object");
+
+function observeExtra(a) {
+  $262.gc();
+  return observeExtra.arguments[2].marker;
+}
+assert.sameValue(
+  observeExtra(0, 1, { marker: 42 }),
+  42,
+  "deferred extra arguments remain GC-reachable"
+);


### PR DESCRIPTION
## Summary

- reuse bounded, reset function environments when their activations do not escape
- pre-size call environments and directly bind simple identifier parameters
- defer sloppy Annex B arguments-object creation until Function.prototype.arguments observes an active frame
- preserve deferred argument and environment GC roots, mapped-arguments aliasing, and escaped closure isolation
- document the design and add focused conformance/unit coverage

## Performance

A release-mode loop making 1,000,000 one-argument calls improved from a 1.98 s median on origin/main to 0.80 s on this branch, approximately 2.48x faster.

In clean full-suite runs under the same 12-worker/120-second limits, the exact origin/main binary passed 97,386 of 99,568 scenarios and this branch passed 99,546. The feature failure set contains zero scenarios absent from the origin/main failure set; 2,160 origin/main timeout failures pass after this change. The 22 shared failures are host Intl-data mismatches, so README and test262-pass.txt remain unchanged.

## Test plan

- cargo fmt --check
- cargo clippy
- ./scripts/lint.sh
- cargo build --release
- cargo test --release (312 unit tests plus smoke oracle)
- uv run python scripts/run-custom-tests.py (8/8)
- targeted arguments/function/Annex B test262 suites (904/904)
- uv run python scripts/run-test262.py test262-extra/function-call-environment-reuse.js (1/1)
- full origin/main-versus-feature test262 differential (0 feature-only failures)

Closes #73
