### PR TITLE
fix(date): honor TZ as the system time zone

### DIFF
--- a/docs/specs/2026-07-24-date-timeclip-zone-offset-design.md
+++ b/docs/specs/2026-07-24-date-timeclip-zone-offset-design.md
@@ -52,6 +52,7 @@ The host-time-zone integration test will assert:
   `+275760-09-13T00:00:00.000Z` in `America/New_York`;
 - lower-boundary local construction using New York's first historical offset;
 - nonzero local offsets and formatting at both boundaries;
+- default Intl formatting using the recurring offset at the upper boundary;
 - existing daylight-saving gap, overlap, and cross-transition behavior.
 
 The full Date test262 subtree and full default test262 suite will guard the

--- a/docs/specs/2026-07-24-date-timeclip-zone-offset-design.md
+++ b/docs/specs/2026-07-24-date-timeclip-zone-offset-design.md
@@ -53,6 +53,7 @@ The host-time-zone integration test will assert:
 - lower-boundary local construction using New York's first historical offset;
 - nonzero local offsets and formatting at both boundaries;
 - default Intl formatting using the recurring offset at the upper boundary;
+- primary default Intl identifiers when `TZ` contains an IANA link name;
 - existing daylight-saving gap, overlap, and cross-transition behavior.
 
 The full Date test262 subtree and full default test262 suite will guard the

--- a/docs/specs/2026-07-24-date-timeclip-zone-offset-design.md
+++ b/docs/specs/2026-07-24-date-timeclip-zone-offset-design.md
@@ -1,0 +1,58 @@
+# Date offsets across the TimeClip range
+
+## Context
+
+`Date` now resolves the host IANA time zone through `chrono-tz`, but chrono
+cannot construct datetimes for every ECMAScript time value. The current
+fallback returns a zero offset when a value is outside chrono's year range.
+That makes valid boundary dates behave as UTC even when `TZ` names another
+zone. In addition, chrono-tz 0.10's generated transitions end after 2099, so
+using a later chrono datetime directly loses recurring daylight-saving rules.
+
+ECMAScript `LocalTime` and `UTC` require the selected IANA zone's political
+rules across the full TimeClip range. `UTC` must also accept nearby nominal
+local values outside that range when applying an offset brings the result back
+inside it.
+
+## Design
+
+Introduce one conversion seam that returns a chrono proxy datetime for an
+ECMAScript time value:
+
+- Values through 2099 that chrono can represent use their exact datetime.
+- Later values use the same month, day, and time in the latest year from
+  2072–2099 with the same leap-year status and weekday for January 1. That
+  28-year window contains every Gregorian calendar shape and chrono-tz's final
+  generated recurring rules, so month/day and weekday-based transitions remain
+  aligned.
+- Values earlier than chrono can represent use chrono's earliest datetime.
+  They therefore select the first offset in the IANA zone history, matching the
+  zone's behavior before its first recorded transition.
+
+UTC-to-local offset lookup, local-to-UTC offset lookup, and time-zone
+abbreviation lookup all use this seam. Local-time gaps and overlaps retain the
+existing ECMAScript-compatible disambiguation: choose the offset before the
+transition.
+
+## Alternatives
+
+Parsing TZif files and POSIX tail rules locally would avoid proxy dates, but
+would add a substantial parser and platform-specific data lookup. Adding a
+second timezone library would duplicate chrono-tz and widen the dependency
+surface. The proxy approach is smaller and uses the IANA data already selected
+by the engine.
+
+## Verification
+
+The host-time-zone integration test will assert:
+
+- winter and summer offsets in an ordinary year;
+- recurring daylight-saving behavior in 2100;
+- upper-boundary local construction clipping to
+  `+275760-09-13T00:00:00.000Z` in `America/New_York`;
+- lower-boundary local construction using New York's first historical offset;
+- nonzero local offsets and formatting at both boundaries;
+- existing daylight-saving gap, overlap, and cross-transition behavior.
+
+The full Date test262 subtree and full default test262 suite will guard the
+existing UTC-pinned conformance behavior.

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -467,6 +467,7 @@ def run_single_test(
             cmd,
             timeout=timeout,
             capture_output=True,
+            env={**os.environ, "TZ": "UTC"},
             preexec_fn=adapter.setup_preexec,
         )
         duration = time.perf_counter() - t0

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -1,3 +1,4 @@
+import os
 import stat
 import subprocess
 import sys
