### PR TITLE
fix(node-shim): match Node %s object dispatch

### DIFF
--- a/docs/specs/2026-07-23-node-shim-format-s-design.md
+++ b/docs/specs/2026-07-23-node-shim-format-s-design.md
@@ -1,0 +1,48 @@
+# Node shim `%s` object dispatch
+
+## Goal
+
+Make `scripts/node-shim.js` choose between `String(value)` and the shim's
+best-effort `inspect(value, { depth: 0 })` the same way Node does for object
+arguments to `util.format("%s", value)`.
+
+This is Node-host compatibility behavior, not an ECMAScript engine change.
+ECMAScript remains authoritative for what `String(value)` does after the shim
+chooses that path: `ToString` calls `ToPrimitive` with a string hint, which
+checks `Symbol.toPrimitive` before ordinary `toString`/`valueOf` coercion.
+
+## Decision
+
+At shim startup, snapshot the capitalized names on `globalThis`, matching
+Node's built-in-constructor name set before user bundle code executes.
+
+For each object:
+
+1. Treat a callable own `toString` or `Symbol.toPrimitive` as user-defined and
+   use `String(value)`.
+2. Treat an object with neither callable hook as built-in and inspect it.
+3. Otherwise walk the prototype chain to the object that owns the inherited
+   hook.
+4. Inspect when that owner has an own function-valued `constructor` whose name
+   is in the startup built-in set; use `String(value)` otherwise.
+
+Functions keep the shim's existing handling because issue #250 is limited to
+object dispatch. Node's internal proxy unwrapping cannot be reproduced by a
+pure-JavaScript shim and is outside this change.
+
+## Alternatives rejected
+
+- Checking only own properties breaks user classes whose `toString` lives on
+  the class prototype.
+- Comparing against a static list of intrinsic method identities diverges for
+  patched built-in prototypes, subclasses/cross-realm-style prototype chains,
+  and Node's constructor-name collision behavior.
+
+## Verification
+
+Extend the byte-compared node-shim self-test with arrays, plain objects,
+user-defined own and inherited hooks, `Symbol.toPrimitive`, `Date`, `RegExp`,
+non-callable hooks, patched built-in prototypes, and a user class named after a
+built-in. Run the shim self-test on jsse and Node, the shared shim fixtures, the
+relevant ECMAScript coercion test262 directories, and the repository's complete
+quality gate.

--- a/docs/specs/2026-07-23-node-shim-format-s-design.md
+++ b/docs/specs/2026-07-23-node-shim-format-s-design.md
@@ -13,8 +13,16 @@ checks `Symbol.toPrimitive` before ordinary `toString`/`valueOf` coercion.
 
 ## Decision
 
-At shim startup, snapshot the capitalized names on `globalThis`, matching
-Node's built-in-constructor name set before user bundle code executes.
+Use an explicit copy of Node 26.5.0's built-in-name membership. Node constructs
+this set from `globalThis` while `internal/util/inspect` bootstraps, before
+later ECMAScript and host globals are installed. Snapshotting jsse's
+`globalThis` when the shim runs is observably different: it incorrectly adds
+names such as `ShadowRealm`, `DisposableStack`, and `Float16Array`.
+
+The explicit set is recovered through Node-oracle constructor-name collision
+probes and versioned in the shim comment. The byte-compared self-test locks
+every included name and representative late, host, and jsse-only exclusions so
+a reference-Node upgrade reports any membership drift.
 
 For each object:
 
@@ -37,12 +45,17 @@ pure-JavaScript shim and is outside this change.
 - Comparing against a static list of intrinsic method identities diverges for
   patched built-in prototypes, subclasses/cross-realm-style prototype chains,
   and Node's constructor-name collision behavior.
+- Snapshotting jsse's globals is not equivalent to Node's earlier bootstrap
+  snapshot and lets engine-specific globals alter host-compat dispatch.
+- Injecting a freshly probed set from the harness would couple every bundle
+  runner to a reference Node process and leave standalone shim use undefined.
 
 ## Verification
 
 Extend the byte-compared node-shim self-test with arrays, plain objects,
 user-defined own and inherited hooks, `Symbol.toPrimitive`, `Date`, `RegExp`,
 non-callable hooks, patched built-in prototypes, and a user class named after a
-built-in. Run the shim self-test on jsse and Node, the shared shim fixtures, the
-relevant ECMAScript coercion test262 directories, and the repository's complete
-quality gate.
+built-in. Lock the full Node bootstrap membership plus representative
+non-members through constructor-name collisions. Run the shim self-test on jsse
+and Node, the shared shim fixtures, the relevant ECMAScript coercion test262
+directories, and the repository's complete quality gate.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -131,10 +131,12 @@ Node is the oracle for the deterministic surfaces — the `util.format` specifie
 (`%s %d %i %f %j %c %%`), byte-accurate `process.stdout.write`, and the
 `console.count`/`group`/`assert` output shapes are asserted exactly. The
 byte-exact `%s` guarantee covers primitives and objects whose coercion hooks
-Node classifies as user-defined. Objects with built-in coercion hooks (including
-plain objects and arrays) route through `util.inspect`; the dispatch matches
-Node, while the resulting inspection is intentionally best-effort (depth,
-cycles, common types) — it does not invoke getters, but it is only smoke-tested
+Node classifies as user-defined. The shim carries Node's bootstrap built-in-name
+set explicitly, because later Node globals and jsse-only globals are not members
+of that classifier. Objects with built-in coercion hooks (including plain
+objects and arrays) route through `util.inspect`; the dispatch matches Node,
+while the resulting inspection is intentionally best-effort (depth, cycles,
+common types) — it does not invoke getters, but it is only smoke-tested
 structurally and never generally byte-compared against Node.
 
 ## Shared test-runner harness (`node-test-harness.js`)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -130,12 +130,12 @@ and on **Node**, and requires both to exit 0 and emit byte-identical stdout.
 Node is the oracle for the deterministic surfaces — the `util.format` specifiers
 (`%s %d %i %f %j %c %%`), byte-accurate `process.stdout.write`, and the
 `console.count`/`group`/`assert` output shapes are asserted exactly. The
-byte-exact `%s` guarantee covers primitives and objects with a user-defined
-`toString`; `%s`/`%o`/`%O` of plain objects and arrays route through
-`util.inspect`, which is intentionally best-effort (depth, cycles, common types)
-— it does not invoke getters, but it is only smoke-tested structurally and never
-byte-compared against Node. (Fully Node-accurate `%s` object dispatch is tracked
-separately.)
+byte-exact `%s` guarantee covers primitives and objects whose coercion hooks
+Node classifies as user-defined. Objects with built-in coercion hooks (including
+plain objects and arrays) route through `util.inspect`; the dispatch matches
+Node, while the resulting inspection is intentionally best-effort (depth,
+cycles, common types) — it does not invoke getters, but it is only smoke-tested
+structurally and never generally byte-compared against Node.
 
 ## Shared test-runner harness (`node-test-harness.js`)
 

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -61,6 +61,9 @@
   // formatter reads built-in internal slots rather than user-overridable
   // prototype methods.
   var functionCall = Function.prototype.call;
+  var functionHasInstance = functionCall.bind(
+    Function.prototype[Symbol.hasInstance]
+  );
   var objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
   var objectGetPrototypeOf = Object.getPrototypeOf;
   var dateGetTime = functionCall.bind(Date.prototype.getTime);
@@ -109,7 +112,7 @@
         return v.stack ? String(v.stack) : String(v.name) + ": " + String(v.message);
       }
       var boxed;
