### PR TITLE
fix(interpreter): guard boxing/error constructors against [[Call]] this-mutation

### DIFF
--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -566,7 +566,12 @@ impl Interpreter {
                         };
                     }
 
-                    if let JsValue::Object(o) = this {
+                    // §20.5.1.1 never reuses `this` — it always allocates via
+                    // OrdinaryCreateFromConstructor. A plain [[Call]] (e.g.
+                    // `Error.call(obj, msg)`) must not mutate an arbitrary `this`.
+                    if interp.new_target.is_some()
+                        && let JsValue::Object(o) = this
+                    {
                         if let Some(obj) = interp.get_object_cell(o.id) {
                             let mut o = obj.borrow_mut();
                             init_error!(o);
@@ -825,7 +830,12 @@ impl Interpreter {
                     1,
                     move |interp, this, args| {
                         let msg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        if let JsValue::Object(o) = this {
+                        // Only box into `this` when invoked via [[Construct]] — a plain
+                        // [[Call]] (e.g. `Test262Error.call(obj, msg)`) must not mutate
+                        // an arbitrary `this`.
+                        if interp.new_target.is_some()
+                            && let JsValue::Object(o) = this
+                        {
                             if let Some(obj) = interp.get_object(o.id) {
                                 let mut o = obj.borrow_mut();
                                 o.class_name = "Test262Error".to_string();
@@ -970,7 +980,12 @@ impl Interpreter {
                         };
                     }
 
-                    if let JsValue::Object(o) = this {
+                    // §20.5.6.1.1 never reuses `this` — it always allocates via
+                    // OrdinaryCreateFromConstructor. A plain [[Call]] (e.g.
+                    // `TypeError.call(obj, msg)`) must not mutate an arbitrary `this`.
+                    if interp.new_target.is_some()
+                        && let JsValue::Object(o) = this
+                    {
                         if let Some(obj) = interp.get_object(o.id) {
                             let mut o = obj.borrow_mut();
                             init_native_error!(o);
@@ -1194,7 +1209,13 @@ impl Interpreter {
                             };
                         }
 
-                        if let JsValue::Object(o) = this {
+                        // §20.5.7.1 never reuses `this` — it always allocates via
+                        // OrdinaryCreateFromConstructor. A plain [[Call]] (e.g.
+                        // `AggregateError.call(obj, errors, msg)`) must not mutate an
+                        // arbitrary `this`.
+                        if interp.new_target.is_some()
+                            && let JsValue::Object(o) = this
+                        {
                             if let Some(obj) = interp.get_object(o.id) {
                                 let mut o = obj.borrow_mut();
                                 init_agg_error!(o);
@@ -1468,6 +1489,8 @@ impl Interpreter {
                         }
                     }
                 };
+                // §22.1.1.1 step 3: only box into `this` when invoked via [[Construct]].
+                // A plain [[Call]] (e.g. `String.call(obj, x)`) must not mutate `this`.
                 if interp.new_target.is_some()
                     && let JsValue::Object(o) = this
                     && let Some(obj) = interp.get_object(o.id)
@@ -1481,10 +1504,6 @@ impl Interpreter {
                     if let Some(proto_rc) = proto {
                         obj.borrow_mut().prototype_id = Some(proto_rc);
                     }
-                }
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
-                {
                     obj.borrow_mut().primitive_value = Some(JsValue::String(js_str.clone()));
                     obj.borrow_mut().class_name = "String".to_string();
                 }
@@ -1589,7 +1608,10 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     }
                 };
-                if let JsValue::Object(o) = this
+                // §21.1.1.1 step 3: only box into `this` when invoked via [[Construct]].
+                // A plain [[Call]] (e.g. `Number.call(obj, x)`) must not mutate `this`.
+                if interp.new_target.is_some()
+                    && let JsValue::Object(o) = this
                     && let Some(obj) = interp.get_object(o.id)
                 {
                     // OrdinaryCreateFromConstructor — realm-aware prototype
@@ -1722,7 +1744,10 @@ impl Interpreter {
             JsFunction::constructor("Boolean".to_string(), 1, |interp, this, args| {
                 let val = args.first().cloned().unwrap_or(JsValue::Undefined);
                 let b = interp.to_boolean_val(&val);
-                if let JsValue::Object(o) = this
+                // §21.3.1.1 step 2: only box into `this` when invoked via [[Construct]].
+                // A plain [[Call]] (e.g. `Boolean.call(obj, x)`) must not mutate `this`.
+                if interp.new_target.is_some()
+                    && let JsValue::Object(o) = this
                     && let Some(obj) = interp.get_object(o.id)
                 {
                     // OrdinaryCreateFromConstructor — realm-aware prototype

--- a/test262-extra/constructor-call-must-not-mutate-this.js
+++ b/test262-extra/constructor-call-must-not-mutate-this.js
@@ -1,0 +1,136 @@
+/*---
+description: >
+  Built-in "constructor" functions that box a primitive or allocate a fresh
+  error object (Boolean, Number, String, Error and the NativeError subtypes,
+  AggregateError) must ignore the passed-in `this` value when invoked via
+  [[Call]] (NewTarget undefined) — e.g. through Function.prototype.call/apply,
+  or as a borrowed method with an explicit thisArg. They must never read or
+  write internal slots (or the [[Prototype]]) of an arbitrary `this` object,
+  only ever act on a fresh object they allocate via
+  OrdinaryCreateFromConstructor when actually invoked via [[Construct]].
+info: |
+  21.3.1.1 Boolean ( value )
+    2. If NewTarget is undefined, return b.
+    3. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Boolean.prototype%", « [[BooleanData]] »).
+
+  21.1.1.1 Number ( value )
+    3. If NewTarget is undefined, return n.
+    4. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Number.prototype%", « [[NumberData]] »).
+
+  22.1.1.1 String ( value )
+    3. If NewTarget is undefined, return s.
+    4. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%String.prototype%", « [[StringData]] »).
+
+  20.5.1.1 Error ( message [ , options ] )
+    1. If NewTarget is undefined, let newTarget be the active function object;
+       else let newTarget be NewTarget.
+    2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%Error.prototype%", « [[ErrorData]] »).
+
+  20.5.6.1.1 NativeError ( message [ , options ] ) and 20.5.7.1 AggregateError
+  follow the same OrdinaryCreateFromConstructor shape as Error — a fresh
+  object, never the incoming `this`.
+
+  None of these abstract operations read from or write to an incoming `this`
+  value; they only ever construct and return a brand-new ordinary object.
+esid: sec-boolean-constructor-boolean-value
+---*/
+
+function assertNotBoxed(obj, protoBefore, label) {
+  if (Object.getPrototypeOf(obj) !== protoBefore) {
+    throw new Test262Error(
+      label + ' must not change the [[Prototype]] of an arbitrary `this`, got ' +
+      Object.getPrototypeOf(obj)
+    );
+  }
+  if (obj.hasOwnProperty('message') || obj.hasOwnProperty('errors') ||
+      obj.hasOwnProperty('cause')) {
+    throw new Test262Error(label + ' must not add own properties to an arbitrary `this`');
+  }
+}
+
+// --- Boolean ---
+{
+  var obj = {};
+  var protoBefore = Object.getPrototypeOf(obj);
+  var result = Boolean.call(obj, 1);
+  assertNotBoxed(obj, protoBefore, 'Boolean.call');
+  assert.sameValue(result, true, 'Boolean.call still performs ToBoolean and returns a primitive');
+  assert.sameValue(typeof result, 'boolean');
+}
+
+// --- Number ---
+{
+  var obj = {};
+  var protoBefore = Object.getPrototypeOf(obj);
+  var result = Number.call(obj, 5);
+  assertNotBoxed(obj, protoBefore, 'Number.call');
+  assert.sameValue(result, 5, 'Number.call still performs ToNumber and returns a primitive');
+  assert.sameValue(typeof result, 'number');
+}
+
+// --- String ---
+{
+  var obj = {};
+  var protoBefore = Object.getPrototypeOf(obj);
+  var result = String.call(obj, 'x');
+  assertNotBoxed(obj, protoBefore, 'String.call');
+  assert.sameValue(result, 'x', 'String.call still performs ToString and returns a primitive');
+  assert.sameValue(typeof result, 'string');
+  assert.sameValue(
+    Object.prototype.toString.call(obj),
+    '[object Object]',
+    'String.call must not tag an arbitrary `this` as a boxed String'
+  );
+}
+
+// --- Error and NativeError subtypes ---
+[Error, TypeError, RangeError, ReferenceError, SyntaxError, EvalError, URIError].forEach(
+  function (Ctor) {
+    var obj = {};
+    var protoBefore = Object.getPrototypeOf(obj);
+    var result = Ctor.call(obj, 'boom');
+    assertNotBoxed(obj, protoBefore, Ctor.name + '.call');
+    if (!(result instanceof Ctor)) {
+      throw new Test262Error(Ctor.name + '.call(this, msg) must still return a fresh ' + Ctor.name);
+    }
+    assert.sameValue(result.message, 'boom');
+    if (result === obj) {
+      throw new Test262Error(Ctor.name + '.call must return a new object, not the passed `this`');
+    }
+  }
+);
+
+// --- AggregateError ---
+{
+  var obj = {};
+  var protoBefore = Object.getPrototypeOf(obj);
+  var result = AggregateError.call(obj, [], 'boom');
+  assertNotBoxed(obj, protoBefore, 'AggregateError.call');
+  if (!(result instanceof AggregateError)) {
+    throw new Test262Error('AggregateError.call(this, errors, msg) must still return a fresh AggregateError');
+  }
+  assert.sameValue(result.message, 'boom');
+}
+
+// --- The exact reported repro: a class method with a defaulted second
+// parameter forwarding a native function via fn.call(thisArg, ...) must not
+// corrupt `thisArg` (or the object arena in a way that affects later calls). ---
+{
+  class C {
+    m(fn, thisArg = this) {
+      return fn.call(thisArg, 1);
+    }
+  }
+  var c = new C();
+  assert.sameValue(c.m(Boolean), true, 'first call, boxed via a native function, returns correctly');
+  assert.sameValue(
+    Object.getPrototypeOf(c),
+    C.prototype,
+    'the receiver`s [[Prototype]] must survive a native-function first call'
+  );
+  assert.sameValue(
+    c.m(function (x) { return x + 1; }),
+    2,
+    'a later call on the same method must still work'
+  );
+}


### PR DESCRIPTION
## Summary

- `Boolean`, `Number`, `String`, `Error`, the `NativeError` subtypes (`TypeError`, `RangeError`, etc.), and `AggregateError` all mutated an arbitrary `this` object's internal slots — and, worse, its `[[Prototype]]` — whenever `this` happened to be an object during a plain `[[Call]]` (e.g. `Boolean.call(obj, 1)`), because none of them checked that `NewTarget` was actually defined before treating `this` as the pre-created object `OrdinaryCreateFromConstructor` sets up for `[[Construct]]`.
- **This turned out to have nothing to do with the pooled call-environment work (#73/PR #352) that the issue suspected** — it reproduces with a bare `Boolean.call({}, 1)`, no class, no default parameter, no pooling involved. The reported repro (`List#some(fn, thisArg = this)` calling `fn.call(thisArg, 1)` with a native function like `Boolean` as `fn`) just happened to be the first place a native function's `this`-clobbering behavior became externally visible: it silently rewrote the receiver's `[[Prototype]]` to `Boolean.prototype`, breaking every later call through that receiver.
- Fix: guard each constructor's this-mutation branch on `interp.new_target.is_some()`, matching the pattern already used correctly by `String`'s prototype-setting branch and `BigInt`.

Fixes #355

## Test plan

- [x] `cargo test --release` — 340 unit tests passing
- [x] `uv run python scripts/run-custom-tests.py` — 9/9 passing
- [x] `uv run python scripts/run-test262.py -j 32` — 99,568/99,568 (100.00%), 0 regressions, 323 new passes
- [x] New regression test `test262-extra/constructor-call-must-not-mutate-this.js` — covers `Boolean`/`Number`/`String`/`Error`+subtypes/`AggregateError` called via `.call()` with an arbitrary `this`, plus the exact issue repro; verified it fails on the pre-fix binary and passes after the fix
- [x] Manual repro confirms the bug is fixed