### PR TITLE
fix(interpreter): deepen StringToNumber; concentrate the WhiteSpace predicate

### DIFF
--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -1775,7 +1775,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 let mut radix = number_ops::to_int32(radix_num);
-                let s = s.trim_matches(crate::interpreter::builtins::string::is_ecma_whitespace);
+                let s = s.trim_matches(crate::interpreter::helpers::is_ecma_whitespace);
                 let (negative, s) = if let Some(rest) = s.strip_prefix('-') {
                     (true, rest)
                 } else if let Some(rest) = s.strip_prefix('+') {
@@ -1835,7 +1835,7 @@ impl Interpreter {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
                 };
-                let s = s.trim_matches(crate::interpreter::builtins::string::is_ecma_whitespace);
+                let s = s.trim_matches(crate::interpreter::helpers::is_ecma_whitespace);
                 if s.is_empty() {
                     return Completion::Normal(JsValue::Number(f64::NAN));
                 }

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -1,22 +1,6 @@
 use super::super::*;
+use crate::interpreter::helpers::is_ecma_whitespace;
 use icu_normalizer::{ComposingNormalizerBorrowed, DecomposingNormalizerBorrowed};
-
-pub(crate) fn is_ecma_whitespace(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{0009}'
-            | '\u{000A}'
-            | '\u{000B}'
-            | '\u{000C}'
-            | '\u{000D}'
-            | '\u{0020}'
-            | '\u{00A0}'
-            | '\u{FEFF}'
-            | '\u{1680}'
-            | '\u{2000}'
-            ..='\u{200A}' | '\u{2028}' | '\u{2029}' | '\u{202F}' | '\u{205F}' | '\u{3000}'
-    )
-}
 
 // §22.1.3 thisStringValue — RequireObjectCoercible + extract primitive from String wrapper
 fn this_string_value(interp: &mut Interpreter, this: &JsValue) -> Result<String, Completion> {

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -70,39 +70,85 @@ pub(crate) fn to_number(val: &JsValue) -> f64 {
     }
 }
 
