### PR TITLE
fix(interpreter): clear tail-call eligibility by default in eval_expr

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -629,15 +629,27 @@ running those thousands of timers natively would otherwise exhaust OS threads.
   `.call()`" makes it disappear. Suspected regression from the pooled
   function-call-environment work (#73).
 
-- **Astral-plane identifiers rejected (jsse#357, open).** esprima's own
-  parser, running unmodified inside jsse, rejects identifiers containing
-  astral-plane (surrogate-pair) Unicode code points that are valid
-  `ID_Start`/`ID_Continue` characters — e.g. `var \u{1E800};` throws
-  `Unexpected token ILLEGAL` on jsse but parses on Node. The same check gates
-  regex named-group names, so those are hit too. Accounts for 49 of the
-  esprima test262-corpus/unit-fixture residuals above (18 test262 identifier
-  files × 2 scenarios, 1 test262 named-groups file × 2 scenarios, 9 esprima
-  unit fixtures, 2 everything.js smoke fixtures).
+- **Astral-plane identifiers truncated by a strict-mode TCO leak (jsse#357,
+  fixed).** Originally suspected to be a lexer/Unicode bug — jsse's own
+  lexer/parser actually handle astral-plane identifiers and regex named
+  groups correctly (100% on test262's identifier and named-groups suites).
+  The real defect: `Return`'s tail-call-optimization eligibility check
+  (`expr_may_contain_tail_call`) over-approximates through a `Conditional`'s
+  two branches with `||`, so a ternary whose consequent is a bare call marks
+  the *whole* return expression tail-call-eligible even while the alternate
+  branch is what actually executes. `eval_expr` evaluated every
+  sub-expression under the ambient `in_tail_position` flag instead of
+  clearing it by default, so a call nested in the branch that runs got
+  returned as an unevaluated `Completion::TailCall`, silently skipping
+  everything after it in that expression. esprima's own
+  `Character.fromCodePoint` — `(cp < 0x10000) ? String.fromCharCode(cp) :
+  String.fromCharCode(A) + String.fromCharCode(B)` — hit this exactly: the
+  alternate's second `fromCharCode` call never ran, truncating every astral
+  surrogate pair to its high half. Fixed at the root: `eval_expr` now
+  captures the ambient tail-call eligibility once at entry and clears it by
+  default, re-propagating only at the handful of genuine tail positions
+  (Conditional's taken branch, Logical's short-circuited right operand,
+  Sequence's last element, Call, TaggedTemplate).
 
 - **Regex property-escape range endpoint not rejected (jsse#358, open).**
   `NonemptyClassRanges` static semantics require a Syntax Error when either

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -259,7 +259,7 @@ needs outside that core (`toThrow` and one inline snapshot).
 | `moment` | 2.30.1 | ✅ 162,868 assertions (cross-checked) | 3,871 tests, 0 failures — fixed by #311/PR #326 |
 | `bignumber.js` | v9.1.2 | ✅ 65,143 (cross-checked) | unblocked by #238 |
 | `css-tree` | v3.2.1 | ⚠️ 16,725 / 16,727 (Node: 16,727) | its own Mocha suite, force-harness; the 2 residual failures are a genuine jsse engine bug, tracked in #355 — see below |
-| `esprima` | (unreleased) `512cd66` | ⚠️ 80,100 / 80,153 (Node: 80,153) | ~65 min; ~1,650 unit fixtures + api/grammar/hostile suites + a 78,402-scenario test262 grammar corpus; residuals tracked in #357 and #358 |
+| `esprima` | (unreleased) `512cd66` | ✅ 80,153 (cross-checked) | ~65 min; ~1,650 unit fixtures + api/grammar/hostile suites + a 78,402-scenario test262 grammar corpus; green since #357/#358 fixed |
 | `uuid` | v14.0.1 | ✅ 75 (cross-checked) | Node's own `node:test`/`node:assert/strict` upstream suite, unmodified; browser build so v3/v5 use pure-JS MD5/SHA-1 and v1/v4/v6/v7 draw randomness via a `crypto.getRandomValues`/`randomUUID` shim (`node-crypto-shim.js`) backed by `__host_random_bytes` |
 | `tweetnacl-js` | 1.0.3 | ✅ 5,470 (cross-checked) | tape corpus: curve25519/Ed25519, secretbox, hash, onetimeauth; curve-heavy vectors sampled — see below |
 
@@ -651,14 +651,14 @@ running those thousands of timers natively would otherwise exhaust OS threads.
   (Conditional's taken branch, Logical's short-circuited right operand,
   Sequence's last element, Call, TaggedTemplate).
 
-- **Regex property-escape range endpoint not rejected (jsse#358, open).**
-  `NonemptyClassRanges` static semantics require a Syntax Error when either
-  endpoint of a character-class range is a Unicode property escape
-  (`\p{...}`), since it denotes a whole class rather than one character.
-  esprima's own regex-validation logic misses this early error when run on
-  jsse (`/[￿-\p{Hex}]/u` and `/[\p{Hex}--]/u` both parse instead of
-  throwing) but catches it correctly on Node. Accounts for the remaining 4
-  esprima test262-corpus residuals above.
+- **Regex property-escape range endpoint not rejected (jsse#358, fixed by
+  PR #365).** `NonemptyClassRanges` static semantics require a Syntax Error
+  when either endpoint of a character-class range is a Unicode property
+  escape (`\p{...}`), since it denotes a whole class rather than one
+  character. esprima's own regex-validation logic missed this early error
+  when run on jsse (`/[￿-\p{Hex}]/u` and `/[\p{Hex}--]/u` both parsed
+  instead of throwing) but caught it correctly on Node. Accounted for the
+  remaining 4 esprima test262-corpus residuals above.
 
 - **Literal `{}` in a regex rejected instead of Annex B fallback (jsse#359,
   open).** Found via manual exploration while wiring the esprima harness, not

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -340,6 +340,19 @@ impl Interpreter {
         }
         self.eval_depth.set(depth + 1);
         let _depth_guard = EvalDepthGuard(std::rc::Rc::clone(&self.eval_depth));
+
+        // A call is only ever in tail position if it is (recursively) the
+        // return statement's own expression: `return`, through a Conditional's
+        // taken branch, a Logical's short-circuited right operand, or a
+        // Sequence's last element (mirrors expr_may_contain_tail_call below).
+        // Capture the ambient eligibility once and clear it by default so
+        // *every* other sub-expression (operands, elements, computed keys,
+        // arguments, ...) evaluates as non-tail unless one of those few arms
+        // explicitly restores it right before its own recursive dispatch —
+        // this makes "not a tail position" the default instead of something
+        // each arm has to remember to establish.
+        let tail = self.in_tail_position;
+        self.in_tail_position = false;
         match expr {
             Expression::Literal(lit) => Completion::Normal(self.eval_literal(lit)),
             Expression::Identifier(name) => {
@@ -473,27 +486,28 @@ impl Interpreter {
                 }
                 result
             }
-            Expression::Logical(op, left, right) => self.eval_logical(*op, left, right, env),
+            Expression::Logical(op, left, right) => {
+                self.in_tail_position = tail;
+                self.eval_logical(*op, left, right, env)
+            }
             Expression::Update(op, prefix, arg) => self.eval_update(*op, *prefix, arg, env),
             Expression::Assign(op, left, right) => self.eval_assign(*op, left, right, env),
             Expression::Conditional(test, cons, alt) => {
-                let saved_tail = self.in_tail_position;
-                self.in_tail_position = false;
                 let test_val = match self.eval_expr(test, env) {
                     Completion::Normal(v) => v,
-                    other => {
-                        self.in_tail_position = saved_tail;
-                        return other;
-                    }
+                    other => return other,
                 };
-                self.in_tail_position = saved_tail;
+                self.in_tail_position = tail;
                 if self.to_boolean_val(&test_val) {
                     self.eval_expr(cons, env)
                 } else {
                     self.eval_expr(alt, env)
                 }
             }
-            Expression::Call(callee, args, site_id) => self.eval_call(callee, args, env, *site_id),
+            Expression::Call(callee, args, site_id) => {
+                self.in_tail_position = tail;
+                self.eval_call(callee, args, env, *site_id)
+            }
             Expression::New(callee, args, site_id) => self.eval_new(callee, args, env, *site_id),
             Expression::Member(obj, prop, site_id) => self.eval_member(obj, prop, env, *site_id),
             Expression::Array(elements, _) => self.eval_array_literal(elements, env),
@@ -904,11 +918,10 @@ impl Interpreter {
                 }
             },
             Expression::Sequence(exprs) | Expression::Comma(exprs) => {
-                let saved_tail = self.in_tail_position;
                 let last_idx = exprs.len().saturating_sub(1);
                 let mut result = JsValue::Undefined;
                 for (i, e) in exprs.iter().enumerate() {
-                    self.in_tail_position = if i == last_idx { saved_tail } else { false };
+                    self.in_tail_position = if i == last_idx { tail } else { false };
                     match self.eval_expr(e, env) {
                         Completion::Normal(v) => result = v,
                         other => return other,
@@ -1322,8 +1335,6 @@ impl Interpreter {
                 self.eval_optional_chain_tail_with_base_this(&base_val, &base_this, prop, env)
             }
             Expression::TaggedTemplate(tag_expr, tmpl) => {
-                let saved_tail = self.in_tail_position;
-                self.in_tail_position = false;
                 let (func_val, this_val) = match tag_expr.as_ref() {
                     Expression::Member(obj_expr, prop, _) => {
                         let obj_val = match self.eval_expr(obj_expr, env) {
@@ -1391,7 +1402,7 @@ impl Interpreter {
                     }
                 }
 
-                if saved_tail {
+                if tail {
                     self.gc_unroot_frame(gc_frame);
                     return Completion::TailCall {
                         func: func_val,

--- a/tests/tail-position-leaks-into-non-tail-subexpressions.js
+++ b/tests/tail-position-leaks-into-non-tail-subexpressions.js
@@ -1,0 +1,226 @@
+// jsse#357: astral-plane identifiers were rejected by esprima's own parser
+// running inside jsse, even though jsse's own lexer/parser handled them fine.
+// The real bug had nothing to do with Unicode: `Return`'s TCO heuristic
+// (`expr_may_contain_tail_call`) over-approximates through a `Conditional`'s
+// two branches with `||`, so a ternary whose consequent is a bare call (e.g.
+// `String.fromCharCode(cp)`) marks the WHOLE return expression tail-call
+// eligible even while evaluating the ALTERNATE branch. Many expression kinds
+// then evaluated their own non-tail sub-expressions (operands, elements,
+// property values, computed keys, `new`/`import()` arguments, template
+// substitutions, assignment/update targets, class computed keys, optional
+// chains) without clearing `in_tail_position` first, so a call nested in the
+// branch that actually executes got mistaken for the tail call: it was
+// returned as a `Completion::TailCall` and everything after it in that
+// expression was silently skipped. Esprima's `Character.fromCodePoint` hit
+// this exactly: `(cp < 0x10000) ? String.fromCharCode(cp) :
+// String.fromCharCode(A) + String.fromCharCode(B)` — the alternate's SECOND
+// `fromCharCode` call never ran, truncating every astral surrogate pair to
+// its high half.
+//
+// Fixed at the root: `eval_expr` now captures the ambient tail-call
+// eligibility once at entry and clears it by default, so every arm evaluates
+// as non-tail unless it is one of the handful of genuine tail positions
+// (Conditional's taken branch, Logical's short-circuited right operand,
+// Sequence's last element, Call, TaggedTemplate) that explicitly restore it
+// right before their own recursive dispatch. This covers every expression
+// kind by construction instead of requiring each one to remember to clear it.
+//
+// Only reproduces in strict mode (TCO is gated on `env.borrow().strict`).
+
+"use strict";
+
+function fromCodePoint(cp) {
+  return cp < 0x10000
+    ? String.fromCharCode(cp)
+    : String.fromCharCode(0xd800 + ((cp - 0x10000) >> 10)) +
+        String.fromCharCode(0xdc00 + ((cp - 0x10000) & 1023));
+}
+
+var s = fromCodePoint(0x1e800);
+if (s.length !== 2 || s.charCodeAt(0) !== 0xd83a || s.charCodeAt(1) !== 0xdc00) {
+  throw new Error(
+    "Binary(+) operand wrongly treated as tail call: length=" +
+      s.length +
+      " codes=[" +
+      Array.from(s)
+        .map((_, i) => s.charCodeAt(i).toString(16))
+        .join(",") +
+      "]"
+  );
+}
+
+// Array literal element.
+(function () {
+  function f(c) {
+    return c ? String.fromCharCode(65) : [String.fromCharCode(66)];
+  }
+  var r = f(false);
+  if (!Array.isArray(r) || r.length !== 1 || r[0] !== "B") {
+    throw new Error("Array literal element wrongly treated as tail call: " + JSON.stringify(r));
+  }
+})();
+
+// Object literal property value.
+(function () {
+  function f(c) {
+    return c ? String.fromCharCode(65) : { k: String.fromCharCode(66) };
+  }
+  var r = f(false);
+  if (typeof r !== "object" || r.k !== "B") {
+    throw new Error("Object literal property wrongly treated as tail call: " + JSON.stringify(r));
+  }
+})();
+
+// Computed member property key.
+(function () {
+  var o = { B: 42 };
+  function f(c) {
+    return c ? String.fromCharCode(65) : o[String.fromCharCode(66)];
+  }
+  var r = f(false);
+  if (r !== 42) {
+    throw new Error("Computed member key wrongly treated as tail call: " + r);
+  }
+})();
+
+// `new` constructor argument.
+(function () {
+  function K(x) {
+    this.v = x;
+  }
+  function f(c) {
+    return c ? String.fromCharCode(65) : new K(String.fromCharCode(66));
+  }
+  var r = f(false);
+  if (r.v !== "B") {
+    throw new Error("`new` argument wrongly treated as tail call: " + JSON.stringify(r));
+  }
+})();
+
+// Template literal substitution.
+(function () {
+  function f(c) {
+    return c ? String.fromCharCode(65) : `x${String.fromCharCode(66)}y`;
+  }
+  var r = f(false);
+  if (r !== "xBy") {
+    throw new Error("Template substitution wrongly treated as tail call: " + JSON.stringify(r));
+  }
+})();
+
+// Optional-chain computed property key.
+(function () {
+  var o = { B: 42 };
+  function f(c) {
+    return c ? String.fromCharCode(65) : o?.[String.fromCharCode(66)];
+  }
+  var r = f(false);
+  if (r !== 42) {
+    throw new Error("OptionalChain computed key wrongly treated as tail call: " + r);
+  }
+})();
+
+// Optional-chain call argument.
+(function () {
+  function g(x) {
+    return x + 1;
+  }
+  function f(c) {
+    return c ? String.fromCharCode(65) : g?.(String.fromCharCode(66).charCodeAt(0));
+  }
+  var r = f(false);
+  if (r !== 67) {
+    throw new Error("OptionalChain call argument wrongly treated as tail call: " + r);
+  }
+})();
+
+// Computed assignment target.
+(function () {
+  var o = {};
+  function f(c) {
+    return c ? String.fromCharCode(65) : (o[String.fromCharCode(66)] = 99);
+  }
+  var r = f(false);
+  if (r !== 99 || o.B !== 99) {
+    throw new Error(
+      "Computed assignment target wrongly treated as tail call: " + JSON.stringify(o) + " r=" + r
+    );
+  }
+})();
+
+// Update (++) on a computed member.
+(function () {
+  var o = { B: 5 };
+  function f(c) {
+    return c ? String.fromCharCode(65) : o[String.fromCharCode(66)]++;
+  }
+  var r = f(false);
+  if (r !== 5 || o.B !== 6) {
+    throw new Error(
+      "Update target wrongly treated as tail call: " + JSON.stringify(o) + " r=" + r
+    );
+  }
+})();
+
+// Class expression computed method key.
+(function () {
+  function f(c) {
+    return c
+      ? String.fromCharCode(65)
+      : new (class {
+          [String.fromCharCode(66)]() {
+            return "ok";
+          }
+        })();
+  }
+  var r = f(false);
+  if (typeof r.B !== "function" || r.B() !== "ok") {
+    throw new Error("Class computed method key wrongly treated as tail call");
+  }
+})();
+
+// Dynamic import() specifier.
+(function () {
+  function f(c) {
+    return c ? String.fromCharCode(65) : import(String.fromCharCode(66) + "://nonexistent");
+  }
+  var r = f(false);
+  if (typeof r.then !== "function") {
+    throw new Error("import() specifier wrongly treated as tail call");
+  }
+})();
+
+// A genuine tail call must still be optimized (no stack growth), including
+// through the other real tail positions (Sequence's last element, Logical's
+// right operand).
+(function () {
+  function count(n, acc) {
+    "use strict";
+    if (n <= 0) return acc;
+    return count(n - 1, acc + 1);
+  }
+  if (count(200000, 0) !== 200000) {
+    throw new Error("proper tail call regressed");
+  }
+})();
+
+(function () {
+  function count(n, acc) {
+    "use strict";
+    return n <= 0 ? acc : (0, count(n - 1, acc + 1));
+  }
+  if (count(200000, 0) !== 200000) {
+    throw new Error("proper tail call through comma operator regressed");
+  }
+})();
+
+(function () {
+  function count(n, acc) {
+    "use strict";
+    if (n <= 0) return acc;
+    return false || count(n - 1, acc + 1);
+  }
+  if (count(200000, 0) !== 200000) {
+    throw new Error("proper tail call through logical operator regressed");
+  }
+})();


### PR DESCRIPTION
## Summary

- Root-caused jsse#357: not a Unicode/lexer bug (jsse's lexer/parser handle astral-plane identifiers and regex named groups correctly — 100% on test262's identifier/named-groups suites), but a strict-mode tail-call-optimization leak. `Return`'s TCO heuristic (`expr_may_contain_tail_call`) over-approximates through a `Conditional`'s two branches with `||`, so a ternary whose consequent is a bare call marks the whole return expression tail-call eligible even while the alternate branch is what actually executes. `eval_expr` let that ambient `in_tail_position` flag leak into every sub-expression instead of clearing it by default, so a call nested in the branch that actually runs could be mistaken for the tail call and returned as an unevaluated `Completion::TailCall`, silently skipping everything after it in that expression.
- Fixed at the root: `eval_expr` now captures the ambient tail-call eligibility once at entry and clears it by default, re-propagating only at the genuine tail positions (`Conditional`'s taken branch, `Logical`'s short-circuited right operand, `Sequence`'s last element, `Call`, `TaggedTemplate`) right before their own recursive dispatch. This covers every expression kind by construction instead of requiring each one to remember to clear the flag.
- Discovered via the esprima Node-compat library harness (#295/PR #360): esprima's own `Character.fromCodePoint` — `(cp < 0x10000) ? String.fromCharCode(cp) : String.fromCharCode(A) + String.fromCharCode(B)` — hit this exactly, truncating every astral surrogate pair to its high half.

Fixes #357

## Test plan

- [x] `uv run python scripts/run-test262.py -j 32` — 100.00% (99568/99568), 0 regressions
- [x] `uv run python scripts/run-custom-tests.py` — 10/10 passing
- [x] `./scripts/lint.sh` — clean (rustfmt + clippy)
- [x] Manual repro confirms the bug is fixed (`jsse -e 'var \u{1E800};'` and the astral-surrogate ternary pattern now match Node)
- [x] New regression test added (`tests/tail-position-leaks-into-non-tail-subexpressions.js`), covering Binary/Array/Object/Member/`new`/Template/OptionalChain/computed-assignment/Update/Class/dynamic-`import()` non-tail positions plus genuine TCO still working through Call/Conditional/Logical/Sequence