### PR TITLE
refactor(interpreter): deepen @@toStringTag install into define_to_string_tag

### DIFF
--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -710,19 +710,7 @@ impl Interpreter {
         });
 
         // @@toStringTag
-        {
-            let tag = JsValue::String(JsString::from_str("Atomics"));
-            let sym_key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor::data(tag, false, false, true);
-            self.get_object_cell_expect(atomics_obj_id)
-                .borrow_mut()
-                .property_order
-                .push(sym_key.clone());
-            self.get_object_cell_expect(atomics_obj_id)
-                .borrow_mut()
-                .properties
-                .insert(sym_key, desc);
-        }
+        self.define_to_string_tag(atomics_obj_id, "Atomics");
 
         let atomics_val = JsValue::Object(crate::types::JsObject { id: atomics_id });
         self.realm()

--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -136,20 +136,7 @@ impl Interpreter {
         }
 
         // @@toStringTag
-        let tag_key = self
-            .get_symbol_key("toStringTag")
-            .unwrap_or_else(|| JsPropertyKey::well_known_symbol("toStringTag"));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                tag_key,
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("BigInt")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(proto_id, "BigInt");
 
         // BigInt() — is a constructor but throws TypeError when called with new
         self.register_global_fn(

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -66,17 +66,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Map Iterator".to_string();
 
-        self.get_object_cell_expect(map_iter_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("Map Iterator")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(map_iter_proto_id, "Map Iterator");
 
         self.define_method(map_iter_proto_id, "next", 0, |interp, this, _args| {
             if let JsValue::Object(o) = this
@@ -443,17 +433,7 @@ impl Interpreter {
         );
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("Map")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(proto_id, "Map");
 
         // constructor property
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
@@ -754,17 +734,7 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Set Iterator".to_string();
 
-        self.get_object_cell_expect(set_iter_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("Set Iterator")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(set_iter_proto_id, "Set Iterator");
 
         self.define_method(set_iter_proto_id, "next", 0, |interp, this, _args| {
             if let JsValue::Object(o) = this
@@ -1500,17 +1470,7 @@ impl Interpreter {
         });
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("Set")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(proto_id, "Set");
 
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
@@ -1868,17 +1828,7 @@ impl Interpreter {
         );
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("WeakMap")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(proto_id, "WeakMap");
 
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
@@ -2130,17 +2080,7 @@ impl Interpreter {
         });
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("WeakSet")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(proto_id, "WeakSet");
 
         let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
 
@@ -2304,25 +2244,7 @@ impl Interpreter {
         });
 
         // @@toStringTag
-        {
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("WeakRef"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "WeakRef");
 
         // WeakRef constructor
         let weakref_ctor = self.create_function(JsFunction::constructor(
@@ -2528,25 +2450,7 @@ impl Interpreter {
         });
 
         // @@toStringTag
-        {
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("FinalizationRegistry"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "FinalizationRegistry");
 
         // FinalizationRegistry constructor
         let fr_ctor = self.create_function(JsFunction::constructor(

--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -219,19 +219,7 @@ impl Interpreter {
             .class_name = "Intl.Collator".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.Collator"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.Collator");
 
         // compare getter
         let compare_getter = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -5617,19 +5617,7 @@ impl Interpreter {
             .class_name = "Intl.DateTimeFormat".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.DateTimeFormat"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.DateTimeFormat");
 
         // format getter (returns a bound function, like Collator.compare)
         let format_getter = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/intl/displaynames.rs
+++ b/src/interpreter/builtins/intl/displaynames.rs
@@ -1079,19 +1079,7 @@ impl Interpreter {
             .class_name = "Intl.DisplayNames".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.DisplayNames"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.DisplayNames");
 
         // of(code)
         let of_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -1148,19 +1148,7 @@ impl Interpreter {
             .class_name = "Intl.DurationFormat".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.DurationFormat"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.DurationFormat");
 
         // format(duration)
         let format_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/intl/listformat.rs
+++ b/src/interpreter/builtins/intl/listformat.rs
@@ -113,19 +113,7 @@ impl Interpreter {
             .class_name = "Intl.ListFormat".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.ListFormat"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.ListFormat");
 
         // format(list)
         let format_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -204,19 +204,7 @@ impl Interpreter {
             .class_name = "Intl.Locale".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.Locale"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.Locale");
 
         // --- Getter accessors ---
 

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -19,25 +19,7 @@ impl Interpreter {
         let intl_id = intl_obj_id;
 
         // @@toStringTag = "Intl" (per spec 8.1.1)
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Intl"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(intl_obj_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(intl_obj_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(intl_obj_id, "Intl");
 
         // Intl.getCanonicalLocales(locales)
         let gcl_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -2964,19 +2964,7 @@ impl Interpreter {
             .class_name = "Intl.NumberFormat".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.NumberFormat"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.NumberFormat");
 
         // format getter
         let format_getter = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -176,19 +176,7 @@ impl Interpreter {
             .class_name = "Intl.PluralRules".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.PluralRules"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.PluralRules");
 
         // select(value)
         let select_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/intl/relativetimeformat.rs
+++ b/src/interpreter/builtins/intl/relativetimeformat.rs
@@ -474,21 +474,7 @@ impl Interpreter {
             .class_name = "Intl.RelativeTimeFormat".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str(
-                        "Intl.RelativeTimeFormat",
-                    ))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.RelativeTimeFormat");
 
         // format(value, unit)
         let format_fn =

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -174,19 +174,7 @@ impl Interpreter {
             .class_name = "Intl.Segmenter".to_string();
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor {
-                    value: Some(JsValue::String(JsString::from_str("Intl.Segmenter"))),
-                    writable: Some(false),
-                    enumerable: Some(false),
-                    configurable: Some(true),
-                    get: None,
-                    set: None,
-                },
-            );
+        self.define_to_string_tag(proto_id, "Intl.Segmenter");
 
         // segment(string)
         let segment_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -1214,17 +1214,7 @@ impl Interpreter {
             .insert_builtin("next".to_string(), arr_iter_next);
 
         // Set @@toStringTag
-        self.get_object_cell_expect(arr_iter_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("Array Iterator")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(arr_iter_proto_id, "Array Iterator");
 
         self.realm_mut().array_iterator_prototype = Some(arr_iter_proto_id);
 
@@ -1308,17 +1298,7 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("next".to_string(), str_iter_next);
 
-        self.get_object_cell_expect(str_iter_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("String Iterator")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(str_iter_proto_id, "String Iterator");
 
         self.realm_mut().string_iterator_prototype = Some(str_iter_proto_id);
     }
@@ -1482,17 +1462,7 @@ impl Interpreter {
                 );
         }
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("Iterator Helper")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(proto_id, "Iterator Helper");
 
         self.realm_mut().iterator_helper_prototype = Some(proto_id);
     }
@@ -3820,17 +3790,7 @@ impl Interpreter {
         // @@iterator is inherited from %IteratorPrototype%
 
         // Symbol.toStringTag
-        self.get_object_cell_expect(gen_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("Generator")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(gen_proto_id, "Generator");
 
         self.realm_mut().generator_prototype = Some(gen_proto_id);
 
@@ -3867,17 +3827,7 @@ impl Interpreter {
             );
 
         // Symbol.toStringTag = "GeneratorFunction"
-        self.get_object_cell_expect(gf_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("GeneratorFunction")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(gf_proto_id, "GeneratorFunction");
 
         // Set constructor on Generator.prototype pointing back to GeneratorFunction.prototype_id
         self.get_object_cell_expect(gen_proto_id)
@@ -4127,17 +4077,7 @@ impl Interpreter {
             );
 
         // Symbol.toStringTag
-        self.get_object_cell_expect(gen_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("AsyncGenerator")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(gen_proto_id, "AsyncGenerator");
 
         self.realm_mut().async_generator_prototype = Some(gen_proto_id);
 
@@ -4159,17 +4099,7 @@ impl Interpreter {
                 ),
             );
         // Symbol.toStringTag
-        self.get_object_cell_expect(agf_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("AsyncGeneratorFunction")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(agf_proto_id, "AsyncGeneratorFunction");
         // Set constructor on AsyncGenerator.prototype pointing back to AsyncGeneratorFunction.prototype_id
         self.get_object_cell_expect(gen_proto_id)
             .borrow_mut()

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -2525,25 +2525,7 @@ impl Interpreter {
             .insert_builtin("sumPrecise".to_string(), sum_precise_fn);
 
         // @@toStringTag
-        {
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Math"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            self.get_object_cell_expect(math_obj_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(math_obj_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(math_obj_id, "Math");
 
         let math_val = JsValue::Object(crate::types::JsObject { id: math_id });
         self.realm()
@@ -3167,17 +3149,7 @@ impl Interpreter {
             }
 
             // Symbol.toStringTag = "AsyncFunction"
-            self.get_object_cell_expect(af_proto_id)
-                .borrow_mut()
-                .insert_property(
-                    JsPropertyKey::well_known_symbol("toStringTag"),
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str("AsyncFunction")),
-                        false,
-                        false,
-                        true,
-                    ),
-                );
+            self.define_to_string_tag(af_proto_id, "AsyncFunction");
 
             self.realm_mut().async_function_prototype = Some(af_proto_id);
         }
@@ -3867,25 +3839,7 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("isRawJSON".to_string(), json_is_raw_json);
         // @@toStringTag
-        {
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("JSON"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            self.get_object_cell_expect(json_obj_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(json_obj_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(json_obj_id, "JSON");
         let json_val = JsValue::Object(crate::types::JsObject { id: json_obj_id });
         self.realm()
             .global_env
@@ -7647,25 +7601,7 @@ impl Interpreter {
             .insert_builtin("setPrototypeOf".to_string(), spo_fn);
 
         // @@toStringTag
-        {
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Reflect"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            self.get_object_cell_expect(reflect_obj_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(reflect_obj_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(reflect_obj_id, "Reflect");
 
         // Register Reflect as global
         let reflect_val = JsValue::Object(crate::types::JsObject { id: reflect_id });
@@ -8147,20 +8083,7 @@ impl Interpreter {
         }
 
         // ShadowRealm.prototype[Symbol.toStringTag] = "ShadowRealm"
-        let to_string_tag_key = self
-            .get_symbol_key("toStringTag")
-            .unwrap_or_else(|| JsPropertyKey::well_known_symbol("toStringTag"));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                to_string_tag_key,
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("ShadowRealm")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(proto_id, "ShadowRealm");
 
         // ShadowRealm.prototype.evaluate
         let evaluate_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -385,17 +385,7 @@ impl Interpreter {
             .insert_builtin("finally".to_string(), finally_fn);
 
         // @@toStringTag
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(
-                    JsValue::String(JsString::from_str("Promise")),
-                    false,
-                    false,
-                    true,
-                ),
-            );
+        self.define_to_string_tag(proto_id, "Promise");
 
         // Promise constructor
         let _promise_proto = self.realm().promise_prototype;

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -1639,25 +1639,7 @@ impl Interpreter {
             .class_name = "Temporal.Duration".to_string();
 
         // @@toStringTag
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Temporal.Duration"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "Temporal.Duration");
 
         // Accessor properties for the 10 components + sign + blank
         let component_names = [

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -21,25 +21,7 @@ impl Interpreter {
             .class_name = "Temporal.Instant".to_string();
 
         // @@toStringTag
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Temporal.Instant"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "Temporal.Instant");
 
         // Getter: epochMilliseconds
         {

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -1617,25 +1617,7 @@ impl Interpreter {
         let temporal_id = temporal_obj_id;
 
         // @@toStringTag = "Temporal"
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Temporal"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(temporal_obj_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(temporal_obj_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(temporal_obj_id, "Temporal");
 
         self.setup_temporal_duration(temporal_obj_id);
         self.setup_temporal_instant(temporal_obj_id);

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -8,25 +8,7 @@ impl Interpreter {
         let now_id = now_obj_id;
 
         // @@toStringTag = "Temporal.Now"
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Temporal.Now"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(now_obj_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(now_obj_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(now_obj_id, "Temporal.Now");
 
         // Temporal.Now.timeZoneId()
         let tz_fn = self.create_function(JsFunction::native(

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -13,25 +13,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .class_name = "Temporal.PlainDate".to_string();
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Temporal.PlainDate"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "Temporal.PlainDate");
 
         // Getter: calendarId
         {

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -542,27 +542,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .class_name = "Temporal.PlainDateTime".to_string();
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str(
-                    "Temporal.PlainDateTime",
-                ))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "Temporal.PlainDateTime");
 
         // Getter: calendarId
         {

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -405,27 +405,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .class_name = "Temporal.PlainMonthDay".to_string();
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str(
-                    "Temporal.PlainMonthDay",
-                ))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "Temporal.PlainMonthDay");
 
         // Getters: calendarId, monthCode, month, day
         {

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -12,25 +12,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .class_name = "Temporal.PlainTime".to_string();
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str("Temporal.PlainTime"))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "Temporal.PlainTime");
 
         // Getters
         for &(name, field_idx) in &[

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -393,27 +393,7 @@ impl Interpreter {
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .class_name = "Temporal.PlainYearMonth".to_string();
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str(
-                    "Temporal.PlainYearMonth",
-                ))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "Temporal.PlainYearMonth");
 
         // Getters: calendarId, year, month, monthCode
         {

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -1804,27 +1804,7 @@ impl Interpreter {
             .class_name = "Temporal.ZonedDateTime".to_string();
 
         // @@toStringTag
-        {
-            let key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor {
-                value: Some(JsValue::String(JsString::from_str(
-                    "Temporal.ZonedDateTime",
-                ))),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                get: None,
-                set: None,
-            };
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .property_order
-                .push(key.clone());
-            self.get_object_cell_expect(proto_id)
-                .borrow_mut()
-                .properties
-                .insert(key, desc);
-        }
+        self.define_to_string_tag(proto_id, "Temporal.ZonedDateTime");
 
         // --- Getters ---
         macro_rules! zdt_getter {

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -883,11 +883,7 @@ impl Interpreter {
             .insert_builtin("resize".to_string(), resize_fn);
 
         // @@toStringTag
-        let tag = JsValue::String(JsString::from_str("ArrayBuffer"));
-        let sym_key = JsPropertyKey::well_known_symbol("toStringTag");
-        self.get_object_cell_expect(ab_proto_id)
-            .borrow_mut()
-            .insert_property(sym_key, PropertyDescriptor::data(tag, false, false, true));
+        self.define_to_string_tag(ab_proto_id, "ArrayBuffer");
 
         // ArrayBuffer constructor
         let ab_proto_clone_id = ab_proto_id;
@@ -1381,19 +1377,7 @@ impl Interpreter {
             .insert_builtin("slice".to_string(), slice_fn);
 
         // @@toStringTag
-        {
-            let tag = JsValue::String(JsString::from_str("SharedArrayBuffer"));
-            let sym_key = crate::interpreter::key_intern::intern_well_known_symbol("toStringTag");
-            let desc = PropertyDescriptor::data(tag, false, false, true);
-            self.get_object_cell_expect(sab_proto_id)
-                .borrow_mut()
-                .property_order
-                .push(sym_key.clone());
-            self.get_object_cell_expect(sab_proto_id)
-                .borrow_mut()
-                .properties
-                .insert(sym_key, desc);
-        }
+        self.define_to_string_tag(sab_proto_id, "SharedArrayBuffer");
 
         // SharedArrayBuffer constructor
         let sab_proto_clone_id = sab_proto_id;
@@ -5690,13 +5674,7 @@ impl Interpreter {
         );
 
         // @@toStringTag
-        let tag = JsValue::String(JsString::from_str("DataView"));
-        self.get_object_cell_expect(dv_proto_id)
-            .borrow_mut()
-            .insert_property(
-                JsPropertyKey::well_known_symbol("toStringTag"),
-                PropertyDescriptor::data(tag, false, false, true),
-            );
+        self.define_to_string_tag(dv_proto_id, "DataView");
 
         // DataView constructor
         let dv_proto_clone_id = dv_proto_id;

--- a/src/interpreter/key_intern.rs
+++ b/src/interpreter/key_intern.rs
@@ -139,11 +139,6 @@ pub(crate) fn intern_js_key(key: JsPropertyKey) -> JsPropertyKey {
     KEY_CACHE.with(|c| c.borrow_mut().intern(key))
 }
 
-#[inline]
-pub(crate) fn intern_well_known_symbol(name: &str) -> JsPropertyKey {
-    intern_js_key(JsPropertyKey::well_known_symbol(name))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1473,6 +1473,35 @@ impl Interpreter {
         getter
     }
 
+    /// Install the `@@toStringTag` data property that gives `Object.prototype.
+    /// toString` (and the spec's `[Symbol.toStringTag]` lookups) their brand:
+    /// `{ [[Value]]: tag, [[Writable]]: false, [[Enumerable]]: false,
+    /// [[Configurable]]: true }` — the shape every builtin prototype's tag has.
+    /// Companion to `define_method` / `define_getter`; concentrates the
+    /// `@@toStringTag` install "dance" that was otherwise open-coded at ~45
+    /// builtin sites as a six-field `PropertyDescriptor` literal (some of which
+    /// bypassed `insert_property` with a raw `property_order.push` +
+    /// `properties.insert` pair). Routing through `insert_property` keeps
+    /// `property_order` and `properties` in sync in one place.
+    ///
+    /// This is the *data*-property tag only. The handful of prototypes whose
+    /// `@@toStringTag` is an accessor (`%TypedArray%.prototype`,
+    /// `Iterator.prototype`) or is non-configurable (Module Namespace exotics)
+    /// keep their bespoke installs.
+    pub(crate) fn define_to_string_tag(&mut self, target_id: u64, tag: &str) {
+        self.get_object_cell_expect(target_id)
+            .borrow_mut()
+            .insert_property(
+                JsPropertyKey::well_known_symbol("toStringTag"),
+                PropertyDescriptor::data(
+                    JsValue::String(JsString::from_str(tag)),
+                    false,
+                    false,
+                    true,
+                ),
+            );
+    }
+
     /// Get a fresh owned clone of the slot's object handle if live.
     /// New callers should prefer `get_object_cell` / `get_object_cell_expect`
     /// (returns `&RefCell<…>`) to avoid the per-call handle refcount change; this

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -266,6 +266,71 @@ fn define_getter_installs_a_correctly_shaped_accessor() {
 }
 
 #[test]
+fn define_to_string_tag_installs_a_correctly_shaped_data_property() {
+    let mut interp = Interpreter::new();
+    let target_id = interp.create_object_id();
+
+    interp.define_to_string_tag(target_id, "CorrectlyShaped");
+
+    // The tag lives under the @@toStringTag well-known symbol key.
+    let tag_key = crate::types::JsPropertyKey::well_known_symbol("toStringTag");
+
+    // Raw stored descriptor pins exactly what define_to_string_tag installs.
+    let desc = interp
+        .get_object_cell_expect(target_id)
+        .borrow()
+        .get_own_property_full(&tag_key)
+        .expect("@@toStringTag property installed");
+
+    // Per spec, @@toStringTag on builtin prototypes is a data property:
+    // { [[Value]]: tag, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+    match desc.value {
+        Some(JsValue::String(ref s)) => assert_eq!(s.to_rust_string(), "CorrectlyShaped"),
+        ref other => panic!("expected string tag value, got {other:?}"),
+    }
+    assert_eq!(desc.writable, Some(false), "@@toStringTag is non-writable");
+    assert_eq!(
+        desc.enumerable,
+        Some(false),
+        "@@toStringTag is non-enumerable"
+    );
+    assert_eq!(
+        desc.configurable,
+        Some(true),
+        "@@toStringTag stays configurable"
+    );
+    assert!(desc.get.is_none(), "data property has no getter");
+    assert!(desc.set.is_none(), "data property has no setter");
+
+    // Routed through insert_property, so property_order and properties stay in
+    // sync: the symbol key must appear exactly once in the enumeration order.
+    let cell = interp.get_object_cell_expect(target_id);
+    let order_hits = cell
+        .borrow()
+        .property_order
+        .iter()
+        .filter(|k| k.as_bytes() == tag_key.as_bytes())
+        .count();
+    assert_eq!(
+        order_hits, 1,
+        "@@toStringTag appears once in property_order"
+    );
+
+    // Observable: Object.prototype.toString sees the installed tag.
+    let target_val = JsValue::Object(crate::types::JsObject { id: target_id });
+    let to_string = match interp.run(&parse_program("Object.prototype.toString;")) {
+        Completion::Normal(v) => v,
+        other => panic!("expected Object.prototype.toString value, got {other:?}"),
+    };
+    match interp.call_function(&to_string, &target_val, &[]) {
+        Completion::Normal(JsValue::String(s)) => {
+            assert_eq!(s.to_rust_string(), "[object CorrectlyShaped]")
+        }
+        other => panic!("unexpected completion: {other:?}"),
+    }
+}
+
+#[test]
 fn microtask_queue_drains_before_run_returns() {
     let interp = run_script(
         r#"


### PR DESCRIPTION
## Refactoring goal

Architectural **deepening** audit (via the *improve-codebase-architecture* process): turn a shallow, repeated "dance" into a deep helper.

The `@@toStringTag` install was open-coded at **47 data-property sites across 28 files**, in several idioms:

- a six-field `PropertyDescriptor { value, writable: false, enumerable: false, configurable: true, get: None, set: None }` literal, or `PropertyDescriptor::data(v, false, false, true)`, passed to `insert_property`;
- worse, a bare `property_order.push(key)` **then** a second `properties.insert(key, desc)` — which double-borrows the object cell and **bypasses the `insert_property` invariant guard** that keeps `properties` and `property_order` in sync.

This PR concentrates all of that into one deep helper — the natural sibling of the existing `define_method` / `define_getter`:

```rust
fn define_to_string_tag(&mut self, target_id: u64, tag: &str)
```

Every data-property `@@toStringTag` install becomes a single self-documenting call. Net **−539 lines** (+141 / −680). Routing through `insert_property` gives the `property_order`/`properties` invariant exactly one home. The now-unused `intern_well_known_symbol` (its only callers were these open-coded installs) is removed.

### Deliberately excluded (converting them would change behavior)
- **Accessor** `@@toStringTag` — `%TypedArray%.prototype`, `Iterator.prototype`, AbstractModuleSource — these are *getters*, not data properties.
- **Module Namespace** exotics, whose `@@toStringTag` is `configurable: false` (spec-mandated).
- The `Object.prototype.toString` **read** site and the `Iterator.prototype[@@toStringTag]` **setter** body.

Each of the 8 remaining `well_known_symbol("toStringTag")` occurrences was individually verified to fall into one of these excluded categories (plus the helper itself and the test).

## Tests that validate it (TDD)

Written **first** (red), then implemented to pass — `define_to_string_tag_installs_a_correctly_shaped_data_property` in `src/interpreter/tests.rs`, mirroring the existing `define_method` / `define_getter` shape tests. It pins:

- the exact stored descriptor: `value = tag`, `writable = false`, `enumerable = false`, `configurable = true`, no `get`/`set`;
- that it routes through `insert_property` (the key appears **once** in `property_order`);
- the observable brand: `Object.prototype.toString` returns `"[object CorrectlyShaped]"`.

## Why it's behavior-preserving

- `PropertyDescriptor::data(v, false, false, true)` is byte-identical to the struct literals it replaces.
- All three prior key spellings — `well_known_symbol`, `intern_well_known_symbol`, `get_symbol_key` — intern to the same property key (verified; the pre-existing `get_symbol_key(...).unwrap_or_else(well_known_symbol)` sites relied on this).

## Validation

- `cargo test --release --bin jsse`: **341/341** pass (incl. the new test).
- `./scripts/lint.sh`: clean (rustfmt + clippy).
- **~48,000 targeted test262 scenarios** with **zero regressions attributable to this change**:
  - 8,156 across every touched built-in object (Map/Set/Weak\*/iterators/generators/Promise/JSON/Math/Reflect/Atomics/ArrayBuffer/DataView/BigInt/ShadowRealm/TypedArray/Object.prototype.toString/Symbol.toStringTag) — 100%;
  - 24,100 across the MOP surface (`Object`, `Proxy`, class, annexB) — 100%;
  - 15,888 across Temporal + intl402 — 22 pre-existing `Intl.DateTimeFormat`/`toLocaleString` failures that are **ICU/locale-data baseline mismatches in this environment**, confirmed to fail identically on a clean `main` build (stash → rebuild → rerun), i.e. not caused by this PR.

The full default suite could not be run to completion synchronously in the CI window; the bounded subset above targets the entire change surface (builtin setup runs for every test, so broad breakage would surface).

🤖 Generated with Claude Code