+// §12 WhiteSpace | LineTerminator — the set trimmed from a StrNumericLiteral and
+// by String.prototype.trim / parseInt / parseFloat. Kept here, in the spec
+// conversions module, as the single canonical predicate every consumer shares.
+// (Distinct from Rust's `char::is_whitespace`, which adds U+0085 and omits U+FEFF.)
+pub(crate) fn is_ecma_whitespace(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{0009}'
+            | '\u{000A}'
+            | '\u{000B}'
+            | '\u{000C}'
+            | '\u{000D}'
+            | '\u{0020}'
+            | '\u{00A0}'
+            | '\u{FEFF}'
+            | '\u{1680}'
+            | '\u{2000}'
+            ..='\u{200A}' | '\u{2028}' | '\u{2029}' | '\u{202F}' | '\u{205F}' | '\u{3000}'
+    )
+}
+
+// Parse the digits of a §7.1.4.1 NonDecimalIntegerLiteral (0x / 0o / 0b) into an
+// f64, accumulating in floating point so a value beyond i64/u64 yields a finite
+// rounded result instead of overflowing to NaN. The accumulation is exact for
+// values ≤ 2^53; above that it is not guaranteed bit-identical to RoundMVResult.
+// Empty or invalid input → NaN.
+fn radix_digits_to_f64(digits: &str, radix: u32) -> f64 {
+    if digits.is_empty() {
+        return f64::NAN;
+    }
+    let mut acc = 0.0_f64;
+    for ch in digits.chars() {
+        match ch.to_digit(radix) {
+            Some(d) => acc = acc * f64::from(radix) + f64::from(d),
+            None => return f64::NAN,
+        }
+    }
+    acc
+}
+
 // §7.1.4.1.1 StringToNumber (uses §7.1.4.1.2 RoundMVResult via f64::parse)
 fn string_to_number(s: &JsString) -> f64 {
     let rust_str = s.to_rust_string();
-    // ECMA-262 §12.2 WhiteSpace includes <ZWNBSP> (U+FEFF), which Rust's
-    // char::is_whitespace omits (Unicode classifies it as Format, not White_Space).
-    let trimmed = rust_str.trim_matches(|c: char| c.is_whitespace() || c == '\u{FEFF}');
+    let trimmed = rust_str.trim_matches(is_ecma_whitespace);
     if trimmed.is_empty() {
         return 0.0;
     }
-    if trimmed.starts_with("0x") || trimmed.starts_with("0X") {
-        return i64::from_str_radix(&trimmed[2..], 16)
-            .map(|n| n as f64)
-            .unwrap_or(f64::NAN);
+    // NonDecimalIntegerLiteral: no sign is permitted, so a leading '+'/'-' keeps
+    // the string out of these branches and it falls through to StrDecimalLiteral.
+    if let Some(rest) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        return radix_digits_to_f64(rest, 16);
     }
-    if trimmed.starts_with("0o") || trimmed.starts_with("0O") {
-        return i64::from_str_radix(&trimmed[2..], 8)
-            .map(|n| n as f64)
-            .unwrap_or(f64::NAN);
+    if let Some(rest) = trimmed
+        .strip_prefix("0o")
+        .or_else(|| trimmed.strip_prefix("0O"))
+    {
+        return radix_digits_to_f64(rest, 8);
     }
-    if trimmed.starts_with("0b") || trimmed.starts_with("0B") {
-        return i64::from_str_radix(&trimmed[2..], 2)
-            .map(|n| n as f64)
-            .unwrap_or(f64::NAN);
+    if let Some(rest) = trimmed
+        .strip_prefix("0b")
+        .or_else(|| trimmed.strip_prefix("0B"))
+    {
+        return radix_digits_to_f64(rest, 2);
     }
-    if trimmed == "Infinity" || trimmed == "+Infinity" {
-        return f64::INFINITY;
+    // StrDecimalLiteral: the only Infinity token is exactly "Infinity" (with an
+    // optional sign). Every other inf/nan spelling Rust's f64 parser would accept
+    // must be NaN, so reject them before handing off to `parse`.
+    match trimmed {
+        "Infinity" | "+Infinity" => return f64::INFINITY,
+        "-Infinity" => return f64::NEG_INFINITY,
+        _ => {}
     }
-    if trimmed == "-Infinity" {
-        return f64::NEG_INFINITY;
-    }
-    if trimmed.eq_ignore_ascii_case("infinity")
-        || trimmed.eq_ignore_ascii_case("+infinity")
-        || trimmed.eq_ignore_ascii_case("-infinity")
+    let unsigned = trimmed.strip_prefix(['+', '-']).unwrap_or(trimmed);
+    if unsigned.eq_ignore_ascii_case("inf")
+        || unsigned.eq_ignore_ascii_case("infinity")
+        || unsigned.eq_ignore_ascii_case("nan")
     {
         return f64::NAN;
     }
@@ -2403,5 +2449,96 @@ mod make_date_clipped_tests {
         let v = make_date_clipped(0.0, 0.0, false);
         assert_eq!(v, 0.0);
         assert!(v.is_sign_positive());
+    }
+}
+
+#[cfg(test)]
+mod string_to_number_tests {
+    // §7.1.4.1 StringToNumber. Expected values below are the independent source
+    // of truth from ECMA-262 §12 (WhiteSpace) and §7.1.4.1 (StrNumericLiteral),
+    // cross-checked against node's `Number(...)`.
+    use super::string_to_number;
+    use crate::types::JsString;
+
+    fn n(s: &str) -> f64 {
+        string_to_number(&JsString::from_str(s))
+    }
+
+    #[test]
+    fn trims_exactly_the_ecmascript_whitespace_set() {
+        // In the ECMAScript StrWhiteSpace set (trimmed): must yield 1.
+        for ws in [
+            "\u{0009}", // TAB
+            "\u{000A}", // LF
+            "\u{000B}", // VT
+            "\u{000C}", // FF
+            "\u{000D}", // CR
+            "\u{0020}", // SP
+            "\u{00A0}", // NBSP
+            "\u{FEFF}", // ZWNBSP
+            "\u{1680}", // OGHAM SPACE MARK
+            "\u{2000}", // EN QUAD
+            "\u{200A}", // HAIR SPACE
+            "\u{2028}", // LINE SEPARATOR
+            "\u{2029}", // PARAGRAPH SEPARATOR
+            "\u{202F}", // NNBSP
+            "\u{205F}", // MMSP
+            "\u{3000}", // IDEOGRAPHIC SPACE
+        ] {
+            assert_eq!(
+                n(&format!("{ws}1{ws}")),
+                1.0,
+                "U+{:04X} must be trimmed",
+                ws.chars().next().unwrap() as u32
+            );
+        }
+        assert_eq!(n("\t\n\r 5 \t\n\r"), 5.0);
+    }
+
+    #[test]
+    fn does_not_trim_non_ecmascript_whitespace() {
+        // U+0085 NEL is in Rust's White_Space but NOT ECMAScript's set.
+        assert!(n("\u{0085}1").is_nan());
+        // U+200B ZERO WIDTH SPACE is not whitespace in either.
+        assert!(n("\u{200B}1").is_nan());
+    }
+
+    #[test]
+    fn infinity_is_case_sensitive_and_only_the_full_word() {
+        assert_eq!(n("Infinity"), f64::INFINITY);
+        assert_eq!(n("+Infinity"), f64::INFINITY);
+        assert_eq!(n("-Infinity"), f64::NEG_INFINITY);
+        // Every other inf/nan spelling Rust's float parser accepts must be NaN.
+        for s in [
+            "inf", "+inf", "-inf", "INF", "infinity", "INFINITY", "nan", "NaN", "NAN",
+        ] {
+            assert!(n(s).is_nan(), "Number({s:?}) must be NaN");
+        }
+    }
+
+    #[test]
+    fn non_decimal_integer_literals() {
+        assert_eq!(n("0x10"), 16.0);
+        assert_eq!(n("0X1F"), 31.0);
+        assert_eq!(n("0o17"), 15.0);
+        assert_eq!(n("0b101"), 5.0);
+        // Large hex must round to the nearest f64, not overflow to NaN.
+        assert_eq!(n("0x10000000000000000"), 2f64.powi(64));
+        // Empty digits, bad digits, and a leading sign are all NaN.
+        for s in ["0x", "0o", "0b", "0xG", "0o8", "0b2", "+0x1", "-0x1"] {
+            assert!(n(s).is_nan(), "Number({s:?}) must be NaN");
+        }
+    }
+
+    #[test]
+    fn decimals_and_empty() {
+        assert_eq!(n(""), 0.0);
+        assert_eq!(n("   "), 0.0);
+        assert_eq!(n("  12.5  "), 12.5);
+        assert_eq!(n("1e3"), 1000.0);
+        assert_eq!(n(".5"), 0.5);
+        assert_eq!(n("5."), 5.0);
+        assert_eq!(n("-0"), 0.0);
+        assert!(n("-0").is_sign_negative());
     }
 }

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -91,23 +91,18 @@ pub(crate) fn is_ecma_whitespace(ch: char) -> bool {
     )
 }
 
-// Parse the digits of a §7.1.4.1 NonDecimalIntegerLiteral (0x / 0o / 0b) into an
-// f64, accumulating in floating point so a value beyond i64/u64 yields a finite
-// rounded result instead of overflowing to NaN. The accumulation is exact for
-// values ≤ 2^53; above that it is not guaranteed bit-identical to RoundMVResult.
+// Parse the digits of a §7.1.4.1 NonDecimalIntegerLiteral (0x / 0o / 0b) as an
+// exact integer, then convert it to f64 once. Parsing through the exact decimal
+// representation gives Rust's float parser the full mathematical value to round,
+// avoiding both fixed-width overflow and intermediate floating-point rounding.
 // Empty or invalid input → NaN.
 fn radix_digits_to_f64(digits: &str, radix: u32) -> f64 {
-    if digits.is_empty() {
+    if digits.is_empty() || !digits.chars().all(|ch| ch.is_digit(radix)) {
         return f64::NAN;
     }
-    let mut acc = 0.0_f64;
-    for ch in digits.chars() {
-        match ch.to_digit(radix) {
-            Some(d) => acc = acc * f64::from(radix) + f64::from(d),
-            None => return f64::NAN,
-        }
-    }
-    acc
+    num_bigint::BigUint::parse_bytes(digits.as_bytes(), radix)
+        .and_then(|exact| exact.to_string().parse::<f64>().ok())
+        .unwrap_or(f64::NAN)
 }
 
 // §7.1.4.1.1 StringToNumber (uses §7.1.4.1.2 RoundMVResult via f64::parse)
@@ -2524,8 +2519,14 @@ mod string_to_number_tests {
         assert_eq!(n("0b101"), 5.0);
         // Large hex must round to the nearest f64, not overflow to NaN.
         assert_eq!(n("0x10000000000000000"), 2f64.powi(64));
+        // Convert the exact integer once: incremental f64 accumulation can
+        // double-round these values one ULP below their correct result.
+        assert_eq!(n("0x6269e107215582e"), 443_215_406_813_239_360.0);
+        assert_eq!(n("0x200000000000011"), 2f64.powi(57) + 32.0);
         // Empty digits, bad digits, and a leading sign are all NaN.
-        for s in ["0x", "0o", "0b", "0xG", "0o8", "0b2", "+0x1", "-0x1"] {
+        for s in [
+            "0x", "0o", "0b", "0xG", "0o8", "0b2", "0x1_0", "0o1_0", "0b1_0", "+0x1", "-0x1",
+        ] {
             assert!(n(s).is_nan(), "Number({s:?}) must be NaN");
         }
     }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1958,11 +1958,15 @@ mod string_to_number_seam_tests {
         let interp = run_script(
             r#"
             var big   = Number("0x10000000000000000"); // 2**64
+            var exact = Number("0x6269e107215582e");
+            var carry = Number("0x200000000000011");
             var small = Number("0o17");
             var empty = Number("0x");
             "#,
         );
         assert_eq!(global_number(&interp, "big"), 2f64.powi(64));
+        assert_eq!(global_number(&interp, "exact"), 443_215_406_813_239_360.0);
+        assert_eq!(global_number(&interp, "carry"), 2f64.powi(57) + 32.0);
         assert_eq!(global_number(&interp, "small"), 15.0);
         assert!(global_number(&interp, "empty").is_nan());
     }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1913,6 +1913,61 @@ mod to_integer_or_infinity_value_tests {
     }
 }
 
+/// §7.1.4.1 StringToNumber through the public `Number(...)` seam. Expected
+/// values are the ECMA-262 truth table (cross-checked against node): these lock
+/// the three divergences the deepened conversion fixes — Rust's whitespace set,
+/// hex overflow, and leaked `inf`/`nan` spellings. Whitespace chars are built
+/// with `String.fromCharCode` so the source stays ASCII-clean.
+mod string_to_number_seam_tests {
+    use super::*;
+
+    #[test]
+    fn ecmascript_whitespace_is_trimmed_but_rust_only_whitespace_is_not() {
+        let interp = run_script(
+            r#"
+            var nel    = Number(String.fromCharCode(0x85) + "1");   // U+0085 NEL: not WhiteSpace
+            var zwnbsp = Number(String.fromCharCode(0xFEFF) + "1"); // U+FEFF ZWNBSP: WhiteSpace
+            var mixed  = Number("\t\n\r 5 \t");
+            "#,
+        );
+        assert!(global_number(&interp, "nel").is_nan());
+        assert_eq!(global_number(&interp, "zwnbsp"), 1.0);
+        assert_eq!(global_number(&interp, "mixed"), 5.0);
+    }
+
+    #[test]
+    fn only_the_capitalized_infinity_word_is_infinite() {
+        let interp = run_script(
+            r#"
+            var inf   = Number("inf");
+            var pInf  = Number("+Infinity");
+            var nInf  = Number("-Infinity");
+            var lc    = Number("infinity");
+            var nan   = +"nan";
+            "#,
+        );
+        assert!(global_number(&interp, "inf").is_nan());
+        assert_eq!(global_number(&interp, "pInf"), f64::INFINITY);
+        assert_eq!(global_number(&interp, "nInf"), f64::NEG_INFINITY);
+        assert!(global_number(&interp, "lc").is_nan());
+        assert!(global_number(&interp, "nan").is_nan());
+    }
+
+    #[test]
+    fn large_non_decimal_literals_round_instead_of_overflowing() {
+        let interp = run_script(
+            r#"
+            var big   = Number("0x10000000000000000"); // 2**64
+            var small = Number("0o17");
+            var empty = Number("0x");
+            "#,
+        );
+        assert_eq!(global_number(&interp, "big"), 2f64.powi(64));
+        assert_eq!(global_number(&interp, "small"), 15.0);
+        assert!(global_number(&interp, "empty").is_nan());
+    }
+}
+
 /// Node host-compat "syscall floor" (issue #229). These exercise the ON-path
 /// (`enable_node_host`); the OFF-path 0-regression guarantee is covered by the
 /// full test262 run, which never enables the floor.

--- a/test262-extra/StringToNumber-whitespace-nondecimal-infinity.js
+++ b/test262-extra/StringToNumber-whitespace-nondecimal-infinity.js
@@ -1,0 +1,73 @@
+// §7.1.4.1 StringToNumber governs ToNumber applied to a String (Number(str),
+// unary +, and arithmetic coercion). Three properties are easy to get wrong when
+// an engine delegates to a host float parser (e.g. Rust's f64::from_str):
+//   1. The set stripped is exactly ECMAScript StrWhiteSpace | StrLineTerminator
+//      (§12): U+0085 <NEL> and U+200B <ZWSP> are NOT in it (Rust's White_Space
+//      wrongly includes NEL), while U+FEFF <ZWNBSP> is.
+//   2. A NonDecimalIntegerLiteral (0x / 0o / 0b) whose value exceeds 2^53 must
+//      round to the nearest Number, not overflow (a naive i64 parse yields NaN).
+//   3. The only Infinity token is the exact word "Infinity" (optionally signed);
+//      the "inf" / "infinity" / "nan" spellings a host parser accepts are NaN.
+// Expected values cross-checked with Node.
+// Spec: ECMAScript, sec-stringtonumber, sec-tonumber-applied-to-the-string-type.
+
+function assertEq(actual, expected, msg) {
+  // Distinguish +0 from -0 as well as ordinary inequality.
+  if (actual !== expected || 1 / actual !== 1 / expected) {
+    throw new Test262Error(
+      msg + ": expected " + expected + " but got " + actual
+    );
+  }
+}
+
+function assertNaN(actual, msg) {
+  if (actual === actual) {
+    throw new Test262Error(msg + ": expected NaN but got " + actual);
+  }
+}
+
+var NEL = String.fromCharCode(0x85);
+var ZWNBSP = String.fromCharCode(0xfeff);
+var ZWSP = String.fromCharCode(0x200b);
+var NBSP = String.fromCharCode(0xa0);
+var LS = String.fromCharCode(0x2028);
+var PS = String.fromCharCode(0x2029);
+var IDSP = String.fromCharCode(0x3000);
+
+// (1) Whitespace: exactly the ECMAScript set is trimmed; Unicode-only members
+// (which Rust's char::is_whitespace would strip) are not.
+assertEq(Number(NBSP + "1" + NBSP), 1, "NBSP is StrWhiteSpace");
+assertEq(Number(ZWNBSP + "1"), 1, "ZWNBSP is StrWhiteSpace");
+assertEq(Number(LS + "1"), 1, "LINE SEPARATOR is StrLineTerminator");
+assertEq(Number(PS + "1"), 1, "PARAGRAPH SEPARATOR is StrLineTerminator");
+assertEq(Number(IDSP + "1"), 1, "IDEOGRAPHIC SPACE is StrWhiteSpace");
+assertEq(Number("\t\n\r 5 "), 5, "ASCII whitespace is trimmed");
+assertNaN(Number(NEL + "1"), "NEL (U+0085) is not StrWhiteSpace");
+assertNaN(Number(ZWSP + "1"), "ZWSP (U+200B) is not StrWhiteSpace");
+
+// (2) Non-decimal integer literals round to the nearest Number, never overflow.
+assertEq(Number("0x1F"), 31, "hex");
+assertEq(Number("0o17"), 15, "octal");
+assertEq(Number("0b101"), 5, "binary");
+assertEq(Number("0x10000000000000000"), Math.pow(2, 64), "hex 2**64 rounds, not NaN");
+assertEq(Number("0xffffffffffffffffffff"), Math.pow(2, 80), "hex 2**80-1 rounds to 2**80");
+assertNaN(Number("0x"), "empty hex digits");
+assertNaN(Number("0b"), "empty binary digits");
+assertNaN(Number("0xG"), "invalid hex digit");
+assertNaN(Number("0o8"), "invalid octal digit");
+assertNaN(Number("+0x1"), "NonDecimalIntegerLiteral forbids a leading sign");
+assertNaN(Number("-0x1"), "NonDecimalIntegerLiteral forbids a leading sign");
+
+// (3) Infinity is case-sensitive and only the full word.
+assertEq(Number("Infinity"), Infinity, "Infinity");
+assertEq(Number("+Infinity"), Infinity, "+Infinity");
+assertEq(Number("-Infinity"), -Infinity, "-Infinity");
+assertNaN(Number("inf"), "inf is not Infinity");
+assertNaN(Number("+inf"), "+inf is not Infinity");
+assertNaN(Number("infinity"), "lowercase infinity is NaN");
+assertNaN(Number("nan"), "nan is NaN");
+assertNaN(Number("NaN"), "the string 'NaN' is NaN");
+
+// The same seam backs unary plus and arithmetic coercion, not just Number().
+assertNaN(+"inf", "unary plus routes through StringToNumber");
+assertEq(+ZWNBSP + 1, 1, "a whitespace-only string coerces to +0");

--- a/test262-extra/StringToNumber-whitespace-nondecimal-infinity.js
+++ b/test262-extra/StringToNumber-whitespace-nondecimal-infinity.js
@@ -51,10 +51,21 @@ assertEq(Number("0o17"), 15, "octal");
 assertEq(Number("0b101"), 5, "binary");
 assertEq(Number("0x10000000000000000"), Math.pow(2, 64), "hex 2**64 rounds, not NaN");
 assertEq(Number("0xffffffffffffffffffff"), Math.pow(2, 80), "hex 2**80-1 rounds to 2**80");
+assertEq(
+  Number("0x6269e107215582e"),
+  443215406813239360,
+  "non-decimal conversion rounds the exact integer once"
+);
+assertEq(
+  Number("0x200000000000011"),
+  Math.pow(2, 57) + 32,
+  "non-decimal conversion does not double-round an intermediate prefix"
+);
 assertNaN(Number("0x"), "empty hex digits");
 assertNaN(Number("0b"), "empty binary digits");
 assertNaN(Number("0xG"), "invalid hex digit");
 assertNaN(Number("0o8"), "invalid octal digit");
+assertNaN(Number("0x1_0"), "numeric separators are not allowed in string numeric literals");
 assertNaN(Number("+0x1"), "NonDecimalIntegerLiteral forbids a leading sign");
 assertNaN(Number("-0x1"), "NonDecimalIntegerLiteral forbids a leading sign");
 


### PR DESCRIPTION
## What & why

This PR is the top recommendation from an architecture review run with the
`improve-codebase-architecture` skill (which surfaced deepening opportunities
across the interpreter). Of the candidates, `StringToNumber` was the highest
impact / lowest risk: a genuine **deepening** that also fixes three spec
conformance divergences, with a blast radius of one pure function plus five
call sites.

### The friction

`string_to_number` (the ECMAScript §7.1.4.1 ToNumber string path in
`helpers.rs`) was a shallow seam that leaked Rust's float grammar to every
ToNumber caller:

- it trimmed with Rust's `char::is_whitespace` (a *second*, wrong copy of the
  WhiteSpace concept — the canonical `is_ecma_whitespace` predicate lived in
  `builtins/string.rs`, unreachable to ToNumber's own module);
- it parsed `0x`/`0o`/`0b` literals via `i64::from_str_radix` (overflows); and
- it fell straight to `f64::parse` (accepts Rust's `inf`/`nan` spellings).

Three divergences from the spec (cross-checked with node) resulted:

| Input | Before | Spec / node |
|---|---|---|
| `Number(NEL + "1")` (U+0085) | `1` | `NaN` (NEL is not StrWhiteSpace) |
| `Number("0x10000000000000000")` | `NaN` | ~`2**64` (rounds, no overflow) |
| `Number("inf")` / `"+inf"` | `Infinity` | `NaN` (only `"Infinity"` is valid) |

### The deepening

- **Concentrate the WhiteSpace predicate.** `is_ecma_whitespace` moves into
  `helpers.rs` (the spec-conversions module), so `trim` / `parseInt` /
  `parseFloat` / ToNumber now all draw from **one** definition instead of
  ToNumber reinventing a wrong one. (locality: one predicate; leverage: 4 call sites)
- **Add `radix_digits_to_f64`.** It validates every non-decimal digit, parses the
  full value as an exact `BigUint`, and converts that exact integer to `f64`
  once. This avoids both fixed-width overflow and intermediate double rounding.
- **Reject `inf`/`infinity`/`nan`** before the final `parse::<f64>`, stopping the
  seam from leaking Rust's grammar.

## Tests (TDD: red -> green)

Written test-first against the ECMA-262 truth table (the independent source of
truth, cross-checked with node); the whitespace / hex-overflow / inf cases
failed on the old implementation before the fix.

- **Pure unit tests** for `string_to_number` in `helpers.rs` — whitespace set,
  inf/nan, non-decimal literals, exact rounding, decimals/empty.
- **JS-driven seam tests** at the public `Number(...)` interface in `tests.rs`.
- **`test262-extra/StringToNumber-whitespace-nondecimal-infinity.js`** — a
  spec-pattern test following the repo's convention, since test262 has no
  coverage for these negative edge cases.

## Validation

- `./scripts/lint.sh`
- 340 release unit tests plus the test262 smoke oracle
- release build
- 9/9 custom tests
- focused `built-ins/Number` test262: 680/680
- full default test262: 99,546/99,568; all 22 failures are in unrelated Intl
  DateTimeFormat/Temporal paths and reproduce unchanged with an exact
  `origin/main` binary, so this patch has zero regressions

## Disclosures

- **README unchanged.** These edge cases have no test262 coverage, so the tracked
  pass count does not move.
- **Scope.** This fixes the three named divergences, including correctly rounded
  non-decimal integers of arbitrary size. Pre-existing decimal-grammar behaviour
  rides the unchanged `parse::<f64>` path and is out of scope.
