### PR TITLE
fix(regexp): preserve exact-zero capture slots

### DIFF
--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -4789,6 +4789,7 @@ pub(crate) struct CachedRegex {
     compiled: CompiledRegex,
     dup_map: DupGroupMap,
     name_order: Vec<String>,
+    total_groups: usize,
 }
 
 const REGEX_CACHE_MAX: usize = 256;
@@ -4807,6 +4808,7 @@ fn build_regex_cached(
         compiled,
         dup_map,
         name_order,
+        total_groups: count_capture_groups(source),
     });
     if interp.regexp_legacy.regex_cache.len() >= REGEX_CACHE_MAX {
         interp.regexp_legacy.regex_cache.clear();
@@ -6828,6 +6830,16 @@ macro_rules! build_captures {
     }};
 }
 
+fn ensure_capture_slots(caps: &mut RegexCaptures, total_groups: usize) {
+    let expected_len = total_groups + 1;
+    if caps.groups.len() < expected_len {
+        caps.groups.resize_with(expected_len, || None);
+    }
+    if caps.names.len() < expected_len {
+        caps.names.resize_with(expected_len, || None);
+    }
+}
+
 fn regex_captures_at(re: &CompiledRegex, text: &str, pos: usize) -> Option<RegexCaptures> {
     match re {
         CompiledRegex::Fancy(r) => {
@@ -7458,6 +7470,7 @@ fn regexp_exec_raw(
     clear_stale_dup_captures(&mut caps, &cached.dup_map);
     strip_renamed_qi_captures(&mut caps);
     reset_quantifier_inner_captures(&mut caps, source);
+    ensure_capture_slots(&mut caps, cached.total_groups);
     let dup_map = &cached.dup_map;
     let name_order = &cached.name_order;
 
@@ -7524,7 +7537,7 @@ fn regexp_exec_raw(
         }
     }
 
-    let has_named = caps.names.iter().any(|n| n.is_some());
+    let has_named = !name_order.is_empty();
     let resolved_named = if has_named {
         Some(resolve_named_group_matches(&caps, dup_map, name_order))
     } else {
@@ -8394,6 +8407,7 @@ impl Interpreter {
                         clear_stale_dup_captures(&mut caps, &cached.dup_map);
                         strip_renamed_qi_captures(&mut caps);
                         reset_quantifier_inner_captures(&mut caps, &source);
+                        ensure_capture_slots(&mut caps, cached.total_groups);
 
                         let full_match = caps.get(0).unwrap();
                         let matched = &full_match.text;
@@ -8423,7 +8437,7 @@ impl Interpreter {
                         }
 
                         // Named captures
-                        let has_named = caps.names.iter().any(|n| n.is_some());
+                        let has_named = !cached.name_order.is_empty();
                         let named_captures_obj = if has_named {
                             let groups_obj_id = interp.create_object_id();
                             interp
@@ -9436,7 +9450,8 @@ impl Interpreter {
                             interp.create_iter_result_object(JsValue::Undefined, true),
                         )
                     }
-                    Some(caps) => {
+                    Some(mut caps) => {
+                        ensure_capture_slots(&mut caps, count_capture_groups(&source));
                         let full = caps.get(0).unwrap();
                         let match_start = last_index + full.start;
                         let match_end = last_index + full.end;

--- a/test262-extra/RegExp-exact-zero-capture-slot.js
+++ b/test262-extra/RegExp-exact-zero-capture-slot.js
@@ -1,0 +1,39 @@
+// Capturing groups occupy a result slot even when an exact-zero quantifier
+// prevents them from participating in a match.
+// Spec: ECMAScript 2026, sec-regexpinitialize and sec-regexpbuiltinexec.
+
+var single = /(a){0}/.exec("");
+assert.sameValue(single.length, 2, "trailing {0} capture keeps its slot");
+assert.sameValue(single[0], "", "full match for trailing {0} capture");
+assert.sameValue(single[1], undefined, "trailing {0} capture is undefined");
+
+var afterCapture = /(b)(a){0,0}/.exec("b");
+assert.sameValue(afterCapture.length, 3, "trailing {0,0} capture keeps its slot");
+assert.sameValue(afterCapture[0], "b", "full match before trailing {0,0} capture");
+assert.sameValue(afterCapture[1], "b", "participating capture before trailing {0,0}");
+assert.sameValue(afterCapture[2], undefined, "trailing {0,0} capture is undefined");
+
+var withIndices = /(a){0}/d.exec("");
+assert.sameValue(withIndices.indices.length, 2, "indices keeps the trailing capture slot");
+assert.sameValue(withIndices.indices[1], undefined, "unmatched trailing capture has no indices");
+
+assert.sameValue(
+  "".replace(/(a){0}/, "x$1y"),
+  "xy",
+  "replacement recognizes the unmatched capture"
+);
+
+var named = /(?<last>a){0}/d.exec("");
+assert.sameValue(named.length, 2, "trailing named capture keeps its slot");
+assert.sameValue(typeof named.groups, "object", "named captures create a groups object");
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(named.groups, "last"),
+  true,
+  "groups has the trailing capture name"
+);
+assert.sameValue(named.groups.last, undefined, "trailing named capture is undefined");
+assert.sameValue(
+  named.indices.groups.last,
+  undefined,
+  "trailing named capture has no named indices"
+);


### PR DESCRIPTION
## Summary

- preserve the ECMAScript syntactic capture count when Rust regex backends optimize unreachable trailing groups away
- restore unmatched slots for exec results, indices, replacement captures, iterators, and named groups
- add conformance coverage for trailing `{0}` and `{0,0}` captures

Closes #377

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy`
- [x] `./scripts/lint.sh`
- [x] `cargo build --release`
- [x] `cargo test --release` — 341 unit tests + smoke oracle
- [x] `/usr/bin/uv run python scripts/run-custom-tests.py` — 10/10
- [x] targeted RegExp/replacement/regexp-literal test262 — 4,340/4,340
- [x] regression test — 2/2 strict and non-strict scenarios
- [x] `TZ=UTC /usr/bin/uv run python scripts/run-test262.py` — 99,568/99,568, zero regressions

The initial full run inherited the worker's Europe/Berlin timezone and exposed 22 unrelated Intl system-timezone failures. All 22 pass in isolation under `TZ=UTC`; the definitive full run used that baseline-compatible environment.