### PR TITLE
fix(interpreter): randomize environment binding hashing

### DIFF
--- a/docs/specs/2026-07-25-environment-binding-hashing-design.md
+++ b/docs/specs/2026-07-25-environment-binding-hashing-design.md
@@ -1,0 +1,58 @@
+# Environment Binding Hashing
+
+## Context
+
+ECMAScript declarative Environment Records bind identifier names supplied by
+the program. Module Environment Records additionally store import names as
+indirect bindings. In JSSE, both sets of names are `String` keys in
+`Environment`.
+
+PR #389 changed these maps from randomized `std::collections::HashMap` to
+deterministic `rustc_hash::FxHashMap` after profiling showed that standard
+hashing accounted for about 20.8% of a cold `setupMandreel()` run. The change
+improved that workload by about 13%, but it also made the bucket placement of
+script-controlled declaration and import names predictable.
+
+JSSE already uses randomized standard hash maps for other collections keyed by
+script-controlled strings, following commit `c59e4db`. Deterministic Fx maps
+remain appropriate for maps keyed by engine-allocated numeric identifiers.
+
+## Decision
+
+Use randomized `std::collections::HashMap` for `Environment::bindings` and
+`Environment::indirect_bindings`.
+
+This applies the existing project threat model consistently: source text is an
+input boundary, even though the same program can consume resources in other
+ways. Hosts can bound source size and execution time independently, so the
+existence of loops does not make avoidable algorithmic-complexity attacks
+irrelevant.
+
+The decision knowingly gives back the measured #389 speedup. A future
+optimization may replace the standard hasher with a keyed fast hasher, but only
+with an explicit HashDoS-resistance argument and benchmarks. The randomly
+seeded Fx variant is not selected because `rustc-hash` documents Fx as a
+non-DoS-resistant algorithm.
+
+## Implementation
+
+Change only the two Environment map types and their constructors in
+`src/interpreter/types.rs`. Keep deterministic `FxHashMap` for `template_cache`
+and other maps whose keys are engine-generated IDs. Add a comment at the type
+definition so future performance work sees the security boundary.
+
+No ECMAScript-visible semantics change. The representation continues to support
+the Declarative Environment Record operations in §9.1.1.1 and
+CreateImportBinding in §9.1.1.5.5.
+
+## Verification
+
+- Run the Environment unit tests and module live-binding coverage.
+- Run targeted test262 language tests for declarations and modules.
+- Run the full test262 suite against the `origin/main` baseline.
+- Run formatting, Clippy, release build, and release unit tests.
+
+No custom conformance test is added: the hasher choice is a Rust representation
+and threat-model property, not ECMAScript-observable behavior. A test comparing
+private random seeds would be probabilistic and would rely on implementation
+details that `HashMap` does not promise.

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -661,7 +661,9 @@ impl Realm {
 }
 
 pub(crate) struct Environment {
-    pub(crate) bindings: FxHashMap<String, Binding>,
+    // Binding names come from script source. Keep randomized hashing here so
+    // deterministic collision sets cannot flood declaration and lookup paths.
+    pub(crate) bindings: HashMap<String, Binding>,
     pub(crate) parent: Option<EnvRef>,
     pub strict: bool,
     pub(crate) is_function_scope: bool,
@@ -682,7 +684,7 @@ pub(crate) struct Environment {
     pub(crate) is_simple_catch_scope: bool,
     pub(crate) is_derived_constructor_scope: bool,
     // §9.1.1.5.5 CreateImportBinding: indirect bindings for module imports
-    pub(crate) indirect_bindings: Option<FxHashMap<String, (EnvRef, String)>>,
+    pub(crate) indirect_bindings: Option<HashMap<String, (EnvRef, String)>>,
     // Module path for import.meta resolution (§16.2.1.5.2 GetActiveScriptOrModule)
     pub(crate) module_path: Option<std::path::PathBuf>,
 }
@@ -757,7 +759,7 @@ impl Environment {
     pub(crate) fn new(parent: Option<EnvRef>) -> EnvRef {
         let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
         Rc::new(RefCell::new(Environment {
-            bindings: FxHashMap::default(),
+            bindings: HashMap::new(),
             parent,
             strict,
             is_function_scope: false,
@@ -788,7 +790,7 @@ impl Environment {
     ) -> EnvRef {
         let strict = parent.as_ref().is_some_and(|p| p.borrow().strict);
         Rc::new(RefCell::new(Environment {
-            bindings: FxHashMap::with_capacity_and_hasher(binding_capacity, Default::default()),
+            bindings: HashMap::with_capacity(binding_capacity),
             parent,
             strict,
             is_function_scope: true,
@@ -882,9 +884,7 @@ impl Environment {
         source_env: EnvRef,
         source_name: String,
     ) {
-        let map = self
-            .indirect_bindings
-            .get_or_insert_with(FxHashMap::default);
+        let map = self.indirect_bindings.get_or_insert_with(HashMap::new);
         map.insert(local_name.to_string(), (source_env, source_name));
     }
 


### PR DESCRIPTION
## Summary

- restore randomized `std::HashMap` hashing for direct and indirect Environment binding names supplied by JavaScript source
- keep deterministic `FxHashMap` on engine-generated numeric-key caches
- document the security/performance decision and the bar for any future keyed fast-hasher optimization

## Why

PR #389 measured an approximately 13% improvement on a cold Mandreel workload by moving these hot maps to deterministic Fx hashing. Environment declaration and import names are nevertheless script-controlled strings, matching the threat boundary established for other JS-controlled maps in commit `c59e4db`. Predictable bucket placement permits offline hash-flooding inputs, including for hosts that separately bound source size and execution time.

The randomly seeded Fx variant was considered, but `rustc-hash` still documents Fx as non-DoS-resistant. Adding a new keyed fast hasher would require its own security review and benchmarks, so this focused change restores the established randomized standard hasher and records the known performance cost.

No custom conformance test is added because the hasher is not ECMAScript-observable and Rust does not guarantee that private `HashMap` seeds compare differently.

Closes #391

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy`
- [x] `cargo build --release`
- [x] `cargo test --release` — 352 unit + 3 integration + smoke oracle passed
- [x] `./scripts/lint.sh`
- [x] `uv run python scripts/run-custom-tests.py` — 11/11 passed
- [x] targeted declarations/modules test262 — 10,914/10,914 scenarios passed
- [x] full `uv run python scripts/run-test262.py` — 99,568/99,568 scenarios passed, 0 regressions

`README.md` and `test262-pass.txt` are unchanged: this representation-only change produced no semantic pass movement; the runner's 323 baseline-new passes are inherited baseline drift from `main`.