### PR TITLE
perf(interpreter): collapse local binding writes to one lookup

### DIFF
--- a/docs/specs/2026-07-25-resolved-local-binding-write-design.md
+++ b/docs/specs/2026-07-25-resolved-local-binding-write-design.md
@@ -1,0 +1,76 @@
+# Resolved local binding write design
+
+## Goal
+
+Reduce repeated environment-map work when executing assignments in broad,
+one-shot call graphs without changing ECMAScript reference, binding, or global
+object semantics.
+
+The motivating Mandreel profile spends about 18% of cold execution in
+identifier resolution. For an assignment to an ordinary function-local
+binding, JSSE currently resolves the binding before evaluating the right-hand
+side and then rediscovers the same binding several times while checking
+mutability and writing the value.
+
+## Specification constraints
+
+`EvaluateCall`, `PrepareForOrdinaryCall`, and
+`FunctionDeclarationInstantiation` require a logically fresh activation and
+the prescribed parameter, `arguments`, var, lexical, and closure semantics.
+Assignment evaluation captures a Reference Record before evaluating the
+right-hand side; `PutValue` later writes through that captured record.
+
+The optimization may therefore retain and use the already-resolved
+Environment Record. It must not redirect the write by resolving the identifier
+again after the right-hand side runs. It must also preserve temporal dead zone,
+constant, immutable, function-name, global-object, import, `with`, and deleted
+binding behavior.
+
+## Design
+
+When `put_value_by_ref` receives `IdentifierRef::SpecificEnv`, first attempt a
+single mutable lookup in that exact Environment Record. If the record is not a
+global environment and the binding is still present:
+
+- initialized `var` and `let` bindings are written directly;
+- uninitialized lexical bindings report the existing TDZ error;
+- initialized `const` bindings report the existing assignment error;
+- function-name and immutable bindings retain their strict/sloppy behavior.
+
+If the record is global, the binding is indirect, or the binding disappeared
+while the right-hand side was evaluated, retain the existing general path.
+That path handles global object mirroring and proxy behavior, module imports,
+and unresolvable-reference semantics.
+
+This is a storage-level shortcut only. It does not omit an Environment Record,
+change reference capture timing, cache a mutable borrow across user code, or
+specialize based on function hotness.
+
+## Alternatives considered
+
+Slot-indexed function frames could remove most string hashing and scope-chain
+walking, including for straight-line code, but require parser/body metadata,
+new binding storage, eval and closure deoptimization rules, and a wider
+correctness surface.
+
+Adding `#[inline]` to indirect-binding checks is smaller, but only removes one
+cross-module call boundary and leaves repeated map probes on every assignment.
+
+Reusing a cached environment location at each AST identifier site would help
+loops after warmup, but not the motivating one-shot sites and would require
+invalidation for `eval` and `with`.
+
+The resolved-record write is the smallest measured vertical slice: it removes
+redundant work for the translated-C register assignments that dominate the
+profile while preserving the existing slow path for observable cases.
+
+## Verification
+
+- Add focused coverage for mutable local writes, TDZ and constant failures,
+  sloppy and strict named-function bindings, closure reference capture across
+  right-hand-side calls, globals, imports, and `with`.
+- Compare cold Mandreel setup wall time and a `perf` profile before and after.
+- Run the language assignment, function-code, and environment-sensitive
+  test262 areas, followed by the full suite against the `origin/main`
+  baseline.
+- Run formatting, Clippy, the release build, and release tests.

--- a/docs/specs/2026-07-25-resolved-local-binding-write-design.md
+++ b/docs/specs/2026-07-25-resolved-local-binding-write-design.md
@@ -8,9 +8,9 @@ object semantics.
 
 The motivating Mandreel profile spends about 18% of cold execution in
 identifier resolution. For an assignment to an ordinary function-local
-binding, JSSE currently resolves the binding before evaluating the right-hand
-side and then rediscovers the same binding several times while checking
-mutability and writing the value.
+binding, JSSE's assignment shortcut first confirms the local binding and then
+`env_set` probes the same binding once to choose an action and again to write
+the value.
 
 ## Specification constraints
 
@@ -20,31 +20,30 @@ the prescribed parameter, `arguments`, var, lexical, and closure semantics.
 Assignment evaluation captures a Reference Record before evaluating the
 right-hand side; `PutValue` later writes through that captured record.
 
-The optimization may therefore retain and use the already-resolved
-Environment Record. It must not redirect the write by resolving the identifier
-again after the right-hand side runs. It must also preserve temporal dead zone,
-constant, immutable, function-name, global-object, import, `with`, and deleted
-binding behavior.
+The optimization may therefore combine the mutability check and value update
+when `env_set` reaches a declarative Environment Record. It must preserve
+temporal dead zone, constant, immutable, function-name, global-object, import,
+`with`, and deleted binding behavior.
 
 ## Design
 
