### PR TITLE
fix(json): include token context in parse errors

### DIFF
--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -827,7 +827,7 @@ pub(crate) fn json_trim(s: &str) -> &str {
 pub(crate) type SourceTextMap = HashMap<(u64, JsPropertyKey), String>;
 
 pub(crate) fn json_parse_value(interp: &mut Interpreter, s: &str) -> Completion {
-    json_parse_value_inner(interp, s, None)
+    json_parse_value_inner(interp, s, None, s)
 }
 
 pub(crate) fn json_parse_value_with_source(
@@ -835,7 +835,7 @@ pub(crate) fn json_parse_value_with_source(
     s: &str,
 ) -> (Completion, SourceTextMap) {
     let mut source_map = SourceTextMap::default();
-    let result = json_parse_value_inner(interp, s, Some(&mut source_map));
+    let result = json_parse_value_inner(interp, s, Some(&mut source_map), s);
     (result, source_map)
 }
 
@@ -843,6 +843,7 @@ fn json_parse_value_inner(
     interp: &mut Interpreter,
     s: &str,
     mut source_map: Option<&mut SourceTextMap>,
+    root_source: &str,
 ) -> Completion {
     let s = json_trim(s);
     if s == "null" {
@@ -869,15 +870,14 @@ fn json_parse_value_inner(
     }
     if s.starts_with('[') && s.ends_with(']') {
         let inner = &s[1..s.len() - 1];
-        if json_has_invalid_comma(inner) {
-            let err = interp.create_error("SyntaxError", "Unexpected token in JSON");
-            return Completion::Throw(err);
+        if let Some(token) = json_invalid_comma_token(inner, ']') {
+            return json_unexpected_token_error(interp, token, root_source);
         }
         let items = json_split_items(inner);
         let mut parsed_items: Vec<(JsValue, String)> = Vec::new();
         for item in &items {
             let trimmed_src = json_trim(item).to_string();
-            match json_parse_value_inner(interp, item, source_map.as_deref_mut()) {
+            match json_parse_value_inner(interp, item, source_map.as_deref_mut(), root_source) {
                 Completion::Normal(v) => parsed_items.push((v, trimmed_src)),
                 other => return other,
             }
@@ -898,9 +898,8 @@ fn json_parse_value_inner(
     }
     if s.starts_with('{') && s.ends_with('}') {
         let inner = &s[1..s.len() - 1];
-        if json_has_invalid_comma(inner) {
-            let err = interp.create_error("SyntaxError", "Unexpected token in JSON");
-            return Completion::Throw(err);
+        if let Some(token) = json_invalid_comma_token(inner, '}') {
+            return json_unexpected_token_error(interp, token, root_source);
         }
         let pairs = json_split_items(inner);
         let obj_id = interp.create_object_id();
@@ -930,7 +929,7 @@ fn json_parse_value_inner(
                 return Completion::Throw(err);
             };
             let val_src = json_trim(val_str).to_string();
-            match json_parse_value_inner(interp, val_str, source_map.as_deref_mut()) {
+            match json_parse_value_inner(interp, val_str, source_map.as_deref_mut(), root_source) {
                 Completion::Normal(v) => {
                     if let Some(ref mut smap) = source_map
                         && is_json_primitive(&v)
@@ -947,8 +946,19 @@ fn json_parse_value_inner(
         }
         return Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }));
     }
+    if let Some(token) = s.chars().next() {
+        return json_unexpected_token_error(interp, token, root_source);
+    }
     let err = interp.create_error("SyntaxError", "Unexpected token in JSON");
     Completion::Throw(err)
+}
+
+fn json_unexpected_token_error(interp: &mut Interpreter, token: char, source: &str) -> Completion {
+    let message = format!(
+        "Unexpected token '{}', \"{}\" is not valid JSON",
+        token, source
+    );
+    Completion::Throw(interp.create_error("SyntaxError", &message))
 }
 
 pub(crate) fn is_json_primitive(val: &JsValue) -> bool {
@@ -1287,10 +1297,10 @@ fn json_is_valid_number(s: &str) -> bool {
     i == bytes.len()
 }
 
-fn json_has_invalid_comma(inner: &str) -> bool {
+fn json_invalid_comma_token(inner: &str, closing_token: char) -> Option<char> {
     let trimmed = json_trim(inner);
     if trimmed.is_empty() {
-        return false;
+        return None;
     }
     let mut depth = 0i32;
     let mut in_string = false;
@@ -1324,7 +1334,7 @@ fn json_has_invalid_comma(inner: &str) -> bool {
             }
             ',' if depth == 0 => {
                 if prev_was_comma {
-                    return true; // double comma or leading comma
+                    return Some(','); // double comma or leading comma
                 }
                 prev_was_comma = true;
             }
@@ -1334,7 +1344,16 @@ fn json_has_invalid_comma(inner: &str) -> bool {
             }
         }
     }
-    prev_was_comma // trailing comma
+    if !prev_was_comma {
+        return None;
+    }
+
+    let before_comma = trimmed.strip_suffix(',').map(json_trim).unwrap_or_default();
+    if closing_token == '}' && before_comma.ends_with(':') {
+        Some(',')
+    } else {
+        Some(closing_token)
+    }
 }
 
 pub(crate) fn json_split_items(s: &str) -> Vec<String> {

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -954,9 +954,21 @@ fn json_parse_value_inner(
 }
 
 fn json_unexpected_token_error(interp: &mut Interpreter, token: char, source: &str) -> Completion {
+    const MAX_SOURCE_CHARS: usize = 20;
+    const TRUNCATED_SOURCE_CHARS: usize = 10;
+
+    let (source, ellipsis) = if source.chars().nth(MAX_SOURCE_CHARS).is_some() {
+        let prefix_end = source
+            .char_indices()
+            .nth(TRUNCATED_SOURCE_CHARS)
+            .map_or(source.len(), |(index, _)| index);
+        (&source[..prefix_end], "...")
+    } else {
+        (source, "")
+    };
     let message = format!(
-        "Unexpected token '{}', \"{}\" is not valid JSON",
-        token, source
+        "Unexpected token '{}', \"{}\"{} is not valid JSON",
+        token, source, ellipsis
     );
     Completion::Throw(interp.create_error("SyntaxError", &message))
 }

--- a/tests/json-parse-error-message.js
+++ b/tests/json-parse-error-message.js
@@ -30,11 +30,28 @@ assertParseMessage(zodSource, function (_key, value) { return value; }, zodMessa
 assertParseMessage(
   '{"outer":{"invalid":,}}',
   undefined,
-  'Unexpected token \',\', "{"outer":{"invalid":,}}" is not valid JSON'
+  'Unexpected token \',\', "{"outer":{"... is not valid JSON'
 );
 
 assertParseMessage(
   '~~invalid~~',
   undefined,
   'Unexpected token \'~\', "~~invalid~~" is not valid JSON'
+);
+
+assertParseMessage(
+  'x'.repeat(20),
+  undefined,
+  'Unexpected token \'x\', "xxxxxxxxxxxxxxxxxxxx" is not valid JSON'
+);
+
+var truncatedMessage =
+  'Unexpected token \'x\', "xxxxxxxxxx"... is not valid JSON';
+assertParseMessage('x'.repeat(21), undefined, truncatedMessage);
+assertParseMessage('x'.repeat(1000000), undefined, truncatedMessage);
+
+assertParseMessage(
+  'é'.repeat(21),
+  undefined,
+  'Unexpected token \'é\', "éééééééééé"... is not valid JSON'
 );

--- a/tests/json-parse-error-message.js
+++ b/tests/json-parse-error-message.js
@@ -1,0 +1,40 @@
+// ParseJSON (§25.5.1.1) requires invalid JSON text to throw a SyntaxError but
+// does not prescribe its message. These assertions pin the Node-compatible
+// token/source context used by the Zod JSON codec.
+
+function assertParseMessage(source, reviver, expected) {
+  var error;
+  try {
+    JSON.parse(source, reviver);
+  } catch (caught) {
+    error = caught;
+  }
+
+  if (!(error instanceof SyntaxError)) {
+    throw new Error("expected SyntaxError for " + source);
+  }
+  if (error.message !== expected) {
+    throw new Error(
+      "unexpected JSON.parse diagnostic: expected " + expected +
+      ", got " + error.message
+    );
+  }
+}
+
+var zodSource = '{"invalid":,}';
+var zodMessage = 'Unexpected token \',\', "{"invalid":,}" is not valid JSON';
+
+assertParseMessage(zodSource, undefined, zodMessage);
+assertParseMessage(zodSource, function (_key, value) { return value; }, zodMessage);
+
+assertParseMessage(
+  '{"outer":{"invalid":,}}',
+  undefined,
+  'Unexpected token \',\', "{"outer":{"invalid":,}}" is not valid JSON'
+);
+
+assertParseMessage(
+  '~~invalid~~',
+  undefined,
+  'Unexpected token \'~\', "~~invalid~~" is not valid JSON'
+);


### PR DESCRIPTION
## Summary

- preserve the original JSON source across recursive parsing
- report Node-compatible unexpected-token and source context for invalid separators and values
- cover normal, reviver, nested, and top-level invalid JSON diagnostics

## Validation

- cargo fmt --check
- cargo clippy
- ./scripts/lint.sh
- cargo build --release
- cargo test --release (341 passed plus smoke oracle)
- custom tests: 11/11
- JSON.parse test262: 154/154
- full test262 with TZ=UTC: 99,568/99,568, zero regressions
- Zod: codec transform error handling passes in normal and jitless modes; total improves from 2,176 to 2,178

The change stays within the existing hand-written JSON parser seam rather than changing global SyntaxError formatting or introducing a new parser.

Closes #315