-      if (v instanceof RegExp) {
+      if (functionHasInstance(RegExp, v)) {
         boxed = tryApplyIntrinsic(regexpGetSource, v);
         if (boxed) return regexpToString(v);
       }

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -43,42 +43,71 @@
   // internals — a bottomless pit); it only needs to be correct on depth,
   // cycles, and the common types.
   function quoteString(s) {
+    s = stringConstructor(s);
     return (
       "'" +
-      String(s)
-        .replace(/\\/g, "\\\\")
-        .replace(/'/g, "\\'")
-        .replace(/\n/g, "\\n") +
+      stringReplace(
+        stringReplace(stringReplace(s, /\\/g, "\\\\"), /'/g, "\\'"),
+        /\n/g,
+        "\\n"
+      ) +
       "'"
     );
   }
 
   function isIdentifierKey(k) {
-    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k);
+    return regexpTest(/^[A-Za-z_$][A-Za-z0-9_$]*$/, k);
   }
 
   // Capture uncurried intrinsics before bundled library code runs. Node's
   // formatter reads built-in internal slots rather than user-overridable
   // prototype methods.
   var functionCall = Function.prototype.call;
+  var arrayConstructor = Array;
+  var bigintConstructor = BigInt;
+  var booleanConstructor = Boolean;
+  var dateConstructor = Date;
+  var errorConstructor = Error;
+  var numberConstructor = Number;
+  var objectConstructor = Object;
+  var regexpConstructor = RegExp;
+  var stringConstructor = String;
+  var symbolConstructor = Symbol;
   var functionHasInstance = functionCall.bind(
-    Function.prototype[Symbol.hasInstance]
+    Function.prototype[symbolConstructor.hasInstance]
   );
-  var objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
-  var objectGetPrototypeOf = Object.getPrototypeOf;
-  var objectToString = functionCall.bind(Object.prototype.toString);
-  var dateGetTime = functionCall.bind(Date.prototype.getTime);
-  var dateToISOString = functionCall.bind(Date.prototype.toISOString);
-  var errorToString = functionCall.bind(Error.prototype.toString);
+  var arrayIndexOf = functionCall.bind(arrayConstructor.prototype.indexOf);
+  var arrayIsArray = arrayConstructor.isArray;
+  var arrayJoin = functionCall.bind(arrayConstructor.prototype.join);
+  var objectGetOwnPropertyDescriptor =
+    objectConstructor.getOwnPropertyDescriptor;
+  var objectGetPrototypeOf = objectConstructor.getPrototypeOf;
+  var objectIs = objectConstructor.is;
+  var objectKeys = objectConstructor.keys;
+  var objectToString = functionCall.bind(objectConstructor.prototype.toString);
+  var numberIsNaN = numberConstructor.isNaN;
+  var dateGetTime = functionCall.bind(dateConstructor.prototype.getTime);
+  var dateToISOString = functionCall.bind(
+    dateConstructor.prototype.toISOString
+  );
+  var errorToString = functionCall.bind(errorConstructor.prototype.toString);
   var regexpGetSource = functionCall.bind(
-    objectGetOwnPropertyDescriptor(RegExp.prototype, "source").get
+    objectGetOwnPropertyDescriptor(regexpConstructor.prototype, "source").get
   );
-  var regexpToString = functionCall.bind(RegExp.prototype.toString);
-  var numberValueOf = functionCall.bind(Number.prototype.valueOf);
-  var stringValueOf = functionCall.bind(String.prototype.valueOf);
-  var booleanValueOf = functionCall.bind(Boolean.prototype.valueOf);
-  var bigintValueOf = functionCall.bind(BigInt.prototype.valueOf);
-  var symbolToString = functionCall.bind(Symbol.prototype.toString);
+  var regexpToString = functionCall.bind(
+    regexpConstructor.prototype.toString
+  );
+  var regexpTest = functionCall.bind(regexpConstructor.prototype.test);
+  var numberValueOf = functionCall.bind(numberConstructor.prototype.valueOf);
+  var stringValueOf = functionCall.bind(stringConstructor.prototype.valueOf);
+  var booleanValueOf = functionCall.bind(
+    booleanConstructor.prototype.valueOf
+  );
+  var bigintValueOf = functionCall.bind(bigintConstructor.prototype.valueOf);
+  var symbolToString = functionCall.bind(
+    symbolConstructor.prototype.toString
+  );
+  var stringReplace = functionCall.bind(stringConstructor.prototype.replace);
 
   function tryApplyIntrinsic(intrinsic, value) {
     try {
@@ -108,17 +137,17 @@
       if (v === null) return "null";
       if (t === "undefined") return "undefined";
       if (t === "string") return quoteString(v);
-      if (t === "number") return Object.is(v, -0) ? "-0" : String(v);
-      if (t === "bigint") return String(v) + "n";
-      if (t === "boolean") return String(v);
+      if (t === "number") return objectIs(v, -0) ? "-0" : stringConstructor(v);
+      if (t === "bigint") return stringConstructor(v) + "n";
+      if (t === "boolean") return stringConstructor(v);
       if (t === "symbol") return v.toString();
       if (t === "function") {
         return "[Function" + (v.name ? ": " + v.name : " (anonymous)") + "]";
       }
 
       // Objects.
-      if (seen.indexOf(v) !== -1) return "[Circular *1]";
-      if (functionHasInstance(Error, v)) {
+      if (arrayIndexOf(seen, v) !== -1) return "[Circular *1]";
+      if (functionHasInstance(errorConstructor, v)) {
         var stack;
         try {
           stack = v.stack;
@@ -126,7 +155,7 @@
           // Node ignores a throwing stack getter and renders the intrinsic
           // Error string as a stackless error.
         }
-        if (stack) return String(stack);
+        if (stack) return stringConstructor(stack);
         try {
           return "[" + errorToString(v) + "]";
         } catch (e) {
@@ -134,60 +163,60 @@
         }
       }
       var boxed;
-      if (functionHasInstance(RegExp, v)) {
+      if (functionHasInstance(regexpConstructor, v)) {
         boxed = tryApplyIntrinsic(regexpGetSource, v);
         if (boxed) return regexpToString(v);
       }
-      if (functionHasInstance(Date, v)) {
+      if (functionHasInstance(dateConstructor, v)) {
         boxed = tryApplyIntrinsic(dateGetTime, v);
         if (boxed) {
-          return isNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);
+          return numberIsNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);
         }
       }
-      if (functionHasInstance(Number, v)) {
+      if (functionHasInstance(numberConstructor, v)) {
         boxed = tryApplyIntrinsic(numberValueOf, v);
         if (boxed) return "[Number: " + render(boxed.value, depth) + "]";
       }
-      if (functionHasInstance(String, v)) {
+      if (functionHasInstance(stringConstructor, v)) {
         boxed = tryApplyIntrinsic(stringValueOf, v);
         if (boxed) return "[String: " + render(boxed.value, depth) + "]";
       }
-      if (functionHasInstance(Boolean, v)) {
+      if (functionHasInstance(booleanConstructor, v)) {
         boxed = tryApplyIntrinsic(booleanValueOf, v);
         if (boxed) return "[Boolean: " + render(boxed.value, depth) + "]";
       }
-      if (functionHasInstance(BigInt, v)) {
+      if (functionHasInstance(bigintConstructor, v)) {
         boxed = tryApplyIntrinsic(bigintValueOf, v);
         if (boxed) {
           // Unlike the older wrappers above, Node's boxed BigInt/Symbol
           // rendering intentionally observes a constructor's current
           // @@hasInstance result. A false or throwing hook selects its generic
           // object shape, but must not intercept the internal-slot probe.
-          return tryInstanceOf(v, BigInt)
+          return tryInstanceOf(v, bigintConstructor)
             ? "[BigInt: " + render(boxed.value, depth) + "]"
             : "Object [BigInt] {}";
         }
       }
-      if (functionHasInstance(Symbol, v)) {
+      if (functionHasInstance(symbolConstructor, v)) {
         boxed = tryApplyIntrinsic(symbolToString, v);
         if (boxed) {
-          return tryInstanceOf(v, Symbol)
+          return tryInstanceOf(v, symbolConstructor)
             ? "[Symbol: " + boxed.value + "]"
             : "Object [Symbol] {}";
         }
       }
 
-      if (depth < 0) return Array.isArray(v) ? "[Array]" : "[Object]";
+      if (depth < 0) return arrayIsArray(v) ? "[Array]" : "[Object]";
 
       seen.push(v);
       var out;
       try {
-        if (Array.isArray(v)) {
+        if (arrayIsArray(v)) {
           var items = [];
           for (var i = 0; i < v.length; i++) items.push(renderMember(v, i, depth));
-          out = items.length ? "[ " + items.join(", ") + " ]" : "[]";
+          out = items.length ? "[ " + arrayJoin(items, ", ") + " ]" : "[]";
         } else {
-          var keys = Object.keys(v);
+          var keys = objectKeys(v);
           var parts = [];
           for (var j = 0; j < keys.length; j++) {
             var k = keys[j];
@@ -196,7 +225,7 @@
           }
           var ctorName = constructorName(v);
           out = parts.length
-            ? ctorName + "{ " + parts.join(", ") + " }"
+            ? ctorName + "{ " + arrayJoin(parts, ", ") + " }"
             : ctorName + "{}";
         }
       } finally {
@@ -309,8 +338,8 @@
     }
     return names;
   })();
-  var objectHasOwnProperty = Object.prototype.hasOwnProperty;
-  var symbolToPrimitive = Symbol.toPrimitive;
+  var objectHasOwnProperty = objectConstructor.prototype.hasOwnProperty;
+  var symbolToPrimitive = symbolConstructor.toPrimitive;
 
   function hasOwnProperty(value, key) {
     return objectHasOwnProperty.call(value, key);

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -338,11 +338,13 @@
     }
     return names;
   })();
-  var objectHasOwnProperty = objectConstructor.prototype.hasOwnProperty;
+  var objectHasOwnProperty = functionCall.bind(
+    objectConstructor.prototype.hasOwnProperty
+  );
   var symbolToPrimitive = symbolConstructor.toPrimitive;
 
   function hasOwnProperty(value, key) {
-    return objectHasOwnProperty.call(value, key);
+    return objectHasOwnProperty(value, key);
   }
 
   function returnFalse() {
@@ -369,13 +371,19 @@
     }
 
     var pointer = value;
-    do {
-      pointer = objectGetPrototypeOf(pointer);
-    } while (
-      pointer !== null &&
-      !hasOwnToString(pointer, "toString") &&
-      !hasOwnToPrimitive(pointer, symbolToPrimitive)
-    );
+    try {
+      do {
+        pointer = objectGetPrototypeOf(pointer);
+      } while (
+        pointer !== null &&
+        !hasOwnToString(pointer, "toString") &&
+        !hasOwnToPrimitive(pointer, symbolToPrimitive)
+      );
+    } catch (e) {
+      // Node can unwrap proxies without invoking their prototype traps. The
+      // pure-JS shim cannot, so a failed owner walk uses ordinary coercion.
+      return false;
+    }
 
     // A callable hook visible through a Proxy get trap may not have an owner in
     // the reported prototype chain. Node can unwrap proxies internally; the

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -66,8 +66,10 @@
   );
   var objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
   var objectGetPrototypeOf = Object.getPrototypeOf;
+  var objectToString = functionCall.bind(Object.prototype.toString);
   var dateGetTime = functionCall.bind(Date.prototype.getTime);
   var dateToISOString = functionCall.bind(Date.prototype.toISOString);
+  var errorToString = functionCall.bind(Error.prototype.toString);
   var regexpGetSource = functionCall.bind(
     objectGetOwnPropertyDescriptor(RegExp.prototype, "source").get
   );
@@ -117,7 +119,19 @@
       // Objects.
       if (seen.indexOf(v) !== -1) return "[Circular *1]";
       if (functionHasInstance(Error, v)) {
-        return v.stack ? String(v.stack) : String(v.name) + ": " + String(v.message);
+        var stack;
+        try {
+          stack = v.stack;
+        } catch (e) {
+          // Node ignores a throwing stack getter and renders the intrinsic
+          // Error string as a stackless error.
+        }
+        if (stack) return String(stack);
+        try {
+          return "[" + errorToString(v) + "]";
+        } catch (e) {
+          return objectToString(v);
+        }
       }
       var boxed;
       if (functionHasInstance(RegExp, v)) {

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -57,6 +57,13 @@
     return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k);
   }
 
+  // Capture uncurried Date intrinsics before bundled library code runs. Node's
+  // formatter reads [[DateValue]] directly, so patched prototype methods must
+  // not affect either valid or invalid Date inspection.
+  var functionCall = Function.prototype.call;
+  var dateGetTime = functionCall.bind(Date.prototype.getTime);
+  var dateToISOString = functionCall.bind(Date.prototype.toISOString);
+
   function inspect(value, opts) {
     opts = opts || {};
     var maxDepth = typeof opts.depth === "number" ? opts.depth : 2;
@@ -82,7 +89,7 @@
       }
       if (v instanceof RegExp) return String(v);
       if (v instanceof Date) {
-        return isNaN(v.getTime()) ? "Invalid Date" : v.toISOString();
+        return isNaN(dateGetTime(v)) ? "Invalid Date" : dateToISOString(v);
       }
 
       if (depth < 0) return Array.isArray(v) ? "[Array]" : "[Object]";

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -206,12 +206,64 @@
   //
   // Node's printf-style formatter. The %s %d %i %f %j %c %% specifiers are
   // deterministic and matched exactly; %o/%O defer to the best-effort inspect.
+  // Node creates this set from globalThis while internal/util/inspect is
+  // bootstrapping. By the time user code runs, Node and jsse have both added
+  // more globals, but those late names are deliberately absent from Node's
+  // classifier. Keep the Node 26.5.0 bootstrap membership explicit so jsse-only
+  // globals (for example ShadowRealm) cannot change %s dispatch.
   var builtInObjectNames = (function () {
     var names = Object.create(null);
-    var globals = Object.getOwnPropertyNames(globalThis);
-    for (var i = 0; i < globals.length; i++) {
-      var name = globals[i];
-      if (/^[A-Z][a-zA-Z0-9]+$/.test(name)) names[name] = true;
+    var nodeBootstrapNames = [
+      "Object",
+      "Function",
+      "Array",
+      "Number",
+      "Infinity",
+      "NaN",
+      "Boolean",
+      "String",
+      "Symbol",
+      "Date",
+      "Promise",
+      "RegExp",
+      "Error",
+      "AggregateError",
+      "EvalError",
+      "RangeError",
+      "ReferenceError",
+      "SyntaxError",
+      "TypeError",
+      "URIError",
+      "JSON",
+      "Math",
+      "Intl",
+      "ArrayBuffer",
+      "Atomics",
+      "Uint8Array",
+      "Int8Array",
+      "Uint16Array",
+      "Int16Array",
+      "Uint32Array",
+      "Int32Array",
+      "BigUint64Array",
+      "BigInt64Array",
+      "Uint8ClampedArray",
+      "Float32Array",
+      "Float64Array",
+      "DataView",
+      "Map",
+      "BigInt",
+      "Set",
+      "Iterator",
+      "WeakMap",
+      "WeakSet",
+      "Proxy",
+      "Reflect",
+      "FinalizationRegistry",
+      "WeakRef",
+    ];
+    for (var i = 0; i < nodeBootstrapNames.length; i++) {
+      names[nodeBootstrapNames[i]] = true;
     }
     return names;
   })();

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -61,6 +61,8 @@
   // formatter reads built-in internal slots rather than user-overridable
   // prototype methods.
   var functionCall = Function.prototype.call;
+  var objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+  var objectGetPrototypeOf = Object.getPrototypeOf;
   var dateGetTime = functionCall.bind(Date.prototype.getTime);
   var dateToISOString = functionCall.bind(Date.prototype.toISOString);
   var regexpToString = functionCall.bind(RegExp.prototype.toString);
@@ -169,7 +171,7 @@
     // cannot make a diagnostic print throw/mutate under jsse where it would not
     // under Node.
     function renderMember(container, key, depth) {
-      var desc = Object.getOwnPropertyDescriptor(container, key);
+      var desc = objectGetOwnPropertyDescriptor(container, key);
       if (desc && (desc.get || desc.set)) {
         return desc.get ? (desc.set ? "[Getter/Setter]" : "[Getter]") : "[Setter]";
       }
@@ -183,13 +185,13 @@
     function constructorName(v) {
       try {
         var ctor;
-        var own = Object.getOwnPropertyDescriptor(v, "constructor");
+        var own = objectGetOwnPropertyDescriptor(v, "constructor");
         if (own) {
           if (!own.get && !own.set) ctor = own.value;
         } else {
-          var proto = Object.getPrototypeOf(v);
+          var proto = objectGetPrototypeOf(v);
           var pd = proto
-            ? Object.getOwnPropertyDescriptor(proto, "constructor")
+            ? objectGetOwnPropertyDescriptor(proto, "constructor")
             : null;
           if (pd && !pd.get && !pd.set) ctor = pd.value;
         }
@@ -299,7 +301,7 @@
 
     var pointer = value;
     do {
-      pointer = Object.getPrototypeOf(pointer);
+      pointer = objectGetPrototypeOf(pointer);
     } while (
       pointer !== null &&
       !hasOwnToString(pointer, "toString") &&
@@ -311,7 +313,7 @@
     // pure-JS shim cannot, so treat that hook as user-defined.
     if (pointer === null) return false;
 
-    var descriptor = Object.getOwnPropertyDescriptor(pointer, "constructor");
+    var descriptor = objectGetOwnPropertyDescriptor(pointer, "constructor");
     return (
       descriptor !== undefined &&
       typeof descriptor.value === "function" &&

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -88,6 +88,14 @@
     }
   }
 
+  function tryInstanceOf(value, constructor) {
+    try {
+      return value instanceof constructor;
+    } catch (e) {
+      return false;
+    }
+  }
+
   function inspect(value, opts) {
     opts = opts || {};
     var maxDepth = typeof opts.depth === "number" ? opts.depth : 2;
@@ -108,7 +116,7 @@
 
       // Objects.
       if (seen.indexOf(v) !== -1) return "[Circular *1]";
-      if (v instanceof Error) {
+      if (functionHasInstance(Error, v)) {
         return v.stack ? String(v.stack) : String(v.name) + ": " + String(v.message);
       }
       var boxed;
@@ -116,31 +124,43 @@
         boxed = tryApplyIntrinsic(regexpGetSource, v);
         if (boxed) return regexpToString(v);
       }
-      if (v instanceof Date) {
+      if (functionHasInstance(Date, v)) {
         boxed = tryApplyIntrinsic(dateGetTime, v);
         if (boxed) {
           return isNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);
         }
       }
-      if (v instanceof Number) {
+      if (functionHasInstance(Number, v)) {
         boxed = tryApplyIntrinsic(numberValueOf, v);
         if (boxed) return "[Number: " + render(boxed.value, depth) + "]";
       }
-      if (v instanceof String) {
+      if (functionHasInstance(String, v)) {
         boxed = tryApplyIntrinsic(stringValueOf, v);
         if (boxed) return "[String: " + render(boxed.value, depth) + "]";
       }
-      if (v instanceof Boolean) {
+      if (functionHasInstance(Boolean, v)) {
         boxed = tryApplyIntrinsic(booleanValueOf, v);
         if (boxed) return "[Boolean: " + render(boxed.value, depth) + "]";
       }
-      if (v instanceof BigInt) {
+      if (functionHasInstance(BigInt, v)) {
         boxed = tryApplyIntrinsic(bigintValueOf, v);
-        if (boxed) return "[BigInt: " + render(boxed.value, depth) + "]";
+        if (boxed) {
+          // Unlike the older wrappers above, Node's boxed BigInt/Symbol
+          // rendering intentionally observes a constructor's current
+          // @@hasInstance result. A false or throwing hook selects its generic
+          // object shape, but must not intercept the internal-slot probe.
+          return tryInstanceOf(v, BigInt)
+            ? "[BigInt: " + render(boxed.value, depth) + "]"
+            : "Object [BigInt] {}";
+        }
       }
-      if (v instanceof Symbol) {
+      if (functionHasInstance(Symbol, v)) {
         boxed = tryApplyIntrinsic(symbolToString, v);
-        if (boxed) return "[Symbol: " + boxed.value + "]";
+        if (boxed) {
+          return tryInstanceOf(v, Symbol)
+            ? "[Symbol: " + boxed.value + "]"
+            : "Object [Symbol] {}";
+        }
       }
 
       if (depth < 0) return Array.isArray(v) ? "[Array]" : "[Object]";

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -65,6 +65,9 @@
   var objectGetPrototypeOf = Object.getPrototypeOf;
   var dateGetTime = functionCall.bind(Date.prototype.getTime);
   var dateToISOString = functionCall.bind(Date.prototype.toISOString);
+  var regexpGetSource = functionCall.bind(
+    objectGetOwnPropertyDescriptor(RegExp.prototype, "source").get
+  );
   var regexpToString = functionCall.bind(RegExp.prototype.toString);
   var numberValueOf = functionCall.bind(Number.prototype.valueOf);
   var stringValueOf = functionCall.bind(String.prototype.valueOf);
@@ -107,8 +110,8 @@
       }
       var boxed;
       if (v instanceof RegExp) {
-        boxed = tryApplyIntrinsic(regexpToString, v);
-        if (boxed) return boxed.value;
+        boxed = tryApplyIntrinsic(regexpGetSource, v);
+        if (boxed) return regexpToString(v);
       }
       if (v instanceof Date) {
         boxed = tryApplyIntrinsic(dateGetTime, v);

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -57,12 +57,17 @@
     return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k);
   }
 
-  // Capture uncurried Date intrinsics before bundled library code runs. Node's
-  // formatter reads [[DateValue]] directly, so patched prototype methods must
-  // not affect either valid or invalid Date inspection.
+  // Capture uncurried intrinsics before bundled library code runs. Node's
+  // formatter reads built-in internal slots rather than user-overridable
+  // prototype methods.
   var functionCall = Function.prototype.call;
   var dateGetTime = functionCall.bind(Date.prototype.getTime);
   var dateToISOString = functionCall.bind(Date.prototype.toISOString);
+  var numberValueOf = functionCall.bind(Number.prototype.valueOf);
+  var stringValueOf = functionCall.bind(String.prototype.valueOf);
+  var booleanValueOf = functionCall.bind(Boolean.prototype.valueOf);
+  var bigintValueOf = functionCall.bind(BigInt.prototype.valueOf);
+  var symbolToString = functionCall.bind(Symbol.prototype.toString);
 
   function inspect(value, opts) {
     opts = opts || {};
@@ -91,6 +96,19 @@
       if (v instanceof Date) {
         return isNaN(dateGetTime(v)) ? "Invalid Date" : dateToISOString(v);
       }
+      if (v instanceof Number) {
+        return "[Number: " + render(numberValueOf(v), depth) + "]";
+      }
+      if (v instanceof String) {
+        return "[String: " + render(stringValueOf(v), depth) + "]";
+      }
+      if (v instanceof Boolean) {
+        return "[Boolean: " + render(booleanValueOf(v), depth) + "]";
+      }
+      if (v instanceof BigInt) {
+        return "[BigInt: " + render(bigintValueOf(v), depth) + "]";
+      }
+      if (v instanceof Symbol) return "[Symbol: " + symbolToString(v) + "]";
 
       if (depth < 0) return Array.isArray(v) ? "[Array]" : "[Object]";
 

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -156,6 +156,67 @@
   //
   // Node's printf-style formatter. The %s %d %i %f %j %c %% specifiers are
   // deterministic and matched exactly; %o/%O defer to the best-effort inspect.
+  var builtInObjectNames = (function () {
+    var names = Object.create(null);
+    var globals = Object.getOwnPropertyNames(globalThis);
+    for (var i = 0; i < globals.length; i++) {
+      var name = globals[i];
+      if (/^[A-Z][a-zA-Z0-9]+$/.test(name)) names[name] = true;
+    }
+    return names;
+  })();
+  var objectHasOwnProperty = Object.prototype.hasOwnProperty;
+  var symbolToPrimitive = Symbol.toPrimitive;
+
+  function hasOwnProperty(value, key) {
+    return objectHasOwnProperty.call(value, key);
+  }
+
+  function returnFalse() {
+    return false;
+  }
+
+  // Match Node's hasBuiltInToString classification. A bundled library's
+  // prototype method is user-defined even when inherited, while coercion hooks
+  // owned by a built-in prototype route through inspect.
+  function hasBuiltInToString(value) {
+    var hasOwnToString = hasOwnProperty;
+    var hasOwnToPrimitive = hasOwnProperty;
+
+    if (typeof value.toString !== "function") {
+      if (typeof value[symbolToPrimitive] !== "function") return true;
+      if (hasOwnProperty(value, symbolToPrimitive)) return false;
+      hasOwnToString = returnFalse;
+    } else if (hasOwnProperty(value, "toString")) {
+      return false;
+    } else if (typeof value[symbolToPrimitive] !== "function") {
+      hasOwnToPrimitive = returnFalse;
+    } else if (hasOwnProperty(value, symbolToPrimitive)) {
+      return false;
+    }
+
+    var pointer = value;
+    do {
+      pointer = Object.getPrototypeOf(pointer);
+    } while (
+      pointer !== null &&
+      !hasOwnToString(pointer, "toString") &&
+      !hasOwnToPrimitive(pointer, symbolToPrimitive)
+    );
+
+    // A callable hook visible through a Proxy get trap may not have an owner in
+    // the reported prototype chain. Node can unwrap proxies internally; the
+    // pure-JS shim cannot, so treat that hook as user-defined.
+    if (pointer === null) return false;
+
+    var descriptor = Object.getOwnPropertyDescriptor(pointer, "constructor");
+    return (
+      descriptor !== undefined &&
+      typeof descriptor.value === "function" &&
+      builtInObjectNames[descriptor.value.name] === true
+    );
+  }
+
   function convS(v) {
     var t = typeof v;
     if (t === "string") return v;
@@ -166,12 +227,7 @@
     if (t === "boolean") return String(v);
     if (t === "symbol") return v.toString();
     if (t === "function") return inspect(v, { depth: 0 });
-    // Object: String() when it defines its own toString, else inspect (Node
-    // uses inspect with depth 0 here).
-    if (typeof v.toString === "function" && v.toString !== Object.prototype.toString) {
-      return String(v);
-    }
-    return inspect(v, { depth: 0 });
+    return hasBuiltInToString(v) ? inspect(v, { depth: 0 }) : String(v);
   }
 
   function convD(v) {

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -63,11 +63,22 @@
   var functionCall = Function.prototype.call;
   var dateGetTime = functionCall.bind(Date.prototype.getTime);
   var dateToISOString = functionCall.bind(Date.prototype.toISOString);
+  var regexpToString = functionCall.bind(RegExp.prototype.toString);
   var numberValueOf = functionCall.bind(Number.prototype.valueOf);
   var stringValueOf = functionCall.bind(String.prototype.valueOf);
   var booleanValueOf = functionCall.bind(Boolean.prototype.valueOf);
   var bigintValueOf = functionCall.bind(BigInt.prototype.valueOf);
   var symbolToString = functionCall.bind(Symbol.prototype.toString);
+
+  function tryApplyIntrinsic(intrinsic, value) {
+    try {
+      return { value: intrinsic(value) };
+    } catch (e) {
+      // `instanceof` also accepts objects that merely inherit a built-in
+      // prototype. Only a genuine instance has the corresponding internal slot.
+      return null;
+    }
+  }
 
   function inspect(value, opts) {
     opts = opts || {};
@@ -92,23 +103,37 @@
       if (v instanceof Error) {
         return v.stack ? String(v.stack) : String(v.name) + ": " + String(v.message);
       }
-      if (v instanceof RegExp) return String(v);
+      var boxed;
+      if (v instanceof RegExp) {
+        boxed = tryApplyIntrinsic(regexpToString, v);
+        if (boxed) return boxed.value;
+      }
       if (v instanceof Date) {
-        return isNaN(dateGetTime(v)) ? "Invalid Date" : dateToISOString(v);
+        boxed = tryApplyIntrinsic(dateGetTime, v);
+        if (boxed) {
+          return isNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);
+        }
       }
       if (v instanceof Number) {
-        return "[Number: " + render(numberValueOf(v), depth) + "]";
+        boxed = tryApplyIntrinsic(numberValueOf, v);
+        if (boxed) return "[Number: " + render(boxed.value, depth) + "]";
       }
       if (v instanceof String) {
-        return "[String: " + render(stringValueOf(v), depth) + "]";
+        boxed = tryApplyIntrinsic(stringValueOf, v);
+        if (boxed) return "[String: " + render(boxed.value, depth) + "]";
       }
       if (v instanceof Boolean) {
-        return "[Boolean: " + render(booleanValueOf(v), depth) + "]";
+        boxed = tryApplyIntrinsic(booleanValueOf, v);
+        if (boxed) return "[Boolean: " + render(boxed.value, depth) + "]";
       }
       if (v instanceof BigInt) {
-        return "[BigInt: " + render(bigintValueOf(v), depth) + "]";
+        boxed = tryApplyIntrinsic(bigintValueOf, v);
+        if (boxed) return "[BigInt: " + render(boxed.value, depth) + "]";
       }
-      if (v instanceof Symbol) return "[Symbol: " + symbolToString(v) + "]";
+      if (v instanceof Symbol) {
+        boxed = tryApplyIntrinsic(symbolToString, v);
+        if (boxed) return "[Symbol: " + boxed.value + "]";
+      }
 
       if (depth < 0) return Array.isArray(v) ? "[Array]" : "[Object]";
 

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -150,6 +150,35 @@ eq(util.format("%s", /re/g), "/re/g", "%s RegExp uses inspect");
     RegExp.prototype.toString = original;
   }
 })();
+(function () {
+  function checkThrowingAccessor(name) {
+    var original = Object.getOwnPropertyDescriptor(RegExp.prototype, name);
+    var sentinel = new Error("patched RegExp " + name);
+    var caught;
+    try {
+      Object.defineProperty(RegExp.prototype, name, {
+        configurable: true,
+        get: function () {
+          throw sentinel;
+        },
+      });
+      try {
+        util.format("%s", /re/g);
+      } catch (e) {
+        caught = e;
+      }
+      truthy(
+        caught === sentinel,
+        "%s RegExp rethrows patched " + name + " accessor error"
+      );
+    } finally {
+      Object.defineProperty(RegExp.prototype, name, original);
+    }
+  }
+
+  checkThrowingAccessor("source");
+  checkThrowingAccessor("flags");
+})();
 eq(
   util.format("%s", Object.create(RegExp.prototype)),
   "RegExp {}",

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -135,6 +135,67 @@ eq(
   "{ toString: null, a: 1 }",
   "%s non-callable toString uses inspect"
 );
+eq(util.format("%s", new Number(-0)), "[Number: -0]", "%s Number wrapper");
+eq(util.format("%s", new String("x")), "[String: 'x']", "%s String wrapper");
+eq(util.format("%s", new Boolean(true)), "[Boolean: true]", "%s Boolean wrapper");
+eq(util.format("%s", Object(10n)), "[BigInt: 10n]", "%s BigInt wrapper");
+eq(
+  util.format("%s", Object(Symbol("wrapped"))),
+  "[Symbol: Symbol(wrapped)]",
+  "%s Symbol wrapper"
+);
+(function () {
+  var methods = [
+    [Number.prototype, "valueOf"],
+    [Number.prototype, "toString"],
+    [String.prototype, "valueOf"],
+    [String.prototype, "toString"],
+    [Boolean.prototype, "valueOf"],
+    [Boolean.prototype, "toString"],
+    [BigInt.prototype, "valueOf"],
+    [BigInt.prototype, "toString"],
+    [Symbol.prototype, "valueOf"],
+    [Symbol.prototype, "toString"],
+  ];
+  var originals = [];
+  try {
+    for (var i = 0; i < methods.length; i++) {
+      originals.push(methods[i][0][methods[i][1]]);
+      methods[i][0][methods[i][1]] = function () {
+        throw new Error("patched wrapper method called");
+      };
+    }
+    eq(
+      util.format("%s", new Number(1)),
+      "[Number: 1]",
+      "%s Number wrapper ignores patched methods"
+    );
+    eq(
+      util.format("%s", new String("x")),
+      "[String: 'x']",
+      "%s String wrapper ignores patched methods"
+    );
+    eq(
+      util.format("%s", new Boolean(true)),
+      "[Boolean: true]",
+      "%s Boolean wrapper ignores patched methods"
+    );
+    eq(
+      util.format("%s", Object(10n)),
+      "[BigInt: 10n]",
+      "%s BigInt wrapper ignores patched methods"
+    );
+    eq(
+      util.format("%s", Object(Symbol("wrapped"))),
+      "[Symbol: Symbol(wrapped)]",
+      "%s Symbol wrapper ignores patched methods"
+    );
+  } finally {
+    for (var j = 0; j < methods.length; j++) {
+      methods[j][0][methods[j][1]] = originals[j];
+    }
+  }
+})();
 (function () {
   var value = {
     [Symbol.toPrimitive]: function (hint) {

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -235,6 +235,129 @@ eq(
   "[Symbol: Symbol(wrapped)]",
   "%s Symbol wrapper"
 );
+(function () {
+  var cases = [
+    [
+      Date,
+      function () {
+        return new Date(0);
+      },
+      "1970-01-01T00:00:00.000Z",
+      "Date",
+    ],
+    [
+      Number,
+      function () {
+        return new Number(1);
+      },
+      "[Number: 1]",
+      "Number",
+    ],
+    [
+      String,
+      function () {
+        return new String("x");
+      },
+      "[String: 'x']",
+      "String",
+    ],
+    [
+      Boolean,
+      function () {
+        return new Boolean(true);
+      },
+      "[Boolean: true]",
+      "Boolean",
+    ],
+    [
+      BigInt,
+      function () {
+        return Object(10n);
+      },
+      "Object [BigInt] {}",
+      "BigInt",
+    ],
+    [
+      Symbol,
+      function () {
+        return Object(Symbol("wrapped"));
+      },
+      "Object [Symbol] {}",
+      "Symbol",
+    ],
+  ];
+
+  for (var i = 0; i < cases.length; i++) {
+    var ctor = cases[i][0];
+    var makeValue = cases[i][1];
+    var expected = cases[i][2];
+    var name = cases[i][3];
+    var original = Object.getOwnPropertyDescriptor(ctor, Symbol.hasInstance);
+    try {
+      Object.defineProperty(ctor, Symbol.hasInstance, {
+        configurable: true,
+        value: function () {
+          return false;
+        },
+      });
+      eq(
+        util.format("%s", makeValue()),
+        expected,
+        "%s " + name + " ignores false Symbol.hasInstance"
+      );
+
+      Object.defineProperty(ctor, Symbol.hasInstance, {
+        configurable: true,
+        value: function () {
+          throw new Error("patched Symbol.hasInstance called");
+        },
+      });
+      eq(
+        util.format("%s", makeValue()),
+        expected,
+        "%s " + name + " ignores throwing Symbol.hasInstance"
+      );
+    } finally {
+      if (original) {
+        Object.defineProperty(ctor, Symbol.hasInstance, original);
+      } else {
+        delete ctor[Symbol.hasInstance];
+      }
+    }
+  }
+})();
+(function () {
+  var original = Object.getOwnPropertyDescriptor(Error, Symbol.hasInstance);
+  var modes = [
+    function () {
+      return false;
+    },
+    function () {
+      throw new Error("patched Error Symbol.hasInstance called");
+    },
+  ];
+  try {
+    for (var i = 0; i < modes.length; i++) {
+      Object.defineProperty(Error, Symbol.hasInstance, {
+        configurable: true,
+        value: modes[i],
+      });
+      truthy(
+        util.format("%s", new Error("has-instance sentinel"))
+          .indexOf("Error: has-instance sentinel") !== -1,
+        "%s Error ignores " +
+          (i === 0 ? "false" : "throwing") +
+          " Symbol.hasInstance"
+      );
+    }
+  } finally {
+    if (original) {
+      Object.defineProperty(Error, Symbol.hasInstance, original);
+    } else {
+      delete Error[Symbol.hasInstance];
+    }
+  }
+})();
 eq(
   util.format("%s", Object.create(Number.prototype)),
   "Number {}",

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -136,6 +136,33 @@ eq(
 );
 eq(util.format("%s", /re/g), "/re/g", "%s RegExp uses inspect");
 (function () {
+  var originalDate = globalThis.Date;
+  var originalRegExp = globalThis.RegExp;
+  var date = new originalDate(0);
+  var regexp = new originalRegExp("re", "g");
+  var formattedDate;
+  var formattedRegExp;
+  try {
+    globalThis.Date = function Date() {};
+    globalThis.RegExp = function RegExp() {};
+    formattedDate = util.format("%s", date);
+    formattedRegExp = util.format("%s", regexp);
+  } finally {
+    globalThis.Date = originalDate;
+    globalThis.RegExp = originalRegExp;
+  }
+  eq(
+    formattedDate,
+    "1970-01-01T00:00:00.000Z",
+    "%s Date ignores a replaced global constructor"
+  );
+  eq(
+    formattedRegExp,
+    "/re/g",
+    "%s RegExp ignores a replaced global constructor"
+  );
+})();
+(function () {
   var original = Object.getOwnPropertyDescriptor(
     RegExp,
     Symbol.hasInstance
@@ -547,6 +574,49 @@ eq(
     Object.getPrototypeOf = originalGetPrototypeOf;
     Object.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
   }
+})();
+(function () {
+  var originalIsArray = Array.isArray;
+  var originalIndexOf = Array.prototype.indexOf;
+  var originalJoin = Array.prototype.join;
+  var originalTest = RegExp.prototype.test;
+  var originalReplace = String.prototype.replace;
+  var originalIs = Object.is;
+  var originalKeys = Object.keys;
+  var formattedArray;
+  var formattedObject;
+  var fail = function () {
+    throw new Error("patched inspect helper called");
+  };
+  try {
+    Array.isArray = fail;
+    Array.prototype.indexOf = fail;
+    Array.prototype.join = fail;
+    Object.is = fail;
+    Object.keys = fail;
+    RegExp.prototype.test = fail;
+    String.prototype.replace = fail;
+    formattedArray = util.format("%s", ["x", -0]);
+    formattedObject = util.format("%s", { "not-key": 1 });
+  } finally {
+    Array.isArray = originalIsArray;
+    Array.prototype.indexOf = originalIndexOf;
+    Array.prototype.join = originalJoin;
+    Object.is = originalIs;
+    Object.keys = originalKeys;
+    RegExp.prototype.test = originalTest;
+    String.prototype.replace = originalReplace;
+  }
+  eq(
+    formattedArray,
+    "[ 'x', -0 ]",
+    "%s array ignores patched inspect helpers"
+  );
+  eq(
+    formattedObject,
+    "{ 'not-key': 1 }",
+    "%s object ignores patched inspect helpers"
+  );
 })();
 (function () {
   class Array {

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -129,7 +129,32 @@ eq(
     Date.prototype.toISOString = originalToISOString;
   }
 })();
+eq(
+  util.format("%s", Object.create(Date.prototype)),
+  "Date {}",
+  "%s Date prototype spoof falls back to ordinary inspect"
+);
 eq(util.format("%s", /re/g), "/re/g", "%s RegExp uses inspect");
+(function () {
+  var original = RegExp.prototype.toString;
+  try {
+    RegExp.prototype.toString = function () {
+      throw new Error("patched RegExp toString called");
+    };
+    eq(
+      util.format("%s", /re/g),
+      "/re/g",
+      "%s RegExp ignores patched toString"
+    );
+  } finally {
+    RegExp.prototype.toString = original;
+  }
+})();
+eq(
+  util.format("%s", Object.create(RegExp.prototype)),
+  "RegExp {}",
+  "%s RegExp prototype spoof falls back to ordinary inspect"
+);
 eq(
   util.format("%s", { toString: null, a: 1 }),
   "{ toString: null, a: 1 }",
@@ -143,6 +168,31 @@ eq(
   util.format("%s", Object(Symbol("wrapped"))),
   "[Symbol: Symbol(wrapped)]",
   "%s Symbol wrapper"
+);
+eq(
+  util.format("%s", Object.create(Number.prototype)),
+  "Number {}",
+  "%s Number prototype spoof falls back to ordinary inspect"
+);
+eq(
+  util.format("%s", Object.create(String.prototype)),
+  "String {}",
+  "%s String prototype spoof falls back to ordinary inspect"
+);
+eq(
+  util.format("%s", Object.create(Boolean.prototype)),
+  "Boolean {}",
+  "%s Boolean prototype spoof falls back to ordinary inspect"
+);
+eq(
+  util.format("%s", Object.create(BigInt.prototype)),
+  "BigInt {}",
+  "%s BigInt prototype spoof falls back to ordinary inspect"
+);
+eq(
+  util.format("%s", Object.create(Symbol.prototype)),
+  "Symbol {}",
+  "%s Symbol prototype spoof falls back to ordinary inspect"
 );
 (function () {
   var methods = [

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -85,6 +85,117 @@ eq(
   "OBJ",
   "%s object with toString"
 );
+eq(util.format("%s", [1, 2, 3]), "[ 1, 2, 3 ]", "%s array uses inspect");
+eq(util.format("%s", { a: 1 }), "{ a: 1 }", "%s plain object uses inspect");
+eq(
+  util.format(
+    "%s",
+    new (class {
+      toString() {
+        return "CLASS";
+      }
+    })()
+  ),
+  "CLASS",
+  "%s class-prototype toString uses String"
+);
+eq(
+  util.format("%s", new Date(0)),
+  "1970-01-01T00:00:00.000Z",
+  "%s Date keeps built-in coercion on inspect path"
+);
+eq(util.format("%s", /re/g), "/re/g", "%s RegExp uses inspect");
+eq(
+  util.format("%s", { toString: null, a: 1 }),
+  "{ toString: null, a: 1 }",
+  "%s non-callable toString uses inspect"
+);
+(function () {
+  var value = {
+    [Symbol.toPrimitive]: function (hint) {
+      return hint === "string" ? "PRIMITIVE" : "WRONG HINT";
+    },
+  };
+  eq(
+    util.format("%s", value),
+    "PRIMITIVE",
+    "%s own Symbol.toPrimitive uses String with string hint"
+  );
+})();
+(function () {
+  function Base() {}
+  Base.prototype.toString = function () {
+    return "INHERITED";
+  };
+  function Child() {}
+  Object.setPrototypeOf(Child.prototype, Base.prototype);
+  eq(
+    util.format("%s", new Child()),
+    "INHERITED",
+    "%s inherited user toString uses String"
+  );
+})();
+(function () {
+  function PrimitiveBase() {}
+  PrimitiveBase.prototype[Symbol.toPrimitive] = function (hint) {
+    return hint === "string" ? "INHERITED PRIMITIVE" : "WRONG HINT";
+  };
+  function PrimitiveChild() {}
+  Object.setPrototypeOf(PrimitiveChild.prototype, PrimitiveBase.prototype);
+  eq(
+    util.format("%s", new PrimitiveChild()),
+    "INHERITED PRIMITIVE",
+    "%s inherited user Symbol.toPrimitive uses String"
+  );
+})();
+(function () {
+  function Widget() {
+    this.a = 1;
+  }
+  eq(
+    util.format("%s", new Widget()),
+    "Widget { a: 1 }",
+    "%s inherited built-in Object toString uses inspect"
+  );
+})();
+(function () {
+  var original = Array.prototype.toString;
+  try {
+    Array.prototype.toString = function () {
+      return "PATCHED ARRAY";
+    };
+    eq(
+      util.format("%s", [1, 2]),
+      "[ 1, 2 ]",
+      "%s patched built-in prototype still uses inspect"
+    );
+  } finally {
+    Array.prototype.toString = original;
+  }
+})();
+(function () {
+  class Array {
+    toString() {
+      return "USER ARRAY";
+    }
+  }
+  eq(
+    util.format("%s", new Array()),
+    "Array {}",
+    "%s follows Node constructor-name classification"
+  );
+})();
+(function () {
+  var value = [1, 2];
+  value[Symbol.toPrimitive] = function () {
+    return "ARRAY PRIMITIVE";
+  };
+  eq(
+    util.format("%s", value),
+    "ARRAY PRIMITIVE",
+    "%s own Symbol.toPrimitive overrides built-in array coercion"
+  );
+})();
 
 // ---- util.format: %d %i %f ------------------------------------------------
 eq(util.format("%d", 42), "42", "%d integer");

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -136,6 +136,43 @@ eq(
 );
 eq(util.format("%s", /re/g), "/re/g", "%s RegExp uses inspect");
 (function () {
+  var original = Object.getOwnPropertyDescriptor(
+    RegExp,
+    Symbol.hasInstance
+  );
+  try {
+    Object.defineProperty(RegExp, Symbol.hasInstance, {
+      configurable: true,
+      value: function () {
+        return false;
+      },
+    });
+    eq(
+      util.format("%s", /re/g),
+      "/re/g",
+      "%s RegExp ignores false Symbol.hasInstance"
+    );
+
+    Object.defineProperty(RegExp, Symbol.hasInstance, {
+      configurable: true,
+      value: function () {
+        throw new Error("patched RegExp Symbol.hasInstance called");
+      },
+    });
+    eq(
+      util.format("%s", /re/g),
+      "/re/g",
+      "%s RegExp ignores throwing Symbol.hasInstance"
+    );
+  } finally {
+    if (original) {
+      Object.defineProperty(RegExp, Symbol.hasInstance, original);
+    } else {
+      delete RegExp[Symbol.hasInstance];
+    }
+  }
+})();
+(function () {
   var original = RegExp.prototype.toString;
   try {
     RegExp.prototype.toString = function () {

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -104,6 +104,31 @@ eq(
   "1970-01-01T00:00:00.000Z",
   "%s Date keeps built-in coercion on inspect path"
 );
+(function () {
+  var originalGetTime = Date.prototype.getTime;
+  var originalToISOString = Date.prototype.toISOString;
+  try {
+    Date.prototype.getTime = function () {
+      throw new Error("patched getTime called");
+    };
+    Date.prototype.toISOString = function () {
+      throw new Error("patched toISOString called");
+    };
+    eq(
+      util.format("%s", new Date(0)),
+      "1970-01-01T00:00:00.000Z",
+      "%s Date ignores patched formatting methods"
+    );
+    eq(
+      util.format("%s", new Date(NaN)),
+      "Invalid Date",
+      "%s invalid Date ignores patched formatting methods"
+    );
+  } finally {
+    Date.prototype.getTime = originalGetTime;
+    Date.prototype.toISOString = originalToISOString;
+  }
+})();
 eq(util.format("%s", /re/g), "/re/g", "%s RegExp uses inspect");
 eq(
   util.format("%s", { toString: null, a: 1 }),

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -619,6 +619,47 @@ eq(
   );
 })();
 (function () {
+  var originalCall = Function.prototype.call;
+  var formatted;
+  try {
+    Function.prototype.call = function () {
+      throw new Error("patched Function call used");
+    };
+    formatted = util.format("%s", { a: 1 });
+  } finally {
+    Function.prototype.call = originalCall;
+  }
+  eq(
+    formatted,
+    "{ a: 1 }",
+    "%s classification ignores patched Function.prototype.call"
+  );
+})();
+(function () {
+  var proxy = new Proxy(
+    {},
+    {
+      get: function (target, key) {
+        if (key === "toString") {
+          return function () {
+            return "PROXY STRING";
+          };
+        }
+        if (key === Symbol.toPrimitive) return undefined;
+        return target[key];
+      },
+      getPrototypeOf: function () {
+        throw new Error("proxy getPrototypeOf trap called");
+      },
+    }
+  );
+  var formatted = util.format("%s", proxy);
+  truthy(
+    formatted === "PROXY STRING" || formatted === "Proxy({})",
+    "%s handles a throwing Proxy prototype walk"
+  );
+})();
+(function () {
   class Array {
     toString() {
       return "USER ARRAY";

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -310,6 +310,31 @@ eq(
   }
 })();
 (function () {
+  var originalGetPrototypeOf = Object.getPrototypeOf;
+  var originalGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+  try {
+    Object.getPrototypeOf = function () {
+      throw new Error("patched getPrototypeOf called");
+    };
+    Object.getOwnPropertyDescriptor = function () {
+      throw new Error("patched getOwnPropertyDescriptor called");
+    };
+    eq(
+      util.format("%s", [1, 2]),
+      "[ 1, 2 ]",
+      "%s ignores patched Object reflection methods for arrays"
+    );
+    eq(
+      util.format("%s", { a: 1 }),
+      "{ a: 1 }",
+      "%s ignores patched Object reflection methods for objects"
+    );
+  } finally {
+    Object.getPrototypeOf = originalGetPrototypeOf;
+    Object.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
+  }
+})();
+(function () {
   class Array {
     toString() {
       return "USER ARRAY";

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -358,6 +358,31 @@ eq(
     }
   }
 })();
+(function () {
+  var originalToString = Error.prototype.toString;
+  var stackReads = 0;
+  var error = new Error("throwing stack sentinel");
+  Object.defineProperty(error, "stack", {
+    configurable: true,
+    get: function () {
+      stackReads++;
+      throw new Error("stack getter called");
+    },
+  });
+  try {
+    Error.prototype.toString = function () {
+      throw new Error("patched Error toString called");
+    };
+    eq(
+      util.format("%s", error),
+      "[Error: throwing stack sentinel]",
+      "%s Error ignores throwing stack and patched toString"
+    );
+    eq(stackReads, 1, "%s Error reads a stack getter once");
+  } finally {
+    Error.prototype.toString = originalToString;
+  }
+})();
 eq(
   util.format("%s", Object.create(Number.prototype)),
   "Number {}",

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -322,6 +322,105 @@ eq(
   );
 })();
 (function () {
+  function namedToStringClass(name, marker) {
+    return ({
+      [name]: class {
+        toString() {
+          return marker;
+        }
+      },
+    })[name];
+  }
+
+  // Node snapshots this exact set while internal/util/inspect bootstraps. Lock
+  // every member through the observable constructor-name collision behavior so
+  // the shim cannot accidentally drift back to jsse's runtime global set.
+  var nodeBootstrapNames = [
+    "Object",
+    "Function",
+    "Array",
+    "Number",
+    "Infinity",
+    "NaN",
+    "Boolean",
+    "String",
+    "Symbol",
+    "Date",
+    "Promise",
+    "RegExp",
+    "Error",
+    "AggregateError",
+    "EvalError",
+    "RangeError",
+    "ReferenceError",
+    "SyntaxError",
+    "TypeError",
+    "URIError",
+    "JSON",
+    "Math",
+    "Intl",
+    "ArrayBuffer",
+    "Atomics",
+    "Uint8Array",
+    "Int8Array",
+    "Uint16Array",
+    "Int16Array",
+    "Uint32Array",
+    "Int32Array",
+    "BigUint64Array",
+    "BigInt64Array",
+    "Uint8ClampedArray",
+    "Float32Array",
+    "Float64Array",
+    "DataView",
+    "Map",
+    "BigInt",
+    "Set",
+    "Iterator",
+    "WeakMap",
+    "WeakSet",
+    "Proxy",
+    "Reflect",
+    "FinalizationRegistry",
+    "WeakRef",
+  ];
+  for (var i = 0; i < nodeBootstrapNames.length; i++) {
+    var builtInName = nodeBootstrapNames[i];
+    var builtInMarker = "USER " + builtInName;
+    var BuiltInCollision = namedToStringClass(builtInName, builtInMarker);
+    truthy(
+      util.format("%s", new BuiltInCollision()) !== builtInMarker,
+      "%s Node bootstrap name uses inspect: " + builtInName
+    );
+  }
+
+  // These names are visible later in Node, visible only in jsse, or supplied by
+  // the host shims. Node's early snapshot excludes all of them, so a colliding
+  // user class must retain its coercion hook.
+  var nonBootstrapNames = [
+    "Buffer",
+    "URL",
+    "Temporal",
+    "ShadowRealm",
+    "SuppressedError",
+    "DisposableStack",
+    "AsyncDisposableStack",
+    "Float16Array",
+    "SharedArrayBuffer",
+    "WebAssembly",
+  ];
+  for (var j = 0; j < nonBootstrapNames.length; j++) {
+    var userName = nonBootstrapNames[j];
+    var userMarker = "USER " + userName;
+    var UserCollision = namedToStringClass(userName, userMarker);
+    eq(
+      util.format("%s", new UserCollision()),
+      userMarker,
+      "%s non-bootstrap name uses String: " + userName
+    );
+  }
+})();
+(function () {
   var value = [1, 2];
   value[Symbol.toPrimitive] = function () {
     return "ARRAY PRIMITIVE";


### PR DESCRIPTION
## Summary

- mirror Node's `hasBuiltInToString` prototype-owner walk and explicit Node 26.5.0 bootstrap built-in-name membership when `%s` classifies object coercion hooks
- keep late, host, and JSSE-only constructor names such as `Temporal`, `ShadowRealm`, `DisposableStack`, `Float16Array`, `SharedArrayBuffer`, `Buffer`, and `URL` on Node's user-defined `String()` path
- capture reflection and formatting primordials before bundled code can patch them, including built-in instance checks, while preserving genuine RegExp `source`/`flags` accessor errors and prototype-spoof fallback
- reproduce Node's distinct boxed BigInt/Symbol fallback when their current `Symbol.hasInstance` hooks return false or throw
- route arrays/plain objects and patched built-in prototypes through getter-safe, intrinsic-safe `inspect`, while own or inherited user `toString`/`Symbol.toPrimitive` hooks use `String`
- expand the byte-compared shim self-test across Node's full 47-name bootstrap set, representative exclusions, patched reflection, RegExp accessors, mutable `Symbol.hasInstance` hooks, built-in slots, inherited hooks, non-callable hooks, and constructor-name collisions
- update the shim documentation and compatibility design

## Test plan

- `./scripts/run-node-shim-selftest.sh --no-build` — 171/171 assertions on JSSE, byte-identical against Node 26.5.0; process probes green
- `./scripts/run-shim-fixtures.sh` — Buffer 266/266, string decoder 23/23, TextDecoder labels 28/28 on JSSE and Node
- `uv run python scripts/run-custom-tests.py` — 10/10
- targeted Object/Array/Date/RegExp test262 directories — 17,861/17,861 scenarios
- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` — 341 Rust tests plus test262 smoke oracle
- `./scripts/lint.sh`
- `TZ=UTC uv run python scripts/run-test262.py --fail-on-failures` — 99,568/99,568 scenarios (100.00%), zero regressions, baseline unchanged

Environment note: UTC reproduces the repository's documented 100% test262 baseline for Intl/Temporal local-time expectations. This branch contains no engine changes.

Closes #250
