### PR TITLE
fix(regexp): scope nullable-quantifier rewrite to nullable alternation branches

### DIFF
--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -5847,11 +5847,27 @@ fn is_assertion_only_content(chars: &[char], start: usize, end: usize) -> bool {
 
 /// Per spec §22.2.2.6.1 step 2.b: when a nullable group body (one that can
 /// match the empty string) is quantified with `*` or `+`, an iteration that
-/// matches empty must fail.  fancy-regex stops the loop instead of
-/// backtracking, so we convert lazy min-0 quantifiers (`??`, `*?`) inside
-/// nullable bodies to greedy, forcing them to consume characters.
+/// matches empty must fail. `regex`/fancy-regex stop the loop instead of
+/// backtracking, so:
+/// - a single-alternative nullable body has its lazy min-0 quantifiers
+///   (`??`, `*?`) converted to greedy, forcing them to consume characters
+///   (greedy sub-quantifiers already prefer to consume as much as possible,
+///   so this alone is enough — see nq_mark_lazy).
+/// - a multi-alternative (`|`) nullable body additionally needs each
+///   individually-nullable branch to be prevented from ever contributing a
+///   zero-width "success" that pre-empts a sibling branch able to consume at
+///   this position (e.g. `(a*|dc??)*` on "dc"). Branches that reduce to a
+///   single quantified atom (`a*`, `a?`, `a{0,n}`) are rewritten to forbid
+///   zero occurrences (`a+`, `a`, `a{1,n}`) — this only removes the
+///   discarded empty match, identical otherwise — while non-nullable sibling
+///   branches are left untouched (previously *all* branches were stripped of
+///   laziness regardless of nullability, which is wrong on its own; see
+///   jsse#370). Branches that are nullable through some other shape (a bare
+///   empty alternative, or several jointly-optional atoms like `a?b?`) are
+///   still just lazy-stripped, matching prior (narrower) behavior — fixing
+///   those needs a lookaround-based rewrite, tracked separately.
 fn fix_nullable_quantifiers(source: &str) -> String {
-    if !source.contains("??") && !source.contains("*?") {
+    if !source.contains('|') && !source.contains("??") && !source.contains("*?") {
         return source.to_string();
     }
 
@@ -5883,6 +5899,7 @@ fn fix_nullable_quantifiers(source: &str) -> String {
     }
 
     let mut remove = vec![false; len];
+    let mut replace: HashMap<usize, char> = HashMap::new();
 
     for open_pos in 0..len {
         if chars[open_pos] != '(' || close_of[open_pos] == 0 {
@@ -5898,21 +5915,200 @@ fn fix_nullable_quantifiers(source: &str) -> String {
         if body_start >= close {
             continue;
         }
-        if nq_is_nullable(&chars, body_start, close, &close_of) {
-            nq_mark_lazy(&chars, body_start, close, &close_of, &mut remove);
+
+        let branches = nq_split_branches(&chars, body_start, close);
+        if branches.len() == 1 {
+            // No top-level alternation: greedy sub-quantifiers already
+            // consume maximally, so only lazy ones need forcing.
+            if nq_is_nullable(&chars, body_start, close, &close_of) {
+                nq_mark_lazy(&chars, body_start, close, &close_of, &mut remove);
+            }
+            continue;
+        }
+        for (bstart, bend) in branches {
+            if bstart >= bend {
+                continue; // bare empty alternative — not handled here (jsse#370 follow-up)
+            }
+            if !nq_is_nullable(&chars, bstart, bend, &close_of) {
+                continue;
+            }
+            if !nq_bump_bare_atom_min(&chars, bstart, bend, &close_of, &mut replace, &mut remove) {
+                nq_mark_lazy(&chars, bstart, bend, &close_of, &mut remove);
+            }
         }
     }
 
-    if !remove.iter().any(|&r| r) {
+    if !remove.iter().any(|&r| r) && replace.is_empty() {
         return source.to_string();
     }
     let mut result = String::with_capacity(len);
     for i in 0..len {
-        if !remove[i] {
-            result.push(chars[i]);
+        if remove[i] {
+            continue;
+        }
+        match replace.get(&i) {
+            Some(&c) => result.push(c),
+            None => result.push(chars[i]),
         }
     }
     result
+}
+
+/// Split `chars[start..end]` into top-level alternative branches (spans),
+/// on `|` not nested inside `(...)`/`[...]` and not escaped.
+fn nq_split_branches(chars: &[char], start: usize, end: usize) -> Vec<(usize, usize)> {
+    let mut branches = Vec::new();
+    let mut branch_start = start;
+    let mut i = start;
+    let mut depth = 0i32;
+    let mut in_cc = false;
+    while i < end {
+        match chars[i] {
+            '\\' if i + 1 < end => {
+                i += 2;
+                continue;
+            }
+            '[' if !in_cc => in_cc = true,
+            ']' if in_cc => in_cc = false,
+            '(' if !in_cc => depth += 1,
+            ')' if !in_cc => depth -= 1,
+            '|' if !in_cc && depth == 0 => {
+                branches.push((branch_start, i));
+                branch_start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    branches.push((branch_start, end));
+    branches
+}
+
+/// If `chars[start..end]` is exactly one atom followed by a single min-0
+/// quantifier (`*`, `?`, or `{0,n}`, greedy or lazy) spanning to `end` with
+/// nothing else in the branch, rewrite that quantifier's lower bound to 1.
+/// This forbids the branch from ever matching empty while leaving every
+/// non-empty match it could produce untouched — exactly the iteration that
+/// spec §22.2.2.6.1 step 2.b would discard anyway. Returns false (no
+/// changes) if the branch isn't this exact bare-atom shape.
+fn nq_bump_bare_atom_min(
+    chars: &[char],
+    start: usize,
+    end: usize,
+    close_of: &[usize],
+    replace: &mut HashMap<usize, char>,
+    remove: &mut [bool],
+) -> bool {
+    if start >= end {
+        return false;
+    }
+    let atom_end = match chars[start] {
+        '\\' if start + 1 < end => start + 2,
+        '[' => {
+            let mut j = start + 1;
+            while j < end && chars[j] != ']' {
+                if chars[j] == '\\' && j + 1 < end {
+                    j += 1;
+                }
+                j += 1;
+            }
+            if j < end { j + 1 } else { j }
+        }
+        '(' => {
+            let close = close_of[start];
+            if close > 0 && close < end {
+                close + 1
+            } else {
+                end
+            }
+        }
+        _ => start + 1,
+    };
+    if atom_end >= end {
+        return false;
+    }
+    match chars[atom_end] {
+        '*' => {
+            let mut q_end = atom_end + 1;
+            if q_end < end && chars[q_end] == '?' {
+                q_end += 1;
+            }
+            if q_end != end {
+                return false;
+            }
+            replace.insert(atom_end, '+');
+            true
+        }
+        '?' => {
+            let mut q_end = atom_end + 1;
+            let lazy = q_end < end && chars[q_end] == '?';
+            if lazy {
+                q_end += 1;
+            }
+            if q_end != end {
+                return false;
+            }
+            remove[atom_end] = true;
+            if lazy {
+                remove[atom_end + 1] = true;
+            }
+            true
+        }
+        '{' => {
+            let brace_end = match quantifier_brace_end(chars, atom_end, end) {
+                Some(e) => e,
+                None => return false,
+            };
+            let mut q_end = brace_end;
+            if q_end < end && chars[q_end] == '?' {
+                q_end += 1;
+            }
+            if q_end != end {
+                return false;
+            }
+            let digit_start = atom_end + 1;
+            let mut digit_end = digit_start;
+            while digit_end < brace_end && chars[digit_end].is_ascii_digit() {
+                digit_end += 1;
+            }
+            if digit_end == digit_start {
+                return false;
+            }
+            let min_val: u32 = chars[digit_start..digit_end]
+                .iter()
+                .collect::<String>()
+                .parse()
+                .unwrap_or(1);
+            if min_val != 0 {
+                return false;
+            }
+            // "}" right after the min digits means an exact-count {0} quantifier —
+            // always empty, no max to bump against; leave it to the lazy-strip fallback.
+            let max_is_zero = if digit_end < brace_end && chars[digit_end] == ',' {
+                let max_start = digit_end + 1;
+                let max_end = brace_end - 1; // position of the closing '}'
+                if max_start == max_end {
+                    false // "{0,}" — unbounded
+                } else {
+                    chars[max_start..max_end]
+                        .iter()
+                        .collect::<String>()
+                        .parse::<u32>()
+                        .unwrap_or(1)
+                        == 0
+                }
+            } else {
+                true
+            };
+            if max_is_zero {
+                return false;
+            }
+            remove[digit_start..digit_end - 1].fill(true);
+            replace.insert(digit_end - 1, '1');
+            true
+        }
+        _ => false,
+    }
 }
 
 fn nq_body_start(chars: &[char], open: usize) -> usize {

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -5866,6 +5866,13 @@ fn is_assertion_only_content(chars: &[char], start: usize, end: usize) -> bool {
 ///   empty alternative, or several jointly-optional atoms like `a?b?`) are
 ///   still just lazy-stripped, matching prior (narrower) behavior — fixing
 ///   those needs a lookaround-based rewrite, tracked separately.
+/// - this bump is scoped to `*` groups only (min=0): under `+` (min=1) the
+///   *required* first iteration is still allowed to match empty per spec —
+///   only later iterations are subject to the 2.b discard — so bumping a
+///   nullable branch's floor there would wrongly forbid a legitimate empty
+///   first iteration (e.g. `/(a*|b)+/.exec("")` must stay `["",""]`). `+`
+///   groups keep falling through to the lazy-strip only, same as before this
+///   branch-aware rewrite existed.
 fn fix_nullable_quantifiers(source: &str) -> String {
     if !source.contains('|') && !source.contains("??") && !source.contains("*?") {
         return source.to_string();
@@ -5932,7 +5939,23 @@ fn fix_nullable_quantifiers(source: &str) -> String {
             if !nq_is_nullable(&chars, bstart, bend, &close_of) {
                 continue;
             }
-            if !nq_bump_bare_atom_min(&chars, bstart, bend, &close_of, &mut replace, &mut remove) {
+            // Under `+` (min=1), the *required* first iteration is still
+            // allowed to match empty per spec — only iterations after it are
+            // subject to the 2.b discard. Bumping a nullable branch's floor
+            // would forbid that legitimate empty first iteration (e.g.
+            // `/(a*|b)+/.exec("")` must stay `["",""]`), so only `*` groups
+            // get the bump; `+` groups fall through to the existing
+            // lazy-strip, exactly as before this branch-aware rewrite.
+            let bumped = chars[after] == '*'
+                && nq_bump_bare_atom_min(
+                    &chars,
+                    bstart,
+                    bend,
+                    &close_of,
+                    &mut replace,
+                    &mut remove,
+                );
+            if !bumped {
                 nq_mark_lazy(&chars, bstart, bend, &close_of, &mut remove);
             }
         }

--- a/test262-extra/RegExp-nullable-alternation-quantifier.js
+++ b/test262-extra/RegExp-nullable-alternation-quantifier.js
@@ -41,3 +41,14 @@ var m = /((a)*|(dc)??)*/.exec("dc");
 assert.sameValue(m[0], "dc");
 assert.sameValue(m[2], undefined);
 assert.sameValue(m[3], "dc");
+
+// The bump must not apply under `+` (min=1): the *required* first iteration
+// of a `+`-quantified group is still allowed to match empty per spec — only
+// iterations after it are discarded if empty — so a nullable branch (`a*`,
+// or its lazy form `a*?`) must stay able to satisfy that first iteration.
+// Forbidding the empty case there (as an earlier draft of this fix did) is
+// its own regression, distinct from the `*` case above.
+assert.sameValue(/(a*|b)+/.exec("")[0], "");
+assert.sameValue(/(a*|b)+/.exec("")[1], "");
+assert.sameValue(/(a*?|b)+/.exec("")[0], "");
+assert.sameValue(/(a*?|b)+/.exec("")[1], "");

--- a/test262-extra/RegExp-nullable-alternation-quantifier.js
+++ b/test262-extra/RegExp-nullable-alternation-quantifier.js
@@ -1,0 +1,43 @@
+// Tests spec §22.2.2.6.1 RepeatMatcher step 2.b for a repeated group whose
+// top-level alternation mixes a nullable branch (one that can match the
+// empty string, e.g. `a*`) with a non-nullable sibling branch. An iteration
+// that matches empty must be discarded — but a backtracking-free engine can
+// otherwise commit to the nullable branch's empty match before ever trying a
+// sibling branch able to consume input at that position, dropping matched
+// text (jsse#370).
+//
+// This is a distinct failure mode from the single-alternative nullable body
+// already covered by test262's built-ins/RegExp/nullable-quantifier.js
+// (`/(a?b??)*/`): there, no alternation is involved, so a lazy sub-quantifier
+// forced greedy is sufficient. Here the fix must not touch a non-nullable
+// sibling branch's own laziness, and must not reorder alternatives (which
+// would change which branch wins when both can consume — see the `ab`
+// checks below).
+
+// The reported repro: outer `*` group alternates a nullable `a*` with a
+// non-nullable, lazily-quantified `dc??`.
+assert.sameValue(/(a*|dc??)*/.exec("dc")[0], "d");
+assert.sameValue(/(a*|dc??)*/.exec("dcc")[0], "d");
+
+// Bounded (`{0,n}`) and unbounded (`{0,}`) nullable branches must be handled
+// the same way as `*`.
+assert.sameValue(/(a{0,2}|dc??)*/.exec("dc")[0], "d");
+assert.sameValue(/(a{0,}|dc??)*/.exec("dc")[0], "d");
+
+// The same root cause reproduces without any lazy quantifier at all — a
+// plain nullable branch alongside a plain mandatory-literal sibling.
+assert.sameValue(/(a*|bc)*/.exec("bc")[0], "bc");
+assert.sameValue(/(a*|bc)*/.exec("abc")[0], "abc");
+
+// The fix must not reorder alternatives: when the nullable branch itself can
+// match non-empty text that a later sibling could also match, the leftmost
+// (nullable) branch's own non-empty match still wins, exactly as today.
+assert.sameValue(/(a*|ab)*/.exec("ab")[0], "a");
+assert.sameValue(/(a+|ab)*/.exec("ab")[0], "a");
+
+// Capture group numbering must be unaffected — the fix rewrites a branch's
+// own quantifier in place, it never moves parentheses.
+var m = /((a)*|(dc)??)*/.exec("dc");
+assert.sameValue(m[0], "dc");
+assert.sameValue(m[2], undefined);
+assert.sameValue(m[3], "dc");


### PR DESCRIPTION
## Summary

- `/(a*|dc??)*/.exec("dc")` matched `""` instead of `"d"` (Node). Per spec §22.2.2.6.1 step 2.b, an iteration of a repeated group that matches empty must be discarded — but `regex`/`fancy-regex` commit to the loop's first zero-width success instead of backtracking, so a nullable alternation branch (`a*`) could pre-empt a sibling branch able to consume input (`dc??`) at the same position.
- The existing `fix_nullable_quantifiers` rewrite (added for the single-alternative case, e.g. `/(a?b??)*/`) also stripped lazy markers off *every* alternation branch indiscriminately, not just the ones that actually make the group nullable — a real bug in its own right, independently confirmed against Node.
- Fix: scope the lazy-strip per branch (only nullable branches get touched), and for a branch that reduces to a single min-0-quantified atom (`a*`, `a?`, `a{0,n}`), forbid the zero-occurrence case outright (`a*`→`a+`, `a?`→`a`, `a{0,n}`→`a{1,n}`) — exactly the iteration spec 2.b already discards, so every non-empty match the branch could produce is unaffected, and no parentheses move (capture-group numbering is untouched).
- An **alternative fix (reordering nullable branches to the end) was tried and rejected**: it's unsound — `/(a*|ab)*/.exec("ab")` is `"a"` on Node (leftmost branch wins even though it's nullable), but reordering to `/(ab|a*)*/` changes that to `"ab"`. Verified via a throwaway probe against both `regex` and `fancy-regex` directly before committing to the bump-in-place approach instead.
- Single-alternative bodies are left exactly as before (still gated on lazy-marker presence) — they don't have this bug (no sibling branch to lose priority to), so touching them was unnecessary risk.
- A few related nullable-alternation shapes (bare empty branch `(|a)*`, jointly-optional compound branch `a?b?`, a nullable atom with no quantifier suffix of its own, and the `{0}`/`{0,0}` exact-zero edge case) are **not** fixed here — confirmed via a Node-diff matrix to be pre-existing, not regressions — and tracked in #373.

Fixes #370

## Test plan

- [x] `cargo test --release` — 341 unit tests + test262 smoke oracle, all passing
- [x] `./scripts/lint.sh` — rustfmt + clippy clean
- [x] `uv run python scripts/run-test262.py -j 32` — 100.00% (99,568/99,568), 0 regressions, 323 new passes
- [x] `uv run python scripts/run-test262.py test262/test/staging/ -j 32` — 98.54% (2,706/2,746), 0 regressions (matches known baseline)
- [x] `uv run python scripts/run-custom-tests.py` — 9/9
- [x] `uv run python scripts/run-test262.py test262-extra/` — new `RegExp-nullable-alternation-quantifier.js` passes; 2 pre-existing unrelated failures (documented `noStrict`-flag gaps)
- [x] Manual repro confirms the bug is fixed (`/(a*|dc??)*/.exec("dc")[0] === "d"`, matching Node)
- [x] New regression test added (`test262-extra/RegExp-nullable-alternation-quantifier.js`), covering the reported repro, a no-laziness variant sharing the same root cause, bounded `{0,n}`/`{0,}` quantifiers, the rejected-reordering counterexample, and capture-group numbering