### PR TITLE
refactor(interpreter): delegate set_object_with_key to canonical [[Set]]

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -4340,7 +4340,7 @@ impl Interpreter {
         strict: bool,
     ) -> Result<(), JsValue> {
         let key = key.to_js_property_key();
-        // Auto-box primitives for property access
+        // Auto-box primitives for property access.
         let obj_val = if !matches!(obj_val, JsValue::Object(_)) {
             match self.to_object(&obj_val) {
                 Completion::Normal(v) => v,
@@ -4351,154 +4351,51 @@ impl Interpreter {
             obj_val
         };
 
-        if let JsValue::Object(ref o) = obj_val
-            && let Some(obj) = self.get_object(o.id)
-        {
-            // Proxy set trap
-            if obj.borrow().is_proxy() || obj.borrow().is_proxy_revoked() {
-                let receiver = obj_val.clone();
-                {
-                    let success = self.proxy_set(o.id, &key, val, &receiver)?;
-                    if !success && strict {
-                        return Err(self.create_type_error(&format!(
-                            "Cannot assign to read only property '{key}'"
-                        )));
-                    }
-                    return Ok(());
-                }
-            }
-            // Module namespace exotic: [[Set]] always returns false
-            if obj.borrow().module_namespace().is_some() {
-                if strict {
-                    return Err(self.create_type_error(&format!(
-                        "Cannot assign to read only property '{key}' of module namespace"
-                    )));
-                }
-                return Ok(());
-            }
-            // Check for setter
-            let desc = self.get_property_descriptor_on_id(o.id, &key);
-            if let Some(ref d) = desc
-                && let Some(ref setter) = d.set
-                && !matches!(setter, JsValue::Undefined)
-            {
-                let setter = setter.clone();
-                let this = obj_val.clone();
-                return match self.call_function(&setter, &this, &[val]) {
-                    Completion::Normal(_) => Ok(()),
-                    Completion::Throw(e) => Err(e),
-                    _ => Ok(()),
-                };
-            }
-            if desc
-                .as_ref()
-                .map(|d| d.is_accessor_descriptor())
-                .unwrap_or(false)
-            {
-                if strict {
-                    return Err(self.create_type_error(&format!(
-                        "Cannot set property '{key}' which has only a getter"
-                    )));
-                }
-                return Ok(());
-            }
-            // TypedArray [[Set]]
-            let is_ta = obj.borrow().typed_array_info().is_some();
-            if is_ta && let Some(index) = canonical_numeric_index_string(&key) {
-                let is_bigint = obj
-                    .borrow()
-                    .typed_array_info()
-                    .map(|ta| ta.kind.is_bigint())
-                    .unwrap_or(false);
-                let num_val = if is_bigint {
-                    self.to_bigint_value(&val)?
-                } else {
-                    JsValue::Number(self.to_number_value(&val)?)
-                };
-                let obj_ref = obj.borrow();
-                let ta = obj_ref.typed_array_info().unwrap();
-                if is_valid_integer_index(ta, index) {
-                    let ta_clone = ta.clone();
-                    drop(obj_ref);
-                    typed_array_set_index(&ta_clone, index as usize, &num_val);
-                }
-                return Ok(());
-            }
-            // OrdinarySet (§10.1.9.2): if no own property, walk prototype chain
-            if !obj.borrow().has_own_property(&key) {
-                let mut proto_opt = obj.borrow().prototype_id;
-                while let Some(proto_rc) = proto_opt {
-                    let proto_id = proto_rc;
-                    // TypedArray [[Set]] §10.4.5.5: canonical numeric index in TA prototype
-                    {
-                        let proto_borrow = self.get_object_cell_expect(proto_rc).borrow();
-                        if let Some(ta) = proto_borrow.typed_array_info()
-                            && let Some(index) = canonical_numeric_index_string(&key)
-                            && !is_valid_integer_index(ta, index)
-                        {
-                            // Not a valid integer index: TypedArray [[Set]] returns true silently
-                            return Ok(());
-                        }
-                        // Valid index: fall through to data descriptor path below
-                    }
-                    if self.get_proxy_info(proto_id).is_some() {
-                        let receiver = obj_val.clone();
-                        {
-                            let success = self.proxy_set(proto_id, &key, val, &receiver)?;
-                            if !success && strict {
-                                return Err(self.create_type_error(&format!(
-                                    "Cannot assign to read only property '{key}'"
-                                )));
-                            }
-                            return Ok(());
-                        }
-                    }
-                    let proto_id = proto_rc;
-                    let inherited = self.get_property_descriptor_on_id(proto_id, &key);
-                    if let Some(ref inherited_desc) = inherited {
-                        if inherited_desc.is_data_descriptor() {
-                            if inherited_desc.writable == Some(false) {
-                                if strict {
-                                    return Err(self.create_type_error(&format!(
-                                        "Cannot assign to read only property '{key}'"
-                                    )));
-                                }
-                                return Ok(());
-                            }
-                            break;
-                        }
-                        if inherited_desc.is_accessor_descriptor() {
-                            if let Some(ref setter) = inherited_desc.set
-                                && !matches!(setter, JsValue::Undefined)
-                            {
-                                let setter = setter.clone();
-                                let this = obj_val.clone();
-                                return match self.call_function(&setter, &this, &[val]) {
-                                    Completion::Normal(_) => Ok(()),
-                                    Completion::Throw(e) => Err(e),
-                                    _ => Ok(()),
-                                };
-                            }
-                            if strict {
-                                return Err(self.create_type_error(&format!(
-                                    "Cannot set property '{key}' which has only a getter"
-                                )));
-                            }
-                            return Ok(());
-                        }
-                        break;
-                    }
-                    proto_opt = self.get_object_cell_expect(proto_rc).borrow().prototype_id;
-                }
-            }
-            let success = obj.borrow_mut().set_property_value(&key, val);
-            if !success && strict {
-                return Err(
-                    self.create_type_error(&format!("Cannot assign to read only property '{key}'"))
-                );
-            }
+        let JsValue::Object(ref o) = obj_val else {
+            return Ok(());
+        };
+        let obj_id = o.id;
+        // Delegate to the canonical [[Set]] entry point: proxy `set` trap,
+        // module-namespace reject, TypedArray integer-index set, accessor
+        // setters, and the OrdinarySet prototype-chain walk all live in
+        // `property.rs`. The receiver is the object itself, matching this
+        // assignment path's PutValue semantics.
+        let receiver = obj_val.clone();
+        let success = self.set_object_property(obj_id, &key, val, &receiver)?;
+        if !success && strict {
+            return Err(self.read_only_assignment_error(obj_id, &key));
         }
         Ok(())
+    }
+
+    /// Builds the strict-mode TypeError for a rejected [[Set]] on `obj_id`,
+    /// preserving the diagnostic distinctions this assignment path historically
+    /// produced: a module-namespace target, a getter-only accessor (own or
+    /// inherited), or a plain read-only data property. Descriptor re-inspection
+    /// is skipped when a proxy sits on the object or its prototype chain, so no
+    /// trap is re-invoked on the error path.
+    fn read_only_assignment_error(&mut self, obj_id: u64, key: &JsPropertyKey) -> JsValue {
+        let Some(cell) = self.get_object_cell(obj_id) else {
+            return self.create_type_error(&format!("Cannot assign to read only property '{key}'"));
+        };
+        let is_module_ns = cell.borrow().module_namespace().is_some();
+        let is_proxy = cell.borrow().is_proxy() || cell.borrow().is_proxy_revoked();
+        if is_module_ns {
+            return self.create_type_error(&format!(
+                "Cannot assign to read only property '{key}' of module namespace"
+            ));
+        }
+        if !is_proxy
+            && !self.has_proxy_in_prototype_chain(obj_id)
+            && self
+                .get_property_descriptor_on_id(obj_id, key)
+                .is_some_and(|d| d.is_accessor_descriptor())
+        {
+            return self.create_type_error(&format!(
+                "Cannot set property '{key}' which has only a getter"
+            ));
+        }
+        self.create_type_error(&format!("Cannot assign to read only property '{key}'"))
     }
 
     fn set_member_property(

--- a/tests/read-only-assignment-destructuring-compound.js
+++ b/tests/read-only-assignment-destructuring-compound.js
@@ -1,0 +1,171 @@
+// Characterization of the [[Set]] path taken by destructuring-assignment and
+// compound-assignment targets (Interpreter::set_object_with_key). It pins both
+// the OrdinarySet *semantics* (spec §10.1.9 / §6.2.5.6 PutValue — the source of
+// truth for the throw/no-throw and value assertions) and jsse's host-compatible
+// strict-reject *diagnostics* (the exact TypeError messages, pinned as a
+// host-compat regression the way tests/read-only-assignment-receiver-diagnostic.js
+// pins the plain-assignment path).
+//
+// This path is distinct from the plain `obj.x = v` path: the truncated
+// "Cannot assign to read only property 'x'" message (no "of object '#<Object>'"
+// suffix) below is the fingerprint that identifies this path.
+
+function fail(msg) {
+  throw new Error("FAIL: " + msg);
+}
+function assert(cond, msg) {
+  if (!cond) fail(msg);
+}
+function assertThrows(fn, name, message, label) {
+  var threw = false;
+  try {
+    fn();
+  } catch (e) {
+    threw = true;
+    if (e.constructor.name !== name) {
+      fail(label + ": expected " + name + " but got " + e.constructor.name + " (" + e.message + ")");
+    }
+    if (message !== undefined && e.message !== message) {
+      fail(label + ": expected message " + JSON.stringify(message) + " but got " + JSON.stringify(e.message));
+    }
+  }
+  if (!threw) fail(label + ": expected a throw but none occurred");
+}
+
+// ---- Strict mode: read-only / getter-only targets reject with TypeError ----
+(function () {
+  "use strict";
+
+  // Destructuring -> frozen own data property.
+  (function () {
+    var o = Object.freeze({ x: 1 });
+    assertThrows(
+      function () { [o.x] = [5]; },
+      "TypeError",
+      "Cannot assign to read only property 'x'",
+      "destructuring frozen own data"
+    );
+    assert(o.x === 1, "frozen own data left unchanged");
+  })();
+
+  // Destructuring -> inherited non-writable data property.
+  (function () {
+    var proto = Object.defineProperty({}, "x", { value: 1, writable: false });
+    var o = Object.create(proto);
+    assertThrows(
+      function () { [o.x] = [5]; },
+      "TypeError",
+      "Cannot assign to read only property 'x'",
+      "destructuring inherited non-writable data"
+    );
+    assert(!Object.prototype.hasOwnProperty.call(o, "x"), "no own x created on receiver");
+  })();
+
+  // Destructuring -> own getter-only accessor.
+  (function () {
+    var o = { get x() { return 1; } };
+    assertThrows(
+      function () { [o.x] = [5]; },
+      "TypeError",
+      "Cannot set property 'x' which has only a getter",
+      "destructuring own getter-only accessor"
+    );
+  })();
+
+  // Destructuring -> inherited getter-only accessor.
+  (function () {
+    var proto = { get x() { return 1; } };
+    var o = Object.create(proto);
+    assertThrows(
+      function () { [o.x] = [5]; },
+      "TypeError",
+      "Cannot set property 'x' which has only a getter",
+      "destructuring inherited getter-only accessor"
+    );
+  })();
+
+  // Compound assignment -> frozen own data property.
+  (function () {
+    var o = Object.freeze({ x: 1 });
+    assertThrows(
+      function () { o.x += 1; },
+      "TypeError",
+      "Cannot assign to read only property 'x'",
+      "compound frozen own data"
+    );
+    assert(o.x === 1, "compound frozen own data left unchanged");
+  })();
+
+  // Compound assignment -> own getter-only accessor.
+  (function () {
+    var o = { get x() { return 1; } };
+    assertThrows(
+      function () { o.x += 1; },
+      "TypeError",
+      "Cannot set property 'x' which has only a getter",
+      "compound own getter-only accessor"
+    );
+  })();
+})();
+
+// ---- Strict mode: successful sets go through the same path ----
+(function () {
+  "use strict";
+
+  // Destructuring invokes an own setter with the assigned value.
+  (function () {
+    var got;
+    var o = { set x(v) { got = v; } };
+    [o.x] = [42];
+    assert(got === 42, "destructuring own setter received value");
+  })();
+
+  // Destructuring invokes an inherited setter.
+  (function () {
+    var got;
+    var proto = { set x(v) { got = v; } };
+    var o = Object.create(proto);
+    [o.x] = [7];
+    assert(got === 7, "destructuring inherited setter received value");
+  })();
+
+  // Destructuring overwrites a writable own data property.
+  (function () {
+    var o = { x: 1 };
+    [o.x] = [5];
+    assert(o.x === 5, "destructuring writable own data set");
+  })();
+
+  // Destructuring creates a new own property on an extensible object.
+  (function () {
+    var o = {};
+    [o.y] = [9];
+    assert(o.y === 9, "destructuring created new own property");
+  })();
+
+  // Destructuring writes through a typed-array integer index.
+  (function () {
+    var ta = new Int8Array(2);
+    [ta[0]] = [9];
+    assert(ta[0] === 9, "destructuring typed-array index set");
+  })();
+
+  // Compound assignment reads via the getter and writes via the setter.
+  (function () {
+    var seen;
+    var o = { get x() { return 10; }, set x(v) { seen = v; } };
+    o.x += 5;
+    assert(seen === 15, "compound accessor read then write");
+  })();
+})();
+
+// ---- Sloppy mode: rejected [[Set]] is a silent no-op, not a throw ----
+(function () {
+  var o = Object.freeze({ x: 1 });
+  [o.x] = [5];
+  assert(o.x === 1, "sloppy destructuring read-only silently ignored");
+
+  var o2 = Object.freeze({ x: 1 });
+  o2.x += 1;
+  assert(o2.x === 1, "sloppy compound read-only silently ignored");
+})();


### PR DESCRIPTION
## Refactoring goal

Surfaced by an `improve-codebase-architecture` audit (deepening opportunity: turn a shallow, duplicated module into a deep one). The interpreter has **three** copies of the OrdinarySet (§10.1.9) `[[Set]]` algorithm:

1. the canonical `Interpreter::set_object_property` / `proxy_set` in `property.rs` (proxy trap, module-namespace reject, TypedArray integer-index set, accessor setters, prototype-chain walk, full receiver logic);
2. a ~150-line reimplementation in `set_object_with_key` (`eval.rs`) — the **compound- and destructuring-assignment** path;
3. an inline block inside `eval_assign` — the plain `obj.x = v` path.

Copy #2 had **drifted** from the canonical algorithm and forced every OrdinarySet change to be made in three places (poor locality). This PR collapses copy #2 into a thin delegation to the canonical entry point, taking the count **from 3 to 2**.

## What changed

- `set_object_with_key` (`src/interpreter/eval.rs`) now auto-boxes primitives, then delegates to `set_object_property(obj_id, key, val, &receiver)`; on a rejected set in strict mode it raises the TypeError. **~150 lines → ~10.**
- New `read_only_assignment_error(obj_id, key)` helper preserves, byte-for-byte, the three strict-reject diagnostics this path historically produced — plain read-only data (`Cannot assign to read only property 'x'`), getter-only accessor (`Cannot set property 'x' which has only a getter`), and module namespace. It skips descriptor re-inspection when a proxy sits on the object or its prototype chain, so **no proxy trap is re-invoked on the error path**.
- Net **−103 lines** in `eval.rs`.

Behavior-preserving for this path's callers (receiver == target). The richer canonical path additionally handles the different-receiver *TypedArray-prototype* index case that the copy handled incorrectly.

Deletion test: deleting the copy concentrates the OrdinarySet complexity in `property.rs` rather than moving it — it was not earning its keep.

## Tests that validate it (TDD, seam-first)

New `tests/read-only-assignment-destructuring-compound.js` characterizes the `set_object_with_key` seam via **destructuring** (`[o.x] = [v]`) and **compound** (`o.x += v`) assignment:

- strict read-only own/inherited data → `TypeError`, value unchanged;
- strict own/inherited getter-only accessor → getter-only `TypeError`;
- own/inherited setter invoked with the assigned value;
- writable-data overwrite, new-property creation, typed-array index write-through;
- sloppy mode → silent no-op (no throw).

Written first and **green before and after** the refactor (a behavior-preserving characterization suite), pinning both the spec semantics and jsse's host-compatible diagnostics. The truncated inherited-data message is the fingerprint that identifies this path (distinct from the plain-assignment path pinned by the existing `read-only-assignment-receiver-diagnostic.js`, which is unaffected).

## Verification (run synchronously)

- `cargo test --release`: **309 unit tests + smoke oracle pass**.
- `run-custom-tests.py`: **9/9** (incl. the new characterization test and the existing diagnostic).
- `rustfmt` + `clippy`: clean.
- test262 subsets — **0 regressions, full pass**:
  - `language/expressions/assignment` 850/850
  - `language/expressions/compound-assignment` 786/786
  - `built-ins/Object/defineProperty` 2250/2250
  - `built-ins/Proxy` 607/607
  - `built-ins/TypedArray` 2876/2876

## Follow-up (out of scope)

The sibling copy inside `eval_assign` (plain `obj.x = v`, which carries an array-append fast path and a global-binding sync) can be consolidated the same way, collapsing 2 copies to 1. Deferred here to keep this PR bounded and low-risk.

🤖 Generated with Claude Code