### PR TITLE
fix(regexp): honor nullable priority under positive quantifiers

### DIFF
--- a/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
+++ b/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
@@ -50,6 +50,11 @@ JavaScript pattern, while the repeated group invokes them with fancy-regex
 subroutine calls. Defining the groups after all JavaScript groups keeps numeric
 capture and backreference indices unchanged. Existing internal-capture cleanup
 removes the sentinel slots before constructing the JavaScript match result.
+The rewrite also returns the exact generated-name set to the translation pass:
+only names in that provenance set are recognized as backend conditionals or
+subroutine calls. Internal definitions are excluded when deciding whether the
+source contains a named capture, so they cannot disable Annex B identity-escape
+handling for source `\k` or `\g` escapes.
 
 The rewrite forces the fancy-regex path because the standard Rust regex engine
 does not support the internal conditionals.
@@ -87,7 +92,8 @@ leaving their positive-minimum priority gap unchanged.
 - lazy outer quantifiers; and
 - multiple independently affected quantified groups;
 - nested entry state isolation; and
-- all-lazy and mixed-greediness jointly optional branches.
+- all-lazy and mixed-greediness jointly optional branches; and
+- Annex B identity escapes whose text resembles internal sentinel syntax.
 
 Validation runs the RegExp-focused test262 directory, the custom suites, and
 the full test262 regression comparison before publishing.

--- a/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
+++ b/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
@@ -1,0 +1,79 @@
+# Nullable positive RegExp quantifiers
+
+## Problem
+
+ECMAScript `RepeatMatcher` permits an atom to match empty while a quantifier's
+minimum is still positive. Once the minimum reaches zero, another empty match
+must fail so the atom can backtrack into a consuming choice before the outer
+continuation is tried.
+
+The Rust regex engines instead stop an unbounded nullable repetition when it
+observes no input progress. For a pattern such as `(a*|dc??)+`, that accepts
+the first branch's empty match and never tries the consuming sibling. The
+existing source rewrite removes that empty path for `*`, but cannot do so
+unconditionally for `+` or `{n,}` because their mandatory iterations may
+legitimately be empty.
+
+## Design
+
+Keep one syntactic copy of every JavaScript capture. For each affected outer
+quantifier with minimum `n > 0`, add `n` internal empty capture groups as
+iteration sentinels:
+
+1. During the first `n` iterations, a nullable branch retains its empty path.
+2. A zero-width setter at the end of the quantified group sets one previously
+   unset sentinel per completed iteration.
+3. Once the final sentinel is set, the branch's empty path is replaced by a
+   failing conditional, while the branch's existing consuming paths remain in
+   their original alternative position.
+
+For a bare nullable quantified atom, the consuming path is the existing
+minimum-bumped rewrite (`a*` to `a+`, `a?` to `a`, or `{0,m}` to `{1,m}`).
+The pre-minimum empty path is added alongside that consuming form, before it
+for a lazy atom and after it for a greedy atom.
+
+Sentinel expansion is capped at 64 mandatory iterations. Larger minima retain
+the existing fallback behavior instead of expanding source proportional to an
+attacker-controlled quantifier bound. This preserves compilation behavior for
+large valid quantifiers without introducing a source-size or compile-time
+denial of service.
+
+The sentinels use names with the existing `__jsse_qi` internal prefix. Their
+definitions are appended in a `(?(DEFINE)...)` block after the translated
+JavaScript pattern, while the repeated group invokes them with fancy-regex
+subroutine calls. Defining the groups after all JavaScript groups keeps numeric
+capture and backreference indices unchanged. Existing internal-capture cleanup
+removes the sentinel slots before constructing the JavaScript match result.
+
+The rewrite forces the fancy-regex path because the standard Rust regex engine
+does not support the internal conditionals.
+
+Patterns that require JSSE's byte matcher (`\p{Cs}`/`\p{Co}` handling) retain
+the previous non-stateful rewrite because that matcher cannot compile
+fancy-regex conditionals. This avoids regressing valid byte-mode patterns while
+leaving their positive-minimum priority gap unchanged.
+
+## Alternatives
+
+- Splitting `X+` into `X X*` duplicates captures and changes last-iteration
+  capture semantics.
+- Compiling a consuming pattern plus an all-empty fallback works for one
+  affected group, but multiple groups require combinatorial variants and an
+  additional match-priority algorithm.
+- Restricting the split to noncapturing groups does not fix the reported
+  capturing pattern.
+
+## Validation
+
+`test262-extra` coverage includes:
+
+- the reported `+` result and last-iteration capture;
+- legitimate empty `+` matches;
+- `{2,}` and bounded `{2,3}` behavior;
+- a continuation that requires falling back to the mandatory empty match;
+- inner capture numbering and last-iteration values;
+- lazy outer quantifiers; and
+- multiple independently affected quantified groups.
+
+Validation runs the RegExp-focused test262 directory, the custom suites, and
+the full test262 regression comparison before publishing.

--- a/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
+++ b/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
@@ -42,7 +42,10 @@ Sentinel expansion is capped at 64 mandatory iterations. Larger minima retain
 the existing fallback behavior instead of expanding source proportional to an
 attacker-controlled quantifier bound. This preserves compilation behavior for
 large valid quantifiers without introducing a source-size or compile-time
-denial of service.
+denial of service. The effective fancy-regex nesting limit also depends on the
+surrounding pattern depth, so a stateful expansion that fails backend
+compilation is retried with the same non-stateful fallback rather than relying
+on the fixed source-growth cap as a compile-depth guarantee.
 
 The sentinels use names with the existing `__jsse_qi` internal prefix. Their
 definitions are appended in a `(?(DEFINE)...)` block after the translated
@@ -93,7 +96,8 @@ leaving their positive-minimum priority gap unchanged.
 - multiple independently affected quantified groups;
 - nested entry state isolation; and
 - all-lazy and mixed-greediness jointly optional branches; and
-- Annex B identity escapes whose text resembles internal sentinel syntax.
+- Annex B identity escapes whose text resembles internal sentinel syntax; and
+- stateful-setter compilation at flat and nested backend-depth boundaries.
 
 Validation runs the RegExp-focused test262 directory, the custom suites, and
 the full test262 regression comparison before publishing.

--- a/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
+++ b/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
@@ -32,6 +32,12 @@ minimum-bumped rewrite (`a*` to `a+`, `a?` to `a`, or `{0,m}` to `{1,m}`).
 The pre-minimum empty path is added alongside that consuming form, before it
 for a lazy atom and after it for a greedy atom.
 
+For a jointly optional sequence, the consuming expansion follows the original
+greedy/lazy decision tree. Each greedy atom places its consuming choice before
+the recursively expanded skip path; each lazy atom places it after. The gated
+all-skipped leaf can therefore appear first, last, or between consuming
+alternatives, preserving the source branch's mandatory-iteration priority.
+
 Sentinel expansion is capped at 64 mandatory iterations. Larger minima retain
 the existing fallback behavior instead of expanding source proportional to an
 attacker-controlled quantifier bound. This preserves compilation behavior for
@@ -47,6 +53,12 @@ removes the sentinel slots before constructing the JavaScript match result.
 
 The rewrite forces the fancy-regex path because the standard Rust regex engine
 does not support the internal conditionals.
+
+Capture-backed sentinels cannot be reset by fancy-regex after they participate.
+An affected positive-minimum quantifier nested inside another repetition
+therefore retains the previous non-stateful rewrite. This avoids leaking a
+completed mandatory-iteration budget into the next entry of the nested
+quantifier, while leaving the pre-existing nested priority gap unchanged.
 
 Patterns that require JSSE's byte matcher (`\p{Cs}`/`\p{Co}` handling) retain
 the previous non-stateful rewrite because that matcher cannot compile
@@ -73,7 +85,9 @@ leaving their positive-minimum priority gap unchanged.
 - a continuation that requires falling back to the mandatory empty match;
 - inner capture numbering and last-iteration values;
 - lazy outer quantifiers; and
