### PR TITLE
fix(interpreter): deepen the String-exotic index predicate into string_exotic_index

### DIFF
--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -6765,6 +6765,22 @@ impl Interpreter {
                             return Completion::Normal(JsValue::Boolean(true));
                         }
                     }
+                    // String exotic [[Delete]] (§10.4.3): "length" and own
+                    // character indices are non-configurable.
+                    {
+                        let b = obj.borrow();
+                        if b.class_name == "String"
+                            && let Some(JsValue::String(ref s)) = b.primitive_value
+                            && (key.as_str() == Some("length")
+                                || crate::interpreter::types::string_exotic_index(
+                                    &key,
+                                    s.code_units.len(),
+                                )
+                                .is_some())
+                        {
+                            return Completion::Normal(JsValue::Boolean(false));
+                        }
+                    }
                     let mut obj_mut = obj.borrow_mut();
                     if let Some(desc) = obj_mut.properties.get(&key)
                         && desc.configurable == Some(false)

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -801,7 +801,11 @@ impl Interpreter {
                                 && obj_b.class_name == "String"
                             {
                                 let is_exotic = key.eq_str("length")
-                                    || key.parse::<usize>().is_ok_and(|i| i < s.code_units.len());
+                                    || crate::interpreter::types::string_exotic_index(
+                                        &key,
+                                        s.code_units.len(),
+                                    )
+                                    .is_some();
                                 if is_exotic {
                                     drop(obj_b);
                                     if is_strict {
@@ -1428,14 +1432,10 @@ impl Interpreter {
             JsValue::String(s) => {
                 if name.eq_str("length") {
                     Completion::Normal(JsValue::Number(s.len() as f64))
-                } else if let Ok(idx) = name.parse::<usize>() {
-                    if idx < s.code_units.len() {
-                        Completion::Normal(JsValue::String(JsString::from_vec(vec![
-                            s.code_units[idx],
-                        ])))
-                    } else {
-                        Completion::Normal(JsValue::Undefined)
-                    }
+                } else if let Some(idx) =
+                    crate::interpreter::types::string_exotic_index(&name, s.code_units.len())
+                {
+                    Completion::Normal(JsValue::String(JsString::from_vec(vec![s.code_units[idx]])))
                 } else if let Some(sp_id) = self.realm().string_prototype {
                     Completion::Normal(self.get_property_on_id(sp_id, &name))
                 } else {

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -898,14 +898,10 @@ impl Interpreter {
             JsValue::String(s) => {
                 if key.eq_str("length") {
                     Completion::Normal(JsValue::Number(s.len() as f64))
-                } else if let Ok(idx) = key.parse::<usize>() {
-                    if idx < s.code_units.len() {
-                        Completion::Normal(JsValue::String(JsString::from_vec(vec![
-                            s.code_units[idx],
-                        ])))
-                    } else {
-                        Completion::Normal(JsValue::Undefined)
-                    }
+                } else if let Some(idx) =
+                    crate::interpreter::types::string_exotic_index(&key, s.code_units.len())
+                {
+                    Completion::Normal(JsValue::String(JsString::from_vec(vec![s.code_units[idx]])))
                 } else {
                     let wrapper = match self.to_object(&obj_val) {
                         Completion::Normal(v) => v,

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -1002,13 +1002,10 @@ impl Interpreter {
                     if key.as_property_key_str() == Some("length") {
                         return Ok(false);
                     }
-                    if let Some(key_str) = key.as_property_key_str()
-                        && let Ok(idx) = key_str.parse::<usize>()
+                    if crate::interpreter::types::string_exotic_index(key, s.code_units.len())
+                        .is_some()
                     {
-                        let char_len = s.to_string().chars().count();
-                        if idx < char_len {
-                            return Ok(false);
-                        }
+                        return Ok(false);
                     }
                 }
             }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -2037,6 +2037,102 @@ mod string_to_number_seam_tests {
     }
 }
 
+/// §10.4.3 String-exotic objects expose an own indexed character property only
+/// when the key is the CanonicalNumericIndexString of an in-range integer.
+/// These exercise the public seams (member read, `in`, GetOwnPropertyDescriptor,
+/// DefineProperty, delete, Reflect) that all route through `string_exotic_index`.
+/// Expected values are node's (spec-conformant) results as known-good literals.
+mod string_exotic_index_seam_tests {
+    use super::*;
+
+    #[test]
+    fn non_canonical_index_keys_are_not_own_string_properties() {
+        // "01"/"+1"/"1.0" are not CanonicalNumericIndexStrings, so they name no
+        // own character property of the string; only "1" does.
+        let interp = run_script(
+            r#"
+            var s = "abc";
+            var o = Object("abc");
+            var report = [
+                String(s["01"]),
+                String(s["+1"]),
+                String(s["1.0"]),
+                String(s["1"]),
+                String(o["01"]),
+                ("01" in o),
+                ("1" in o),
+                (Object.getOwnPropertyDescriptor(o, "01") === undefined),
+                Object.keys(o).join(",")
+            ].join("|");
+            "#,
+        );
+        assert_eq!(
+            global_string(&interp, "report"),
+            "undefined|undefined|undefined|b|undefined|false|true|true|0,1,2"
+        );
+    }
+
+    #[test]
+    fn define_property_on_non_canonical_index_is_allowed() {
+        // "01" is an ordinary property key, so defineProperty must succeed and
+        // the value must read back (the string-index redefinition guard must
+        // not fire for a look-alike key).
+        let interp = run_script(
+            r#"
+            var o = Object("abc");
+            Object.defineProperty(o, "01", {
+                value: "z", writable: true, configurable: true, enumerable: true
+            });
+            // [[Set]] of a look-alike key must also store an ordinary property
+            // (the non-writable string-index guard must not fire for "+2").
+            var p = Object("abc");
+            p["+2"] = "w";
+            var report = String(o["01"]) + "|" + String(p["+2"]);
+            "#,
+        );
+        assert_eq!(global_string(&interp, "report"), "z|w");
+    }
+
+    #[test]
+    fn delete_distinguishes_canonical_indices_from_look_alikes() {
+        // Own indices are non-configurable (delete -> false); look-alikes are
+        // ordinary absent properties (delete -> true). Indexing is by UTF-16
+        // code unit, so both halves of a non-BMP code point are in range.
+        let interp = run_script(
+            r#"
+            var report = [
+                delete Object("abc")["01"],
+                delete Object("abc")[1],
+                Reflect.deleteProperty(Object("abc"), "1"),
+                Reflect.deleteProperty(Object("abc"), "01"),
+                Reflect.deleteProperty(Object("\u{1F4A9}"), "1"),
+                Reflect.deleteProperty(Object("\u{1F4A9}"), "0")
+            ].join(",");
+            "#,
+        );
+        assert_eq!(
+            global_string(&interp, "report"),
+            "true,false,false,true,false,false"
+        );
+    }
+
+    #[test]
+    fn strict_delete_of_own_string_index_throws_but_look_alike_succeeds() {
+        // Index 1 is a non-configurable own property, so strict-mode delete
+        // throws a TypeError; "01" is deletable and returns true.
+        let interp = run_script(
+            r#"
+            "use strict";
+            var deleted01 = delete Object("abc")["01"];
+            var threw = false;
+            try { delete Object("abc")[1]; } catch (e) { threw = (e instanceof TypeError); }
+            var report = String(deleted01) + "|" + String(threw);
+            "#,
+        );
+        assert_eq!(global_string(&interp, "report"), "true|true");
+    }
+}
+
 /// Node host-compat "syscall floor" (issue #229). These exercise the ON-path
 /// (`enable_node_host`); the OFF-path 0-regression guarantee is covered by the
 /// full test262 run, which never enables the floor.

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -2073,9 +2073,7 @@ impl JsObjectData {
             if key == "length" {
                 return Some(JsValue::Number(units.len() as f64));
             }
-            if let Ok(idx) = key.parse::<usize>()
-                && idx < units.len()
-            {
+            if let Some(idx) = string_exotic_index(key, units.len()) {
                 return Some(JsValue::String(crate::types::JsString::from_vec(vec![
                     units[idx],
                 ])));
@@ -2150,10 +2148,7 @@ impl JsObjectData {
                     set: None,
                 });
             }
-            if let Some(key_str) = key.as_property_key_str()
-                && let Ok(idx) = key_str.parse::<usize>()
-                && idx < units.len()
-            {
+            if let Some(idx) = string_exotic_index(key, units.len()) {
                 return Some(PropertyDescriptor {
                     value: Some(JsValue::String(crate::types::JsString::from_vec(vec![
                         units[idx],
@@ -2263,10 +2258,7 @@ impl JsObjectData {
                     false,
                 ));
             }
-            if let Some(key_str) = key.as_property_key_str()
-                && let Ok(idx) = key_str.parse::<usize>()
-                && idx < s.code_units.len()
-            {
+            if let Some(idx) = string_exotic_index(key, s.code_units.len()) {
                 return Some(PropertyDescriptor::data(
                     JsValue::String(JsString::from_vec(vec![s.code_units[idx]])),
                     false,
@@ -2307,11 +2299,7 @@ impl JsObjectData {
             if key.as_property_key_str() == Some("length") {
                 return true;
             }
-            if let Some(key_str) = key.as_property_key_str()
-                && let Ok(idx) = key_str.parse::<usize>()
-            {
-                return idx < s.code_units.len();
-            }
+            return string_exotic_index(key, s.code_units.len()).is_some();
         }
         false
     }
@@ -2330,8 +2318,7 @@ impl JsObjectData {
         // String exotic §10.4.3.3 [[DefineOwnProperty]]: reject changes to character index properties
         if self.class_name == "String"
             && let Some(JsValue::String(ref s)) = self.primitive_value
-            && let Ok(idx) = key.parse::<usize>()
-            && idx < s.code_units.len()
+            && let Some(idx) = string_exotic_index(&key, s.code_units.len())
         {
             // String index property: {value: char, writable: false, enumerable: true, configurable: false}
             // Only allow if desc is compatible (no changes to value, not setting writable/configurable)
@@ -2886,10 +2873,7 @@ impl JsObjectData {
             if let Some(JsValue::String(ref s)) = self.primitive_value
                 && self.class_name == "String"
                 && (key.as_property_key_str() == Some("length")
-                    || key
-                        .as_property_key_str()
-                        .and_then(|k| k.parse::<usize>().ok())
-                        .is_some_and(|i| i < s.code_units.len()))
+                    || string_exotic_index(key, s.code_units.len()).is_some())
             {
                 return false;
             }
@@ -3079,10 +3063,7 @@ impl JsObjectData {
                     set: None,
                 });
             }
-            if let Some(key_str) = key.as_property_key_str()
-                && let Ok(idx) = key_str.parse::<usize>()
-                && idx < units.len()
-            {
+            if let Some(idx) = string_exotic_index(key, units.len()) {
                 return Some(PropertyDescriptor {
                     value: Some(JsValue::String(crate::types::JsString::from_vec(vec![
                         units[idx],
@@ -3218,6 +3199,40 @@ pub(crate) fn canonical_numeric_index_string<K: crate::types::PropertyKeyLike + 
     } else {
         None
     }
+}
+
+/// §10.4.3 String-exotic own indexed-property test (the index branch of
+/// StringGetOwnProperty).
+///
+/// Returns `Some(i)` when `key` is the CanonicalNumericIndexString of an
+/// integral index `i` with `0 <= i < len` — i.e. `key` names an own indexed
+/// character property of a String value whose UTF-16 length is `len`. Returns
+/// `None` for non-canonical spellings (`"01"`, `"+1"`, `"1.0"`), `-0`,
+/// negative, non-integral, or non-finite indices, and indices `>= len`.
+///
+/// This concentrates the one canonical predicate so every String-exotic MOP
+/// operation ([[Get]], [[GetOwnProperty]], [[HasProperty]],
+/// [[DefineOwnProperty]], [[Set]], [[Delete]]) agrees, instead of each caller
+/// reaching for `str::parse::<usize>()`, which wrongly accepts a leading `+`
+/// and leading zeros. `len` must be the string's UTF-16 code-unit length.
+pub(crate) fn string_exotic_index<K: crate::types::PropertyKeyLike + ?Sized>(
+    key: &K,
+    len: usize,
+) -> Option<usize> {
+    let n = canonical_numeric_index_string(key)?;
+    // IsIntegralNumber(index) is false, or index is -0𝔽 -> not an own index.
+    if !n.is_finite() || n.fract() != 0.0 {
+        return None;
+    }
+    if n == 0.0 && n.is_sign_negative() {
+        return None;
+    }
+    // index < 0 or len <= index -> not an own index. Range-check before the
+    // cast so a huge finite index can never saturate into a valid `usize`.
+    if n < 0.0 || n >= len as f64 {
+        return None;
+    }
+    Some(n as usize)
 }
 
 pub(crate) fn typed_array_length(ta: &TypedArrayInfo) -> usize {
@@ -4048,5 +4063,67 @@ mod property_bag_tests {
         assert!(obj.remove_property("a").is_some());
         assert!(obj.remove_property("a").is_none());
         assert!(keys(&obj).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod string_exotic_index_tests {
+    use super::string_exotic_index;
+
+    // §10.4.3 StringGetOwnProperty own-index predicate. Expected values are the
+    // ECMAScript truth table (CanonicalNumericIndexString + IsIntegralNumber +
+    // -0 + range), cross-checked against node.
+    #[test]
+    fn canonical_in_range_indices_resolve() {
+        assert_eq!(string_exotic_index("0", 3), Some(0));
+        assert_eq!(string_exotic_index("1", 3), Some(1));
+        assert_eq!(string_exotic_index("2", 3), Some(2));
+    }
+
+    #[test]
+    fn out_of_range_is_none() {
+        assert_eq!(string_exotic_index("3", 3), None);
+        assert_eq!(string_exotic_index("0", 0), None);
+        assert_eq!(string_exotic_index("9999999999", 3), None);
+    }
+
+    #[test]
+    fn non_canonical_spellings_are_none() {
+        // Round-trippable ToString(ToNumber(key)) != key -> not a canonical index.
+        assert_eq!(string_exotic_index("01", 3), None);
+        assert_eq!(string_exotic_index("00", 3), None);
+        assert_eq!(string_exotic_index("+1", 3), None);
+        assert_eq!(string_exotic_index("1.0", 3), None);
+        assert_eq!(string_exotic_index(" 1", 3), None);
+        assert_eq!(string_exotic_index("1 ", 3), None);
+        assert_eq!(string_exotic_index("1e0", 3), None);
+        assert_eq!(string_exotic_index("0x1", 3), None);
+        assert_eq!(string_exotic_index("", 3), None);
+    }
+
+    #[test]
+    fn non_integral_canonical_numbers_are_none() {
+        assert_eq!(string_exotic_index("1.5", 3), None);
+        assert_eq!(string_exotic_index("0.5", 3), None);
+    }
+
+    #[test]
+    fn negative_and_negative_zero_are_none() {
+        assert_eq!(string_exotic_index("-1", 3), None);
+        // CanonicalNumericIndexString("-0") is -0f; StringGetOwnProperty rejects it.
+        assert_eq!(string_exotic_index("-0", 3), None);
+    }
+
+    #[test]
+    fn non_finite_canonical_words_are_none() {
+        // "Infinity"/"NaN" round-trip through ToString but are not integral indices.
+        assert_eq!(string_exotic_index("Infinity", 3), None);
+        assert_eq!(string_exotic_index("-Infinity", 3), None);
+        assert_eq!(string_exotic_index("NaN", 3), None);
+    }
+
+    #[test]
+    fn length_word_is_not_an_index() {
+        assert_eq!(string_exotic_index("length", 3), None);
     }
 }

--- a/test262-extra/String-exotic-canonical-index.js
+++ b/test262-extra/String-exotic-canonical-index.js
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 the JSSE project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  A String exotic object exposes an own character property for a key P only when
+  P is the CanonicalNumericIndexString of an integer index in [0, length). A key
+  that merely parses as a number under a host integer parser -- a leading "+", a
+  leading zero ("01"), a non-integral or non-finite spelling -- is NOT such an
+  index and must behave as an ordinary (absent) property across every MOP
+  operation: [[Get]], [[HasProperty]], [[GetOwnProperty]], [[DefineOwnProperty]],
+  [[Delete]], and [[OwnPropertyKeys]]. Indexing is by UTF-16 code unit, so both
+  halves of a supplementary code point are in range. Expected values are
+  cross-checked with Node.
+info: |
+  10.4.3.5 StringGetOwnProperty ( S, P )
+    2. Let index be CanonicalNumericIndexString(P).
+    3. If index is undefined, return undefined.
+    4. If IsIntegralNumber(index) is false, return undefined.
+    5. If index is -0𝔽, return undefined.
+    ...
+    8. If ℝ(index) < 0 or len ≤ ℝ(index), return undefined.
+
+  7.1.21 CanonicalNumericIndexString ( argument )
+    ... 3. If SameValue(! ToString(n), argument) is false, return undefined.
+includes: [propertyHelper.js]
+---*/
+
+var NON_INDEX_KEYS = ["01", "00", "+1", "-1", "1.0", "1.5", "1e0", " 1", "0x1", "Infinity", "NaN"];
+
+// --- Primitive string [[Get]] and wrapper [[Get]] ---
+NON_INDEX_KEYS.forEach(function (k) {
+  assert.sameValue("abc"[k], undefined, 'primitive read "abc"[' + JSON.stringify(k) + ']');
+  assert.sameValue(Object("abc")[k], undefined, 'wrapper read Object("abc")[' + JSON.stringify(k) + ']');
+});
+assert.sameValue("abc"["0"], "a", 'canonical index "0"');
+assert.sameValue("abc"["1"], "b", 'canonical index "1"');
+assert.sameValue("abc"["2"], "c", 'canonical index "2"');
+assert.sameValue("abc"["3"], undefined, 'out-of-range index "3"');
+
+// --- [[HasProperty]] ---
+var wrapper = Object("abc");
+NON_INDEX_KEYS.forEach(function (k) {
+  assert.sameValue(k in wrapper, false, '"' + k + '" in Object("abc")');
+});
+assert.sameValue("1" in wrapper, true, '"1" in Object("abc")');
+assert.sameValue("3" in wrapper, false, '"3" in Object("abc")');
+
+// --- [[GetOwnProperty]] ---
+NON_INDEX_KEYS.forEach(function (k) {
+  assert.sameValue(
+    Object.getOwnPropertyDescriptor(wrapper, k),
+    undefined,
+    "getOwnPropertyDescriptor of look-alike " + JSON.stringify(k)
+  );
+});
+// Canonical index property has the spec-mandated attributes.
+verifyProperty(Object("abc"), "1", {
+  value: "b",
+  writable: false,
+  enumerable: true,
+  configurable: false,
+});
+
+// --- [[OwnPropertyKeys]] ---
+assert.sameValue(Object.keys(Object("abc")).join(","), "0,1,2", "Object.keys");
+assert.sameValue(
+  Object.getOwnPropertyNames(Object("abc")).join(","),
+  "0,1,2,length",
+  "getOwnPropertyNames"
+);
+
+// --- [[DefineOwnProperty]] on a look-alike key succeeds (ordinary property) ---
+var def = Object("abc");
+Object.defineProperty(def, "01", { value: "z", writable: true, enumerable: true, configurable: true });
+assert.sameValue(def["01"], "z", 'defineProperty(o, "01", ...) creates an ordinary property');
+var d = Object.getOwnPropertyDescriptor(def, "01");
+assert.sameValue(d.configurable, true, "the defined property is configurable, unlike a real index");
+
+// --- [[Set]] on a look-alike key stores an ordinary property ---
+// The non-writable string-index guard must not fire for a key that is not a
+// CanonicalNumericIndexString, so an ordinary assignment succeeds.
+var setObj = Object("abc");
+setObj["01"] = "z";
+assert.sameValue(setObj["01"], "z", 'assigning to "01" creates an ordinary property');
+
+// --- [[Delete]] via Reflect (mode-independent: never throws) ---
+assert.sameValue(Reflect.deleteProperty(Object("abc"), "1"), false, "own index 1 is non-configurable");
+assert.sameValue(Reflect.deleteProperty(Object("abc"), "01"), true, '"01" is an ordinary absent property');
+assert.sameValue(Reflect.deleteProperty(Object("abc"), "3"), true, "out-of-range index is absent");
+
+// --- UTF-16 code-unit indexing (supplementary code point occupies two indices) ---
+var poo = Object("\u{1F4A9}"); // U+1F4A9, encoded as the surrogate pair D83D DCA9
+assert.sameValue(poo.length, 2, "length counts UTF-16 code units");
+assert.sameValue("0" in poo, true, "lead surrogate is own index 0");
+assert.sameValue("1" in poo, true, "trail surrogate is own index 1");
+assert.sameValue("2" in poo, false, "index 2 is out of range");
+// Both halves are non-configurable; delete must report false (this is the
+// code-unit-vs-code-point regression: a code-point count would make index 1 absent).
+assert.sameValue(Reflect.deleteProperty(Object("\u{1F4A9}"), "1"), false, "trail surrogate index is in range");
+assert.sameValue(Reflect.deleteProperty(Object("\u{1F4A9}"), "0"), false, "lead surrogate index is in range");


### PR DESCRIPTION
## What this is

An **architecture audit** (`improve-codebase-architecture` skill) surfaced a scattered spec predicate; this PR concentrates it into one deep module, driven **test-first** (`tdd` skill). It is a *deepening* refactor in the house style of #371 (`deepen @@toStringTag`) and 96ac1b0 (`deepen StringToNumber; concentrate the WhiteSpace predicate`) — and, like the latter, the concentration exposes and fixes real ECMAScript divergences.

## Reviewing the audit results — the candidates

The scan turned up three deepening opportunities. Ranked on the task's criteria (impact on maintainability + real technical debt, safety, testability):

| Candidate | Shape | Real bug? | Sites | Verdict |
|---|---|---|---|---|
| **String-exotic index predicate** | §10.4.3 own-index test reimplemented via `str::parse::<usize>()` | **Yes** — 5 confirmed divergences | **11** + a missing Reflect check | ✅ **chosen** |
| ToLength (§7.1.20) | `min(2^53-1)` open-coded, no helper | No | ~11 | clean concentration, no bug |
| BigInt↔Number ordering | mixed-comparison block copied 5× in `eval.rs` | No | 5 | pure, testable, no bug |

The string-index candidate wins: strongest **locality** payoff (one predicate, eleven callers that had already drifted), a real bug surface, and it fits an established repo pattern — the canonical helper `canonical_numeric_index_string` already existed and was simply not used on these paths.

## The friction

Eleven String-exotic MOP paths each re-derived *"is P an own character index?"* with `str::parse::<usize>()` + a code-unit length compare. Rust's integer parser accepts spellings that are **not** CanonicalNumericIndexStrings (a leading `+`, leading zeros), so a look-alike key was treated as a real indexed property. The interface was as complex as the implementation, copied eleven times — a shallow, drift-prone seam.

## The deepening

One predicate, `types::string_exotic_index(key, len) -> Option<usize>` (CanonicalNumericIndexString + IsIntegralNumber + reject `-0` + range), placed next to `canonical_numeric_index_string`. Every String-exotic operation — `[[Get]]`, `[[GetOwnProperty]]`, `[[HasProperty]]`, `[[DefineOwnProperty]]`, `[[Set]]`, `[[Delete]]` — now crosses that single seam.

## Divergences fixed (each cross-checked with node)

- `"abc"["01"]` / `"abc"["+1"]` returned `"b"` → now `undefined`.
- `"01" in Object("abc")`, `getOwnPropertyDescriptor(Object("abc"),"01")`, and strict `delete Object("abc")["01"]` all treated `"01"` as an own index → now ordinary (absent / deletable).
- `Object.defineProperty(Object("abc"), "01", {...})` threw a `TypeError` from the string-index redefinition guard → now definable.
- `proxy_delete_property` measured length with `to_string().chars().count()` (code **points**), so `Reflect.deleteProperty(Object("💩"),"1")` returned `true` → now `false` (UTF-16 code **units**).
- `Reflect.deleteProperty` had **no** String-exotic `[[Delete]]` check at all → added via the new helper.
- Bonus: the read fast paths now delegate out-of-range keys to the prototype walk, fixing `"abc"[5]` missing `String.prototype[5]`.

**Scope:** concentrates the String-exotic index predicate only. Array / arguments / typed-array index paths keep their own canonical rules and are untouched.

## Tests validating the refactor (test-first, red → green)

- **Unit** — `string_exotic_index_tests` (types.rs): the ECMA-262 truth table — canonical/non-canonical spellings, `-0`, non-integral, `Infinity`/`NaN`, range. (Red before the helper existed.)
- **JS seam** — `string_exotic_index_seam_tests` (tests.rs): Get / `in` / GetOwnProperty / defineProperty / strict+sloppy delete / Reflect / non-BMP. (Red on the old predicate.)
- **test262-extra** — `String-exotic-canonical-index.js`: negative edge cases test262 doesn't cover, using the standard `assert`/`verifyProperty` harness.

## Verification (run to completion, this branch)

- `cargo test --release`: **352 passed, 0 failed** + smoke oracle ok.
- test262, **0 regressions**: `built-ins/String` 2443/2443, `built-ins/Object` 6802/6802, `built-ins/Reflect` + `language/expressions/delete` + `language/expressions/property-accessors` 451/451.
- test262-extra new file 2/2; custom tests 10/10; `for-in` / spread / `Object.assign` enumeration byte-identical to node.
- `./scripts/lint.sh` clean (rustfmt + clippy).

🤖 Generated with Claude Code
