### PR TITLE
fix(regexp): respect Unicode mode for property escapes

### DIFF
--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -3246,7 +3246,7 @@ fn push_case_fold_guarded(result: &mut String, ch: char, in_char_class: bool) {
     }
 }
 
-fn resolve_class_escape(chars: &[char], i: &mut usize) -> Option<u32> {
+fn resolve_class_escape(chars: &[char], i: &mut usize, unicode: bool) -> Option<u32> {
     if *i >= chars.len() {
         return None;
     }
@@ -3315,7 +3315,7 @@ fn resolve_class_escape(chars: &[char], i: &mut usize) -> Option<u32> {
                     }
                 }
                 'd' | 'D' | 'w' | 'W' | 's' | 'S' | 'b' | 'B' => None,
-                'p' | 'P' => {
+                'p' | 'P' if unicode => {
                     if *i < chars.len() && chars[*i] == '{' {
                         *i += 1;
                         while *i < chars.len() && chars[*i] != '}' {
@@ -4330,7 +4330,7 @@ pub(crate) fn validate_js_pattern(source: &str, flags: &str) -> Result<(), Strin
                     }
 
                     let save_i = i;
-                    let val = resolve_class_escape(&chars, &mut i);
+                    let val = resolve_class_escape(&chars, &mut i, unicode);
                     let is_class_esc = val.is_none()
                         && save_i < len
                         && chars[save_i] == '\\'

--- a/test262-extra/RegExp-non-unicode-property-identity-escape-ranges.js
+++ b/test262-extra/RegExp-non-unicode-property-identity-escape-ranges.js
@@ -1,0 +1,25 @@
+// Tests Annex B non-Unicode IdentityEscape parsing in character-class ranges.
+// Spec: ECMAScript 2026, sec-regular-expressions-patterns and
+// sec-additional-regular-expressions-patterns.
+
+function assertSyntaxError(pattern) {
+  try {
+    new RegExp(pattern);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return;
+    }
+    throw new Test262Error("expected SyntaxError, got " + error);
+  }
+  throw new Test262Error("expected invalid range to be rejected: " + pattern);
+}
+
+// Without Unicode mode, `\p` is an IdentityEscape for the character `p`.
+// These are therefore the out-of-order ranges U+FFFF-p and `}`-`-`.
+assertSyntaxError("[\uFFFF-\\p{Hex}]");
+assertSyntaxError("[\\p{Hex}--]");
+
+var identityEscape = new RegExp("[\\p{Any}]");
+if (!identityEscape.test("p") || identityEscape.test("z")) {
+  throw new Test262Error("non-Unicode \\p was not parsed as an identity escape");
+}


### PR DESCRIPTION
## Summary

- recognize `\p{...}` and `\P{...}` as character-class escapes only in Unicode mode
- preserve Annex B non-Unicode identity-escape parsing so esprima approximation ranges receive normal ordering validation
- add a focused `test262-extra` regression for both range directions and valid identity-escape behavior

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (332 unit tests plus smoke oracle)
- `uv run python scripts/run-custom-tests.py` (9/9)
- focused custom regression (1/1)
- Unicode property-escape test262 directory (1,226/1,226; 0 regressions)
- minimized unmodified esprima bundle rejects both original repros
- full test262: 99,546/99,568, with 22 unrelated Intl baseline regressions and 323 unrelated new passes; one Intl failure was reproduced after temporarily restoring `regexp.rs` byte-for-byte to `origin/main`, proving it predates this change

The targeted test262 area reports no new baseline passes, so this change does not alter the README pass count.

Closes #358