-- multiple independently affected quantified groups.
+- multiple independently affected quantified groups;
+- nested entry state isolation; and
+- all-lazy and mixed-greediness jointly optional branches.
 
 Validation runs the RegExp-focused test262 directory, the custom suites, and
 the full test262 regression comparison before publishing.

--- a/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
+++ b/docs/specs/2026-07-25-regexp-nullable-positive-quantifier-design.md
@@ -67,6 +67,19 @@ An affected positive-minimum quantifier nested inside another repetition
 therefore retains the previous non-stateful rewrite. This avoids leaking a
 completed mandatory-iteration budget into the next entry of the nested
 quantifier, while leaving the pre-existing nested priority gap unchanged.
+The same fallback applies when the quantified body contains a JavaScript
+capture and the source contains a backreference. RepeatMatcher clears captures
+inside the atom before every iteration, but the backend retains a capture from
+an earlier alternative. The backend has the same stale-backreference limitation
+without this rewrite; bypassing sentinels keeps the new iteration mechanism
+from adding another stateful path to those patterns. Capture-only patterns stay
+eligible because JSSE's existing result normalization clears stale output
+captures after matching.
+
+Bounded min-zero quantifiers (`?` and `{0,m}`) use the consuming-branch
+rewrite, which bumps the inner minimum while preserving its greedy/lazy marker.
+They do not use the unbounded single-branch lazy-strip shortcut: with a bounded
+maximum, stripping the inner lazy marker changes the selected match.
 
 Patterns that require JSSE's byte matcher (`\p{Cs}`/`\p{Co}` handling) retain
 the previous non-stateful rewrite because that matcher cannot compile
@@ -95,7 +108,9 @@ leaving their positive-minimum priority gap unchanged.
 - lazy outer quantifiers; and
 - multiple independently affected quantified groups;
 - nested entry state isolation; and
+- sentinel bypass for backreference-observable inner captures; and
 - all-lazy and mixed-greediness jointly optional branches; and
+- bounded min-zero lazy quantifiers; and
 - Annex B identity escapes whose text resembles internal sentinel syntax; and
 - stateful-setter compilation at flat and nested backend-depth boundaries.
 

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -1465,9 +1465,14 @@ fn translate_js_pattern(source: &str, flags: &str) -> Result<String, String> {
     translate_js_pattern_ex(source, flags).map(|r| r.pattern)
 }
 