@@ -65,6 +66,7 @@ class RunTest262ExitStatusTests(unittest.TestCase):
                 "test262/test/sample.js",
             ],
             cwd=self.root,
+            env={**os.environ, "TZ": "America/New_York"},
             text=True,
             capture_output=True,
             check=False,
@@ -95,6 +97,25 @@ class RunTest262ExitStatusTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("REGRESSED: test262/test/sample.js", result.stdout)
         self.assertIn("Error: 1 baseline regression(s) detected.", result.stderr)
+
+    def test_child_engine_runs_in_utc(self):
+        engine = self.root / "engine_timezone.py"
+        engine.write_text(
+            textwrap.dedent(
+                f"""\
+                #!{sys.executable}
+                import os
+                import sys
+                sys.exit(0 if os.environ.get("TZ") == "UTC" else 1)
+                """
+            ),
+            encoding="utf-8",
+        )
+        engine.chmod(engine.stat().st_mode | stat.S_IXUSR)
+
+        result = self.run_runner(engine, "--fail-on-failures")
+
+        self.assertEqual(result.returncode, 0)
 
 
 if __name__ == "__main__":

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -1539,7 +1539,7 @@ mod date_field_tests {
     fn local_branch_routes_through_local_time_utc_branch_does_not() {
         // The UTC branch must pass t through unchanged; the local branch must
         // apply local_time, so the two branches differ by exactly the host
-        // offset local_tza(). This has teeth only for a developer running in a
+        // offset local_tza(t). This has teeth only for a developer running in a
         // non-UTC zone: on a UTC host (the CI default) local_tza() is 0 and the
         // branches coincide -- an inherent blind spot, since local_time is
         // host-derived and not injectable, so routing is unobservable there.
@@ -1547,7 +1547,7 @@ mod date_field_tests {
         assert_eq!(date_field_value(Y2021, false, id), Y2021);
         assert_eq!(
             date_field_value(Y2021, true, id) - date_field_value(Y2021, false, id),
-            local_tza(),
+            local_tza(Y2021),
         );
     }
 }

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1,7 +1,7 @@
 use super::super::super::*;
 use crate::interpreter::helpers::{
-    date_from_time, hour_from_time, min_from_time, month_from_time, ms_from_time, now_ms,
-    sec_from_time, week_day, year_from_time,
+    date_from_time, hour_from_time, min_from_time, month_from_time, ms_from_time,
+    named_time_zone_offset_ms, now_ms, sec_from_time, week_day, year_from_time,
 };
 
 fn extract_unicode_extension(locale: &str, key: &str) -> Option<String> {
@@ -202,7 +202,6 @@ fn tz_offset_ms(tz: &str, epoch_ms: f64) -> f64 {
         return total_min as f64 * 60_000.0;
     }
 
-    use chrono::{Offset, TimeZone, Utc};
     use chrono_tz::Tz;
 
     let canonical = canonicalize_timezone(tz);
@@ -212,13 +211,10 @@ fn tz_offset_ms(tz: &str, epoch_ms: f64) -> f64 {
         tz.to_string()
     };
 
-    if let Ok(tz_parsed) = tz_str.parse::<Tz>() {
-        let epoch_secs = (epoch_ms / 1000.0).floor() as i64;
-        let nanos = ((epoch_ms % 1000.0) * 1_000_000.0).abs() as u32;
-        if let Some(dt) = Utc.timestamp_opt(epoch_secs, nanos).single() {
-            let offset = dt.with_timezone(&tz_parsed).offset().fix();
-            return offset.local_minus_utc() as f64 * 1000.0;
-        }
+    if let Ok(tz_parsed) = tz_str.parse::<Tz>()
+        && let Some(offset_ms) = named_time_zone_offset_ms(tz_parsed, epoch_ms)
+    {
+        return offset_ms;
     }
 
     // Fallback to static lookup

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -1,4 +1,5 @@
 use super::super::super::*;
+use super::super::temporal::canonicalize_iana_tz;
 use crate::interpreter::helpers::{
     date_from_time, hour_from_time, min_from_time, month_from_time, ms_from_time,
     named_time_zone_offset_ms, now_ms, sec_from_time, week_day, year_from_time,
@@ -6325,7 +6326,7 @@ impl Interpreter {
                             canonicalize_timezone(&tz)
                         }
                     } else {
-                        canonicalize_timezone(&system_time_zone_identifier())
+                        canonicalize_iana_tz(&system_time_zone_identifier())
                     };
 
                 // Step 36: Table 7 component options (in table order)

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -6329,7 +6329,7 @@ impl Interpreter {
                             canonicalize_timezone(&tz)
                         }
                     } else {
-                        "UTC".to_string()
+                        canonicalize_timezone(&system_time_zone_identifier())
                     };
 
                 // Step 36: Table 7 component options (in table order)

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -2825,9 +2825,7 @@ pub(super) fn to_temporal_time_zone_identifier(
     arg: &JsValue,
 ) -> Result<String, Completion> {
     match arg {
-        JsValue::Undefined => {
-            Ok(iana_time_zone::get_timezone().unwrap_or_else(|_| "UTC".to_string()))
-        }
+        JsValue::Undefined => Ok(canonicalize_iana_tz(&system_time_zone_identifier())),
         JsValue::String(s) => {
             let s_str = s.to_string();
             match parse_temporal_time_zone_string(&s_str) {

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -15,7 +15,7 @@ impl Interpreter {
             "timeZoneId".to_string(),
             0,
             |_interp, _this, _args| {
-                let tz = iana_time_zone::get_timezone().unwrap_or_else(|_| "UTC".to_string());
+                let tz = super::canonicalize_iana_tz(&system_time_zone_identifier());
                 Completion::Normal(JsValue::String(JsString::from_str(&tz)))
             },
         ));

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -1590,24 +1590,64 @@ pub(crate) fn system_time_zone_identifier() -> String {
     system_time_zone().name().to_string()
 }
 
-fn naive_datetime_from_time_value(t: f64) -> Option<chrono::NaiveDateTime> {
+fn time_zone_datetime_from_time_value(t: f64) -> Option<chrono::NaiveDateTime> {
+    use chrono::Datelike;
+
     if !t.is_finite() {
         return None;
     }
     let epoch_ms = t.floor() as i64;
     let epoch_secs = epoch_ms.div_euclid(1000);
     let nanos = epoch_ms.rem_euclid(1000) as u32 * 1_000_000;
-    chrono::DateTime::from_timestamp(epoch_secs, nanos).map(|dt| dt.naive_utc())
+    let direct = chrono::DateTime::from_timestamp(epoch_secs, nanos).map(|dt| dt.naive_utc());
+
+    // chrono-tz's generated transition tables include recurring rules through
+    // 2099. Beyond that they retain the final fixed offset, so project future
+    // dates onto the last complete 28-year calendar cycle instead.
+    if direct.as_ref().is_some_and(|dt| dt.year() <= 2099) {
+        return direct;
+    }
+
+    // A time before chrono's range also precedes every recorded IANA
+    // transition. Its earliest datetime therefore selects the zone's first
+    // historical offset.
+    if t.is_sign_negative() {
+        return Some(chrono::NaiveDateTime::MIN);
+    }
+
+    let year = year_from_time(t);
+    if !(i32::MIN as f64..=i32::MAX as f64).contains(&year) {
+        return None;
+    }
+    let year = year as i32;
+    let year_start_weekday = week_day(time_from_year(year as f64));
+    let days_in_target_year = days_in_year(year as f64);
+    let proxy_year = (2072..=2099).rev().find(|candidate| {
+        days_in_year(*candidate as f64) == days_in_target_year
+            && week_day(time_from_year(*candidate as f64)) == year_start_weekday
+    })?;
+
+    chrono::NaiveDate::from_ymd_opt(
+        proxy_year,
+        month_from_time(t) as u32 + 1,
+        date_from_time(t) as u32,
+    )?
+    .and_hms_milli_opt(
+        hour_from_time(t) as u32,
+        min_from_time(t) as u32,
+        sec_from_time(t) as u32,
+        ms_from_time(t) as u32,
+    )
 }
 
 pub(crate) fn local_tza(t: f64) -> f64 {
-    use chrono::Offset;
+    use chrono::{Offset, TimeZone};
 
-    let Some(utc) = naive_datetime_from_time_value(t).map(|dt| dt.and_utc()) else {
+    let Some(utc) = time_zone_datetime_from_time_value(t) else {
         return 0.0;
     };
-    utc.with_timezone(&system_time_zone())
-        .offset()
+    system_time_zone()
+        .offset_from_utc_datetime(&utc)
         .fix()
         .local_minus_utc() as f64
         * 1000.0
@@ -1620,19 +1660,19 @@ pub(crate) fn local_time(t: f64) -> f64 {
 pub(crate) fn utc_time(t: f64) -> f64 {
     use chrono::{MappedLocalTime, Offset, TimeDelta, TimeZone};
 
-    let Some(local) = naive_datetime_from_time_value(t) else {
+    let Some(local) = time_zone_datetime_from_time_value(t) else {
         return t;
     };
     let tz = system_time_zone();
-    let offset = match tz.from_local_datetime(&local) {
-        MappedLocalTime::Single(dt) => dt.offset().fix().local_minus_utc(),
+    let offset = match tz.offset_from_local_datetime(&local) {
+        MappedLocalTime::Single(offset) => offset.fix().local_minus_utc(),
         MappedLocalTime::Ambiguous(first, second) => {
-            let earlier = if first.timestamp() <= second.timestamp() {
-                first
-            } else {
-                second
-            };
-            earlier.offset().fix().local_minus_utc()
+            // The larger offset maps the repeated local time to the earlier
+            // instant, matching possibleInstants[0] in UTC.
+            first
+                .fix()
+                .local_minus_utc()
+                .max(second.fix().local_minus_utc())
         }
         MappedLocalTime::None => {
             let mut offset_before = None;
@@ -1640,18 +1680,21 @@ pub(crate) fn utc_time(t: f64) -> f64 {
                 let Some(probe) = local.checked_sub_signed(TimeDelta::minutes(minutes)) else {
                     break;
                 };
-                match tz.from_local_datetime(&probe) {
-                    MappedLocalTime::Single(dt) => {
-                        offset_before = Some(dt.offset().fix().local_minus_utc());
+                match tz.offset_from_local_datetime(&probe) {
+                    MappedLocalTime::Single(offset) => {
+                        offset_before = Some(offset.fix().local_minus_utc());
                         break;
                     }
                     MappedLocalTime::Ambiguous(first, second) => {
-                        let later = if first.timestamp() >= second.timestamp() {
+                        // The smaller offset maps the repeated local time to
+                        // the later instant, the last possible instant before
+                        // a gap.
+                        offset_before = Some(
                             first
-                        } else {
-                            second
-                        };
-                        offset_before = Some(later.offset().fix().local_minus_utc());
+                                .fix()
+                                .local_minus_utc()
+                                .min(second.fix().local_minus_utc()),
+                        );
                         break;
                     }
                     MappedLocalTime::None => {}
@@ -1664,13 +1707,10 @@ pub(crate) fn utc_time(t: f64) -> f64 {
 }
 
 fn local_time_zone_abbreviation(t: f64) -> String {
-    naive_datetime_from_time_value(t)
-        .map(|dt| {
-            dt.and_utc()
-                .with_timezone(&system_time_zone())
-                .format("%Z")
-                .to_string()
-        })
+    use chrono::TimeZone;
+
+    time_zone_datetime_from_time_value(t)
+        .map(|dt| system_time_zone().offset_from_utc_datetime(&dt).to_string())
         .unwrap_or_else(system_time_zone_identifier)
 }
 

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -1558,6 +1558,7 @@ pub(crate) fn time_clip(time: f64) -> f64 {
 
 fn resolve_system_time_zone() -> chrono_tz::Tz {
     let parse = |identifier: &str| {
+        let identifier = identifier.strip_prefix(':').unwrap_or(identifier);
         identifier.parse::<chrono_tz::Tz>().ok().or_else(|| {
             chrono_tz::TZ_VARIANTS
                 .iter()

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -1640,17 +1640,21 @@ fn time_zone_datetime_from_time_value(t: f64) -> Option<chrono::NaiveDateTime> {
     )
 }
 
-pub(crate) fn local_tza(t: f64) -> f64 {
+pub(crate) fn named_time_zone_offset_ms(time_zone: chrono_tz::Tz, t: f64) -> Option<f64> {
     use chrono::{Offset, TimeZone};
 
-    let Some(utc) = time_zone_datetime_from_time_value(t) else {
-        return 0.0;
-    };
-    system_time_zone()
-        .offset_from_utc_datetime(&utc)
-        .fix()
-        .local_minus_utc() as f64
-        * 1000.0
+    let utc = time_zone_datetime_from_time_value(t)?;
+    Some(
+        time_zone
+            .offset_from_utc_datetime(&utc)
+            .fix()
+            .local_minus_utc() as f64
+            * 1000.0,
+    )
+}
+
+pub(crate) fn local_tza(t: f64) -> f64 {
+    named_time_zone_offset_ms(system_time_zone(), t).unwrap_or(0.0)
 }
 
 pub(crate) fn local_time(t: f64) -> f64 {

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -1556,18 +1556,121 @@ pub(crate) fn time_clip(time: f64) -> f64 {
     if t == 0.0 { 0.0_f64 } else { t }
 }
 
-pub(crate) fn local_tza() -> f64 {
-    use chrono::Local;
-    let now = Local::now();
-    now.offset().local_minus_utc() as f64 * 1000.0
+fn resolve_system_time_zone() -> chrono_tz::Tz {
+    let parse = |identifier: &str| {
+        identifier.parse::<chrono_tz::Tz>().ok().or_else(|| {
+            chrono_tz::TZ_VARIANTS
+                .iter()
+                .copied()
+                .find(|tz| tz.name().eq_ignore_ascii_case(identifier))
+        })
+    };
+
+    if let Some(tz) = std::env::var("TZ").ok().and_then(|tz| parse(&tz)) {
+        return tz;
+    }
+    if let Some(tz) = iana_time_zone::get_timezone()
+        .ok()
+        .and_then(|tz| parse(&tz))
+    {
+        return tz;
+    }
+    chrono_tz::UTC
+}
+
+fn system_time_zone() -> chrono_tz::Tz {
+    use std::sync::OnceLock;
+
+    static SYSTEM_TIME_ZONE: OnceLock<chrono_tz::Tz> = OnceLock::new();
+    *SYSTEM_TIME_ZONE.get_or_init(resolve_system_time_zone)
+}
+
+pub(crate) fn system_time_zone_identifier() -> String {
+    system_time_zone().name().to_string()
+}
+
+fn naive_datetime_from_time_value(t: f64) -> Option<chrono::NaiveDateTime> {
+    if !t.is_finite() {
+        return None;
+    }
+    let epoch_ms = t.floor() as i64;
+    let epoch_secs = epoch_ms.div_euclid(1000);
+    let nanos = epoch_ms.rem_euclid(1000) as u32 * 1_000_000;
+    chrono::DateTime::from_timestamp(epoch_secs, nanos).map(|dt| dt.naive_utc())
+}
+
+pub(crate) fn local_tza(t: f64) -> f64 {
+    use chrono::Offset;
+
+    let Some(utc) = naive_datetime_from_time_value(t).map(|dt| dt.and_utc()) else {
+        return 0.0;
+    };
+    utc.with_timezone(&system_time_zone())
+        .offset()
+        .fix()
+        .local_minus_utc() as f64
+        * 1000.0
 }
 
 pub(crate) fn local_time(t: f64) -> f64 {
-    t + local_tza()
+    t + local_tza(t)
 }
 
 pub(crate) fn utc_time(t: f64) -> f64 {
-    t - local_tza()
+    use chrono::{MappedLocalTime, Offset, TimeDelta, TimeZone};
+
+    let Some(local) = naive_datetime_from_time_value(t) else {
+        return t;
+    };
+    let tz = system_time_zone();
+    let offset = match tz.from_local_datetime(&local) {
+        MappedLocalTime::Single(dt) => dt.offset().fix().local_minus_utc(),
+        MappedLocalTime::Ambiguous(first, second) => {
+            let earlier = if first.timestamp() <= second.timestamp() {
+                first
+            } else {
+                second
+            };
+            earlier.offset().fix().local_minus_utc()
+        }
+        MappedLocalTime::None => {
+            let mut offset_before = None;
+            for minutes in 1..=2 * 24 * 60 {
+                let Some(probe) = local.checked_sub_signed(TimeDelta::minutes(minutes)) else {
+                    break;
+                };
+                match tz.from_local_datetime(&probe) {
+                    MappedLocalTime::Single(dt) => {
+                        offset_before = Some(dt.offset().fix().local_minus_utc());
+                        break;
+                    }
+                    MappedLocalTime::Ambiguous(first, second) => {
+                        let later = if first.timestamp() >= second.timestamp() {
+                            first
+                        } else {
+                            second
+                        };
+                        offset_before = Some(later.offset().fix().local_minus_utc());
+                        break;
+                    }
+                    MappedLocalTime::None => {}
+                }
+            }
+            offset_before.unwrap_or(0)
+        }
+    };
+    t - offset as f64 * 1000.0
+}
+
+fn local_time_zone_abbreviation(t: f64) -> String {
+    naive_datetime_from_time_value(t)
+        .map(|dt| {
+            dt.and_utc()
+                .with_timezone(&system_time_zone())
+                .format("%Z")
+                .to_string()
+        })
+        .unwrap_or_else(system_time_zone_identifier)
 }
 
 /// Shared final step of every `Date.prototype.set*` method: combine a day
@@ -1640,14 +1743,14 @@ pub(crate) fn format_date_string(t: f64) -> String {
     let min = min_from_time(lt);
     let s = sec_from_time(lt);
 
-    let offset_ms = local_tza();
+    let offset_ms = local_tza(t);
     let offset_min = (offset_ms / 60_000.0) as i32;
     let sign = if offset_min >= 0 { '+' } else { '-' };
     let abs_offset = offset_min.unsigned_abs();
     let oh = abs_offset / 60;
     let om = abs_offset % 60;
 
-    let tz_abbr = chrono::Local::now().format("%Z").to_string();
+    let tz_abbr = local_time_zone_abbreviation(t);
     format!(
         "{} {} {:02} {} {:02}:{:02}:{:02} GMT{}{:02}{:02} ({})",
         day_name(wd),
@@ -1738,14 +1841,14 @@ pub(crate) fn format_time_only_string(t: f64) -> String {
     let min = min_from_time(lt);
     let s = sec_from_time(lt);
 
-    let offset_ms = local_tza();
+    let offset_ms = local_tza(t);
     let offset_min = (offset_ms / 60_000.0) as i32;
     let sign = if offset_min >= 0 { '+' } else { '-' };
     let abs_offset = offset_min.unsigned_abs();
     let oh = abs_offset / 60;
     let om = abs_offset % 60;
 
-    let tz_abbr = chrono::Local::now().format("%Z").to_string();
+    let tz_abbr = local_time_zone_abbreviation(t);
     format!(
         "{:02}:{:02}:{:02} GMT{}{:02}{:02} ({})",
         h as i32, min as i32, s as i32, sign, oh, om, tz_abbr

--- a/tests/host_time_zone.rs
+++ b/tests/host_time_zone.rs
@@ -14,6 +14,11 @@ console.log(new Date(2024, 0, 15, 12).toISOString());
 console.log(new Date(2024, 2, 10, 2, 30).toISOString());
 console.log(new Date(2024, 10, 3, 1, 30).toISOString());
 console.log((new Date(2023, 4, 6) - new Date(2023, 0, 1)) / 3600000);
+console.log(new Date(2100, 6, 15, 12).toISOString());
+console.log(new Date(275760, 8, 12, 20).toISOString());
+console.log(new Date(8640000000000000).getTimezoneOffset());
+console.log(new Date(-271821, 3, 20, 20).toISOString());
+console.log(new Date(-8640000000000000).getTimezoneOffset() !== 0);
 "#,
         ])
         .output()
@@ -35,6 +40,11 @@ console.log((new Date(2023, 4, 6) - new Date(2023, 0, 1)) / 3600000);
             "2024-03-10T07:30:00.000Z\n",
             "2024-11-03T05:30:00.000Z\n",
             "2999\n",
+            "2100-07-15T16:00:00.000Z\n",
+            "+275760-09-13T00:00:00.000Z\n",
+            "240\n",
+            "-271821-04-21T00:56:02.000Z\n",
+            "true\n",
         )
     );
 }

--- a/tests/host_time_zone.rs
+++ b/tests/host_time_zone.rs
@@ -17,6 +17,12 @@ console.log((new Date(2023, 4, 6) - new Date(2023, 0, 1)) / 3600000);
 console.log(new Date(2100, 6, 15, 12).toISOString());
 console.log(new Date(275760, 8, 12, 20).toISOString());
 console.log(new Date(8640000000000000).getTimezoneOffset());
+var maxDateParts = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  timeZoneName: "shortOffset"
+}).formatToParts(new Date(8640000000000000));
+console.log(maxDateParts.find(function(part) { return part.type === "hour"; }).value);
+console.log(maxDateParts.find(function(part) { return part.type === "timeZoneName"; }).value);
 console.log(new Date(-271821, 3, 20, 20).toISOString());
 console.log(new Date(-8640000000000000).getTimezoneOffset() !== 0);
 "#,
@@ -43,6 +49,8 @@ console.log(new Date(-8640000000000000).getTimezoneOffset() !== 0);
             "2100-07-15T16:00:00.000Z\n",
             "+275760-09-13T00:00:00.000Z\n",
             "240\n",
+            "8\n",
+            "GMT-4\n",
             "-271821-04-21T00:56:02.000Z\n",
             "true\n",
         )

--- a/tests/host_time_zone.rs
+++ b/tests/host_time_zone.rs
@@ -1,9 +1,8 @@
 use std::process::Command;
 
-#[test]
-fn tz_environment_controls_the_system_time_zone_and_date_offsets() {
+fn assert_tz_environment_controls_the_system_time_zone(tz: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_jsse"))
-        .env("TZ", "America/New_York")
+        .env("TZ", tz)
         .args([
             "-e",
             r#"
@@ -38,4 +37,14 @@ console.log((new Date(2023, 4, 6) - new Date(2023, 0, 1)) / 3600000);
             "2999\n",
         )
     );
+}
+
+#[test]
+fn tz_environment_controls_the_system_time_zone_and_date_offsets() {
+    assert_tz_environment_controls_the_system_time_zone("America/New_York");
+}
+
+#[test]
+fn posix_tz_environment_controls_the_system_time_zone_and_date_offsets() {
+    assert_tz_environment_controls_the_system_time_zone(":America/New_York");
 }

--- a/tests/host_time_zone.rs
+++ b/tests/host_time_zone.rs
@@ -66,3 +66,8 @@ fn tz_environment_controls_the_system_time_zone_and_date_offsets() {
 fn posix_tz_environment_controls_the_system_time_zone_and_date_offsets() {
     assert_tz_environment_controls_the_system_time_zone(":America/New_York");
 }
+
+#[test]
+fn iana_link_tz_environment_uses_the_primary_time_zone_identifier() {
+    assert_tz_environment_controls_the_system_time_zone("US/Eastern");
+}

--- a/tests/host_time_zone.rs
+++ b/tests/host_time_zone.rs
@@ -1,0 +1,41 @@
+use std::process::Command;
+
+#[test]
+fn tz_environment_controls_the_system_time_zone_and_date_offsets() {
+    let output = Command::new(env!("CARGO_BIN_EXE_jsse"))
+        .env("TZ", "America/New_York")
+        .args([
+            "-e",
+            r#"
+console.log(new Intl.DateTimeFormat().resolvedOptions().timeZone);
+console.log(Temporal.Now.timeZoneId());
+console.log(new Date("2024-01-15T12:00:00Z").getTimezoneOffset());
+console.log(new Date("2024-07-15T12:00:00Z").getTimezoneOffset());
+console.log(new Date(2024, 0, 15, 12).toISOString());
+console.log(new Date(2024, 2, 10, 2, 30).toISOString());
+console.log(new Date(2024, 10, 3, 1, 30).toISOString());
+console.log((new Date(2023, 4, 6) - new Date(2023, 0, 1)) / 3600000);
+"#,
+        ])
+        .output()
+        .expect("failed to run jsse");
+
+    assert!(
+        output.status.success(),
+        "jsse failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("jsse stdout was not UTF-8"),
+        concat!(
+            "America/New_York\n",
+            "America/New_York\n",
+            "300\n",
+            "240\n",
+            "2024-01-15T17:00:00.000Z\n",
+            "2024-03-10T07:30:00.000Z\n",
+            "2024-11-03T05:30:00.000Z\n",
+            "2999\n",
+        )
+    );
+}


### PR DESCRIPTION
## Summary

- resolve a valid IANA `TZ` override before the OS zone fallback, with UTC as the final fallback
- make Date local/UTC conversions use the named zone's offset at the requested instant, including DST gaps and overlaps
- share the resolved system zone with default `Intl.DateTimeFormat` and Temporal system-zone operations
- pin test262 child engines to UTC so conformance runs remain host-independent

## Design note

A shared named-zone resolver keeps Date, Intl, and Temporal consistent. Using `chrono::Local` alone could provide offsets but not the IANA identifier, while patching only Intl would leave Date on a fixed current offset. Invalid or non-IANA `TZ` values fall back to the detected OS zone instead of exposing an unsupported identifier.

## Test plan

- [x] `./scripts/lint.sh`
- [x] `cargo build --release`
- [x] `cargo test --release` — 341 unit tests plus integration tests
- [x] `uv run python -m unittest scripts/test_run_test262.py`
- [x] `uv run python scripts/run-custom-tests.py` — 10/10
- [x] targeted Date/DateTimeFormat/Temporal.Now test262 — 1,808/1,808
- [x] `uv run python scripts/run-test262.py` — 99,568/99,568 (100.00%), no regressions
- [x] `./scripts/run-library-tests.sh luxon --no-cross-check` — #263's `SystemZone.instance.name` and 2,999-hour cross-DST assertions pass; the overall 1,009/1,152 result remains red on separately tracked locale and explicit-IANA-zone gaps

Closes #263