### PR TITLE
fix(interpreter): invoke primitive optional-chain getters

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1426,6 +1426,8 @@ impl Interpreter {
         base_val: &JsValue,
         name: &K,
     ) -> Completion {
+        // §6.2.5.5 GetValue permits eliding the transient primitive wrapper,
+        // but its prototype [[Get]] must still receive the primitive itself.
         let name = name.to_js_property_key();
         match base_val {
             JsValue::Object(o) => self.get_object_property(o.id, &name, base_val),
@@ -1437,35 +1439,35 @@ impl Interpreter {
                 {
                     Completion::Normal(JsValue::String(JsString::from_vec(vec![s.code_units[idx]])))
                 } else if let Some(sp_id) = self.realm().string_prototype {
-                    Completion::Normal(self.get_property_on_id(sp_id, &name))
+                    self.get_object_property(sp_id, &name, base_val)
                 } else {
                     Completion::Normal(JsValue::Undefined)
                 }
             }
             JsValue::Number(_) => {
                 if let Some(np_id) = self.realm().number_prototype {
-                    Completion::Normal(self.get_property_on_id(np_id, &name))
+                    self.get_object_property(np_id, &name, base_val)
                 } else {
                     Completion::Normal(JsValue::Undefined)
                 }
             }
             JsValue::Boolean(_) => {
                 if let Some(bp_id) = self.realm().boolean_prototype {
-                    Completion::Normal(self.get_property_on_id(bp_id, &name))
+                    self.get_object_property(bp_id, &name, base_val)
                 } else {
                     Completion::Normal(JsValue::Undefined)
                 }
             }
             JsValue::Symbol(_) => {
                 if let Some(sp_id) = self.realm().symbol_prototype {
-                    Completion::Normal(self.get_property_on_id(sp_id, &name))
+                    self.get_object_property(sp_id, &name, base_val)
                 } else {
                     Completion::Normal(JsValue::Undefined)
                 }
             }
             JsValue::BigInt(_) => {
                 if let Some(bp_id) = self.realm().bigint_prototype {
-                    Completion::Normal(self.get_property_on_id(bp_id, &name))
+                    self.get_object_property(bp_id, &name, base_val)
                 } else {
                     Completion::Normal(JsValue::Undefined)
                 }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -2133,6 +2133,60 @@ mod string_exotic_index_seam_tests {
     }
 }
 
+/// §13.3.7 Optional Chains and §6.2.5.5 GetValue require primitive property
+/// references to perform wrapper [[Get]] with the primitive as the receiver.
+mod optional_chain_primitive_get_tests {
+    use super::*;
+
+    #[test]
+    fn prototype_accessors_are_invoked_with_the_primitive_receiver() {
+        run_script(
+            r#"
+            function install(proto, key, expectedThis, result) {
+                Object.defineProperty(proto, key, {
+                    configurable: true,
+                    get: function () {
+                        "use strict";
+                        if (this !== expectedThis) {
+                            throw new Error("getter received the wrong primitive");
+                        }
+                        return result;
+                    }
+                });
+            }
+
+            var symbol = Symbol("receiver");
+            install(String.prototype, "01", "abc", 41);
+            install(String.prototype, "5", "abc", 42);
+            install(Number.prototype, "optionalAccessor", 5, 43);
+            install(Boolean.prototype, "optionalAccessor", true, 44);
+            install(Symbol.prototype, "optionalAccessor", symbol, 45);
+            install(BigInt.prototype, "optionalAccessor", 7n, 46);
+
+            if ("abc"?.["01"] !== 41) throw new Error("String look-alike getter skipped");
+            if ("abc"?.["5"] !== 42) throw new Error("String out-of-range getter skipped");
+            if ((5)?.optionalAccessor !== 43) throw new Error("Number getter skipped");
+            if ((true)?.["optionalAccessor"] !== 44) throw new Error("Boolean getter skipped");
+            if (symbol?.optionalAccessor !== 45) throw new Error("Symbol getter skipped");
+            if ((7n)?.["optionalAccessor"] !== 46) throw new Error("BigInt getter skipped");
+
+            var marker = {};
+            Object.defineProperty(Boolean.prototype, "throwingOptionalAccessor", {
+                configurable: true,
+                get: function () { throw marker; }
+            });
+            var propagated = false;
+            try {
+                (false)?.throwingOptionalAccessor;
+            } catch (error) {
+                propagated = error === marker;
+            }
+            if (!propagated) throw new Error("getter exception was not propagated");
+            "#,
+        );
+    }
+}
+
 /// Node host-compat "syscall floor" (issue #229). These exercise the ON-path
 /// (`enable_node_host`); the OFF-path 0-regression guarantee is covered by the
 /// full test262 run, which never enables the floor.

--- a/test262-extra/Optional-chaining-primitive-prototype-accessors.js
+++ b/test262-extra/Optional-chaining-primitive-prototype-accessors.js
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 the JSSE project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-optional-chaining-evaluation
+description: >
+  Optional-chain property access on a primitive invokes accessor getters found
+  on the corresponding wrapper prototype.
+info: |
+  13.3.7.1 Runtime Semantics: Evaluation
+    OptionalExpression : MemberExpression OptionalChain
+      4. Return ? ChainEvaluation of OptionalChain with arguments baseValue and
+         baseReference.
+
+  13.3.7.2 Runtime Semantics: ChainEvaluation
+    OptionalChain : ?. [ Expression ]
+      2. Return ? EvaluatePropertyAccessWithExpressionKey(baseValue,
+         Expression, strict).
+    OptionalChain : ?. IdentifierName
+      2. Return EvaluatePropertyAccessWithIdentifierKey(baseValue,
+         IdentifierName, strict).
+
+  6.2.5.5 GetValue ( V )
+    3.a. Let baseObj be ? ToObject(V.[[Base]]).
+    3.d. Return ? baseObj.[[Get]](V.[[ReferencedName]], GetThisValue(V)).
+
+  10.1.8.1 OrdinaryGet ( O, P, Receiver )
+    If an accessor descriptor is found, Call(getter, Receiver).
+features: [optional-chaining, BigInt, Symbol]
+---*/
+
+function install(proto, key, expectedThis, result) {
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    get: function () {
+      "use strict";
+      assert.sameValue(this, expectedThis, key + " getter receiver");
+      return result;
+    },
+  });
+}
+
+var symbol = Symbol("receiver");
+install(String.prototype, "01", "abc", 41);
+install(String.prototype, "5", "abc", 42);
+install(Number.prototype, "optionalAccessor", 5, 43);
+install(Boolean.prototype, "optionalAccessor", true, 44);
+install(Symbol.prototype, "optionalAccessor", symbol, 45);
+install(BigInt.prototype, "optionalAccessor", 7n, 46);
+
+assert.sameValue("abc"?.["01"], 41, "computed String look-alike key");
+assert.sameValue("abc"?.["5"], 42, "computed String out-of-range key");
+assert.sameValue((5)?.optionalAccessor, 43, "named Number key");
+assert.sameValue((true)?.["optionalAccessor"], 44, "computed Boolean key");
+assert.sameValue(symbol?.optionalAccessor, 45, "named Symbol key");
+assert.sameValue((7n)?.["optionalAccessor"], 46, "computed BigInt key");
+
+var marker = {};
+Object.defineProperty(Boolean.prototype, "throwingOptionalAccessor", {
+  configurable: true,
+  get: function () {
+    throw marker;
+  },
+});
+var caught;
+try {
+  (false)?.throwingOptionalAccessor;
+} catch (error) {
+  caught = error;
+}
+assert.sameValue(caught, marker, "getter abrupt completion is propagated");


### PR DESCRIPTION
## Summary

- route optional-chain primitive prototype fallbacks through accessor-aware `[[Get]]`
- preserve the primitive receiver for String, Number, Boolean, Symbol, and BigInt prototype getters
- add Rust and test262-extra regressions for named/computed access, String fallback keys, receiver identity, and abrupt completion propagation

## Root cause

`access_property_on_value` used `get_property_on_id` for primitive prototype fallbacks. That descriptor-value lookup does not invoke accessor getters, unlike the full property MOP used by ordinary member access.

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` — 353 unit tests, 3 integration tests, and smoke oracle passed
- `./scripts/lint.sh`
- custom JS tests — 11/11
- targeted optional-chaining + regression test262 — 78/78
- full test262 — 99,568/99,568, 0 regressions
- new test262-extra file on Node — 2/2

Closes #384