-fn nq_internal_condition_header_end(chars: &[char], start: usize) -> Option<usize> {
+fn nq_internal_condition_header_end(
+    chars: &[char],
+    start: usize,
+    sentinel_names: &HashSet<String>,
+) -> Option<usize> {
     let len = chars.len();
-    if start + 10 <= len
+    if !sentinel_names.is_empty()
+        && start + 10 <= len
         && chars[start..start + 10] == ['(', '?', '(', 'D', 'E', 'F', 'I', 'N', 'E', ')']
     {
         return Some(start + 10);
@@ -1488,10 +1493,14 @@ fn nq_internal_condition_header_end(chars: &[char], start: usize) -> Option<usiz
         return None;
     }
     let name: String = chars[start + 4..name_end].iter().collect();
-    name.starts_with("__jsse_qi_nq").then_some(name_end + 2)
+    sentinel_names.contains(&name).then_some(name_end + 2)
 }
 
-fn nq_internal_subroutine_end(chars: &[char], start: usize) -> Option<usize> {
+fn nq_internal_subroutine_end(
+    chars: &[char],
+    start: usize,
+    sentinel_names: &HashSet<String>,
+) -> Option<usize> {
     let len = chars.len();
     if start + 4 >= len
         || chars[start] != '\\'
@@ -1508,7 +1517,7 @@ fn nq_internal_subroutine_end(chars: &[char], start: usize) -> Option<usize> {
         return None;
     }
     let name: String = chars[start + 3..name_end].iter().collect();
-    name.starts_with("__jsse_qi_nq").then_some(name_end + 1)
+    sentinel_names.contains(&name).then_some(name_end + 1)
 }
 
 /// Find the closing ')' matching the '(' at position `open` in `chars`.
@@ -1925,6 +1934,14 @@ pub(super) fn translate_js_pattern_ex(
     source: &str,
     flags: &str,
 ) -> Result<TranslationResult, String> {
+    translate_js_pattern_ex_with_sentinels(source, flags, &HashSet::new())
+}
+
+fn translate_js_pattern_ex_with_sentinels(
+    source: &str,
+    flags: &str,
+    sentinel_names: &HashSet<String>,
+) -> Result<TranslationResult, String> {
     let mut result = String::new();
     if flags.contains('i') {
         result.push_str("(?i)");
@@ -1972,7 +1989,10 @@ pub(super) fn translate_js_pattern_ex(
         let mut j = 0;
         let mut in_cc = false;
         while j < len {
-            if !in_cc && let Some(header_end) = nq_internal_condition_header_end(&chars, j) {
+            if !in_cc
+                && let Some(header_end) =
+                    nq_internal_condition_header_end(&chars, j, sentinel_names)
+            {
                 j = header_end;
                 continue;
             }
@@ -1998,7 +2018,7 @@ pub(super) fn translate_js_pattern_ex(
                                     name_end += 1;
                                 }
                                 let name: String = chars[j + 3..name_end].iter().collect();
-                                if !name.starts_with("__jsse_qi_nq") {
+                                if !sentinel_names.contains(&name) {
                                     count += 1; // JavaScript named group
                                 }
                             }
@@ -2127,6 +2147,9 @@ pub(super) fn translate_js_pattern_ex(
     // When any named groups exist, fancy_regex requires ALL backreferences to
     // use named syntax. We auto-name unnamed capturing groups with a special
     // prefix so we can use named backreferences throughout.
+    let has_source_named_groups = all_group_names
+        .iter()
+        .any(|name| !sentinel_names.contains(name));
     let has_named_groups = !all_group_names.is_empty();
     // Track how many times we've seen each duplicated name during translation
     let mut dup_seen_count: HashMap<String, u32> = HashMap::new();
@@ -2137,7 +2160,9 @@ pub(super) fn translate_js_pattern_ex(
     while i < len {
         let c = chars[i];
 
-        if !in_char_class && let Some(header_end) = nq_internal_condition_header_end(&chars, i) {
+        if !in_char_class
+            && let Some(header_end) = nq_internal_condition_header_end(&chars, i, sentinel_names)
+        {
             dotall_stack.push(None);
             multiline_stack.push(None);
             icase_stack.push(None);
@@ -2150,7 +2175,9 @@ pub(super) fn translate_js_pattern_ex(
             i = header_end;
             continue;
         }
-        if !in_char_class && let Some(subroutine_end) = nq_internal_subroutine_end(&chars, i) {
+        if !in_char_class
+            && let Some(subroutine_end) = nq_internal_subroutine_end(&chars, i, sentinel_names)
+        {
             result.extend(chars[i..subroutine_end].iter());
             i = subroutine_end;
             continue;
@@ -2250,7 +2277,7 @@ pub(super) fn translate_js_pattern_ex(
             match next {
                 // Named backreference: \k<name> → (?P=name) or alternation for duplicates
                 'k' if !in_char_class && i + 2 < len && chars[i + 2] == '<' => {
-                    if !unicode && all_group_names.is_empty() {
+                    if !unicode && !has_source_named_groups {
                         // Annex B: \k without named groups is identity escape
                         if non_unicode_icase(icase) {
                             push_case_fold_guarded(&mut result, 'k', false);
@@ -5963,6 +5990,11 @@ fn is_assertion_only_content(chars: &[char], start: usize, end: usize) -> bool {
 ///   (jsse#378).
 const NQ_MAX_ITERATION_SENTINELS: usize = 64;
 
+struct NullableQuantifierRewrite {
+    source: String,
+    sentinel_names: HashSet<String>,
+}
+
 struct NqOuterQuantifier {
     min: usize,
     max: Option<usize>,
@@ -6053,9 +6085,15 @@ fn nq_iteration_names(source: &str, state_id: &mut usize, min: usize) -> Vec<Str
     }
 }
 
-fn fix_nullable_quantifiers(source: &str, stateful_positive_minimum: bool) -> String {
+fn fix_nullable_quantifiers(
+    source: &str,
+    stateful_positive_minimum: bool,
+) -> NullableQuantifierRewrite {
     if !source.contains('|') && !source.contains("??") && !source.contains("*?") {
-        return source.to_string();
+        return NullableQuantifierRewrite {
+            source: source.to_string(),
+            sentinel_names: HashSet::new(),
+        };
     }
 
     let chars: Vec<char> = source.chars().collect();
@@ -6181,7 +6219,10 @@ fn fix_nullable_quantifiers(source: &str, stateful_positive_minimum: bool) -> St
         && span_replace.is_empty()
         && sentinel_names.is_empty()
     {
-        return source.to_string();
+        return NullableQuantifierRewrite {
+            source: source.to_string(),
+            sentinel_names: HashSet::new(),
+        };
     }
     let mut result = String::with_capacity(len);
     let mut i = 0;
@@ -6209,12 +6250,15 @@ fn fix_nullable_quantifiers(source: &str, stateful_positive_minimum: bool) -> St
     }
     if !sentinel_names.is_empty() {
         result.push_str("(?(DEFINE)");
-        for name in sentinel_names {
+        for name in &sentinel_names {
             result.push_str(&format!("(?<{name}>)"));
         }
         result.push(')');
     }
-    result
+    NullableQuantifierRewrite {
+        source: result,
+        sentinel_names: sentinel_names.into_iter().collect(),
+    }
 }
 
 /// Process a full set of top-level alternation branches: for each nullable
@@ -7021,12 +7065,18 @@ fn build_regex_ex(
     flags: &str,
 ) -> Result<(CompiledRegex, DupGroupMap, Vec<String>), String> {
     let original_source = source;
-    let mut source = fix_nullable_quantifiers(original_source, true);
-    let mut tr = translate_js_pattern_ex(&source, flags)?;
-    if tr.needs_bytes_mode && source.contains("(?(DEFINE)(?<__jsse_qi_nq") {
-        source = fix_nullable_quantifiers(original_source, false);
-        tr = translate_js_pattern_ex(&source, flags)?;
+    let mut rewrite = fix_nullable_quantifiers(original_source, true);
+    let mut tr =
+        translate_js_pattern_ex_with_sentinels(&rewrite.source, flags, &rewrite.sentinel_names)?;
+    if tr.needs_bytes_mode && !rewrite.sentinel_names.is_empty() {
+        rewrite = fix_nullable_quantifiers(original_source, false);
+        tr = translate_js_pattern_ex_with_sentinels(
+            &rewrite.source,
+            flags,
+            &rewrite.sentinel_names,
+        )?;
     }
+    let source = rewrite.source;
     let dup_map = tr.dup_group_map;
     let name_order = tr.group_name_order;
 

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -6085,6 +6085,28 @@ fn nq_iteration_names(source: &str, state_id: &mut usize, min: usize) -> Vec<Str
     }
 }
 
+fn nq_has_source_backreference(chars: &[char]) -> bool {
+    let mut i = 0;
+    let mut in_cc = false;
+    while i < chars.len() {
+        match chars[i] {
+            '[' if !in_cc => in_cc = true,
+            ']' if in_cc => in_cc = false,
+            '\\' if !in_cc && i + 1 < chars.len() => {
+                if matches!(chars[i + 1], '1'..='9')
+                    || (chars[i + 1] == 'k' && i + 2 < chars.len() && chars[i + 2] == '<')
+                {
+                    return true;
+                }
+                i += 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
 fn fix_nullable_quantifiers(
     source: &str,
     stateful_positive_minimum: bool,
@@ -6129,6 +6151,7 @@ fn fix_nullable_quantifiers(
     let mut insert_at: Vec<Vec<String>> = vec![Vec::new(); len + 1];
     let mut sentinel_names: Vec<String> = Vec::new();
     let mut state_id = 0usize;
+    let has_source_backreference = nq_has_source_backreference(&chars);
 
     for open_pos in 0..len {
         if chars[open_pos] != '(' || close_of[open_pos] == 0 {
@@ -6152,14 +6175,17 @@ fn fix_nullable_quantifiers(
         if outer_quantifier.min > 0
             && (!stateful_positive_minimum
                 || outer_quantifier.min > NQ_MAX_ITERATION_SENTINELS
-                || nq_is_nested_in_repeated_group(&chars, open_pos, &close_of))
+                || nq_is_nested_in_repeated_group(&chars, open_pos, &close_of)
+                || (has_source_backreference && nq_branch_has_capture(&chars, body_start, close)))
         {
             // Preserve the pre-jsse#378 `+` fallback when stateful conditions
             // are unavailable (notably the byte matcher), the minimum would
             // require attacker-controlled source expansion, or a containing
-            // repetition could enter this quantifier more than once. Backend
-            // captures cannot be unset, so nested sentinels would leak their
-            // mandatory-iteration state into the next entry.
+            // repetition could enter this quantifier more than once, or an
+            // inner source capture is observable by a backreference. Backend
+            // captures cannot be unset between iterations, so sentinels would
+            // either leak their mandatory-iteration state into the next entry
+            // or compound the backend's stale-backreference limitation.
             if chars[after] != '+' {
                 continue;
             }
@@ -6178,7 +6204,7 @@ fn fix_nullable_quantifiers(
             );
             continue;
         }
-        if outer_quantifier.min == 0 && branches.len() == 1 {
+        if outer_quantifier.min == 0 && outer_quantifier.max.is_none() && branches.len() == 1 {
             // No top-level alternation: greedy sub-quantifiers already
             // consume maximally, so only lazy ones need forcing.
             if nq_is_nullable(&chars, body_start, close, &close_of) {
@@ -6258,6 +6284,29 @@ fn fix_nullable_quantifiers(
     NullableQuantifierRewrite {
         source: result,
         sentinel_names: sentinel_names.into_iter().collect(),
+    }
+}
+
+#[cfg(test)]
+mod nullable_quantifier_rewrite_tests {
+    use super::fix_nullable_quantifiers;
+
+    #[test]
+    fn bounded_min_zero_preserves_inner_laziness() {
+        assert_eq!(fix_nullable_quantifiers("(a*?)?", true).source, "(a+?)?");
+        assert_eq!(
+            fix_nullable_quantifiers("(a*?){0,2}", true).source,
+            "(a+?){0,2}"
+        );
+    }
+
+    #[test]
+    fn backreferenced_inner_captures_bypass_sentinels() {
+        let with_backreference = fix_nullable_quantifiers("^(a*|(d)){2,3}(e)\\2", true);
+        assert!(with_backreference.sentinel_names.is_empty());
+
+        let capture_only = fix_nullable_quantifiers("^(a*|(d)){2,3}(e)", true);
+        assert!(!capture_only.sentinel_names.is_empty());
     }
 }
 

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -1465,6 +1465,52 @@ fn translate_js_pattern(source: &str, flags: &str) -> Result<String, String> {
     translate_js_pattern_ex(source, flags).map(|r| r.pattern)
 }
 
+fn nq_internal_condition_header_end(chars: &[char], start: usize) -> Option<usize> {
+    let len = chars.len();
+    if start + 10 <= len
+        && chars[start..start + 10] == ['(', '?', '(', 'D', 'E', 'F', 'I', 'N', 'E', ')']
+    {
+        return Some(start + 10);
+    }
+    if start + 5 >= len
+        || chars[start] != '('
+        || chars[start + 1] != '?'
+        || chars[start + 2] != '('
+        || chars[start + 3] != '<'
+    {
+        return None;
+    }
+    let mut name_end = start + 4;
+    while name_end < len && chars[name_end] != '>' {
+        name_end += 1;
+    }
+    if name_end + 1 >= len || chars[name_end + 1] != ')' {
+        return None;
+    }
+    let name: String = chars[start + 4..name_end].iter().collect();
+    name.starts_with("__jsse_qi_nq").then_some(name_end + 2)
+}
+
+fn nq_internal_subroutine_end(chars: &[char], start: usize) -> Option<usize> {
+    let len = chars.len();
+    if start + 4 >= len
+        || chars[start] != '\\'
+        || chars[start + 1] != 'g'
+        || chars[start + 2] != '<'
+    {
+        return None;
+    }
+    let mut name_end = start + 3;
+    while name_end < len && chars[name_end] != '>' {
+        name_end += 1;
+    }
+    if name_end >= len {
+        return None;
+    }
+    let name: String = chars[start + 3..name_end].iter().collect();
+    name.starts_with("__jsse_qi_nq").then_some(name_end + 1)
+}
+
 /// Find the closing ')' matching the '(' at position `open` in `chars`.
 /// Returns None if not found.
 fn find_matching_close_paren(chars: &[char], open: usize) -> Option<usize> {
@@ -1926,6 +1972,10 @@ pub(super) fn translate_js_pattern_ex(
         let mut j = 0;
         let mut in_cc = false;
         while j < len {
+            if !in_cc && let Some(header_end) = nq_internal_condition_header_end(&chars, j) {
+                j = header_end;
+                continue;
+            }
             match chars[j] {
                 '[' if !in_cc => {
                     in_cc = true;
@@ -1943,7 +1993,14 @@ pub(super) fn translate_js_pattern_ex(
                             if j + 3 < len && (chars[j + 3] == '=' || chars[j + 3] == '!') {
                                 // lookbehind, not capturing
                             } else {
-                                count += 1; // named group
+                                let mut name_end = j + 3;
+                                while name_end < len && chars[name_end] != '>' {
+                                    name_end += 1;
+                                }
+                                let name: String = chars[j + 3..name_end].iter().collect();
+                                if !name.starts_with("__jsse_qi_nq") {
+                                    count += 1; // JavaScript named group
+                                }
                             }
                         }
                         // (?:...), (?=...), (?!...) are non-capturing
@@ -2079,6 +2136,25 @@ pub(super) fn translate_js_pattern_ex(
 
     while i < len {
         let c = chars[i];
+
+        if !in_char_class && let Some(header_end) = nq_internal_condition_header_end(&chars, i) {
+            dotall_stack.push(None);
+            multiline_stack.push(None);
+            icase_stack.push(None);
+            group_is_capturing.push(false);
+            is_lookbehind_group.push(false);
+            is_lookahead_group.push(false);
+            group_result_start.push(None);
+            open_group_names.push(None);
+            result.extend(chars[i..header_end].iter());
+            i = header_end;
+            continue;
+        }
+        if !in_char_class && let Some(subroutine_end) = nq_internal_subroutine_end(&chars, i) {
+            result.extend(chars[i..subroutine_end].iter());
+            i = subroutine_end;
+            continue;
+        }
 
         if c == '[' && !in_char_class {
             // An empty JS character class matches nothing, but it is a
@@ -5879,14 +5955,93 @@ fn is_assertion_only_content(chars: &[char], start: usize, end: usize) -> bool {
 ///   same as before jsse#373) whenever a capturing group is involved —
 ///   deleting or duplicating one would silently renumber every later
 ///   capture group.
-/// - this bump is scoped to `*` groups only (min=0): under `+` (min=1) the
-///   *required* first iteration is still allowed to match empty per spec —
-///   only later iterations are subject to the 2.b discard — so bumping a
-///   nullable branch's floor there would wrongly forbid a legitimate empty
-///   first iteration (e.g. `/(a*|b)+/.exec("")` must stay `["",""]`). `+`
-///   groups keep falling through to the lazy-strip only, same as before this
-///   branch-aware rewrite existed.
-fn fix_nullable_quantifiers(source: &str) -> String {
+/// - positive-minimum outer quantifiers use internal iteration sentinels. A
+///   nullable branch keeps a gated empty path for the first `min` iterations,
+///   then only its consuming rewrite remains. The sentinels are defined after
+///   all JavaScript capture groups and stripped from the result, preserving
+///   numeric capture/backreference indices and last-iteration captures
+///   (jsse#378).
+const NQ_MAX_ITERATION_SENTINELS: usize = 64;
+
+struct NqOuterQuantifier {
+    min: usize,
+    max: Option<usize>,
+}
+
+impl NqOuterQuantifier {
+    fn has_post_min_iteration(&self) -> bool {
+        self.max.is_none_or(|max| max > self.min)
+    }
+}
+
+fn nq_outer_quantifier(chars: &[char], pos: usize, end: usize) -> Option<NqOuterQuantifier> {
+    if pos >= end {
+        return None;
+    }
+    match chars[pos] {
+        '*' => Some(NqOuterQuantifier { min: 0, max: None }),
+        '+' => Some(NqOuterQuantifier { min: 1, max: None }),
+        '?' => Some(NqOuterQuantifier {
+            min: 0,
+            max: Some(1),
+        }),
+        '{' => {
+            let brace_end = quantifier_brace_end(chars, pos, end)?;
+            let comma = chars[pos + 1..brace_end - 1]
+                .iter()
+                .position(|&c| c == ',')
+                .map(|offset| pos + 1 + offset);
+            let min_end = comma.unwrap_or(brace_end - 1);
+            let min = chars[pos + 1..min_end]
+                .iter()
+                .collect::<String>()
+                .parse::<usize>()
+                .ok()?;
+            let max = match comma {
+                None => Some(min),
+                Some(comma_pos) if comma_pos + 1 == brace_end - 1 => None,
+                Some(comma_pos) => Some(
+                    chars[comma_pos + 1..brace_end - 1]
+                        .iter()
+                        .collect::<String>()
+                        .parse::<usize>()
+                        .ok()?,
+                ),
+            };
+            Some(NqOuterQuantifier { min, max })
+        }
+        _ => None,
+    }
+}
+
+fn nq_iteration_setter(names: &[String]) -> String {
+    let Some((name, rest)) = names.split_first() else {
+        return String::new();
+    };
+    format!(
+        "(?(<{name}>){rest_setter}|\\g<{name}>)",
+        rest_setter = nq_iteration_setter(rest)
+    )
+}
+
+fn nq_empty_gate(name: &str) -> String {
+    format!("(?(<{name}>)(?!)|)")
+}
+
+fn nq_iteration_names(source: &str, state_id: &mut usize, min: usize) -> Vec<String> {
+    loop {
+        let id = *state_id;
+        *state_id += 1;
+        let names: Vec<String> = (1..=min)
+            .map(|iteration| format!("__jsse_qi_nq{id}_{iteration}"))
+            .collect();
+        if names.iter().all(|name| !source.contains(name)) {
+            return names;
+        }
+    }
+}
+
+fn fix_nullable_quantifiers(source: &str, stateful_positive_minimum: bool) -> String {
     if !source.contains('|') && !source.contains("??") && !source.contains("*?") {
         return source.to_string();
     }
@@ -5921,6 +6076,9 @@ fn fix_nullable_quantifiers(source: &str) -> String {
     let mut remove = vec![false; len];
     let mut replace: HashMap<usize, char> = HashMap::new();
     let mut span_replace: HashMap<usize, (usize, String)> = HashMap::new();
+    let mut insert_at: Vec<Vec<String>> = vec![Vec::new(); len + 1];
+    let mut sentinel_names: Vec<String> = Vec::new();
+    let mut state_id = 0usize;
 
     for open_pos in 0..len {
         if chars[open_pos] != '(' || close_of[open_pos] == 0 {
@@ -5928,7 +6086,10 @@ fn fix_nullable_quantifiers(source: &str) -> String {
         }
         let close = close_of[open_pos];
         let after = close + 1;
-        if after >= len || !matches!(chars[after], '*' | '+') {
+        let Some(outer_quantifier) = nq_outer_quantifier(&chars, after, len) else {
+            continue;
+        };
+        if !outer_quantifier.has_post_min_iteration() {
             continue;
         }
         // Find body start (skip group type prefix)
@@ -5938,7 +6099,31 @@ fn fix_nullable_quantifiers(source: &str) -> String {
         }
 
         let branches = nq_split_branches(&chars, body_start, close);
-        if branches.len() == 1 {
+        if outer_quantifier.min > 0
+            && (!stateful_positive_minimum || outer_quantifier.min > NQ_MAX_ITERATION_SENTINELS)
+        {
+            // Preserve the pre-jsse#378 `+` fallback when stateful conditions
+            // are unavailable (notably the byte matcher) or the minimum would
+            // require attacker-controlled source expansion.
+            if chars[after] != '+' {
+                continue;
+            }
+            let mut gate_used = false;
+            nq_fix_branches(
+                &chars,
+                &branches,
+                &close_of,
+                false,
+                None,
+                &mut replace,
+                &mut remove,
+                &mut span_replace,
+                &mut insert_at,
+                &mut gate_used,
+            );
+            continue;
+        }
+        if outer_quantifier.min == 0 && branches.len() == 1 {
             // No top-level alternation: greedy sub-quantifiers already
             // consume maximally, so only lazy ones need forcing.
             if nq_is_nullable(&chars, body_start, close, &close_of) {
@@ -5946,30 +6131,47 @@ fn fix_nullable_quantifiers(source: &str) -> String {
             }
             continue;
         }
-        // Under `+` (min=1), the *required* first iteration is still allowed
-        // to match empty per spec — only iterations after it are subject to
-        // the 2.b discard. Bumping a nullable branch's floor would forbid
-        // that legitimate empty first iteration (e.g. `/(a*|b)+/.exec("")`
-        // must stay `["",""]`), so only `*` groups get the bump/rewrite
-        // treatment; `+` groups fall through to the existing lazy-strip.
-        let allow_bump = chars[after] == '*';
+
+        let iteration_names = if outer_quantifier.min == 0 {
+            Vec::new()
+        } else {
+            nq_iteration_names(source, &mut state_id, outer_quantifier.min)
+        };
+        let empty_gate = iteration_names.last().map(|name| nq_empty_gate(name));
+        let mut gate_used = false;
         nq_fix_branches(
             &chars,
             &branches,
             &close_of,
-            allow_bump,
+            true,
+            empty_gate.as_deref(),
             &mut replace,
             &mut remove,
             &mut span_replace,
+            &mut insert_at,
+            &mut gate_used,
         );
+        if gate_used {
+            insert_at[body_start].insert(0, "(?:".to_string());
+            insert_at[close].push(")".to_string());
+            insert_at[close].push(nq_iteration_setter(&iteration_names));
+            sentinel_names.extend(iteration_names);
+        }
     }
 
-    if !remove.iter().any(|&r| r) && replace.is_empty() && span_replace.is_empty() {
+    if !remove.iter().any(|&r| r)
+        && replace.is_empty()
+        && span_replace.is_empty()
+        && sentinel_names.is_empty()
+    {
         return source.to_string();
     }
     let mut result = String::with_capacity(len);
     let mut i = 0;
     while i < len {
+        for text in &insert_at[i] {
+            result.push_str(text);
+        }
         if let Some((send, text)) = span_replace.get(&i) {
             result.push_str(text);
             i = *send;
@@ -5984,6 +6186,16 @@ fn fix_nullable_quantifiers(source: &str) -> String {
             None => result.push(chars[i]),
         }
         i += 1;
+    }
+    for text in &insert_at[len] {
+        result.push_str(text);
+    }
+    if !sentinel_names.is_empty() {
+        result.push_str("(?(DEFINE)");
+        for name in sentinel_names {
+            result.push_str(&format!("(?<{name}>)"));
+        }
+        result.push(')');
     }
     result
 }
@@ -6002,16 +6214,23 @@ fn nq_fix_branches(
     branches: &[(usize, usize)],
     close_of: &[usize],
     allow_bump: bool,
+    empty_gate: Option<&str>,
     replace: &mut HashMap<usize, char>,
     remove: &mut [bool],
     span_replace: &mut HashMap<usize, (usize, String)>,
+    insert_at: &mut [Vec<String>],
+    gate_used: &mut bool,
 ) -> bool {
     let mut touched = false;
     for (idx, &(bstart, bend)) in branches.iter().enumerate() {
         if bstart >= bend {
             // A bare empty alternative contains no capturing group by
             // construction, so splicing it out is always capture-safe.
-            if allow_bump {
+            if let Some(gate) = empty_gate {
+                insert_at[bstart].push(gate.to_string());
+                *gate_used = true;
+                touched = true;
+            } else if allow_bump {
                 nq_delete_branch(branches, idx, remove);
                 touched = true;
             }
@@ -6020,11 +6239,16 @@ fn nq_fix_branches(
         if !nq_is_nullable(chars, bstart, bend, close_of) {
             continue;
         }
-        if allow_bump
-            && nq_branch_always_empty(chars, bstart, bend, close_of)
-            && !nq_branch_has_capture(chars, bstart, bend)
-        {
-            nq_delete_branch(branches, idx, remove);
+        if allow_bump && nq_branch_always_empty(chars, bstart, bend, close_of) {
+            if let Some(gate) = empty_gate {
+                insert_at[bstart].push(format!("(?:{gate}(?:"));
+                insert_at[bend].push("))".to_string());
+                *gate_used = true;
+            } else if !nq_branch_has_capture(chars, bstart, bend) {
+                nq_delete_branch(branches, idx, remove);
+            } else {
+                continue;
+            }
             touched = true;
             continue;
         }
@@ -6034,9 +6258,12 @@ fn nq_fix_branches(
             bend,
             close_of,
             allow_bump,
+            empty_gate,
             replace,
             remove,
             span_replace,
+            insert_at,
+            gate_used,
         ) {
             touched = true;
         }
@@ -6197,14 +6424,25 @@ fn nq_fix_branch(
     bend: usize,
     close_of: &[usize],
     allow_bump: bool,
+    empty_gate: Option<&str>,
     replace: &mut HashMap<usize, char>,
     remove: &mut [bool],
     span_replace: &mut HashMap<usize, (usize, String)>,
+    insert_at: &mut [Vec<String>],
+    gate_used: &mut bool,
 ) -> bool {
-    // Under `+` (min=1), the *required* first iteration is still allowed to
-    // match empty per spec, so the caller disables bumping/rewriting
-    // entirely for those outer groups; only the lazy-strip fallback applies.
+    let empty_first = nq_bare_atom_quantifier_is_lazy(chars, bstart, bend, close_of);
     if allow_bump && nq_bump_bare_atom_min(chars, bstart, bend, close_of, replace, remove) {
+        if let Some(gate) = empty_gate {
+            if empty_first {
+                insert_at[bstart].push(format!("(?:{gate}|"));
+                insert_at[bend].push(")".to_string());
+            } else {
+                insert_at[bstart].push("(?:".to_string());
+                insert_at[bend].push(format!("|{gate})"));
+            }
+            *gate_used = true;
+        }
         return true;
     }
     // Several jointly-optional atoms (e.g. `a?b?`) rather than one — expand
@@ -6215,6 +6453,13 @@ fn nq_fix_branch(
         && !nq_branch_has_capture(chars, bstart, bend)
         && let Some(text) = nq_expand_joint_optional(chars, bstart, bend, close_of)
     {
+        let text = match empty_gate {
+            Some(gate) => {
+                *gate_used = true;
+                format!("(?:{text}|{gate})")
+            }
+            None => text,
+        };
         span_replace.insert(bstart, (bend, text));
         return true;
     }
@@ -6233,17 +6478,64 @@ fn nq_fix_branch(
                     &interior_branches,
                     close_of,
                     allow_bump,
+                    empty_gate,
                     replace,
                     remove,
                     span_replace,
+                    insert_at,
+                    gate_used,
                 ) {
                     return true;
                 }
             }
         }
     }
-    nq_mark_lazy(chars, bstart, bend, close_of, remove);
-    true
+    nq_mark_lazy(chars, bstart, bend, close_of, remove)
+}
+
+fn nq_bare_atom_quantifier_is_lazy(
+    chars: &[char],
+    start: usize,
+    end: usize,
+    close_of: &[usize],
+) -> bool {
+    if start >= end {
+        return false;
+    }
+    let atom_end = match chars[start] {
+        '\\' if start + 1 < end => start + 2,
+        '[' => {
+            let mut j = start + 1;
+            while j < end && chars[j] != ']' {
+                if chars[j] == '\\' && j + 1 < end {
+                    j += 1;
+                }
+                j += 1;
+            }
+            if j < end { j + 1 } else { j }
+        }
+        '(' => {
+            let close = close_of[start];
+            if close > 0 && close < end {
+                close + 1
+            } else {
+                return false;
+            }
+        }
+        _ => start + 1,
+    };
+    if atom_end >= end {
+        return false;
+    }
+    let quantifier_end = match chars[atom_end] {
+        '?' | '*' | '+' => atom_end + 1,
+        '{' => match quantifier_brace_end(chars, atom_end, end) {
+            Some(end) => end,
+            None => return false,
+        },
+        _ => return false,
+    };
+    quantifier_end + 1 == end && chars[quantifier_end] == '?'
 }
 
 /// If `chars[start..end]` is a sequence of two or more atoms, each with its
@@ -6637,7 +6929,14 @@ fn nq_skip_quant(chars: &[char], pos: usize, end: usize) -> usize {
 }
 
 /// Mark lazy modifiers (`?` after `?` or `*`) for removal in nullable bodies.
-fn nq_mark_lazy(chars: &[char], start: usize, end: usize, close_of: &[usize], remove: &mut [bool]) {
+fn nq_mark_lazy(
+    chars: &[char],
+    start: usize,
+    end: usize,
+    close_of: &[usize],
+    remove: &mut [bool],
+) -> bool {
+    let mut touched = false;
     let mut i = start;
     while i < end {
         let atom_end = match chars[i] {
@@ -6672,18 +6971,25 @@ fn nq_mark_lazy(chars: &[char], start: usize, end: usize, close_of: &[usize], re
             let lazy_pos = atom_end + 1;
             if lazy_pos < end && chars[lazy_pos] == '?' {
                 remove[lazy_pos] = true;
+                touched = true;
             }
         }
         i = nq_skip_quant(chars, atom_end, end);
     }
+    touched
 }
 
 fn build_regex_ex(
     source: &str,
     flags: &str,
 ) -> Result<(CompiledRegex, DupGroupMap, Vec<String>), String> {
-    let source = fix_nullable_quantifiers(source);
-    let tr = translate_js_pattern_ex(&source, flags)?;
+    let original_source = source;
+    let mut source = fix_nullable_quantifiers(original_source, true);
+    let mut tr = translate_js_pattern_ex(&source, flags)?;
+    if tr.needs_bytes_mode && source.contains("(?(DEFINE)(?<__jsse_qi_nq") {
+        source = fix_nullable_quantifiers(original_source, false);
+        tr = translate_js_pattern_ex(&source, flags)?;
+    }
     let dup_map = tr.dup_group_map;
     let name_order = tr.group_name_order;
 

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -7064,18 +7064,22 @@ fn build_regex_ex(
     source: &str,
     flags: &str,
 ) -> Result<(CompiledRegex, DupGroupMap, Vec<String>), String> {
+    build_regex_ex_with_nullable_state(source, flags, true)
+}
+
+fn build_regex_ex_with_nullable_state(
+    source: &str,
+    flags: &str,
+    stateful_positive_minimum: bool,
+) -> Result<(CompiledRegex, DupGroupMap, Vec<String>), String> {
     let original_source = source;
-    let mut rewrite = fix_nullable_quantifiers(original_source, true);
-    let mut tr =
+    let rewrite = fix_nullable_quantifiers(original_source, stateful_positive_minimum);
+    let tr =
         translate_js_pattern_ex_with_sentinels(&rewrite.source, flags, &rewrite.sentinel_names)?;
     if tr.needs_bytes_mode && !rewrite.sentinel_names.is_empty() {
-        rewrite = fix_nullable_quantifiers(original_source, false);
-        tr = translate_js_pattern_ex_with_sentinels(
-            &rewrite.source,
-            flags,
-            &rewrite.sentinel_names,
-        )?;
+        return build_regex_ex_with_nullable_state(original_source, flags, false);
     }
+    let retry_without_sentinels = stateful_positive_minimum && !rewrite.sentinel_names.is_empty();
     let source = rewrite.source;
     let dup_map = tr.dup_group_map;
     let name_order = tr.group_name_order;
@@ -7118,6 +7122,9 @@ fn build_regex_ex(
                     try_build_custom_lookbehind(&source, flags, dup_map.clone(), name_order.clone())
             {
                 return Ok(result);
+            }
+            if retry_without_sentinels {
+                return build_regex_ex_with_nullable_state(original_source, flags, false);
             }
             regex::Regex::new(&tr.pattern)
                 .map(|r| (CompiledRegex::Standard(r), dup_map, name_order))

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -6014,6 +6014,18 @@ fn nq_outer_quantifier(chars: &[char], pos: usize, end: usize) -> Option<NqOuter
     }
 }
 
+fn nq_is_nested_in_repeated_group(chars: &[char], open_pos: usize, close_of: &[usize]) -> bool {
+    close_of
+        .iter()
+        .enumerate()
+        .any(|(ancestor_open, &ancestor_close)| {
+            ancestor_open < open_pos
+                && ancestor_close > open_pos
+                && nq_outer_quantifier(chars, ancestor_close + 1, chars.len())
+                    .is_some_and(|quantifier| quantifier.max.is_none_or(|max| max > 1))
+        })
+}
+
 fn nq_iteration_setter(names: &[String]) -> String {
     let Some((name, rest)) = names.split_first() else {
         return String::new();
@@ -6100,11 +6112,16 @@ fn fix_nullable_quantifiers(source: &str, stateful_positive_minimum: bool) -> St
 
         let branches = nq_split_branches(&chars, body_start, close);
         if outer_quantifier.min > 0
-            && (!stateful_positive_minimum || outer_quantifier.min > NQ_MAX_ITERATION_SENTINELS)
+            && (!stateful_positive_minimum
+                || outer_quantifier.min > NQ_MAX_ITERATION_SENTINELS
+                || nq_is_nested_in_repeated_group(&chars, open_pos, &close_of))
         {
             // Preserve the pre-jsse#378 `+` fallback when stateful conditions
-            // are unavailable (notably the byte matcher) or the minimum would
-            // require attacker-controlled source expansion.
+            // are unavailable (notably the byte matcher), the minimum would
+            // require attacker-controlled source expansion, or a containing
+            // repetition could enter this quantifier more than once. Backend
+            // captures cannot be unset, so nested sentinels would leak their
+            // mandatory-iteration state into the next entry.
             if chars[after] != '+' {
                 continue;
             }
@@ -6451,15 +6468,9 @@ fn nq_fix_branch(
     // atoms across new branches would renumber captures).
     if allow_bump
         && !nq_branch_has_capture(chars, bstart, bend)
-        && let Some(text) = nq_expand_joint_optional(chars, bstart, bend, close_of)
+        && let Some(text) = nq_expand_joint_optional(chars, bstart, bend, close_of, empty_gate)
     {
-        let text = match empty_gate {
-            Some(gate) => {
-                *gate_used = true;
-                format!("(?:{text}|{gate})")
-            }
-            None => text,
-        };
+        *gate_used |= empty_gate.is_some();
         span_replace.insert(bstart, (bend, text));
         return true;
     }
@@ -6554,6 +6565,7 @@ fn nq_expand_joint_optional(
     start: usize,
     end: usize,
     close_of: &[usize],
+    empty_gate: Option<&str>,
 ) -> Option<String> {
     let mut atoms: Vec<(usize, usize)> = Vec::new();
     let mut i = start;
@@ -6591,7 +6603,7 @@ fn nq_expand_joint_optional(
         return None; // single-atom case is nq_bump_bare_atom_min's job
     }
 
-    let mut branches: Vec<String> = Vec::with_capacity(atoms.len());
+    let mut consuming_choices: Vec<(String, bool)> = Vec::with_capacity(atoms.len());
     for (k, &(astart, aend)) in atoms.iter().enumerate() {
         let mut a_replace: HashMap<usize, char> = HashMap::new();
         let mut a_remove = vec![false; chars.len()];
@@ -6608,9 +6620,34 @@ fn nq_expand_joint_optional(
         for &(bstart, bend) in &atoms[k + 1..] {
             piece.extend(chars[bstart..bend].iter());
         }
-        branches.push(piece);
+        consuming_choices.push((
+            piece,
+            nq_bare_atom_quantifier_is_lazy(chars, astart, aend, close_of),
+        ));
     }
-    Some(format!("(?:{})", branches.join("|")))
+
+    // Each optional atom contributes a consume-vs-skip choice. Preserve that
+    // decision tree exactly: a greedy atom's consuming choice precedes the
+    // recursively expanded skip path, while a lazy atom's choice follows it.
+    // The gated all-skipped leaf therefore lands at its source priority,
+    // which may be first, last, or between consuming alternatives.
+    let mut branches = std::collections::VecDeque::with_capacity(
+        consuming_choices.len() + usize::from(empty_gate.is_some()),
+    );
+    if let Some(gate) = empty_gate {
+        branches.push_back(gate.to_string());
+    }
+    for (piece, lazy) in consuming_choices.into_iter().rev() {
+        if lazy {
+            branches.push_back(piece);
+        } else {
+            branches.push_front(piece);
+        }
+    }
+    Some(format!(
+        "(?:{})",
+        branches.into_iter().collect::<Vec<_>>().join("|")
+    ))
 }
 
 /// Split `chars[start..end]` into top-level alternative branches (spans),

--- a/test262-extra/RegExp-nullable-alternation-quantifier.js
+++ b/test262-extra/RegExp-nullable-alternation-quantifier.js
@@ -96,3 +96,84 @@ assert.sameValue(/(a{0,0}|dc??)*/.exec("dc")[0], "d");
 var m2 = /(a{0}|(dc)??)*/.exec("dc");
 assert.sameValue(m2[0], "dc");
 assert.sameValue(m2[1], "dc");
+
+// --- Positive-minimum outer quantifiers (jsse#378) ---
+// The first `min` iterations may match empty. Once `min` reaches zero, another
+// empty iteration must fail and backtrack into a consuming sibling before the
+// outer continuation is accepted.
+var plus = /(a*|dc??)+/.exec("dc");
+assert.sameValue(plus[0], "d");
+assert.sameValue(plus[1], "d");
+
+// The last consuming iteration still owns the capture; rewriting `X+` as
+// `X X*` would incorrectly leave the mandatory copy's capture in a new slot.
+var plusLast = /(a*|dc??)+/.exec("aaadc");
+assert.sameValue(plusLast[0], "aaad");
+assert.sameValue(plusLast[1], "d");
+
+// More than one mandatory empty iteration is permitted for `{n,}` and bounded
+// `{n,m}` forms. The consuming sibling is tried only in the optional
+// post-minimum iteration.
+var atLeastTwo = /(a*|d){2,}/.exec("d");
+assert.sameValue(atLeastTwo[0], "d");
+assert.sameValue(atLeastTwo[1], "d");
+var twoToThree = /(a*|d){2,3}/.exec("d");
+assert.sameValue(twoToThree[0], "d");
+assert.sameValue(twoToThree[1], "d");
+
+// An exact quantifier has no post-minimum iteration. Its left nullable branch
+// therefore remains the correct winner.
+var exactlyTwo = /(a*|d){2}/.exec("d");
+assert.sameValue(exactlyTwo[0], "");
+assert.sameValue(exactlyTwo[1], "");
+
+// If consuming the sibling makes the sequel fail, RepeatMatcher must still
+// backtrack to the mandatory empty iteration and try the continuation there.
+var continuationFallback = /(a*|d)+d/.exec("d");
+assert.sameValue(continuationFallback[0], "d");
+assert.sameValue(continuationFallback[1], "");
+
+// Inner capture numbering and last-iteration values must remain unchanged.
+var innerCaptures = /((a)*|(dc)??)+/.exec("dc");
+assert.sameValue(innerCaptures[0], "dc");
+assert.sameValue(innerCaptures[1], "dc");
+assert.sameValue(innerCaptures[2], undefined);
+assert.sameValue(innerCaptures[3], "dc");
+
+// Internal iteration state is defined after all JavaScript captures, so later
+// numeric slots and backreferences retain their source-level numbering.
+var laterBackref = /(a*|d)+(e)\2/.exec("dee");
+assert.sameValue(laterBackref[0], "dee");
+assert.sameValue(laterBackref[1], "d");
+assert.sameValue(laterBackref[2], "e");
+var namedBackref = /(?<x>a*|d)+\k<x>/.exec("dd");
+assert.sameValue(namedBackref[0], "dd");
+assert.sameValue(namedBackref.groups.x, "d");
+
+// A lazy outer quantifier still accepts its mandatory empty match when the
+// continuation succeeds, and consumes a sibling only when the continuation
+// forces another iteration.
+assert.sameValue(/(a*|d)+?/.exec("d")[0], "");
+var lazyInnerAndOuter = /(a*?|d)+?/.exec("a");
+assert.sameValue(lazyInnerAndOuter[0], "");
+assert.sameValue(lazyInnerAndOuter[1], "");
+var lazyForced = /(a*|d)+?c/.exec("dc");
+assert.sameValue(lazyForced[0], "dc");
+assert.sameValue(lazyForced[1], "d");
+
+// The positive-minimum treatment also covers the residual nullable shapes
+// handled for `*`: bare empty, exact-zero, and jointly-optional branches.
+assert.sameValue(/(|d)+/.exec("d")[0], "d");
+assert.sameValue(/(a{0}|d)+/.exec("d")[0], "d");
+assert.sameValue(/(a?b?|d)+/.exec("d")[0], "d");
+
+// Separate positive-minimum groups keep independent iteration state. Either
+// group may legitimately finish with only its mandatory empty iteration.
+var sequentialOne = /^(a*|d)+(b*|e)+/.exec("d");
+assert.sameValue(sequentialOne[0], "d");
+assert.sameValue(sequentialOne[1], "d");
+assert.sameValue(sequentialOne[2], "");
+var sequentialBoth = /^(a*|d)+(b*|e)+/.exec("de");
+assert.sameValue(sequentialBoth[0], "de");
+assert.sameValue(sequentialBoth[1], "d");
+assert.sameValue(sequentialBoth[2], "e");

--- a/test262-extra/RegExp-nullable-alternation-quantifier.js
+++ b/test262-extra/RegExp-nullable-alternation-quantifier.js
@@ -229,3 +229,15 @@ assert.sameValue(/(a??b?|d)+?/.exec("a")[0], "");
 assert.sameValue(/(a??b?|d)+?/.exec("b")[0], "b");
 assert.sameValue(/(a?b??|d)+?/.exec("a")[0], "a");
 assert.sameValue(/(a?b??|d)+?/.exec("b")[0], "");
+
+// The no-progress rewrite is for unbounded repetition. A bounded min-zero
+// quantifier cannot add another iteration after an empty choice to recover
+// skipped input, so stripping its inner laziness changes both the match and
+// capture. These forms force the inner atom to consume while retaining its
+// lazy marker.
+var boundedOptional = /(a*?)?/.exec("aa");
+assert.sameValue(boundedOptional[0], "a");
+assert.sameValue(boundedOptional[1], "a");
+var boundedTwo = /(a*?){0,2}/.exec("aaa");
+assert.sameValue(boundedTwo[0], "aa");
+assert.sameValue(boundedTwo[1], "a");

--- a/test262-extra/RegExp-nullable-alternation-quantifier.js
+++ b/test262-extra/RegExp-nullable-alternation-quantifier.js
@@ -177,3 +177,27 @@ var sequentialBoth = /^(a*|d)+(b*|e)+/.exec("de");
 assert.sameValue(sequentialBoth[0], "de");
 assert.sameValue(sequentialBoth[1], "d");
 assert.sameValue(sequentialBoth[2], "e");
+
+// A nested positive-minimum quantifier starts a fresh mandatory-iteration
+// budget each time its containing atom is entered. Internal state from the
+// first outer iteration must not reject the second iteration's required empty
+// match.
+var nestedPositive = /((a*|b)+c)+/.exec("cc");
+assert.sameValue(nestedPositive[0], "cc");
+assert.sameValue(nestedPositive[1], "c");
+assert.sameValue(nestedPositive[2], "");
+
+// If every atom in a jointly optional branch is lazy, its all-empty path is
+// preferred during a mandatory iteration. Separating the empty path from the
+// consuming expansion must preserve that original choice priority.
+var lazyJointOptional = /(a??b??|d)+?/.exec("a");
+assert.sameValue(lazyJointOptional[0], "");
+assert.sameValue(lazyJointOptional[1], "");
+
+// With mixed greediness, the empty leaf can sit between consuming choices:
+// `a??b?` prefers consuming `b` but skips both before backtracking to `a`,
+// while `a?b??` has the opposite ordering.
+assert.sameValue(/(a??b?|d)+?/.exec("a")[0], "");
+assert.sameValue(/(a??b?|d)+?/.exec("b")[0], "b");
+assert.sameValue(/(a?b??|d)+?/.exec("a")[0], "a");
+assert.sameValue(/(a?b??|d)+?/.exec("b")[0], "");

--- a/test262-extra/RegExp-nullable-alternation-quantifier.js
+++ b/test262-extra/RegExp-nullable-alternation-quantifier.js
@@ -150,6 +150,22 @@ var namedBackref = /(?<x>a*|d)+\k<x>/.exec("dd");
 assert.sameValue(namedBackref[0], "dd");
 assert.sameValue(namedBackref.groups.x, "d");
 
+// Internal positive-quantifier state must not change Annex B parsing. In a
+// non-Unicode pattern with no source-level named captures, `\k` and `\g` are
+// identity escapes even when their following text resembles an internal
+// sentinel name.
+var legacyNamedEscape = /(a*|d)+\k<x>/.exec("dk<x>");
+assert.sameValue(legacyNamedEscape[0], "dk<x>");
+assert.sameValue(legacyNamedEscape[1], "d");
+assert.sameValue(
+  /\g<__jsse_qi_nq0_1>/.test("g<__jsse_qi_nq0_1>"),
+  true,
+);
+var legacyInternalLookingEscape =
+  /(a*|d)+\g<__jsse_qi_nq0_1>/.exec("dg<__jsse_qi_nq0_1>");
+assert.sameValue(legacyInternalLookingEscape[0], "dg<__jsse_qi_nq0_1>");
+assert.sameValue(legacyInternalLookingEscape[1], "d");
+
 // A lazy outer quantifier still accepts its mandatory empty match when the
 // continuation succeeds, and consumes a sibling only when the continuation
 // forces another iteration.

--- a/test262-extra/RegExp-nullable-alternation-quantifier.js
+++ b/test262-extra/RegExp-nullable-alternation-quantifier.js
@@ -121,6 +121,18 @@ var twoToThree = /(a*|d){2,3}/.exec("d");
 assert.sameValue(twoToThree[0], "d");
 assert.sameValue(twoToThree[1], "d");
 
+// Sentinel expansion near fancy-regex's recursion limit must either compile
+// successfully or fall back to the pre-stateful rewrite. The effective
+// backend limit also shrinks with enclosing group depth, so it cannot be
+// represented by one fixed minimum cap.
+var belowBackendDepthLimit = /(a*|d){62,63}/.exec("d");
+assert.sameValue(belowBackendDepthLimit[0], "d");
+assert.sameValue(belowBackendDepthLimit[1], "d");
+assert.sameValue(/(a*|d){63,64}/.exec("")[0], "");
+assert.sameValue(/(a*|d){63,}/.exec("")[0], "");
+assert.sameValue(/(a*|d){64,}/.exec("")[0], "");
+assert.sameValue(/(?:(a*|d){62,})/.exec("")[0], "");
+
 // An exact quantifier has no post-minimum iteration. Its left nullable branch
 // therefore remains the correct winner.
 var exactlyTwo = /(a*|d){2}/.exec("d");


### PR DESCRIPTION
## Summary

- preserve mandatory empty iterations for positive-minimum RegExp groups with internal sentinels
- disable nullable empty branches only after the quantifier minimum is satisfied, without duplicating JavaScript captures or renumbering backreferences
- preserve Annex B identity escapes by carrying the exact generated sentinel-name set into translation instead of recognizing user-controllable prefixes
- fall back to the prior non-stateful rewrite when pattern depth makes a generated sentinel setter exceed fancy-regex's compile limit
- preserve lazy choice order for bounded min-zero groups by using the consuming-branch rewrite instead of the unbounded lazy-strip shortcut
- cover `+`, `{n,}`, bounded, lazy, capture, continuation, multiple-group, sentinel-like identity-escape, and backend-depth cases

## Implementation notes

Sentinel expansion is capped at 64 mandatory iterations to avoid source expansion proportional to attacker-controlled bounds. Larger minima retain the previous non-stateful rewrite. The backend nesting limit also depends on surrounding pattern depth, so any stateful expansion rejected during fancy-regex compilation is retried through that same fallback instead of relying on the source-growth cap as a compile-depth guarantee.

Patterns requiring JSSE's byte matcher also retain the previous non-stateful rewrite because that backend cannot compile the required fancy-regex conditionals. Capture-backed sentinels are bypassed inside repeated ancestors because fancy-regex cannot reset their state between entries. They are also bypassed when an inner source capture is observable through a source backreference. The reported stale-backreference result also occurs on `origin/main` and the non-sentinel backend path; this PR avoids adding sentinel state to that pre-existing matcher limitation rather than claiming to solve general per-iteration capture clearing.

Bounded min-zero forms (`?` and `{0,m}`) do not enter the unbounded single-branch lazy-strip shortcut. Their nullable inner atom is instead made consuming while its greedy/lazy marker is preserved, matching RepeatMatcher choice order.

The nullable rewrite returns its generated sentinel names alongside the rewritten source. The translation pass only recognizes exact names from that provenance set as fancy-regex conditionals or subroutines, and excludes internal sentinel definitions when deciding whether source-level named captures enable `\k` backreference syntax under Annex B.

## Validation

- `./scripts/lint.sh`
- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (354 unit, 3 host, smoke oracle)
- `uv run python scripts/run-custom-tests.py` (11/11)
- focused `test262-extra/RegExp-nullable-alternation-quantifier.js` (2/2 scenarios)
- RegExp-targeted test262 paths (4,232/4,232 scenarios)
- full `uv run python scripts/run-test262.py` (99,568/99,568; zero regressions)

Closes #378
