### PR TITLE
perf(interpreter): use FxHashMap for environment bindings

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -515,7 +515,7 @@ impl Interpreter {
             Expression::Function(f) => {
                 let closure_env = if let Some(ref name) = f.name {
                     let func_env = Rc::new(RefCell::new(Environment {
-                        bindings: HashMap::new(),
+                        bindings: Default::default(),
                         parent: Some(env.clone()),
                         strict: env.borrow().strict || f.body_is_strict,
                         is_function_scope: false,

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -999,7 +999,7 @@ impl Interpreter {
                 if let JsValue::Object(obj_ref) = &obj_val {
                     if self.get_object_cell(obj_ref.id).is_some() {
                         let with_env = Rc::new(RefCell::new(Environment {
-                            bindings: HashMap::new(),
+                            bindings: Default::default(),
                             parent: Some(env.clone()),
                             strict: env.borrow().strict,
                             is_function_scope: false,

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -661,7 +661,7 @@ impl Realm {
 }
 
 pub(crate) struct Environment {
-    pub(crate) bindings: HashMap<String, Binding>,
+    pub(crate) bindings: FxHashMap<String, Binding>,
     pub(crate) parent: Option<EnvRef>,
     pub strict: bool,
     pub(crate) is_function_scope: bool,
@@ -682,7 +682,7 @@ pub(crate) struct Environment {
     pub(crate) is_simple_catch_scope: bool,
     pub(crate) is_derived_constructor_scope: bool,
     // §9.1.1.5.5 CreateImportBinding: indirect bindings for module imports
-    pub(crate) indirect_bindings: Option<HashMap<String, (EnvRef, String)>>,
+    pub(crate) indirect_bindings: Option<FxHashMap<String, (EnvRef, String)>>,
     // Module path for import.meta resolution (§16.2.1.5.2 GetActiveScriptOrModule)
     pub(crate) module_path: Option<std::path::PathBuf>,
 }
@@ -757,7 +757,7 @@ impl Environment {
     pub(crate) fn new(parent: Option<EnvRef>) -> EnvRef {
         let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
         Rc::new(RefCell::new(Environment {
-            bindings: HashMap::new(),
+            bindings: FxHashMap::default(),
             parent,
             strict,
             is_function_scope: false,
@@ -788,7 +788,7 @@ impl Environment {
     ) -> EnvRef {
         let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
         Rc::new(RefCell::new(Environment {
-            bindings: HashMap::with_capacity(binding_capacity),
+            bindings: FxHashMap::with_capacity_and_hasher(binding_capacity, Default::default()),
             parent,
             strict,
             is_function_scope: true,
@@ -882,7 +882,9 @@ impl Environment {
         source_env: EnvRef,
         source_name: String,
     ) {
-        let map = self.indirect_bindings.get_or_insert_with(HashMap::default);
+        let map = self
+            .indirect_bindings
+            .get_or_insert_with(FxHashMap::default);
         map.insert(local_name.to_string(), (source_env, source_name));
     }
 


### PR DESCRIPTION
## Summary

- Switch `Environment.bindings` and `Environment.indirect_bindings` from the default SipHash `HashMap` to `rustc_hash::FxHashMap`. These maps are probed on **every** variable resolve / set / declare and are the hottest maps in the tree-walker.
- Profiling the mandreel one-shot init call graph (#387) showed **~20.8% of cold `setupMandreel()` runtime was SipHash string hashing** — `hash_one::<&str>` was the single largest symbol at 10.7%, driven by `resolve_identifier`. FxHash (already used in this same file for the hoist and template caches) cuts that share to ~3.3%.

## Why this is the right first lever

#387 is about the constant-factor cost of the interpreter's per-call / per-statement paths for broad one-shot init code (each function runs once, so no hot-loop optimisation pays off). A `perf` flat profile of a cold `setupMandreel()` — one ~24s call, IC missing on every call — pointed squarely at environment-binding hashing. Env keys are interpreter-internal scope metadata (variable/parameter names), consistent with the existing Fx-hashed `hoist_cache`/`template_cache`; the deliberately-randomised map (`PropertyMap`, for hash-flooding resistance) is left untouched.

## Benchmarks (this host, clean release builds, no profiler)

| Workload | Before | After |
| --- | --- | --- |
| Cold `setupMandreel()` (3 runs) | 24,178 / 24,144 / 24,146 ms | 20,914 / 20,846 / 20,960 ms (**~13% faster**) |
| SipHash family, % of cold runtime | ~20.8% | ~3.3% |

## Scope / follow-ups (deliberately out of this PR)

This is **measured progress on the epic, not a full close** — remaining levers from #387:
- The residual ~3% SipHash is `PropertyMap`'s spilled object-property map, which is **intentionally randomised** for hash-flooding DoS resistance — swapping it needs a security analysis, not a drop-in change.
- Per-call `String` key allocations (`this` / `arguments` / parameter names re-allocated every call), slot-indexed variable lookup (no cached slot indices in the tree-walker), and `Completion` enum size are the next candidates.

## Test plan

- [x] Full test262 suite: **0 regressions** vs the `origin/main` baseline (the correctness gate). The 2 fails are a single pre-existing test (`TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js`) not in the baseline and unrelated to hashing; they surface from a local `test262` submodule revision that this PR does not modify.
- [x] `uv run python scripts/run-custom-tests.py` — 11/11 pass.
- [x] `cargo build --release` clean; `./scripts/lint.sh` (rustfmt + clippy) clean.

Notes:
- **README pass count untouched on purpose**: this is a pure hasher swap with 0 regressions, so it does not move the pass count. The suite's `266 new passes` are pre-existing gains inherited from earlier `main` commits not yet rolled into the baseline file — **not** produced by this change.
- Determinism: FxHash is deterministic where `RandomState` was per-run randomised. `0 regressions` confirms no observable binding-enumeration-order dependency broke — any such test was already order-flaky under `RandomState`.

Refs #387