-When `put_value_by_ref` receives `IdentifierRef::SpecificEnv`, first attempt a
-single mutable lookup in that exact Environment Record. If the record is not a
-global environment and the binding is still present:
+Deepen `env_set` so each Environment Record is probed once with a mutable map
+lookup. If a binding is found in a record that has no global object:
 
-- initialized `var` and `let` bindings are written directly;
+- mutable bindings are written through the live map entry;
 - uninitialized lexical bindings report the existing TDZ error;
 - initialized `const` bindings report the existing assignment error;
 - function-name and immutable bindings retain their strict/sloppy behavior.
 
-If the record is global, the binding is indirect, or the binding disappeared
-while the right-hand side was evaluated, retain the existing general path.
-That path handles global object mirroring and proxy behavior, module imports,
-and unresolvable-reference semantics.
+If the record has a global object, retain the existing deferred action: release
+the environment borrow, perform the potentially re-entrant global object or
+proxy write, then update the binding mirror. Indirect imports, absent bindings,
+and parent traversal retain their existing paths.
 
-This is a storage-level shortcut only. It does not omit an Environment Record,
-change reference capture timing, cache a mutable borrow across user code, or
-specialize based on function hotness.
+This is a change inside the existing storage seam. It does not expand the
+already-large assignment dispatcher, omit an Environment Record, change
+reference capture timing, hold a mutable borrow across user code, or specialize
+based on function hotness.
 
 ## Alternatives considered
 
@@ -53,24 +52,37 @@ walking, including for straight-line code, but require parser/body metadata,
 new binding storage, eval and closure deoptimization rules, and a wider
 correctness surface.
 
-Adding `#[inline]` to indirect-binding checks is smaller, but only removes one
-cross-module call boundary and leaves repeated map probes on every assignment.
+Writing directly inside `eval_assign` was prototyped first. Although it avoided
+`env_set`, it expanded the large dispatcher and regressed cold Mandreel CPU
+time from about 28-29 seconds to 34-36 seconds, so it was discarded.
 
 Reusing a cached environment location at each AST identifier site would help
 loops after warmup, but not the motivating one-shot sites and would require
 invalidation for `eval` and `with`.
 
-The resolved-record write is the smallest measured vertical slice: it removes
-redundant work for the translated-C register assignments that dominate the
-profile while preserving the existing slow path for observable cases.
+The single-probe `env_set` write is the smallest measured vertical slice: it
+removes redundant work for translated-C register assignments while keeping the
+same out-of-line control-flow shape and observable slow paths.
 
 ## Verification
 
-- Add focused coverage for mutable local writes, TDZ and constant failures,
-  sloppy and strict named-function bindings, closure reference capture across
-  right-hand-side calls, globals, imports, and `with`.
+- Add focused coverage for mutable local writes, constant failures, sloppy and
+  strict named-function bindings, closure writes, global binding mirrors, and
+  `with`.
 - Compare cold Mandreel setup wall time and a `perf` profile before and after.
 - Run the language assignment, function-code, and environment-sensitive
   test262 areas, followed by the full suite against the `origin/main`
   baseline.
 - Run formatting, Clippy, the release build, and release tests.
+
+## Measured result
+
+On CPU-pinned adjacent A/B runs, cold Mandreel initialization used 14.7% to
+20.9% less user CPU time than the exact `origin/main` binary (15.4% median
+paired reduction across three pairs). A focused 20-million-iteration local
+assignment check improved from 8.80 to 8.34 seconds and from 8.64 to 8.01
+seconds in reversed run order.
+
+In `perf` profiles of the cold Mandreel load, `env_set` self-samples fell from
+2.94% to 1.17%. The broader identifier-resolution cost remains visible and is a
+candidate for later, separately scoped work.

