### PR TITLE
chore(lint): restrict unreachable pub visibility across the crate

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,23 +6,23 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static NEXT_TEMPLATE_ID: AtomicU64 = AtomicU64::new(1);
 
-pub fn next_template_id() -> u64 {
+pub(crate) fn next_template_id() -> u64 {
     NEXT_TEMPLATE_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 #[derive(Clone, Debug)]
-pub struct SourceText {
+pub(crate) struct SourceText {
     source: Rc<str>,
     start: usize,
     end: usize,
 }
 
 impl SourceText {
-    pub fn new(source: Rc<str>, start: usize, end: usize) -> Self {
+    pub(crate) fn new(source: Rc<str>, start: usize, end: usize) -> Self {
         Self { source, start, end }
     }
 
-    pub fn as_str(&self) -> &str {
+    pub(crate) fn as_str(&self) -> &str {
         &self.source[self.start..self.end]
     }
 }
@@ -45,7 +45,7 @@ impl fmt::Display for SourceText {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SourceType {
+pub(crate) enum SourceType {
     Script,
     Module,
 }
@@ -53,24 +53,24 @@ pub enum SourceType {
 /// Dense identifier for a call IC site within a single `Body`.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct CallSiteId(pub u32);
+pub(crate) struct CallSiteId(pub u32);
 
 /// Dense identifier for a property-access IC site within a single `Body`.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct PropSiteId(pub u32);
+pub(crate) struct PropSiteId(pub u32);
 
 impl CallSiteId {
-    pub const UNASSIGNED: Self = Self(u32::MAX);
+    pub(crate) const UNASSIGNED: Self = Self(u32::MAX);
 }
 
 impl PropSiteId {
-    pub const UNASSIGNED: Self = Self(u32::MAX);
+    pub(crate) const UNASSIGNED: Self = Self(u32::MAX);
 }
 
 /// Metadata describing the number of IC sites in a `Body`.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct BodyIcInfo {
+pub(crate) struct BodyIcInfo {
     pub call_site_count: u32,
     pub prop_site_count: u32,
     pub assigned: bool,
@@ -80,20 +80,20 @@ pub struct BodyIcInfo {
 /// Carries the statement vector and IC metadata; the runtime cache lives in the
 /// interpreter, keyed by the body's identity.
 #[derive(Clone, Debug)]
-pub struct Body {
+pub(crate) struct Body {
     pub statements: Rc<Vec<Statement>>,
     pub ic: BodyIcInfo,
 }
 
 impl Body {
-    pub fn new(statements: Vec<Statement>) -> Self {
+    pub(crate) fn new(statements: Vec<Statement>) -> Self {
         Self {
             statements: Rc::new(statements),
             ic: BodyIcInfo::default(),
         }
     }
 
-    pub fn as_slice(&self) -> &[Statement] {
+    pub(crate) fn as_slice(&self) -> &[Statement] {
         &self.statements
     }
 }
@@ -102,7 +102,7 @@ impl Body {
 /// member site in `body`, and record the final counts in `body.ic`.
 /// This is a single shared pass used by the parser, generator transform,
 /// `eval`, and `new Function`.
-pub fn assign_ic_sites(body: &mut Body) {
+pub(crate) fn assign_ic_sites(body: &mut Body) {
     let mut call_id = 0u32;
     let mut prop_id = 0u32;
     for stmt in Rc::make_mut(&mut body.statements).iter_mut() {
@@ -116,7 +116,7 @@ pub fn assign_ic_sites(body: &mut Body) {
 /// Assign IC sites to a nested body that was created synthetically (e.g. an
 /// arrow expression body or a dynamic `Function` body). Returns the number of
 /// call and property sites found.
-pub fn assign_ic_sites_for_body(body: &mut Body) -> (u32, u32) {
+pub(crate) fn assign_ic_sites_for_body(body: &mut Body) -> (u32, u32) {
     let before_call = body.ic.call_site_count;
     let before_prop = body.ic.prop_site_count;
     if !body.ic.assigned {
@@ -133,7 +133,7 @@ pub fn assign_ic_sites_for_body(body: &mut Body) -> (u32, u32) {
 /// share a single dense namespace keyed by the program's `body` field. This
 /// keeps IC sites on module top-level executable expressions valid while the
 /// interpreter is executing module items.
-pub fn assign_ic_sites_for_module(program: &mut Program) {
+pub(crate) fn assign_ic_sites_for_module(program: &mut Program) {
     if program.source_type == SourceType::Script {
         assign_ic_sites(&mut program.body);
         return;
@@ -174,7 +174,7 @@ fn assign_export_sites(export: &mut ExportDeclaration, call_id: &mut u32, prop_i
 }
 
 #[derive(Clone, Debug)]
-pub struct Program {
+pub(crate) struct Program {
     pub source_type: SourceType,
     pub body: Body,
     pub module_items: Vec<ModuleItem>,
@@ -183,21 +183,21 @@ pub struct Program {
 
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum ModuleItem {
+pub(crate) enum ModuleItem {
     Statement(Statement),
     ImportDeclaration(ImportDeclaration),
     ExportDeclaration(ExportDeclaration),
 }
 
 #[derive(Clone, Debug)]
-pub struct ImportDeclaration {
+pub(crate) struct ImportDeclaration {
     pub specifiers: Vec<ImportSpecifier>,
     pub source: String,
     pub attributes: Vec<(String, String)>,
 }
 
 #[derive(Clone, Debug)]
-pub enum ImportSpecifier {
+pub(crate) enum ImportSpecifier {
     Named { imported: String, local: String },
     Default(String),
     Namespace(String),
@@ -206,7 +206,7 @@ pub enum ImportSpecifier {
 }
 
 #[derive(Clone, Debug)]
-pub enum ExportDeclaration {
+pub(crate) enum ExportDeclaration {
     Named {
         specifiers: Vec<ExportSpecifier>,
         source: Option<String>,
@@ -222,13 +222,13 @@ pub enum ExportDeclaration {
 }
 
 #[derive(Clone, Debug)]
-pub struct ExportSpecifier {
+pub(crate) struct ExportSpecifier {
     pub local: String,
     pub exported: String,
 }
 
 #[derive(Clone, Debug)]
-pub enum Statement {
+pub(crate) enum Statement {
     Empty,
     Expression(Expression),
     Block(Vec<Statement>),
@@ -253,13 +253,13 @@ pub enum Statement {
 }
 
 #[derive(Clone, Debug)]
-pub struct VariableDeclaration {
+pub(crate) struct VariableDeclaration {
     pub kind: VarKind,
     pub declarations: Vec<VariableDeclarator>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum VarKind {
+pub(crate) enum VarKind {
     Var,
     Let,
     Const,
@@ -268,13 +268,13 @@ pub enum VarKind {
 }
 
 #[derive(Clone, Debug)]
-pub struct VariableDeclarator {
+pub(crate) struct VariableDeclarator {
     pub pattern: Pattern,
     pub init: Option<Expression>,
 }
 
 #[derive(Clone, Debug)]
-pub enum Pattern {
+pub(crate) enum Pattern {
     Identifier(String),
     Array(Vec<Option<ArrayPatternElement>>),
     Object(Vec<ObjectPatternProperty>),
@@ -284,13 +284,13 @@ pub enum Pattern {
 }
 
 #[derive(Clone, Debug)]
-pub enum ArrayPatternElement {
+pub(crate) enum ArrayPatternElement {
     Pattern(Pattern),
     Rest(Pattern),
 }
 
 #[derive(Clone, Debug)]
-pub enum ObjectPatternProperty {
+pub(crate) enum ObjectPatternProperty {
     KeyValue(PropertyKey, Pattern),
     Shorthand(String),
     Rest(Pattern),
@@ -332,7 +332,7 @@ impl Pattern {
 }
 
 #[derive(Clone, Debug)]
-pub enum Expression {
+pub(crate) enum Expression {
     Literal(Literal),
     Identifier(String),
     This,
@@ -380,14 +380,14 @@ pub enum Expression {
 }
 
 #[derive(Clone, Debug)]
-pub enum MemberProperty {
+pub(crate) enum MemberProperty {
     Dot(String),
     Computed(Box<Expression>),
     Private(String),
 }
 
 #[derive(Clone, Debug)]
-pub enum Literal {
+pub(crate) enum Literal {
     Null,
     Boolean(bool),
     Number(f64),
@@ -397,7 +397,7 @@ pub enum Literal {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum UnaryOp {
+pub(crate) enum UnaryOp {
     Minus,
     Plus,
     Not,
@@ -405,7 +405,7 @@ pub enum UnaryOp {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum BinaryOp {
+pub(crate) enum BinaryOp {
     Add,
     Sub,
     Mul,
@@ -431,20 +431,20 @@ pub enum BinaryOp {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum LogicalOp {
+pub(crate) enum LogicalOp {
     And,
     Or,
     NullishCoalescing,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum UpdateOp {
+pub(crate) enum UpdateOp {
     Increment,
     Decrement,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum AssignOp {
+pub(crate) enum AssignOp {
     Assign,
     AddAssign,
     SubAssign,
@@ -464,7 +464,7 @@ pub enum AssignOp {
 }
 
 #[derive(Clone, Debug)]
-pub struct Property {
+pub(crate) struct Property {
     pub key: PropertyKey,
     pub value: Expression,
     pub kind: PropertyKind,
@@ -474,7 +474,7 @@ pub struct Property {
 }
 
 #[derive(Clone, Debug)]
-pub enum PropertyKey {
+pub(crate) enum PropertyKey {
     Identifier(String),
     String(Vec<u16>),
     Number(f64),
@@ -483,7 +483,7 @@ pub enum PropertyKey {
 }
 
 impl PropertyKey {
-    pub fn matches_name(&self, name: &str) -> bool {
+    pub(crate) fn matches_name(&self, name: &str) -> bool {
         match self {
             Self::Identifier(identifier) => identifier == name,
             Self::String(units) => units.iter().copied().eq(name.encode_utf16()),
@@ -493,33 +493,33 @@ impl PropertyKey {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PropertyKind {
+pub(crate) enum PropertyKind {
     Init,
     Get,
     Set,
 }
 
 #[derive(Clone, Debug)]
-pub struct IfStatement {
+pub(crate) struct IfStatement {
     pub test: Expression,
     pub consequent: Box<Statement>,
     pub alternate: Option<Box<Statement>>,
 }
 
 #[derive(Clone, Debug)]
-pub struct WhileStatement {
+pub(crate) struct WhileStatement {
     pub test: Expression,
     pub body: Box<Statement>,
 }
 
 #[derive(Clone, Debug)]
-pub struct DoWhileStatement {
+pub(crate) struct DoWhileStatement {
     pub test: Expression,
     pub body: Box<Statement>,
 }
 
 #[derive(Clone, Debug)]
-pub struct ForStatement {
+pub(crate) struct ForStatement {
     pub init: Option<ForInit>,
     pub test: Option<Expression>,
     pub update: Option<Expression>,
@@ -527,20 +527,20 @@ pub struct ForStatement {
 }
 
 #[derive(Clone, Debug)]
-pub enum ForInit {
+pub(crate) enum ForInit {
     Variable(VariableDeclaration),
     Expression(Expression),
 }
 
 #[derive(Clone, Debug)]
-pub struct ForInStatement {
+pub(crate) struct ForInStatement {
     pub left: ForInOfLeft,
     pub right: Expression,
     pub body: Box<Statement>,
 }
 
 #[derive(Clone, Debug)]
-pub struct ForOfStatement {
+pub(crate) struct ForOfStatement {
     pub left: ForInOfLeft,
     pub right: Expression,
     pub body: Box<Statement>,
@@ -548,39 +548,39 @@ pub struct ForOfStatement {
 }
 
 #[derive(Clone, Debug)]
-pub enum ForInOfLeft {
+pub(crate) enum ForInOfLeft {
     Variable(VariableDeclaration),
     Pattern(Pattern),
     Expression(Expression),
 }
 
 #[derive(Clone, Debug)]
-pub struct TryStatement {
+pub(crate) struct TryStatement {
     pub block: Vec<Statement>,
     pub handler: Option<CatchClause>,
     pub finalizer: Option<Vec<Statement>>,
 }
 
 #[derive(Clone, Debug)]
-pub struct CatchClause {
+pub(crate) struct CatchClause {
     pub param: Option<Pattern>,
     pub body: Vec<Statement>,
 }
 
 #[derive(Clone, Debug)]
-pub struct SwitchStatement {
+pub(crate) struct SwitchStatement {
     pub discriminant: Expression,
     pub cases: Vec<SwitchCase>,
 }
 
 #[derive(Clone, Debug)]
-pub struct SwitchCase {
+pub(crate) struct SwitchCase {
     pub test: Option<Expression>,
     pub consequent: Vec<Statement>,
 }
 
 #[derive(Clone, Debug)]
-pub struct FunctionDecl {
+pub(crate) struct FunctionDecl {
     pub name: String,
     pub params: Vec<Pattern>,
     pub body: Body,
@@ -591,7 +591,7 @@ pub struct FunctionDecl {
 }
 
 #[derive(Clone, Debug)]
-pub struct FunctionExpr {
+pub(crate) struct FunctionExpr {
     pub name: Option<String>,
     pub params: Vec<Pattern>,
     pub body: Body,
@@ -602,7 +602,7 @@ pub struct FunctionExpr {
 }
 
 #[derive(Clone, Debug)]
-pub struct ArrowFunction {
+pub(crate) struct ArrowFunction {
     pub params: Vec<Pattern>,
     pub body: ArrowBody,
     pub is_async: bool,
@@ -611,7 +611,7 @@ pub struct ArrowFunction {
 }
 
 #[derive(Clone, Debug)]
-pub enum ArrowBody {
+pub(crate) enum ArrowBody {
     /// Concise arrow-function body: `() => expr`. The `Body` contains a single
     /// `Statement::Expression` so it participates in the same per-body IC
     /// numbering and store as a block arrow body.
@@ -621,13 +621,13 @@ pub enum ArrowBody {
 }
 
 impl ArrowBody {
-    pub fn body(&self) -> &Body {
+    pub(crate) fn body(&self) -> &Body {
         match self {
             ArrowBody::Expression(b) | ArrowBody::Block(b) => b,
         }
     }
 
-    pub fn body_mut(&mut self) -> &mut Body {
+    pub(crate) fn body_mut(&mut self) -> &mut Body {
         match self {
             ArrowBody::Expression(b) | ArrowBody::Block(b) => b,
         }
@@ -635,7 +635,7 @@ impl ArrowBody {
 }
 
 #[derive(Clone, Debug)]
-pub struct ClassDecl {
+pub(crate) struct ClassDecl {
     pub name: String,
     pub super_class: Option<Box<Expression>>,
     pub body: Vec<ClassElement>,
@@ -643,7 +643,7 @@ pub struct ClassDecl {
 }
 
 #[derive(Clone, Debug)]
-pub struct ClassExpr {
+pub(crate) struct ClassExpr {
     pub name: Option<String>,
     pub super_class: Option<Box<Expression>>,
     pub body: Vec<ClassElement>,
@@ -651,7 +651,7 @@ pub struct ClassExpr {
 }
 
 #[derive(Clone, Debug)]
-pub enum ClassElement {
+pub(crate) enum ClassElement {
     Method(ClassMethod),
     Property(ClassProperty),
     AutoAccessor(ClassProperty),
@@ -659,7 +659,7 @@ pub enum ClassElement {
 }
 
 #[derive(Clone, Debug)]
-pub struct ClassMethod {
+pub(crate) struct ClassMethod {
     pub key: PropertyKey,
     pub kind: ClassMethodKind,
     pub value: FunctionExpr,
@@ -668,7 +668,7 @@ pub struct ClassMethod {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ClassMethodKind {
+pub(crate) enum ClassMethodKind {
     Method,
     Get,
     Set,
@@ -676,7 +676,7 @@ pub enum ClassMethodKind {
 }
 
 #[derive(Clone, Debug)]
-pub struct ClassProperty {
+pub(crate) struct ClassProperty {
     pub key: PropertyKey,
     pub value: Option<Expression>,
     pub is_static: bool,
@@ -686,7 +686,7 @@ pub struct ClassProperty {
 impl Expression {
     /// Per spec §13.2.1.2 — returns true only for function/class/arrow
     /// expressions that have no binding name of their own.
-    pub fn is_anonymous_function_definition(&self) -> bool {
+    pub(crate) fn is_anonymous_function_definition(&self) -> bool {
         match self {
             Expression::Function(f) => f.name.as_ref().is_none_or(|n| n.is_empty()),
             Expression::ArrowFunction(_) => true,
@@ -697,7 +697,7 @@ impl Expression {
 }
 
 #[derive(Clone, Debug)]
-pub struct TemplateLiteral {
+pub(crate) struct TemplateLiteral {
     pub id: u64,
     pub quasis: Vec<Option<Vec<u16>>>,
     pub raw_quasis: Vec<String>,
@@ -706,7 +706,7 @@ pub struct TemplateLiteral {
 
 /// Check if a function (body + params) references the `arguments` identifier.
 /// Also checks parameter default expressions (which can reference arguments).
-pub fn func_uses_arguments(params: &[Pattern], body: &Body) -> bool {
+pub(crate) fn func_uses_arguments(params: &[Pattern], body: &Body) -> bool {
     params_use_arguments(params) || stmts_use_arguments(body.as_slice())
 }
 
@@ -714,7 +714,7 @@ pub fn func_uses_arguments(params: &[Pattern], body: &Body) -> bool {
 /// solely of single-name (identifier) bindings — no rest, defaults, or
 /// destructuring. This gates the fast parameter-binding path and mapped
 /// `arguments` objects, so it is cached on `JsFunction::User` at creation time.
-pub fn params_are_simple(params: &[Pattern]) -> bool {
+pub(crate) fn params_are_simple(params: &[Pattern]) -> bool {
     params.iter().all(|p| matches!(p, Pattern::Identifier(_)))
 }
 
@@ -725,7 +725,7 @@ fn params_use_arguments(params: &[Pattern]) -> bool {
 /// Check if a function body references the `arguments` identifier.
 /// Recurses into arrow functions (they inherit arguments) but not into
 /// regular functions, generators, or class methods (they have their own).
-pub fn stmts_use_arguments(stmts: &[Statement]) -> bool {
+pub(crate) fn stmts_use_arguments(stmts: &[Statement]) -> bool {
     stmts.iter().any(stmt_uses_arguments)
 }
 
@@ -1275,7 +1275,7 @@ fn assign_expr_sites(expr: &mut Expression, call_id: &mut u32, prop_id: &mut u32
 /// because they execute under their own stores; a class literal's `extends`,
 /// computed keys, and static-field initializers are cleared because they evaluate
 /// at class-definition time (i.e. when the terminator expression runs).
-pub fn clear_expr_ic_sites(expr: &mut Expression) {
+pub(crate) fn clear_expr_ic_sites(expr: &mut Expression) {
     match expr {
         Expression::Call(callee, args, site) => {
             clear_expr_ic_sites(callee);
@@ -1527,7 +1527,7 @@ fn clear_stmt_ic_sites(stmt: &mut Statement) {
     }
 }
 
-pub fn clear_for_in_of_left(left: &mut ForInOfLeft) {
+pub(crate) fn clear_for_in_of_left(left: &mut ForInOfLeft) {
     match left {
         ForInOfLeft::Variable(decl) => {
             for d in decl.declarations.iter_mut() {
@@ -1545,7 +1545,7 @@ pub fn clear_for_in_of_left(left: &mut ForInOfLeft) {
 /// Pattern companion to [`clear_expr_ic_sites`], for patterns reachable from a
 /// terminator (e.g. destructuring declarations inside a class static block, or
 /// a for-of binding / catch parameter evaluated at a state transition).
-pub fn clear_pattern_ic_sites(pat: &mut Pattern) {
+pub(crate) fn clear_pattern_ic_sites(pat: &mut Pattern) {
     match pat {
         Pattern::Identifier(_) => {}
         Pattern::Array(elems) => {

--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 /// Convert an f64 integer value to a BigInt, handling the full range of
 /// IEEE 754 double-precision values (not just the i64 range).
-pub fn f64_to_bigint(n: f64) -> num_bigint::BigInt {
+pub(crate) fn f64_to_bigint(n: f64) -> num_bigint::BigInt {
     if n == 0.0 {
         return num_bigint::BigInt::from(0);
     }

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -22,7 +22,7 @@ impl Interpreter {
     ///
     /// Must run after `setup_globals` (so the global object exists) and before
     /// the Node prelude/main are executed. Never called under test262.
-    pub fn enable_node_host(&mut self) {
+    pub(crate) fn enable_node_host(&mut self) {
         self.node_host_enabled = true;
         self.host_clock_start = Some(std::time::Instant::now());
         self.setup_node_host();

--- a/src/interpreter/builtins/regexp_lookbehind.rs
+++ b/src/interpreter/builtins/regexp_lookbehind.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 /// reverse order, so a later group captures before an earlier group.
 
 #[derive(Debug, Clone)]
-pub struct LookbehindInfo {
+pub(super) struct LookbehindInfo {
     pub positive: bool,
     pub content: String,
     /// Whether this lookbehind is at the end of the pattern (suffix position).
@@ -23,7 +23,7 @@ pub struct LookbehindInfo {
 }
 
 #[derive(Debug, Clone)]
-pub enum LbAtom {
+pub(super) enum LbAtom {
     Literal(char),
     CharClass(Vec<(char, char)>, bool),
     Dot(bool),
@@ -50,7 +50,7 @@ pub enum LbAtom {
 }
 
 #[derive(Debug, Clone)]
-pub enum AnchorKind {
+pub(super) enum AnchorKind {
     Start,
     End,
     WordBoundary,
@@ -58,7 +58,7 @@ pub enum AnchorKind {
 }
 
 #[derive(Debug, Clone)]
-pub struct LbFlags {
+pub(super) struct LbFlags {
     pub ignore_case: bool,
     pub multiline: bool,
     pub dot_all: bool,
@@ -72,7 +72,7 @@ fn is_line_terminator(c: char) -> bool {
 // Pattern parser
 // ============================================================================
 
-pub fn parse_lb_atoms(pattern: &str, flags: &LbFlags, capture_offset: u32) -> Vec<LbAtom> {
+pub(super) fn parse_lb_atoms(pattern: &str, flags: &LbFlags, capture_offset: u32) -> Vec<LbAtom> {
     let chars: Vec<char> = pattern.chars().collect();
     let mut gc = capture_offset;
     let (atoms, _) = parse_seq(&chars, 0, &mut gc, flags);
@@ -395,7 +395,7 @@ fn maybe_quantify(chars: &[char], atom: LbAtom, i: usize) -> (LbAtom, usize) {
 
 /// Match atoms right-to-left from `end_pos`. Returns start position if successful.
 /// Captures are in char-index space (not byte offsets).
-pub fn match_rtl(
+pub(super) fn match_rtl(
     atoms: &[LbAtom],
     input: &[char],
     end_pos: usize,
@@ -1329,7 +1329,7 @@ fn is_suffix_position(chars: &[char], pos: usize) -> bool {
     true
 }
 
-pub fn extract_lookbehinds(source: &str) -> (Vec<LookbehindInfo>, String) {
+pub(super) fn extract_lookbehinds(source: &str) -> (Vec<LookbehindInfo>, String) {
     let chars: Vec<char> = source.chars().collect();
     let len = chars.len();
     let mut lookbehinds = Vec::new();
@@ -1463,7 +1463,7 @@ pub fn extract_lookbehinds(source: &str) -> (Vec<LookbehindInfo>, String) {
 
 /// Extract the remaining pattern (after stripping all lookbehinds) without
 /// marker groups. Returns (lookbehinds, remaining_pattern).
-pub fn extract_lookbehinds_remaining(source: &str) -> (Vec<LookbehindInfo>, String) {
+pub(super) fn extract_lookbehinds_remaining(source: &str) -> (Vec<LookbehindInfo>, String) {
     let chars: Vec<char> = source.chars().collect();
     let len = chars.len();
     let mut lookbehinds = Vec::new();
@@ -1543,7 +1543,7 @@ pub fn extract_lookbehinds_remaining(source: &str) -> (Vec<LookbehindInfo>, Stri
 // Integration: match with custom lookbehind
 // ============================================================================
 
-pub fn match_with_lookbehind(
+pub(super) fn match_with_lookbehind(
     outer_regex: &fancy_regex::Regex,
     lookbehinds: &[LookbehindInfo],
     text: &str,
@@ -1707,7 +1707,7 @@ pub fn match_with_lookbehind(
 /// Match pattern where lookbehind captures are referenced by external backrefs.
 /// Iterates positions, runs RTL lookbehind at each, substitutes capture values
 /// as literals into the remaining pattern, and tries to match.
-pub fn match_with_lookbehind_no_backtrack(
+pub(super) fn match_with_lookbehind_no_backtrack(
     lookbehinds: &[LookbehindInfo],
     remaining_source: &str,
     flags_str: &str,
@@ -1894,7 +1894,7 @@ fn regex_escape_for_js(s: &str) -> String {
 /// which means fancy-regex might backtrack into the lookbehind (violating spec).
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct LookbehindVerifyInfo {
+pub(super) struct LookbehindVerifyInfo {
     pub positive: bool,
     pub content: String,
     /// Global capture group numbers that are inside this lookbehind

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -170,7 +170,7 @@ impl Interpreter {
     }
 
     /// IsSymbolLikeNamespaceKey(P, O): true if P is a Symbol, or deferred + "then"
-    pub fn is_symbol_like_namespace_key<K: PropertyKeyLike + ?Sized>(
+    pub(crate) fn is_symbol_like_namespace_key<K: PropertyKeyLike + ?Sized>(
         key: &K,
         deferred: bool,
     ) -> bool {

--- a/src/interpreter/generator_analysis.rs
+++ b/src/interpreter/generator_analysis.rs
@@ -2,7 +2,7 @@ use crate::ast::*;
 use std::collections::HashSet;
 
 #[derive(Debug, Clone)]
-pub struct GeneratorAnalysis {
+pub(crate) struct GeneratorAnalysis {
     pub yield_points: Vec<YieldPoint>,
     pub local_vars: Vec<LocalVariable>,
     pub try_contexts: Vec<TryContext>,
@@ -12,7 +12,7 @@ pub struct GeneratorAnalysis {
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct YieldPoint {
+pub(crate) struct YieldPoint {
     pub id: usize,
     pub is_delegate: bool,
     pub inside_try: Option<usize>,
@@ -22,7 +22,7 @@ pub struct YieldPoint {
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct LocalVariable {
+pub(crate) struct LocalVariable {
     pub name: String,
     pub kind: VarKind,
     pub scope_depth: usize,
@@ -30,7 +30,7 @@ pub struct LocalVariable {
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct TryContext {
+pub(crate) struct TryContext {
     pub id: usize,
     pub has_catch: bool,
     pub has_finally: bool,
@@ -40,7 +40,7 @@ pub struct TryContext {
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct LoopContext {
+pub(crate) struct LoopContext {
     pub id: usize,
     pub loop_type: LoopType,
     pub label: Option<String>,
@@ -49,7 +49,7 @@ pub struct LoopContext {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LoopType {
+pub(crate) enum LoopType {
     While,
     DoWhile,
     For,
@@ -83,7 +83,7 @@ impl AnalysisContext {
     }
 }
 
-pub fn analyze_generator_body(body: &[Statement], params: &[Pattern]) -> GeneratorAnalysis {
+pub(crate) fn analyze_generator_body(body: &[Statement], params: &[Pattern]) -> GeneratorAnalysis {
     let mut analysis = GeneratorAnalysis {
         yield_points: Vec::new(),
         local_vars: Vec::new(),
@@ -630,7 +630,7 @@ fn collect_pattern_vars(
     }
 }
 
-pub fn contains_yield(stmt: &Statement) -> bool {
+pub(crate) fn contains_yield(stmt: &Statement) -> bool {
     match stmt {
         Statement::Empty | Statement::Debugger | Statement::Break(_) | Statement::Continue(_) => {
             false
@@ -688,7 +688,7 @@ pub fn contains_yield(stmt: &Statement) -> bool {
     }
 }
 
-pub fn expr_contains_yield(expr: &Expression) -> bool {
+pub(crate) fn expr_contains_yield(expr: &Expression) -> bool {
     match expr {
         Expression::Yield(_, _) => true,
         Expression::Literal(_)
@@ -742,7 +742,7 @@ pub fn expr_contains_yield(expr: &Expression) -> bool {
     }
 }
 
-pub fn expr_contains_suspension(expr: &Expression) -> bool {
+pub(crate) fn expr_contains_suspension(expr: &Expression) -> bool {
     match expr {
         Expression::Yield(_, _) | Expression::Await(_) => true,
         Expression::Literal(_)
@@ -801,7 +801,7 @@ pub fn expr_contains_suspension(expr: &Expression) -> bool {
 /// Checks if a statement is or contains a Block with `await using` declarations.
 /// Only blocks need special handling because their disposal (at block exit) must
 /// trigger an Await suspension. For/try/switch handle disposal internally.
-pub fn has_block_with_await_using(stmt: &Statement) -> bool {
+pub(crate) fn has_block_with_await_using(stmt: &Statement) -> bool {
     match stmt {
         Statement::Block(stmts) => block_has_await_using(stmts),
         Statement::If(i) => {
@@ -815,13 +815,13 @@ pub fn has_block_with_await_using(stmt: &Statement) -> bool {
     }
 }
 
-pub fn block_has_await_using(stmts: &[Statement]) -> bool {
+pub(crate) fn block_has_await_using(stmts: &[Statement]) -> bool {
     stmts
         .iter()
         .any(|s| matches!(s, Statement::Variable(decl) if decl.kind == VarKind::AwaitUsing))
 }
 
-pub fn contains_suspension(stmt: &Statement) -> bool {
+pub(crate) fn contains_suspension(stmt: &Statement) -> bool {
     match stmt {
         Statement::Empty | Statement::Debugger | Statement::Break(_) | Statement::Continue(_) => {
             false

--- a/src/interpreter/generator_transform.rs
+++ b/src/interpreter/generator_transform.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct GeneratorStateMachine {
+pub(crate) struct GeneratorStateMachine {
     pub states: Vec<GeneratorState>,
     pub local_vars: Vec<LocalVariable>,
     pub params: Vec<Pattern>,
@@ -15,14 +15,14 @@ pub struct GeneratorStateMachine {
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct GeneratorState {
+pub(crate) struct GeneratorState {
     pub id: usize,
     pub body: Body,
     pub terminator: StateTerminator,
 }
 
 #[derive(Debug, Clone)]
-pub enum StateTerminator {
+pub(crate) enum StateTerminator {
     Yield {
         value: Option<Expression>,
         is_delegate: bool,
@@ -166,24 +166,24 @@ fn clear_terminator_ic_sites(t: &mut StateTerminator) {
 }
 
 #[derive(Debug, Clone)]
-pub struct CatchInfo {
+pub(crate) struct CatchInfo {
     pub state: usize,
     pub param: Option<Pattern>,
 }
 
 #[derive(Debug, Clone)]
-pub struct SwitchCaseTarget {
+pub(crate) struct SwitchCaseTarget {
     pub test: Expression,
     pub state: usize,
 }
 
 #[derive(Debug, Clone)]
-pub struct SentValueBinding {
+pub(crate) struct SentValueBinding {
     pub kind: SentValueBindingKind,
 }
 
 #[derive(Debug, Clone)]
-pub enum SentValueBindingKind {
+pub(crate) enum SentValueBindingKind {
     Variable(String),
     Pattern(Pattern),
     #[allow(dead_code)]
@@ -288,11 +288,14 @@ impl TransformContext {
     }
 }
 
-pub fn transform_generator(body: &[Statement], params: &[Pattern]) -> GeneratorStateMachine {
+pub(crate) fn transform_generator(body: &[Statement], params: &[Pattern]) -> GeneratorStateMachine {
     transform_generator_inner(body, params, false)
 }
 
-pub fn transform_async_generator(body: &[Statement], params: &[Pattern]) -> GeneratorStateMachine {
+pub(crate) fn transform_async_generator(
+    body: &[Statement],
+    params: &[Pattern],
+) -> GeneratorStateMachine {
     transform_generator_inner(body, params, true)
 }
 
@@ -2094,7 +2097,10 @@ fn transform_labeled_statement(
     ctx.current_state_id = after_labeled;
 }
 
-pub fn transform_async_function(body: &[Statement], params: &[Pattern]) -> GeneratorStateMachine {
+pub(crate) fn transform_async_function(
+    body: &[Statement],
+    params: &[Pattern],
+) -> GeneratorStateMachine {
     let rewritten = rewrite_stmts_await_to_yield(body);
     let mut machine = transform_generator_inner_opts(&rewritten, params, true, true);
     rewrite_terminators_yield_to_await(&mut machine);

--- a/src/interpreter/ic_store.rs
+++ b/src/interpreter/ic_store.rs
@@ -18,10 +18,10 @@ use crate::interpreter::ic::{CallIcSlot, PropIcSlot};
 /// index so it can be passed down through the evaluator without borrowing the
 /// interpreter.
 #[derive(Clone, Copy, Debug)]
-pub struct BodyStoreHandle(pub usize);
+pub(crate) struct BodyStoreHandle(pub usize);
 
 /// Interpreter-side side table that maps a body identity to its cache.
-pub struct IcStore {
+pub(crate) struct IcStore {
     /// Map from the body statement-vector pointer to the store index. The key
     /// is the `Rc` pointer so that cloned ASTs sharing the same body share the
     /// same cache. Each `BodyIcStore` pins a clone of the body's statement `Rc`
@@ -32,7 +32,7 @@ pub struct IcStore {
 }
 
 impl IcStore {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             index: HashMap::new(),
             stores: Vec::new(),
@@ -42,7 +42,7 @@ impl IcStore {
     /// Return the handle for a body's cache, creating it on first request.
     /// The body must already have had its IC sites assigned (e.g. by the
     /// parser or by `ast::assign_ic_sites` for dynamic code).
-    pub fn for_body(&mut self, body: &Body) -> BodyStoreHandle {
+    pub(crate) fn for_body(&mut self, body: &Body) -> BodyStoreHandle {
         let key = Rc::as_ptr(&body.statements);
         if let Some(&idx) = self.index.get(&key) {
             return BodyStoreHandle(idx);
@@ -55,14 +55,14 @@ impl IcStore {
     }
 
     /// Return a mutable reference to the cache for a handle.
-    pub fn store_mut(&mut self, handle: BodyStoreHandle) -> &mut BodyIcStore {
+    pub(crate) fn store_mut(&mut self, handle: BodyStoreHandle) -> &mut BodyIcStore {
         &mut self.stores[handle.0]
     }
 }
 
 /// Per-body cache for call and property IC slots. Sized once from the
 /// `BodyIcInfo` produced by `ast::assign_ic_sites`.
-pub struct BodyIcStore {
+pub(crate) struct BodyIcStore {
     call_slots: Vec<CallIcSlot>,
     prop_slots: Vec<PropIcSlot>,
     /// Pins the body's statement `Rc` alive so its `Rc::as_ptr` address (used as
@@ -82,13 +82,13 @@ impl BodyIcStore {
 
     /// Return a mutable reference to the call slot for a site id.
     #[inline]
-    pub fn call_slot(&mut self, id: CallSiteId) -> &mut CallIcSlot {
+    pub(crate) fn call_slot(&mut self, id: CallSiteId) -> &mut CallIcSlot {
         &mut self.call_slots[id.0 as usize]
     }
 
     /// Return a mutable reference to the property slot for a site id.
     #[inline]
-    pub fn prop_slot(&mut self, id: PropSiteId) -> &mut PropIcSlot {
+    pub(crate) fn prop_slot(&mut self, id: PropSiteId) -> &mut PropIcSlot {
         &mut self.prop_slots[id.0 as usize]
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -10,12 +10,12 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 
-pub struct AgentBroadcastMsg {
+pub(crate) struct AgentBroadcastMsg {
     pub sab_shared: Arc<types::SharedBufferInner>,
 }
 
 mod types;
-pub use types::*;
+pub(crate) use types::*;
 
 mod helpers;
 pub(crate) use helpers::*;
@@ -78,7 +78,7 @@ pub(crate) struct HoistAnalysis {
     _body: Rc<Vec<Statement>>,
 }
 
-pub struct Interpreter {
+pub(crate) struct Interpreter {
     pub(crate) realms: Vec<Realm>,
     pub(crate) current_realm_id: usize,
     objects: object_arena::ObjectArena,
@@ -306,7 +306,7 @@ pub(crate) enum AsyncGenRequestKind {
     Throw,
 }
 
-pub struct LoadedModule {
+pub(crate) struct LoadedModule {
     pub path: PathBuf,
     pub env: EnvRef,
     pub exports: HashMap<String, JsValue>,
@@ -334,7 +334,7 @@ pub struct LoadedModule {
 }
 
 impl Interpreter {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let global = Environment::new(None);
 
         {
@@ -1860,7 +1860,7 @@ impl Interpreter {
         JsValue::String(exact_key.to_js_string())
     }
 
-    pub fn run(&mut self, program: &Program) -> Completion {
+    pub(crate) fn run(&mut self, program: &Program) -> Completion {
         self.gc_safepoint();
         let result = match program.source_type {
             SourceType::Script => {
@@ -1882,7 +1882,7 @@ impl Interpreter {
         result
     }
 
-    pub fn run_with_path(&mut self, program: &Program, path: &Path) -> Completion {
+    pub(crate) fn run_with_path(&mut self, program: &Program, path: &Path) -> Completion {
         self.gc_safepoint();
         match program.source_type {
             SourceType::Script => {
@@ -5181,7 +5181,7 @@ impl Interpreter {
         }
     }
 
-    pub fn format_value(&self, val: &JsValue) -> String {
+    pub(crate) fn format_value(&self, val: &JsValue) -> String {
         match val {
             JsValue::Object(o) => {
                 if self.get_object_cell(o.id).is_some() {

--- a/src/interpreter/property_map.rs
+++ b/src/interpreter/property_map.rs
@@ -16,7 +16,7 @@ const INLINE_CAP: usize = 4;
 // once the inline buffer overflows. Spill is one-way; deletes never collapse
 // back to inline. Iteration order is unspecified — ordered iteration must
 // continue to go through `JsObjectData.property_order`.
-pub struct PropertyMap {
+pub(crate) struct PropertyMap {
     inner: PropertyMapInner,
 }
 
@@ -34,13 +34,13 @@ enum PropertyMapInner {
 }
 
 impl PropertyMap {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             inner: PropertyMapInner::Inline(SmallVec::new()),
         }
     }
 
-    pub fn contains_key<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> bool {
+    pub(crate) fn contains_key<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> bool {
         match &self.inner {
             PropertyMapInner::Inline(v) => v
                 .iter()
@@ -49,7 +49,7 @@ impl PropertyMap {
         }
     }
 
-    pub fn get<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> Option<&PropertyDescriptor> {
+    pub(crate) fn get<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> Option<&PropertyDescriptor> {
         match &self.inner {
             PropertyMapInner::Inline(v) => v
                 .iter()
@@ -59,7 +59,7 @@ impl PropertyMap {
         }
     }
 
-    pub fn get_mut<K: PropertyKeyLike + ?Sized>(
+    pub(crate) fn get_mut<K: PropertyKeyLike + ?Sized>(
         &mut self,
         key: &K,
     ) -> Option<&mut PropertyDescriptor> {
@@ -72,7 +72,7 @@ impl PropertyMap {
         }
     }
 
-    pub fn insert(
+    pub(crate) fn insert(
         &mut self,
         key: JsPropertyKey,
         value: PropertyDescriptor,
@@ -102,7 +102,10 @@ impl PropertyMap {
         }
     }
 
-    pub fn remove<K: PropertyKeyLike + ?Sized>(&mut self, key: &K) -> Option<PropertyDescriptor> {
+    pub(crate) fn remove<K: PropertyKeyLike + ?Sized>(
+        &mut self,
+        key: &K,
+    ) -> Option<PropertyDescriptor> {
         match &mut self.inner {
             PropertyMapInner::Inline(v) => {
                 let pos = v
@@ -114,7 +117,7 @@ impl PropertyMap {
         }
     }
 
-    pub fn iter(&self) -> PropertyMapIter<'_> {
+    pub(crate) fn iter(&self) -> PropertyMapIter<'_> {
         let inner = match &self.inner {
             PropertyMapInner::Inline(v) => PropertyMapIterInner::Inline(v.iter()),
             PropertyMapInner::Spilled(m) => PropertyMapIterInner::Spilled(m.iter()),
@@ -122,11 +125,11 @@ impl PropertyMap {
         PropertyMapIter { inner }
     }
 
-    pub fn keys(&self) -> impl Iterator<Item = &JsPropertyKey> {
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &JsPropertyKey> {
         self.iter().map(|(k, _)| k)
     }
 
-    pub fn values(&self) -> impl Iterator<Item = &PropertyDescriptor> {
+    pub(crate) fn values(&self) -> impl Iterator<Item = &PropertyDescriptor> {
         self.iter().map(|(_, v)| v)
     }
 }
@@ -137,7 +140,7 @@ impl Default for PropertyMap {
     }
 }
 
-pub struct PropertyMapIter<'a> {
+pub(crate) struct PropertyMapIter<'a> {
     inner: PropertyMapIterInner<'a>,
 }
 

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -25,7 +25,7 @@ pub(crate) fn fresh_shape_id() -> u64 {
 
 static NEXT_SAB_ID: AtomicU64 = AtomicU64::new(1);
 
-pub fn next_sab_id() -> u64 {
+pub(crate) fn next_sab_id() -> u64 {
     NEXT_SAB_ID.fetch_add(1, Ordering::Relaxed)
 }
 
@@ -48,14 +48,14 @@ fn new_math_random_state() -> u64 {
     process_seed ^ splitmix64_mix(realm_index)
 }
 
-pub struct SharedBufferInner {
+pub(crate) struct SharedBufferInner {
     words: RwLock<Vec<u64>>,
     len: AtomicUsize,
     pub id: u64,
 }
 
 impl SharedBufferInner {
-    pub fn new(data: Vec<u8>, id: u64) -> Self {
+    pub(crate) fn new(data: Vec<u8>, id: u64) -> Self {
         let len = data.len();
         let mut words = vec![0u64; len.div_ceil(8)];
         for (idx, byte) in data.into_iter().enumerate() {
@@ -70,7 +70,7 @@ impl SharedBufferInner {
         }
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.len.load(Ordering::SeqCst)
     }
 
@@ -87,19 +87,19 @@ impl SharedBufferInner {
         &mut bytes[..len]
     }
 
-    pub fn with_read<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
+    pub(crate) fn with_read<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
         let len = self.len();
         let guard = self.words.read().unwrap();
         f(Self::byte_slice(&guard, len))
     }
 
-    pub fn with_write<R>(&self, f: impl FnOnce(&mut [u8]) -> R) -> R {
+    pub(crate) fn with_write<R>(&self, f: impl FnOnce(&mut [u8]) -> R) -> R {
         let len = self.len();
         let mut guard = self.words.write().unwrap();
         f(Self::byte_slice_mut(&mut guard, len))
     }
 
-    pub fn resize(&self, new_len: usize, value: u8) {
+    pub(crate) fn resize(&self, new_len: usize, value: u8) {
         let old_len = self.len();
         let mut guard = self.words.write().unwrap();
         let new_words_len = new_len.div_ceil(8);
@@ -127,7 +127,7 @@ impl SharedBufferInner {
         self.len.store(new_len, Ordering::SeqCst);
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
+    pub(crate) fn to_vec(&self) -> Vec<u8> {
         self.with_read(|bytes| bytes.to_vec())
     }
 
@@ -156,27 +156,27 @@ impl std::fmt::Debug for SharedBufferInner {
 }
 
 #[derive(Debug)]
-pub enum BufferData {
+pub(crate) enum BufferData {
     Owned(Vec<u8>),
     Shared(Arc<SharedBufferInner>),
 }
 
 impl BufferData {
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         match self {
             BufferData::Owned(v) => v.len(),
             BufferData::Shared(s) => s.len(),
         }
     }
 
-    pub fn resize(&mut self, new_len: usize, value: u8) {
+    pub(crate) fn resize(&mut self, new_len: usize, value: u8) {
         match self {
             BufferData::Owned(v) => v.resize(new_len, value),
             BufferData::Shared(s) => s.resize(new_len, value),
         }
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
+    pub(crate) fn to_vec(&self) -> Vec<u8> {
         match self {
             BufferData::Owned(v) => v.clone(),
             BufferData::Shared(s) => s.to_vec(),
@@ -184,26 +184,26 @@ impl BufferData {
     }
 
     #[allow(dead_code)]
-    pub fn is_shared(&self) -> bool {
+    pub(crate) fn is_shared(&self) -> bool {
         matches!(self, BufferData::Shared(_))
     }
 
     #[allow(dead_code)]
-    pub fn shared_inner(&self) -> Option<&Arc<SharedBufferInner>> {
+    pub(crate) fn shared_inner(&self) -> Option<&Arc<SharedBufferInner>> {
         match self {
             BufferData::Shared(s) => Some(s),
             _ => None,
         }
     }
 
-    pub fn with_read<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
+    pub(crate) fn with_read<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
         match self {
             BufferData::Owned(v) => f(v),
             BufferData::Shared(s) => s.with_read(f),
         }
     }
 
-    pub fn with_write<R>(&mut self, f: impl FnOnce(&mut [u8]) -> R) -> R {
+    pub(crate) fn with_write<R>(&mut self, f: impl FnOnce(&mut [u8]) -> R) -> R {
         match self {
             BufferData::Owned(v) => f(v),
             BufferData::Shared(s) => s.with_write(f),
@@ -218,7 +218,7 @@ impl Clone for BufferData {
 }
 
 #[derive(Debug)]
-pub enum Completion {
+pub(crate) enum Completion {
     Normal(JsValue),
     Return(JsValue),
     Throw(JsValue),
@@ -277,7 +277,7 @@ pub(crate) struct GeneratorContext {
 }
 
 #[derive(Debug, Clone)]
-pub enum GeneratorExecutionState {
+pub(crate) enum GeneratorExecutionState {
     #[allow(dead_code)]
     SuspendedStart,
     SuspendedYield {
@@ -290,7 +290,7 @@ pub enum GeneratorExecutionState {
 }
 
 #[derive(Debug, Clone)]
-pub enum StateMachineExecutionState {
+pub(crate) enum StateMachineExecutionState {
     SuspendedStart,
     SuspendedAtState { state_id: usize },
     Executing,
@@ -298,7 +298,7 @@ pub enum StateMachineExecutionState {
 }
 
 #[derive(Debug, Clone)]
-pub struct TryContextInfo {
+pub(crate) struct TryContextInfo {
     pub catch_state: Option<usize>,
     pub finally_state: Option<usize>,
     pub _after_state: usize,
@@ -306,7 +306,7 @@ pub struct TryContextInfo {
     pub entered_finally: bool,
 }
 
-pub struct AsyncFunctionState {
+pub(crate) struct AsyncFunctionState {
     pub state_machine: Rc<GeneratorStateMachine>,
     pub func_env: EnvRef,
     pub is_strict: bool,
@@ -323,17 +323,17 @@ pub struct AsyncFunctionState {
 }
 
 #[derive(Debug, Clone)]
-pub struct DelegatedIteratorInfo {
+pub(crate) struct DelegatedIteratorInfo {
     pub iterator: JsValue,
     pub next_method: JsValue,
     pub resume_state: usize,
     pub sent_value_binding: Option<SentValueBinding>,
 }
 
-pub type EnvRef = Rc<RefCell<Environment>>;
+pub(crate) type EnvRef = Rc<RefCell<Environment>>;
 
 #[allow(clippy::type_complexity)]
-pub struct Realm {
+pub(crate) struct Realm {
     pub(crate) global_env: EnvRef,
     math_random_state: u64,
     pub(crate) global_object: Option<u64>,
@@ -660,7 +660,7 @@ impl Realm {
     }
 }
 
-pub struct Environment {
+pub(crate) struct Environment {
     pub(crate) bindings: HashMap<String, Binding>,
     pub(crate) parent: Option<EnvRef>,
     pub strict: bool,
@@ -723,7 +723,7 @@ pub(crate) struct Binding {
 }
 
 impl Binding {
-    pub fn new(value: JsValue, kind: BindingKind, initialized: bool) -> Self {
+    pub(crate) fn new(value: JsValue, kind: BindingKind, initialized: bool) -> Self {
         Self {
             value,
             kind,
@@ -745,7 +745,7 @@ pub(crate) enum BindingKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum SetBindingCheck {
+pub(crate) enum SetBindingCheck {
     Ok,
     ConstAssign,
     FunctionNameAssign,
@@ -754,7 +754,7 @@ pub enum SetBindingCheck {
 }
 
 impl Environment {
-    pub fn new(parent: Option<EnvRef>) -> EnvRef {
+    pub(crate) fn new(parent: Option<EnvRef>) -> EnvRef {
         let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
         Rc::new(RefCell::new(Environment {
             bindings: HashMap::new(),
@@ -778,11 +778,11 @@ impl Environment {
         }))
     }
 
-    pub fn new_function_scope(parent: Option<EnvRef>) -> EnvRef {
+    pub(crate) fn new_function_scope(parent: Option<EnvRef>) -> EnvRef {
         Self::new_function_scope_with_capacity(parent, 0)
     }
 
-    pub fn new_function_scope_with_capacity(
+    pub(crate) fn new_function_scope_with_capacity(
         parent: Option<EnvRef>,
         binding_capacity: usize,
     ) -> EnvRef {
@@ -832,7 +832,7 @@ impl Environment {
         self.module_path = None;
     }
 
-    pub fn find_module_path(env: &EnvRef) -> Option<std::path::PathBuf> {
+    pub(crate) fn find_module_path(env: &EnvRef) -> Option<std::path::PathBuf> {
         if let Some(ref mp) = env.borrow().module_path {
             return Some(mp.clone());
         }
@@ -844,7 +844,7 @@ impl Environment {
 
     /// Find the nearest function scope (for var hoisting).
     /// Returns self if this is a function scope, otherwise traverses up.
-    pub fn find_var_scope(env: &EnvRef) -> EnvRef {
+    pub(crate) fn find_var_scope(env: &EnvRef) -> EnvRef {
         if env.borrow().is_function_scope || env.borrow().global_object_id.is_some() {
             return env.clone();
         }
@@ -854,7 +854,7 @@ impl Environment {
         env.clone()
     }
 
-    pub fn declare(&mut self, name: &str, kind: BindingKind) {
+    pub(crate) fn declare(&mut self, name: &str, kind: BindingKind) {
         self.bindings.insert(
             name.to_string(),
             Binding {
@@ -867,7 +867,7 @@ impl Environment {
     }
 
     /// §9.1.1.1.4 InitializeBinding — sets value and marks initialized (no TDZ check)
-    pub fn initialize_binding(&mut self, name: &str, value: JsValue) {
+    pub(crate) fn initialize_binding(&mut self, name: &str, value: JsValue) {
         if let Some(binding) = self.bindings.get_mut(name) {
             binding.value = value;
             binding.initialized = true;
@@ -876,7 +876,7 @@ impl Environment {
 
     /// §9.1.1.5.5 CreateImportBinding(N, M, N2)
     /// Creates an immutable indirect binding that references another module's environment.
-    pub fn create_import_binding(
+    pub(crate) fn create_import_binding(
         &mut self,
         local_name: &str,
         source_env: EnvRef,
@@ -887,7 +887,7 @@ impl Environment {
     }
 
     /// Resolve an indirect binding, returning the current value from the source environment.
-    pub fn resolve_indirect_binding(&self, name: &str) -> Option<Option<JsValue>> {
+    pub(crate) fn resolve_indirect_binding(&self, name: &str) -> Option<Option<JsValue>> {
         if let Some(ref indirect) = self.indirect_bindings
             && let Some((source_env, source_name)) = indirect.get(name)
         {
@@ -916,13 +916,13 @@ impl Environment {
     }
 
     /// Check if name is an indirect binding.
-    pub fn is_indirect_binding(&self, name: &str) -> bool {
+    pub(crate) fn is_indirect_binding(&self, name: &str) -> bool {
         self.indirect_bindings
             .as_ref()
             .is_some_and(|m| m.contains_key(name))
     }
 
-    pub fn declare_deletable(&mut self, name: &str, kind: BindingKind) {
+    pub(crate) fn declare_deletable(&mut self, name: &str, kind: BindingKind) {
         self.bindings.insert(
             name.to_string(),
             Binding {
@@ -937,7 +937,7 @@ impl Environment {
     /// Bindings-only fallback for `Interpreter::env_declare_global_var` (used
     /// when the env has no `global_object_id`). The wrapper handles the
     /// global-object property side via the slab.
-    pub fn declare_global_var(&mut self, name: &str) {
+    pub(crate) fn declare_global_var(&mut self, name: &str) {
         if !self.bindings.contains_key(name) {
             self.declare(name, BindingKind::Var);
         }
@@ -945,7 +945,7 @@ impl Environment {
 
     /// Bindings-only fallback for
     /// `Interpreter::env_declare_global_var_configurable`.
-    pub fn declare_global_var_configurable(&mut self, name: &str) {
+    pub(crate) fn declare_global_var_configurable(&mut self, name: &str) {
         if !self.bindings.contains_key(name) {
             self.declare(name, BindingKind::Var);
         }
@@ -954,7 +954,7 @@ impl Environment {
     /// Bindings-only fallback for
     /// `Interpreter::env_declare_global_function_binding`. The wrapper sets the
     /// value mirror on the global object via the slab.
-    pub fn declare_global_function_binding(
+    pub(crate) fn declare_global_function_binding(
         &mut self,
         name: &str,
         value: JsValue,
@@ -969,7 +969,7 @@ impl Environment {
 
     /// Bindings-only set. Mirroring to the realm's global object lives in
     /// `Interpreter::env_set`. External callers should always use that wrapper.
-    pub fn set(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
+    pub(crate) fn set(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         // Indirect bindings (module imports) are immutable
         if self.is_indirect_binding(name) {
             return Err(JsValue::String(JsString::from_str(
@@ -1017,7 +1017,7 @@ impl Environment {
     /// Bindings-only get. Falls through to `None` at the chain root; the
     /// global-object fall-through lives in `Interpreter::env_get` /
     /// `env_get_ref`.
-    pub fn get(&self, name: &str) -> Option<JsValue> {
+    pub(crate) fn get(&self, name: &str) -> Option<JsValue> {
         // Check indirect bindings first (module imports)
         if let Some(resolved) = self.resolve_indirect_binding(name) {
             return resolved; // None = TDZ, Some(v) = value
@@ -1036,7 +1036,7 @@ impl Environment {
 
     /// Check if a binding exists but is uninitialized (in TDZ).
     /// Only checks the current environment, not parents.
-    pub fn is_in_tdz(&self, name: &str) -> bool {
+    pub(crate) fn is_in_tdz(&self, name: &str) -> bool {
         // Check indirect bindings first
         if let Some(resolved) = self.resolve_indirect_binding(name) {
             return resolved.is_none(); // None means TDZ
@@ -1050,7 +1050,7 @@ impl Environment {
 
     /// Bindings-only `has`. Global-object fall-through lives in
     /// `Interpreter::env_has`.
-    pub fn has(&self, name: &str) -> bool {
+    pub(crate) fn has(&self, name: &str) -> bool {
         if self.is_indirect_binding(name) || self.bindings.contains_key(name) {
             true
         } else if let Some(parent) = &self.parent {
@@ -1060,7 +1060,7 @@ impl Environment {
         }
     }
 
-    pub fn find_binding_env(env: &EnvRef, name: &str) -> Option<EnvRef> {
+    pub(crate) fn find_binding_env(env: &EnvRef, name: &str) -> Option<EnvRef> {
         let e = env.borrow();
         if e.is_indirect_binding(name) || e.bindings.contains_key(name) {
             return Some(env.clone());
@@ -1077,7 +1077,7 @@ impl Environment {
     }
 }
 
-pub enum JsFunction {
+pub(crate) enum JsFunction {
     User {
         name: Option<String>,
         params: Rc<Vec<Pattern>>,
@@ -1105,7 +1105,7 @@ pub enum JsFunction {
 }
 
 impl JsFunction {
-    pub fn native(
+    pub(crate) fn native(
         name: String,
         arity: usize,
         f: impl Fn(&mut super::Interpreter, &JsValue, &[JsValue]) -> Completion + 'static,
@@ -1113,7 +1113,7 @@ impl JsFunction {
         JsFunction::Native(name, arity, Rc::new(f), false)
     }
 
-    pub fn constructor(
+    pub(crate) fn constructor(
         name: String,
         arity: usize,
         f: impl Fn(&mut super::Interpreter, &JsValue, &[JsValue]) -> Completion + 'static,
@@ -1173,7 +1173,7 @@ impl std::fmt::Debug for JsFunction {
 }
 
 #[derive(Debug, Clone)]
-pub struct PropertyDescriptor {
+pub(crate) struct PropertyDescriptor {
     pub value: Option<JsValue>,
     pub writable: Option<bool>,
     pub get: Option<JsValue>,
@@ -1183,7 +1183,12 @@ pub struct PropertyDescriptor {
 }
 
 impl PropertyDescriptor {
-    pub fn data(value: JsValue, writable: bool, enumerable: bool, configurable: bool) -> Self {
+    pub(crate) fn data(
+        value: JsValue,
+        writable: bool,
+        enumerable: bool,
+        configurable: bool,
+    ) -> Self {
         Self {
             value: Some(value),
             writable: Some(writable),
@@ -1194,11 +1199,11 @@ impl PropertyDescriptor {
         }
     }
 
-    pub fn data_default(value: JsValue) -> Self {
+    pub(crate) fn data_default(value: JsValue) -> Self {
         Self::data(value, true, true, true)
     }
 
-    pub fn accessor(
+    pub(crate) fn accessor(
         get: Option<JsValue>,
         set: Option<JsValue>,
         enumerable: bool,
@@ -1214,17 +1219,17 @@ impl PropertyDescriptor {
         }
     }
 
-    pub fn is_data_descriptor(&self) -> bool {
+    pub(crate) fn is_data_descriptor(&self) -> bool {
         self.value.is_some() || self.writable.is_some()
     }
 
-    pub fn is_accessor_descriptor(&self) -> bool {
+    pub(crate) fn is_accessor_descriptor(&self) -> bool {
         self.get.is_some() || self.set.is_some()
     }
 }
 
 #[derive(Debug, Clone)]
-pub enum PrivateFieldDef {
+pub(crate) enum PrivateFieldDef {
     Field {
         name: String,
         initializer: Option<Expression>,
@@ -1242,7 +1247,7 @@ pub enum PrivateFieldDef {
 
 /// Unified ordered instance field definition (private or public), preserving source order.
 #[derive(Debug, Clone)]
-pub enum InstanceFieldDef {
+pub(crate) enum InstanceFieldDef {
     Private(PrivateFieldDef),
     Public(JsPropertyKey, Option<Expression>),
     /// Auto accessor backing storage initialization: (storage_slot_name, initializer)
@@ -1250,7 +1255,7 @@ pub enum InstanceFieldDef {
 }
 
 #[derive(Debug, Clone)]
-pub enum PrivateElement {
+pub(crate) enum PrivateElement {
     Field(JsValue),
     Method(JsValue),
     Accessor {
@@ -1260,14 +1265,14 @@ pub enum PrivateElement {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum IteratorKind {
+pub(crate) enum IteratorKind {
     Key,
     Value,
     KeyValue,
 }
 
 #[derive(Debug, Clone)]
-pub enum IteratorState {
+pub(crate) enum IteratorState {
     ArrayIterator {
         array_id: u64,
         index: usize,
@@ -1350,7 +1355,7 @@ pub enum IteratorState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum TypedArrayKind {
+pub(crate) enum TypedArrayKind {
     Int8,
     Uint8,
     Uint8Clamped,
@@ -1366,7 +1371,7 @@ pub enum TypedArrayKind {
 }
 
 impl TypedArrayKind {
-    pub fn bytes_per_element(&self) -> usize {
+    pub(crate) fn bytes_per_element(&self) -> usize {
         match self {
             TypedArrayKind::Int8 | TypedArrayKind::Uint8 | TypedArrayKind::Uint8Clamped => 1,
             TypedArrayKind::Int16 | TypedArrayKind::Uint16 | TypedArrayKind::Float16 => 2,
@@ -1375,7 +1380,7 @@ impl TypedArrayKind {
         }
     }
 
-    pub fn name(&self) -> &'static str {
+    pub(crate) fn name(&self) -> &'static str {
         match self {
             TypedArrayKind::Int8 => "Int8Array",
             TypedArrayKind::Uint8 => "Uint8Array",
@@ -1392,13 +1397,13 @@ impl TypedArrayKind {
         }
     }
 
-    pub fn is_bigint(&self) -> bool {
+    pub(crate) fn is_bigint(&self) -> bool {
         matches!(self, TypedArrayKind::BigInt64 | TypedArrayKind::BigUint64)
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct TypedArrayInfo {
+pub(crate) struct TypedArrayInfo {
     pub kind: TypedArrayKind,
     pub buffer: Rc<RefCell<BufferData>>,
     pub byte_offset: usize,
@@ -1412,7 +1417,7 @@ pub struct TypedArrayInfo {
 }
 
 #[derive(Debug, Clone)]
-pub struct DataViewInfo {
+pub(crate) struct DataViewInfo {
     pub buffer: Rc<RefCell<BufferData>>,
     pub byte_offset: usize,
     pub byte_length: usize,
@@ -1621,7 +1626,7 @@ pub(crate) enum TemporalData {
     },
 }
 
-pub struct JsObjectData {
+pub(crate) struct JsObjectData {
     /// Slab index of this object. Set exactly once by
     /// `Interpreter::alloc_object` at allocation time and never reassigned.
     pub id: Option<u64>,
@@ -1696,7 +1701,7 @@ pub(crate) struct ArrayBufferData {
 /// expressible only by convention — e.g. `default && !derived` was nonsense
 /// but compiled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConstructorKind {
+pub(crate) enum ConstructorKind {
     /// A regular function — or the constructor slot is unused.
     Function,
     /// A base class constructor (`class C { ... }` without `extends`).
@@ -1942,27 +1947,27 @@ impl JsObjectData {
     );
 
     /// True iff this is an *active* (non-revoked) proxy. Preserves pre-bundling semantics.
-    pub fn is_proxy(&self) -> bool {
+    pub(crate) fn is_proxy(&self) -> bool {
         self.proxy().is_some_and(|p| !p.revoked)
     }
 
     /// True iff this object has been revoked.
-    pub fn is_proxy_revoked(&self) -> bool {
+    pub(crate) fn is_proxy_revoked(&self) -> bool {
         self.proxy().is_some_and(|p| p.revoked)
     }
 
     /// Target id for an active proxy, `None` otherwise (including revoked).
-    pub fn proxy_target_id(&self) -> Option<u64> {
+    pub(crate) fn proxy_target_id(&self) -> Option<u64> {
         self.proxy().and_then(|p| p.target_id)
     }
 
     /// True iff this object is a class constructor of any flavor.
-    pub fn is_class_constructor(&self) -> bool {
+    pub(crate) fn is_class_constructor(&self) -> bool {
         !matches!(self.constructor_kind, ConstructorKind::Function)
     }
 
     /// True iff this object is a derived class constructor (explicit or default).
-    pub fn is_derived_class_constructor(&self) -> bool {
+    pub(crate) fn is_derived_class_constructor(&self) -> bool {
         matches!(
             self.constructor_kind,
             ConstructorKind::DerivedClass | ConstructorKind::DefaultDerivedClass
@@ -1970,7 +1975,7 @@ impl JsObjectData {
     }
 
     /// True iff this is a synthesized default derived constructor.
-    pub fn is_default_derived_constructor(&self) -> bool {
+    pub(crate) fn is_default_derived_constructor(&self) -> bool {
         matches!(self.constructor_kind, ConstructorKind::DefaultDerivedClass)
     }
 
@@ -2017,27 +2022,27 @@ impl JsObjectData {
     }
 
     /// Backing bytes for an ArrayBuffer / SharedArrayBuffer.
-    pub fn arraybuffer_data(&self) -> Option<&Rc<RefCell<BufferData>>> {
+    pub(crate) fn arraybuffer_data(&self) -> Option<&Rc<RefCell<BufferData>>> {
         self.arraybuffer().map(|b| &b.data)
     }
 
     /// Detached cell for a regular ArrayBuffer. `None` for SAB or non-buffers.
-    pub fn arraybuffer_detached(&self) -> Option<&Rc<Cell<bool>>> {
+    pub(crate) fn arraybuffer_detached(&self) -> Option<&Rc<Cell<bool>>> {
         self.arraybuffer().and_then(|b| b.detached.as_ref())
     }
 
     /// Max byte length for a resizable / growable AB; `None` for non-resizable.
-    pub fn arraybuffer_max_byte_length(&self) -> Option<usize> {
+    pub(crate) fn arraybuffer_max_byte_length(&self) -> Option<usize> {
         self.arraybuffer().and_then(|b| b.max_byte_length)
     }
 
     /// True iff this is a SharedArrayBuffer.
-    pub fn arraybuffer_is_shared(&self) -> bool {
+    pub(crate) fn arraybuffer_is_shared(&self) -> bool {
         self.arraybuffer().is_some_and(|b| b.is_shared)
     }
 
     /// True iff this is an immutable ArrayBuffer (post-`sliceToImmutable`).
-    pub fn arraybuffer_is_immutable(&self) -> bool {
+    pub(crate) fn arraybuffer_is_immutable(&self) -> bool {
         self.arraybuffer().is_some_and(|b| b.is_immutable)
     }
 
@@ -2051,13 +2056,13 @@ impl JsObjectData {
     }
 
     /// SAB shared inner state. `Some` iff this is a SharedArrayBuffer.
-    pub fn sab_shared(&self) -> Option<&Arc<SharedBufferInner>> {
+    pub(crate) fn sab_shared(&self) -> Option<&Arc<SharedBufferInner>> {
         self.arraybuffer().and_then(|b| b.sab_shared.as_ref())
     }
 
     /// Id of the ArrayBuffer wrapper object that backs this TypedArray or DataView,
     /// pulled from whichever kind slot is populated. `None` for non-view objects.
-    pub fn view_buffer_object_id(&self) -> Option<u64> {
+    pub(crate) fn view_buffer_object_id(&self) -> Option<u64> {
         self.typed_array_info()
             .as_ref()
             .and_then(|ta| ta.buffer_object_id)
@@ -2089,7 +2094,7 @@ impl JsObjectData {
 
     // Like get_property_descriptor but without prototype chain walk.
     // Includes parameter_map and array_elements handling.
-    pub fn get_own_property_full<K: PropertyKeyLike + ?Sized>(
+    pub(crate) fn get_own_property_full<K: PropertyKeyLike + ?Sized>(
         &self,
         key: &K,
     ) -> Option<PropertyDescriptor> {
@@ -2164,7 +2169,7 @@ impl JsObjectData {
         None
     }
 
-    pub fn get_own_property<K: PropertyKeyLike + ?Sized>(
+    pub(crate) fn get_own_property<K: PropertyKeyLike + ?Sized>(
         &self,
         key: &K,
     ) -> Option<PropertyDescriptor> {
@@ -2270,7 +2275,7 @@ impl JsObjectData {
         None
     }
 
-    pub fn has_own_property<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> bool {
+    pub(crate) fn has_own_property<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> bool {
         // Module namespace exotic: [[HasProperty]] checks export list
         if let Some(key_str) = key.as_property_key_str()
             && let Some(ns_data) = self.module_namespace()
@@ -2309,7 +2314,7 @@ impl JsObjectData {
     // `Interpreter::has_property_on_id`. Own-only variants live as
     // `own_enumerable_keys_with_shadow` / `own_has_property` on this impl.
 
-    pub fn define_own_property<K: Into<JsPropertyKey>>(
+    pub(crate) fn define_own_property<K: Into<JsPropertyKey>>(
         &mut self,
         key: K,
         mut desc: PropertyDescriptor,
@@ -2674,7 +2679,7 @@ impl JsObjectData {
         true
     }
 
-    pub fn set_property_value<K: PropertyKeyLike + ?Sized>(
+    pub(crate) fn set_property_value<K: PropertyKeyLike + ?Sized>(
         &mut self,
         key: &K,
         value: JsValue,
@@ -2892,7 +2897,7 @@ impl JsObjectData {
         }
     }
 
-    pub fn insert_value<K: Into<JsPropertyKey>>(&mut self, key: K, value: JsValue) {
+    pub(crate) fn insert_value<K: Into<JsPropertyKey>>(&mut self, key: K, value: JsValue) {
         let key = intern_js_key(key.into());
         if !self.properties.contains_key(&key) {
             self.property_order.push(key.clone());
@@ -2901,7 +2906,7 @@ impl JsObjectData {
             .insert(key, PropertyDescriptor::data_default(value));
     }
 
-    pub fn insert_builtin<K: Into<JsPropertyKey>>(&mut self, key: K, value: JsValue) {
+    pub(crate) fn insert_builtin<K: Into<JsPropertyKey>>(&mut self, key: K, value: JsValue) {
         let key = intern_js_key(key.into());
         if !self.properties.contains_key(&key) {
             self.property_order.push(key.clone());
@@ -2910,7 +2915,11 @@ impl JsObjectData {
             .insert(key, PropertyDescriptor::data(value, true, false, true));
     }
 
-    pub fn insert_property<K: Into<JsPropertyKey>>(&mut self, key: K, desc: PropertyDescriptor) {
+    pub(crate) fn insert_property<K: Into<JsPropertyKey>>(
+        &mut self,
+        key: K,
+        desc: PropertyDescriptor,
+    ) {
         let key = intern_js_key(key.into());
         if !self.properties.contains_key(&key) {
             self.property_order.push(key.clone());
@@ -2923,7 +2932,7 @@ impl JsObjectData {
     /// together, and this is the single place that guarantees it. Returns the
     /// removed descriptor, or `None` if the key was absent (in which case the
     /// order list is left untouched).
-    pub fn remove_property<K: PropertyKeyLike + ?Sized>(
+    pub(crate) fn remove_property<K: PropertyKeyLike + ?Sized>(
         &mut self,
         key: &K,
     ) -> Option<PropertyDescriptor> {
@@ -2935,7 +2944,10 @@ impl JsObjectData {
         removed
     }
 
-    pub fn get_property_value<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> Option<JsValue> {
+    pub(crate) fn get_property_value<K: PropertyKeyLike + ?Sized>(
+        &self,
+        key: &K,
+    ) -> Option<JsValue> {
         self.properties.get(key).and_then(|d| d.value.clone())
     }
 
@@ -2944,7 +2956,10 @@ impl JsObjectData {
     /// module-namespace live bindings, parameter_map, array_elements, typed_array
     /// canonical numeric indices, and string exotic indices). Returns `None` if
     /// the caller should continue walking the prototype chain.
-    pub fn own_property_lookup<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> Option<JsValue> {
+    pub(crate) fn own_property_lookup<K: PropertyKeyLike + ?Sized>(
+        &self,
+        key: &K,
+    ) -> Option<JsValue> {
         if let Some(key_str) = key.as_property_key_str()
             && let Some(ns_data) = self.module_namespace()
             && let Some(binding_name) = ns_data.export_to_binding.get(key_str)
@@ -2996,7 +3011,7 @@ impl JsObjectData {
     /// Mirrors the pre-chain-walk branches of that method exactly (including
     /// OrdinaryGetOwnProperty accessor completion and TypedArray canonical index
     /// with `configurable: false` per §10.4.5.2).
-    pub fn own_property_descriptor_lookup<K: PropertyKeyLike + ?Sized>(
+    pub(crate) fn own_property_descriptor_lookup<K: PropertyKeyLike + ?Sized>(
         &self,
         key: &K,
     ) -> Option<PropertyDescriptor> {
@@ -3084,7 +3099,7 @@ impl JsObjectData {
     /// canonical-numeric-index on a typed array that's out of range (per
     /// §10.4.5.2, typed arrays never consult the prototype for these),
     /// and `None` to continue walking the chain.
-    pub fn own_has_property<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> Option<bool> {
+    pub(crate) fn own_has_property<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> Option<bool> {
         if let Some(ta) = self.typed_array_info()
             && let Some(index) = canonical_numeric_index_string(key)
         {
@@ -3101,7 +3116,9 @@ impl JsObjectData {
     /// keys in insertion order) and the full shadow set of all own keys
     /// (enumerable + non-enumerable) so the caller can suppress inherited
     /// properties with matching names.
-    pub fn own_enumerable_keys_with_shadow(&self) -> (Vec<JsPropertyKey>, HashSet<JsPropertyKey>) {
+    pub(crate) fn own_enumerable_keys_with_shadow(
+        &self,
+    ) -> (Vec<JsPropertyKey>, HashSet<JsPropertyKey>) {
         let mut seen = HashSet::default();
         let mut index_keys: Vec<(u32, JsPropertyKey)> = Vec::new();
         let mut string_keys: Vec<JsPropertyKey> = Vec::new();
@@ -3761,20 +3778,20 @@ fn to_biguint64(v: &JsValue) -> u64 {
 }
 
 #[derive(Debug, Clone)]
-pub enum PromiseState {
+pub(crate) enum PromiseState {
     Pending,
     Fulfilled(JsValue),
     Rejected(JsValue),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PromiseReactionType {
+pub(crate) enum PromiseReactionType {
     Fulfill,
     Reject,
 }
 
 #[derive(Debug, Clone)]
-pub struct PromiseReaction {
+pub(crate) struct PromiseReaction {
     pub handler: Option<JsValue>,
     pub promise_id: Option<u64>,
     pub resolve: JsValue,
@@ -3783,7 +3800,7 @@ pub struct PromiseReaction {
 }
 
 #[derive(Debug, Clone)]
-pub struct PromiseData {
+pub(crate) struct PromiseData {
     pub state: PromiseState,
     pub fulfill_reactions: Vec<PromiseReaction>,
     pub reject_reactions: Vec<PromiseReaction>,
@@ -3791,7 +3808,7 @@ pub struct PromiseData {
 }
 
 impl PromiseData {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             state: PromiseState::Pending,
             fulfill_reactions: Vec::new(),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::str::Chars;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Token {
+pub(crate) enum Token {
     // Identifiers and keywords
     Identifier(String),
     IdentifierWithEscape(String), // identifier containing Unicode escapes
@@ -95,7 +95,7 @@ pub enum Token {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Keyword {
+pub(crate) enum Keyword {
     Async,
     Await,
     Break,
@@ -138,7 +138,7 @@ pub enum Keyword {
 }
 
 impl Keyword {
-    pub fn from_str(s: &str) -> Option<Keyword> {
+    pub(crate) fn from_str(s: &str) -> Option<Keyword> {
         match s {
             "async" => Some(Keyword::Async),
             "await" => Some(Keyword::Await),
@@ -232,13 +232,13 @@ impl fmt::Display for Keyword {
 }
 
 #[derive(Clone, Debug)]
-pub struct SourceLocation {
+pub(crate) struct SourceLocation {
     pub line: u32,
     pub column: u32,
 }
 
 #[derive(Clone, Debug)]
-pub struct LexError {
+pub(crate) struct LexError {
     pub message: String,
     pub location: SourceLocation,
 }
@@ -253,7 +253,7 @@ impl fmt::Display for LexError {
     }
 }
 
-pub struct Lexer<'a> {
+pub(crate) struct Lexer<'a> {
     source: &'a str,
     chars: Chars<'a>,
     current: Option<char>,
@@ -269,7 +269,7 @@ pub struct Lexer<'a> {
 }
 
 impl<'a> Lexer<'a> {
-    pub fn new(source: &'a str) -> Self {
+    pub(crate) fn new(source: &'a str) -> Self {
         let mut chars = source.chars();
         let current = chars.next();
         Self {
@@ -983,7 +983,7 @@ impl<'a> Lexer<'a> {
         })
     }
 
-    pub fn lex_regex(&mut self) -> Result<Token, LexError> {
+    pub(crate) fn lex_regex(&mut self) -> Result<Token, LexError> {
         let mut pattern = String::new();
         let mut in_class = false;
         loop {
@@ -1036,15 +1036,15 @@ impl<'a> Lexer<'a> {
         Ok(Token::RegExpLiteral { pattern, flags })
     }
 
-    pub fn token_start(&self) -> usize {
+    pub(crate) fn token_start(&self) -> usize {
         self.token_start
     }
 
-    pub fn offset(&self) -> usize {
+    pub(crate) fn offset(&self) -> usize {
         self.offset
     }
 
-    pub fn save_state(&self) -> (usize, Option<char>, u32, u32, usize, bool) {
+    pub(crate) fn save_state(&self) -> (usize, Option<char>, u32, u32, usize, bool) {
         (
             self.offset,
             self.current,
@@ -1055,7 +1055,7 @@ impl<'a> Lexer<'a> {
         )
     }
 
-    pub fn restore_state(&mut self, state: (usize, Option<char>, u32, u32, usize, bool)) {
+    pub(crate) fn restore_state(&mut self, state: (usize, Option<char>, u32, u32, usize, bool)) {
         self.offset = state.0;
         self.current = state.1;
         self.line = state.2;
@@ -1067,7 +1067,7 @@ impl<'a> Lexer<'a> {
         self.chars = self.source[self.offset + skip..].chars();
     }
 
-    pub fn next_token(&mut self) -> Result<Token, LexError> {
+    pub(crate) fn next_token(&mut self) -> Result<Token, LexError> {
         loop {
             self.skip_whitespace();
             self.token_start = self.offset;
@@ -1303,7 +1303,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    pub fn read_template_continuation(&mut self) -> Result<Token, LexError> {
+    pub(crate) fn read_template_continuation(&mut self) -> Result<Token, LexError> {
         let (cooked, raw, is_tail) = self.read_template_chars()?;
         if is_tail {
             Ok(Token::TemplateTail(cooked, raw))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
+#![warn(unreachable_pub)]
 mod ast;
 pub(crate) mod emoji_strings;
 mod interpreter;

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -29,7 +29,7 @@ fn validate_regexp_literal(pattern: &str, flags: &str) -> Result<(), ParseError>
 }
 
 impl<'a> Parser<'a> {
-    pub fn parse_expression(&mut self) -> Result<Expression, ParseError> {
+    pub(crate) fn parse_expression(&mut self) -> Result<Expression, ParseError> {
         let expr = self.parse_assignment_expression()?;
         if self.current == Token::Comma {
             let mut exprs = vec![expr];

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,7 +17,7 @@ enum PrivateNameKind {
 }
 
 #[derive(Debug)]
-pub struct ParseError {
+pub(crate) struct ParseError {
     pub message: String,
 }
 
@@ -33,7 +33,7 @@ impl From<LexError> for ParseError {
     }
 }
 
-pub struct Parser<'a> {
+pub(crate) struct Parser<'a> {
     source: &'a str,
     source_text_source: Rc<str>,
     lexer: Lexer<'a>,
@@ -81,7 +81,7 @@ pub struct Parser<'a> {
 const MAX_PARSE_DEPTH: u32 = 4_000;
 
 impl<'a> Parser<'a> {
-    pub fn new(source: &'a str) -> Result<Self, ParseError> {
+    pub(crate) fn new(source: &'a str) -> Result<Self, ParseError> {
         let mut lexer = Lexer::new(source);
         let mut had_lt = false;
         let current = loop {
@@ -225,31 +225,31 @@ impl<'a> Parser<'a> {
         Some(SourceText::new(self.source_text_source.clone(), start, end))
     }
 
-    pub fn set_strict(&mut self, strict: bool) {
+    pub(crate) fn set_strict(&mut self, strict: bool) {
         self.strict = strict;
         self.lexer.strict = strict;
     }
 
-    pub fn set_eval_in_class_with_names(&mut self, names: HashSet<String>) {
+    pub(crate) fn set_eval_in_class_with_names(&mut self, names: HashSet<String>) {
         self.private_name_scopes.push((names, Vec::new()));
     }
 
-    pub fn set_eval_in_field_initializer(&mut self) {
+    pub(crate) fn set_eval_in_field_initializer(&mut self) {
         self.in_field_initializer_eval = true;
         self.allow_super_property = true;
         self.in_function += 1;
         self.in_non_arrow_function += 1;
     }
 
-    pub fn set_eval_new_target_allowed(&mut self) {
+    pub(crate) fn set_eval_new_target_allowed(&mut self) {
         self.eval_new_target_allowed = true;
     }
 
-    pub fn set_eval_allow_super_property(&mut self) {
+    pub(crate) fn set_eval_allow_super_property(&mut self) {
         self.allow_super_property = true;
     }
 
-    pub fn set_eval_allow_super_call(&mut self) {
+    pub(crate) fn set_eval_allow_super_call(&mut self) {
         self.allow_super_call = true;
     }
 
@@ -278,7 +278,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    pub fn validate_eval_private_names(&mut self) -> Result<(), ParseError> {
+    pub(crate) fn validate_eval_private_names(&mut self) -> Result<(), ParseError> {
         while !self.private_name_scopes.is_empty() {
             self.pop_private_scope()?;
         }
@@ -1068,7 +1068,7 @@ impl<'a> Parser<'a> {
         )
     }
 
-    pub fn parse_program(&mut self) -> Result<Program, ParseError> {
+    pub(crate) fn parse_program(&mut self) -> Result<Program, ParseError> {
         let mut body = Vec::new();
         let mut in_directive_prologue = true;
         let mut body_is_strict = false;
@@ -1152,7 +1152,7 @@ impl<'a> Parser<'a> {
         Ok(program)
     }
 
-    pub fn parse_program_as_module(&mut self) -> Result<Program, ParseError> {
+    pub(crate) fn parse_program_as_module(&mut self) -> Result<Program, ParseError> {
         self.is_module = true;
         self.lexer.is_module = true;
         self.set_strict(true);

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
-pub enum JsValue {
+pub(crate) enum JsValue {
     Undefined,
     Null,
     Boolean(bool),
@@ -23,7 +23,7 @@ pub enum JsValue {
 // Consumers land in follow-up #69 NaN-box migration PRs.
 #[allow(dead_code)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
-pub enum ValueKind {
+pub(crate) enum ValueKind {
     Undefined,
     Null,
     Boolean,
@@ -37,38 +37,38 @@ pub enum ValueKind {
 // UTF-16 code unit string per spec §6.1.4
 // Uses Arc<Vec<u16>> so cloning (e.g. env.get) is O(1).
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct JsString {
+pub(crate) struct JsString {
     pub code_units: Arc<Vec<u16>>,
 }
 
 impl JsString {
-    pub fn from_str(s: &str) -> Self {
+    pub(crate) fn from_str(s: &str) -> Self {
         Self {
             code_units: Arc::new(s.encode_utf16().collect()),
         }
     }
 
-    pub fn from_vec(v: Vec<u16>) -> Self {
+    pub(crate) fn from_vec(v: Vec<u16>) -> Self {
         Self {
             code_units: Arc::new(v),
         }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.code_units.is_empty()
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.code_units.len()
     }
 
-    pub fn to_rust_string(&self) -> String {
+    pub(crate) fn to_rust_string(&self) -> String {
         String::from_utf16_lossy(&self.code_units)
     }
 
     /// Get mutable access to code_units, cloning only if shared.
     /// Take ownership of the inner Vec (clones if shared).
-    pub fn into_vec(self) -> Vec<u16> {
+    pub(crate) fn into_vec(self) -> Vec<u16> {
         Arc::try_unwrap(self.code_units).unwrap_or_else(|arc| (*arc).clone())
     }
 }
@@ -88,25 +88,25 @@ impl fmt::Display for JsString {
 /// carry a leading byte that canonical WTF-8 can never produce, keeping their
 /// identity disjoint from every possible String key.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct JsPropertyKey {
+pub(crate) struct JsPropertyKey {
     bytes: Arc<[u8]>,
 }
 
 const SYMBOL_PROPERTY_KEY_SIGIL: u8 = 0xFF;
 
-pub enum JsPropertyKeyParseError<E> {
+pub(crate) enum JsPropertyKeyParseError<E> {
     IllFormedUtf16,
     Value(E),
 }
 
 impl JsPropertyKey {
-    pub fn from_str(s: &str) -> Self {
+    pub(crate) fn from_str(s: &str) -> Self {
         Self {
             bytes: Arc::from(s.as_bytes()),
         }
     }
 
-    pub fn from_js_string(s: &JsString) -> Self {
+    pub(crate) fn from_js_string(s: &JsString) -> Self {
         let units = &s.code_units;
         let mut bytes = Vec::with_capacity(units.len() * 3);
         let mut i = 0;
@@ -157,18 +157,18 @@ impl JsPropertyKey {
         Self::from_symbol_encoding(format!("Symbol(Symbol.{name})"))
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
+    pub(crate) fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }
 
-    pub fn as_str(&self) -> Option<&str> {
+    pub(crate) fn as_str(&self) -> Option<&str> {
         if self.is_symbol() {
             return None;
         }
         std::str::from_utf8(&self.bytes).ok()
     }
 
-    pub fn is_symbol(&self) -> bool {
+    pub(crate) fn is_symbol(&self) -> bool {
         self.bytes.first() == Some(&SYMBOL_PROPERTY_KEY_SIGIL)
     }
 
@@ -177,11 +177,11 @@ impl JsPropertyKey {
             .then(|| std::str::from_utf8(&self.bytes[1..]).expect("Symbol encoding is UTF-8"))
     }
 
-    pub fn eq_str(&self, other: &str) -> bool {
+    pub(crate) fn eq_str(&self, other: &str) -> bool {
         self.bytes.as_ref() == other.as_bytes()
     }
 
-    pub fn parse<T: FromStr>(&self) -> Result<T, JsPropertyKeyParseError<T::Err>> {
+    pub(crate) fn parse<T: FromStr>(&self) -> Result<T, JsPropertyKeyParseError<T::Err>> {
         let text = self
             .as_str()
             .ok_or(JsPropertyKeyParseError::IllFormedUtf16)?;
@@ -193,7 +193,7 @@ impl JsPropertyKey {
         Arc::ptr_eq(&self.bytes, &other.bytes)
     }
 
-    pub fn to_js_string(&self) -> JsString {
+    pub(crate) fn to_js_string(&self) -> JsString {
         let bytes = if self.is_symbol() {
             &self.bytes[1..]
         } else {
@@ -266,7 +266,7 @@ impl fmt::Display for JsPropertyKey {
     }
 }
 
-pub trait PropertyKeyLike {
+pub(crate) trait PropertyKeyLike {
     fn as_property_key_bytes(&self) -> &[u8];
 
     fn as_property_key_str(&self) -> Option<&str> {
@@ -333,7 +333,7 @@ impl<T: PropertyKeyLike + ?Sized> PropertyKeyLike for &T {
 }
 
 #[derive(Clone, Debug)]
-pub struct JsSymbol {
+pub(crate) struct JsSymbol {
     pub id: u64,
     pub description: Option<JsString>,
 }
@@ -343,7 +343,7 @@ impl JsSymbol {
     /// Well-known symbols (description starts with "Symbol.") use a stable format
     /// without id, so bootstrap lookups can construct the same key directly.
     /// User-created symbols include the unique id to avoid collisions.
-    pub fn to_property_key(&self) -> JsPropertyKey {
+    pub(crate) fn to_property_key(&self) -> JsPropertyKey {
         let encoding = match &self.description {
             Some(desc) if desc.to_string().starts_with("Symbol.") => {
                 format!("Symbol({})", desc)
@@ -356,13 +356,13 @@ impl JsSymbol {
 }
 
 #[derive(Clone, Debug)]
-pub struct JsBigInt {
+pub(crate) struct JsBigInt {
     pub value: num_bigint::BigInt,
 }
 
 // Placeholder — full object model comes in Phase 5
 #[derive(Clone, Debug)]
-pub struct JsObject {
+pub(crate) struct JsObject {
     pub id: u64,
 }
 
@@ -373,39 +373,39 @@ pub struct JsObject {
 // Consumers land in follow-up #69 NaN-box migration PRs.
 #[allow(dead_code)]
 impl JsValue {
-    pub const UNDEFINED: JsValue = JsValue::Undefined;
-    pub const NULL: JsValue = JsValue::Null;
-    pub const TRUE: JsValue = JsValue::Boolean(true);
-    pub const FALSE: JsValue = JsValue::Boolean(false);
+    pub(crate) const UNDEFINED: JsValue = JsValue::Undefined;
+    pub(crate) const NULL: JsValue = JsValue::Null;
+    pub(crate) const TRUE: JsValue = JsValue::Boolean(true);
+    pub(crate) const FALSE: JsValue = JsValue::Boolean(false);
 
-    pub fn boolean(b: bool) -> Self {
+    pub(crate) fn boolean(b: bool) -> Self {
         JsValue::Boolean(b)
     }
 
     /// Construct a Number value. NaN canonicalisation lands here in Phase 3
     /// (issue #69) — for now this is a thin wrapper.
-    pub fn number(n: f64) -> Self {
+    pub(crate) fn number(n: f64) -> Self {
         JsValue::Number(n)
     }
 
-    pub fn string(s: JsString) -> Self {
+    pub(crate) fn string(s: JsString) -> Self {
         JsValue::String(s)
     }
 
     /// Sugar for `JsValue::string(JsString::from_str(s))`.
-    pub fn from_str(s: &str) -> Self {
+    pub(crate) fn from_str(s: &str) -> Self {
         JsValue::String(JsString::from_str(s))
     }
 
-    pub fn symbol(s: JsSymbol) -> Self {
+    pub(crate) fn symbol(s: JsSymbol) -> Self {
         JsValue::Symbol(s)
     }
 
-    pub fn bigint(b: JsBigInt) -> Self {
+    pub(crate) fn bigint(b: JsBigInt) -> Self {
         JsValue::BigInt(b)
     }
 
-    pub fn object(id: u64) -> Self {
+    pub(crate) fn object(id: u64) -> Self {
         JsValue::Object(JsObject { id })
     }
 
@@ -417,21 +417,21 @@ impl JsValue {
     // `&JsString` are unsound (no Rust-level borrowee exists), so the
     // `with_*` form is the only zero-refcount-bump path.
 
-    pub fn as_boolean(&self) -> Option<bool> {
+    pub(crate) fn as_boolean(&self) -> Option<bool> {
         match self {
             JsValue::Boolean(b) => Some(*b),
             _ => None,
         }
     }
 
-    pub fn as_number(&self) -> Option<f64> {
+    pub(crate) fn as_number(&self) -> Option<f64> {
         match self {
             JsValue::Number(n) => Some(*n),
             _ => None,
         }
     }
 
-    pub fn as_object_id(&self) -> Option<u64> {
+    pub(crate) fn as_object_id(&self) -> Option<u64> {
         match self {
             JsValue::Object(o) => Some(o.id),
             _ => None,
@@ -440,56 +440,56 @@ impl JsValue {
 
     /// Cloning accessor — under the future NaN-box this becomes an Arc
     /// refcount bump, so it stays O(1).
-    pub fn as_string(&self) -> Option<JsString> {
+    pub(crate) fn as_string(&self) -> Option<JsString> {
         match self {
             JsValue::String(s) => Some(s.clone()),
             _ => None,
         }
     }
 
-    pub fn as_symbol(&self) -> Option<JsSymbol> {
+    pub(crate) fn as_symbol(&self) -> Option<JsSymbol> {
         match self {
             JsValue::Symbol(s) => Some(s.clone()),
             _ => None,
         }
     }
 
-    pub fn as_bigint(&self) -> Option<JsBigInt> {
+    pub(crate) fn as_bigint(&self) -> Option<JsBigInt> {
         match self {
             JsValue::BigInt(b) => Some(b.clone()),
             _ => None,
         }
     }
 
-    pub fn with_string<R>(&self, f: impl FnOnce(&[u16]) -> R) -> Option<R> {
+    pub(crate) fn with_string<R>(&self, f: impl FnOnce(&[u16]) -> R) -> Option<R> {
         match self {
             JsValue::String(s) => Some(f(&s.code_units)),
             _ => None,
         }
     }
 
-    pub fn with_symbol<R>(&self, f: impl FnOnce(&JsSymbol) -> R) -> Option<R> {
+    pub(crate) fn with_symbol<R>(&self, f: impl FnOnce(&JsSymbol) -> R) -> Option<R> {
         match self {
             JsValue::Symbol(s) => Some(f(s)),
             _ => None,
         }
     }
 
-    pub fn with_bigint<R>(&self, f: impl FnOnce(&num_bigint::BigInt) -> R) -> Option<R> {
+    pub(crate) fn with_bigint<R>(&self, f: impl FnOnce(&num_bigint::BigInt) -> R) -> Option<R> {
         match self {
             JsValue::BigInt(b) => Some(f(&b.value)),
             _ => None,
         }
     }
 
-    pub fn into_string(self) -> Option<JsString> {
+    pub(crate) fn into_string(self) -> Option<JsString> {
         match self {
             JsValue::String(s) => Some(s),
             _ => None,
         }
     }
 
-    pub fn into_bigint(self) -> Option<JsBigInt> {
+    pub(crate) fn into_bigint(self) -> Option<JsBigInt> {
         match self {
             JsValue::BigInt(b) => Some(b),
             _ => None,
@@ -497,7 +497,7 @@ impl JsValue {
     }
 
     /// Eight-way value tag for exhaustive dispatch. See `ValueKind`.
-    pub fn discriminant(&self) -> ValueKind {
+    pub(crate) fn discriminant(&self) -> ValueKind {
         match self {
             JsValue::Undefined => ValueKind::Undefined,
             JsValue::Null => ValueKind::Null,
@@ -511,62 +511,62 @@ impl JsValue {
     }
 
     /// Alias for `discriminant()` — the canonical `ValueKind` accessor.
-    pub fn kind(&self) -> ValueKind {
+    pub(crate) fn kind(&self) -> ValueKind {
         self.discriminant()
     }
 
-    pub fn is_object(&self) -> bool {
+    pub(crate) fn is_object(&self) -> bool {
         matches!(self, JsValue::Object(_))
     }
 }
 
 // §6.1.6.1 — Number type operations
 impl JsValue {
-    pub fn is_undefined(&self) -> bool {
+    pub(crate) fn is_undefined(&self) -> bool {
         matches!(self, JsValue::Undefined)
     }
 
-    pub fn is_null(&self) -> bool {
+    pub(crate) fn is_null(&self) -> bool {
         matches!(self, JsValue::Null)
     }
 
-    pub fn is_boolean(&self) -> bool {
+    pub(crate) fn is_boolean(&self) -> bool {
         matches!(self, JsValue::Boolean(_))
     }
 
-    pub fn is_number(&self) -> bool {
+    pub(crate) fn is_number(&self) -> bool {
         matches!(self, JsValue::Number(_))
     }
 
-    pub fn is_string(&self) -> bool {
+    pub(crate) fn is_string(&self) -> bool {
         matches!(self, JsValue::String(_))
     }
 
-    pub fn is_symbol(&self) -> bool {
+    pub(crate) fn is_symbol(&self) -> bool {
         matches!(self, JsValue::Symbol(_))
     }
 
-    pub fn is_bigint(&self) -> bool {
+    pub(crate) fn is_bigint(&self) -> bool {
         matches!(self, JsValue::BigInt(_))
     }
 
-    pub fn is_nullish(&self) -> bool {
+    pub(crate) fn is_nullish(&self) -> bool {
         matches!(self, JsValue::Undefined | JsValue::Null)
     }
 }
 
 // §6.1.6.1 Number type operations
-pub mod number_ops {
-    pub fn unary_minus(x: f64) -> f64 {
+pub(crate) mod number_ops {
+    pub(crate) fn unary_minus(x: f64) -> f64 {
         if x.is_nan() { f64::NAN } else { -x }
     }
 
-    pub fn bitwise_not(x: f64) -> f64 {
+    pub(crate) fn bitwise_not(x: f64) -> f64 {
         let n = to_int32(x);
         f64::from(!n)
     }
 
-    pub fn exponentiate(base: f64, exp: f64) -> f64 {
+    pub(crate) fn exponentiate(base: f64, exp: f64) -> f64 {
         // §6.1.6.1.4 step 3: if exponent is NaN, return NaN
         if exp.is_nan() {
             return f64::NAN;
@@ -578,49 +578,49 @@ pub mod number_ops {
         base.powf(exp)
     }
 
-    pub fn multiply(x: f64, y: f64) -> f64 {
+    pub(crate) fn multiply(x: f64, y: f64) -> f64 {
         x * y
     }
 
-    pub fn divide(x: f64, y: f64) -> f64 {
+    pub(crate) fn divide(x: f64, y: f64) -> f64 {
         x / y
     }
 
-    pub fn remainder(x: f64, y: f64) -> f64 {
+    pub(crate) fn remainder(x: f64, y: f64) -> f64 {
         // IEEE 754 remainder
         x % y
     }
 
-    pub fn add(x: f64, y: f64) -> f64 {
+    pub(crate) fn add(x: f64, y: f64) -> f64 {
         x + y
     }
 
-    pub fn subtract(x: f64, y: f64) -> f64 {
+    pub(crate) fn subtract(x: f64, y: f64) -> f64 {
         x - y
     }
 
-    pub fn left_shift(x: f64, y: f64) -> f64 {
+    pub(crate) fn left_shift(x: f64, y: f64) -> f64 {
         let lnum = to_int32(x);
         let rnum = to_uint32(y);
         let shift = rnum & 0x1F;
         f64::from(lnum.wrapping_shl(shift))
     }
 
-    pub fn signed_right_shift(x: f64, y: f64) -> f64 {
+    pub(crate) fn signed_right_shift(x: f64, y: f64) -> f64 {
         let lnum = to_int32(x);
         let rnum = to_uint32(y);
         let shift = rnum & 0x1F;
         f64::from(lnum.wrapping_shr(shift))
     }
 
-    pub fn unsigned_right_shift(x: f64, y: f64) -> f64 {
+    pub(crate) fn unsigned_right_shift(x: f64, y: f64) -> f64 {
         let lnum = to_uint32(x);
         let rnum = to_uint32(y);
         let shift = rnum & 0x1F;
         lnum.wrapping_shr(shift) as f64
     }
 
-    pub fn less_than(x: f64, y: f64) -> Option<bool> {
+    pub(crate) fn less_than(x: f64, y: f64) -> Option<bool> {
         if x.is_nan() || y.is_nan() {
             None // undefined
         } else {
@@ -628,14 +628,14 @@ pub mod number_ops {
         }
     }
 
-    pub fn equal(x: f64, y: f64) -> bool {
+    pub(crate) fn equal(x: f64, y: f64) -> bool {
         if x.is_nan() || y.is_nan() {
             return false;
         }
         x == y
     }
 
-    pub fn same_value(x: f64, y: f64) -> bool {
+    pub(crate) fn same_value(x: f64, y: f64) -> bool {
         if x.is_nan() && y.is_nan() {
             return true;
         }
@@ -645,19 +645,19 @@ pub mod number_ops {
         x == y
     }
 
-    pub fn bitwise_and(x: f64, y: f64) -> f64 {
+    pub(crate) fn bitwise_and(x: f64, y: f64) -> f64 {
         f64::from(to_int32(x) & to_int32(y))
     }
 
-    pub fn bitwise_xor(x: f64, y: f64) -> f64 {
+    pub(crate) fn bitwise_xor(x: f64, y: f64) -> f64 {
         f64::from(to_int32(x) ^ to_int32(y))
     }
 
-    pub fn bitwise_or(x: f64, y: f64) -> f64 {
+    pub(crate) fn bitwise_or(x: f64, y: f64) -> f64 {
         f64::from(to_int32(x) | to_int32(y))
     }
 
-    pub fn to_string(x: f64) -> String {
+    pub(crate) fn to_string(x: f64) -> String {
         if x.is_nan() {
             return "NaN".to_string();
         }
@@ -675,7 +675,7 @@ pub mod number_ops {
     // §7.1.7 ToUint32 — reduce the truncated real value modulo 2^32. The modular
     // step is done in f64 (exact for integer-valued doubles) so it stays correct
     // for magnitudes beyond the i64 range, where an `as i64` cast would saturate.
-    pub fn to_uint32(x: f64) -> u32 {
+    pub(crate) fn to_uint32(x: f64) -> u32 {
         if !x.is_finite() || x == 0.0 {
             return 0;
         }
@@ -690,26 +690,26 @@ pub mod number_ops {
     }
 
     // §7.1.6 ToInt32 — the same int32bit as ToUint32, reinterpreted as signed.
-    pub fn to_int32(x: f64) -> i32 {
+    pub(crate) fn to_int32(x: f64) -> i32 {
         to_uint32(x) as i32
     }
 }
 
 // §6.1.6.2 BigInt type operations
-pub mod bigint_ops {
+pub(crate) mod bigint_ops {
     use num_bigint::BigInt;
 
-    pub fn unary_minus(x: &BigInt) -> BigInt {
+    pub(crate) fn unary_minus(x: &BigInt) -> BigInt {
         -x
     }
 
-    pub fn bitwise_not(x: &BigInt) -> BigInt {
+    pub(crate) fn bitwise_not(x: &BigInt) -> BigInt {
         // ~x = -(x + 1) for arbitrary precision
         let result: BigInt = x + 1;
         -result
     }
 
-    pub fn exponentiate(base: &BigInt, exp: &BigInt) -> Result<BigInt, &'static str> {
+    pub(crate) fn exponentiate(base: &BigInt, exp: &BigInt) -> Result<BigInt, &'static str> {
         use num_bigint::Sign;
         if exp.sign() == Sign::Minus {
             return Err("BigInt exponent must be non-negative");
@@ -718,33 +718,33 @@ pub mod bigint_ops {
         Ok(base.pow(exp_u32))
     }
 
-    pub fn multiply(x: &BigInt, y: &BigInt) -> BigInt {
+    pub(crate) fn multiply(x: &BigInt, y: &BigInt) -> BigInt {
         x * y
     }
 
-    pub fn divide(x: &BigInt, y: &BigInt) -> Result<BigInt, &'static str> {
+    pub(crate) fn divide(x: &BigInt, y: &BigInt) -> Result<BigInt, &'static str> {
         if y.sign() == num_bigint::Sign::NoSign {
             return Err("Division by zero");
         }
         Ok(x / y)
     }
 
-    pub fn remainder(x: &BigInt, y: &BigInt) -> Result<BigInt, &'static str> {
+    pub(crate) fn remainder(x: &BigInt, y: &BigInt) -> Result<BigInt, &'static str> {
         if y.sign() == num_bigint::Sign::NoSign {
             return Err("Division by zero");
         }
         Ok(x % y)
     }
 
-    pub fn add(x: &BigInt, y: &BigInt) -> BigInt {
+    pub(crate) fn add(x: &BigInt, y: &BigInt) -> BigInt {
         x + y
     }
 
-    pub fn subtract(x: &BigInt, y: &BigInt) -> BigInt {
+    pub(crate) fn subtract(x: &BigInt, y: &BigInt) -> BigInt {
         x - y
     }
 
-    pub fn left_shift(x: &BigInt, y: &BigInt) -> BigInt {
+    pub(crate) fn left_shift(x: &BigInt, y: &BigInt) -> BigInt {
         let shift: i64 = y.try_into().unwrap_or(0);
         if shift >= 0 {
             x << (shift as u64)
@@ -753,7 +753,7 @@ pub mod bigint_ops {
         }
     }
 
-    pub fn signed_right_shift(x: &BigInt, y: &BigInt) -> BigInt {
+    pub(crate) fn signed_right_shift(x: &BigInt, y: &BigInt) -> BigInt {
         let shift: i64 = y.try_into().unwrap_or(0);
         if shift >= 0 {
             x >> (shift as u64)
@@ -762,23 +762,23 @@ pub mod bigint_ops {
         }
     }
 
-    pub fn less_than(x: &BigInt, y: &BigInt) -> Option<bool> {
+    pub(crate) fn less_than(x: &BigInt, y: &BigInt) -> Option<bool> {
         Some(x < y)
     }
 
-    pub fn equal(x: &BigInt, y: &BigInt) -> bool {
+    pub(crate) fn equal(x: &BigInt, y: &BigInt) -> bool {
         x == y
     }
 
-    pub fn bitwise_and(x: &BigInt, y: &BigInt) -> BigInt {
+    pub(crate) fn bitwise_and(x: &BigInt, y: &BigInt) -> BigInt {
         x & y
     }
 
-    pub fn bitwise_xor(x: &BigInt, y: &BigInt) -> BigInt {
+    pub(crate) fn bitwise_xor(x: &BigInt, y: &BigInt) -> BigInt {
         x ^ y
     }
 
-    pub fn bitwise_or(x: &BigInt, y: &BigInt) -> BigInt {
+    pub(crate) fn bitwise_or(x: &BigInt, y: &BigInt) -> BigInt {
         x | y
     }
 }

--- a/src/unicode_tables.rs
+++ b/src/unicode_tables.rs
@@ -27887,7 +27887,7 @@ const BINARY_ASSIGNED: &[(u32, u32)] = &[
     (0x100000, 0x10FFFD),
 ];
 
-pub fn lookup_property(content: &str) -> Option<&'static [(u32, u32)]> {
+pub(crate) fn lookup_property(content: &str) -> Option<&'static [(u32, u32)]> {
     if let Some(eq_pos) = content.find('=') {
         let prop_name = &content[..eq_pos];
         let prop_value = &content[eq_pos + 1..];


### PR DESCRIPTION
## Summary
- Adds `#![warn(unreachable_pub)]` to `src/main.rs` so rustc flags `pub` items that are reachable only within the crate.
- Mechanically applies `cargo fix`'s suggested visibility restrictions (`pub` → `pub(crate)`/`pub(super)`) at all 359 flagged sites across 16 files. No behavior change — purely a visibility tightening.
- No dead code surfaced after the restriction (i.e. nothing was `pub` solely to hide the fact it was otherwise unused), so no removals were needed.

This was prompted by evaluating [astral-sh/hawk](https://github.com/astral-sh/hawk) (a Cargo lint for unnecessary pub visibility across Cargo *workspaces*). hawk didn't fit here since jsse is a single crate, not a workspace — its cross-crate analysis is moot, and rustc's built-in `unreachable_pub` lint already gets the same single-crate benefit for free with no pinned toolchain or experimental dependency.

## Test plan
- [x] `./scripts/lint.sh` (rustfmt + `clippy -D warnings`) passes clean
- [x] `cargo test --release` — 352 unit tests pass
- [x] `scripts/run-custom-tests.py` — 11/11 pass
- [x] Full test262 suite — 100.00% (99,568/99,568), 0 regressions, both before and after rebasing onto latest origin/main