--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -48,15 +48,19 @@ impl Interpreter {
     ) -> Result<(), JsValue> {
         let mut current = env.clone();
         loop {
-            // Inspect this frame without mutating; capture the next action.
+            // A declarative local write needs no re-entrant object operation,
+            // so update it while this single map probe is live. Global writes
+            // still defer mutation until after the mirrored object write.
             let action = {
-                let e = current.borrow();
+                let mut e = current.borrow_mut();
                 if e.is_indirect_binding(name) {
                     return Err(JsValue::String(JsString::from_str(
                         "Assignment to constant variable.",
                     )));
                 }
-                if let Some(binding) = e.bindings.get(name) {
+                let strict = e.strict;
+                let global_object_id = e.global_object_id;
+                if let Some(binding) = e.bindings.get_mut(name) {
                     if !binding.initialized
                         && matches!(binding.kind, BindingKind::Let | BindingKind::Const)
                     {
@@ -73,25 +77,27 @@ impl Interpreter {
                         || binding.kind == BindingKind::ImmutableValue)
                         && binding.initialized
                     {
-                        if e.strict {
+                        if strict {
                             return Err(JsValue::String(JsString::from_str(
                                 "Assignment to constant variable.",
                             )));
                         }
                         return Ok(());
                     }
-                    let mirror = if binding.kind == BindingKind::Var {
-                        e.global_object_id
+                    if global_object_id.is_none() {
+                        binding.value = value;
+                        binding.initialized = true;
+                        return Ok(());
+                    }
+                    let mirror_gid = if binding.kind == BindingKind::Var {
+                        global_object_id
                     } else {
                         None
                     };
-                    EnvSetAction::WriteBinding {
-                        mirror_gid: mirror,
-                        strict: e.strict,
-                    }
+                    EnvSetAction::WriteBinding { mirror_gid, strict }
                 } else if e.parent.is_some() {
                     EnvSetAction::Recurse(e.parent.clone().unwrap())
-                } else if let Some(gid) = e.global_object_id {
+                } else if let Some(gid) = global_object_id {
                     EnvSetAction::ImplicitGlobal { gid }
                 } else {
                     EnvSetAction::CreateBinding

--- a/test262-extra/resolved-local-binding-write.js
+++ b/test262-extra/resolved-local-binding-write.js
@@ -1,0 +1,85 @@
+/*---
+description: Resolved local binding writes preserve PutValue semantics
+info: |
+  6.2.5.6 PutValue
+  10.2.1.3 OrdinaryCallEvaluateBody
+
+  Assignment captures its Reference Record before evaluating the right-hand
+  side. Mutable declarative bindings update that exact record, while immutable,
+  global-object, and object environment records retain their distinct behavior.
+esid: sec-putvalue
+flags: [noStrict]
+---*/
+
+function writeLocals() {
+  var r0 = 1;
+  let r1 = 2;
+  r0 = 3;
+  r1 = 4;
+  return r0 + r1;
+}
+assert.sameValue(writeLocals(), 7, "mutable local bindings are updated");
+
+assert.throws(TypeError, function () {
+  function constWrite() {
+    const value = 1;
+    value = 2;
+  }
+  constWrite();
+});
+
+var sloppyNamed = function immutableName() {
+  immutableName = 1;
+  return immutableName;
+};
+assert.sameValue(
+  sloppyNamed(),
+  sloppyNamed,
+  "sloppy writes to a named-function binding are ignored"
+);
+
+var strictNamed = function immutableName() {
+  "use strict";
+  immutableName = 1;
+};
+assert.throws(TypeError, strictNamed);
+
+function preserveReference() {
+  var capturedLocal = 1;
+  function rhs() {
+    capturedLocal = 40;
+    return 2;
+  }
+  capturedLocal = rhs();
+  return capturedLocal;
+}
+assert.sameValue(
+  preserveReference(),
+  2,
+  "the captured local reference is written after the RHS returns"
+);
+
+var globalWrite = 1;
+globalWrite = 2;
+assert.sameValue(globalWrite, 2, "the global binding is updated");
+assert.sameValue(globalThis.globalWrite, 2, "the global object mirror is updated");
+
+function globalFunctionWrite() {}
+globalFunctionWrite = 3;
+assert.sameValue(globalFunctionWrite, 3, "the global function binding is updated");
+assert.sameValue(
+  globalThis.globalFunctionWrite,
+  3,
+  "a global function write is mirrored to the global object"
+);
+
+var withTarget = { value: 1 };
+function writeWithObject() {
+  var value = 2;
+  with (withTarget) {
+    value = 3;
+  }
+  return value;
+}
+assert.sameValue(writeWithObject(), 2, "with does not overwrite the local binding");
+assert.sameValue(withTarget.value, 3, "with writes through the object environment record");


### PR DESCRIPTION
## Summary

- update ordinary declarative local bindings through the same mutable map entry used for validation
- preserve the deferred global-object mirror path so proxy/re-entrant writes still happen without an active environment borrow
- add focused PutValue coverage and document the measured design tradeoffs

## Performance

- CPU-pinned adjacent A/B cold Mandreel runs against the exact `origin/main` binary used 14.7% to 20.9% less user CPU (15.4% median paired reduction across three pairs)
- a focused 20-million local-write check improved by 5.2% and 7.3% in reversed run order
- `perf` self-samples for `env_set` fell from 2.94% to 1.17%

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release` (352 unit, 3 host-time-zone, smoke oracle)
- `./scripts/lint.sh`
- targeted assignment/function-code test262: 2,049/2,049
- full test262: 99,568/99,568, zero regressions
- focused `test262-extra` regression: 1/1
- custom tests: 11/11

Closes #387