### PR TITLE
perf(bytecode): compile member/array-element access

### DIFF
--- a/docs/specs/2026-07-25-bytecode-member-access-slice.md
+++ b/docs/specs/2026-07-25-bytecode-member-access-slice.md
@@ -1,0 +1,162 @@
+# Bytecode member/array-element access slice
+
+## Context
+
+Issue #388 found that the mandreel benchmark's heap-copy loop,
+`for (i=0;i<N;i++) heap32[i]=my_heap32[i]`, is a textbook eligible-shaped
+numeric loop that still falls back to the tree-walker, purely because its body
+is a `MemberExpression` read plus a `MemberExpression` assignment — explicitly
+out of scope for the numeric-loop slice (docs/specs/2026-07-20-bytecode-loop-slice-design.md).
+The issue's own suggested first slice bundled member/array-element access with
+a restricted `Call` opcode. This slice deliberately narrows that to member
+access only: `Call` carries its own hazard surface (GC-rooting across a call,
+IC-handle plumbing, a bail list for `eval`/spread/optional-call/`super()`/`new`,
+call-depth parity with the tree-walker's catchable guard) large enough to
+warrant its own follow-up issue and PR, decided explicitly with the user
+before this work began.
+
+## Approaches considered
+
+1. **Extend the existing stack VM with dedicated Get/Set opcodes, reusing the
+   tree-walker's shared MOP entry points in `property.rs`.** Selected. Mirrors
+   how `Op::Add`/`Op::Sub`/etc. already reuse `eval_binary` rather than
+   re-deriving arithmetic semantics in the VM. Four new opcodes cover static
+   (`a.b`) and computed (`a[k]`) access, read and simple-assignment write.
+2. **Also support compound-assignment (`a[k] += v`) and update (`a[k]++`) on
+   member targets.** Rejected for this slice. Both require re-reading the
+   current property value using the *same* base+key without re-evaluating
+   either (to avoid double side effects), which forces a choice between a new
+   "peek-without-pop" opcode shape or a parallel `PropRef` stack analogous to
+   the existing `IdentifierRef`/`ResolveName`/`LoadResolvedName` machinery —
+   real mechanical cost not justified by the motivating workload, since
+   mandreel's heap-copy loop is a plain `Assign`, not a compound op. Left
+   unsupported; the whole containing function bails to the tree-walker via the
+   existing eligibility membrane, exactly as it did before this slice.
+3. **Compile every `Member`/`MemberProperty` shape, including private fields,
+   optional chaining, and `delete`.** Rejected — matches issue #67's own
+   rejected "compile everything, enable by default" approach. Each of these
+   shapes has its own semantics to get exactly right (private-field brand
+   checks, optional short-circuit, `[[Delete]]`'s return-value semantics) and
+   none appear in the motivating numeric-loop workload.
+
+## Design
+
+The bytecode module remains a deep module with one external seam:
+`compile_body` either returns a complete `Chunk` or rejects the entire `Body`.
+Four new opcodes were added (`op.rs`, values 43-46): `GetProp`/`SetProp` (dot
+access, `u16` name-pool index operand) and `GetElement`/`SetElement` (computed
+access, key already on the operand stack). `compiler.rs` gained an
+`Expression::Member` rvalue case and extended `Expression::Assign`'s target
+match to accept a `Member` target restricted to `AssignOp::Assign` — any
+compound `AssignOp` on a `Member` target still falls through to
+`CompileError::Unsupported`, bailing the whole function. The `Expression::Update`
+arm needed no change: its existing `Identifier`-only guard already rejected
+`Member` targets structurally.
+
+Because compound-assign/update-on-member are out of scope, no new ref-stack or
+`Chunk` field was needed: base, (computed) key, and RHS are pushed onto the
+existing operand stack in source order and consumed by a single terminal
+opcode, exactly symmetric with the existing `Binary` op's `pop_n`/`push_n`
+accounting.
+
+Each new opcode's `member_get`/`member_get_computed`/`member_set`/
+`member_set_computed` helper (free functions in `vm.rs`) replicates the
+tree-walker's exact evaluation order and error-message text rather than
+re-deriving it from spec text, since the tree-walker is this project's proven
+100%-test262 parity baseline:
+
+- **Read**: null/undefined-base check (throwing the tree-walker's exact
+  message — the computed case's message has **no key interpolated**, unlike
+  the Dot case, which does) → (computed only) `to_property_key` → primitive
+  boxing via `to_object` if the base isn't already an object →
+  `get_object_property` (property.rs).
+- **Write (simple assign only)**: (computed only) `to_property_key` on the
+  already-evaluated raw key → null/undefined-base check → `set_object_with_key`
+  (`eval.rs`, bumped from private to `pub(super)` — the same reuse target
+  `eval_update`'s write path already uses, in preference to `eval_assign`'s own
+  Member-write arm, which duplicates most of `[[Set]]` inline rather than
+  calling the canonical `property.rs::proxy_set`).
+
+### GC rooting (the load-bearing new invariant)
+
+`JsValue::Object` is a bare arena `u64` id with no `Rc`/`Drop` — holding a
+Rust-local clone does not keep it alive. `gc_safepoint()` builds its root set
+from an explicit, hand-maintained list (realms, call-stack envs/frames,
+`gc_temp_roots`) and never scans the VM's native `Vec<JsValue>` operand stack.
+A collection can run **synchronously nested** inside any of the new opcodes'
+own property-access call, since a getter, a proxy trap, or `ToPropertyKey`
+coercion can itself execute arbitrary JS, and any JS function body reaches a
+real `gc_safepoint()` at the top of its first statement.
+
+An initial design rooted only each opcode's own operands immediately before
+its own property.rs call. Adversarial review found this insufficient: a
+chained expression like `a.b.value = a.c` compiles to `GetProp(b)` [pushes
+`R1`, an object] → the RHS sub-expression `a.c`'s own `GetProp(c)` [invokes a
+getter that can itself force a GC] → `SetProp(value)` [finally consumes `R1`].
+`R1` sits unrooted on the operand stack for the entire window between the
+first and last opcode, spanning an arbitrary number of intervening,
+GC-capable opcodes — rooting only the *current* opcode's own operands misses a
+value pushed by an *earlier* opcode and consumed by a *later* one.
+
+The fix: every one of the four new opcodes roots the **entire current operand
+stack** (not just its own operands) before calling into `get_object_property`/
+`to_property_key`/`to_object`/`set_object_with_key`, via a small
+`root_operand_stack` helper built on the existing `gc_root_frame`/
+`gc_root_value`/`gc_unroot_frame` machinery (the same mechanism `eval_binary`
+already uses to root its operands across `ToPrimitive` coercion). Rooting is
+by object id and does not require continued ownership of the `JsValue`, so
+rooting before popping this opcode's own operands already covers both any
+older pending stack entry and this opcode's own soon-to-be-popped locals via
+the same ids.
+
+## Error handling and limits
+
+Every new opcode returns `Completion::Throw`/`Err` on a JS-level failure
+(null/undefined base, a rejected strict-mode `[[Set]]`, a `ToPropertyKey`
+failure) exactly like existing opcodes — never `.expect()` outside a genuine
+internal invariant violation (stack underflow), matching existing style.
+Unsupported member-access shapes (private fields, optional chaining, member
+access as a call callee, compound-assign/update on a member target) reject the
+whole `Body` via `CompileError::Unsupported`, per the existing whole-body
+eligibility-membrane design — there is no per-instruction fallback.
+
+## Validation
+
+- Unit + end-to-end tests in `bytecode/tests.rs` cover: dot and computed reads
+  (plain array and typed array), dot and computed simple-assignment writes,
+  null/undefined-base error-message parity between AST and bytecode modes
+  (compared against each other, not a hardcoded string, so a future
+  tree-walker message change can't silently desync the two), and explicit
+  bail-out tests for compound-assign-on-member, update-on-member, private
+  fields, and optional member access.
+- A dedicated two-hop GC-hazard regression test
+  (`end_to_end_member_chain_base_survives_gc_during_rhs_evaluation`) exercises
+  exactly the `a.base.value = a.rhs` shape described above, with `a.rhs`'s
+  getter forcing a collection (`$262.gc()`) while `a.base`'s freshly-allocated,
+  otherwise-unreferenced result is still pending on the operand stack.
+  Verified to actually discriminate: temporarily reverting to the
+  per-op-only rooting design made this specific test fail (`observed` never
+  got set, i.e. the base was corrupted), confirming it is not a
+  vacuously-passing test.
+- A release-mode timing comparison (tree-walker vs `--bytecode`) on the exact
+  motivating heap-copy-loop shape (`dst[i] = src[i]` over `Int32Array`s, 20
+  iterations of a 200,000-element copy) showed a stable ~33% wall-clock
+  reduction (≈9.0s → ≈6.0s across two runs each) — a genuine, reproducible win
+  on issue #388's own motivating workload, evidence rather than a unit-test
+  assertion. This is despite computed-key access unconditionally routing
+  through `to_property_key` (an allocate-then-parse round trip for a raw
+  `Number` key that the tree-walker's own read fast path in
+  `eval/access.rs` avoids) — a further optimization opportunity noted as a
+  natural fast-follow, not required to land this slice since a net win is
+  already demonstrated.
+- Full test262 suite held 100% (0 regressions) alongside the full unit suite
+  and `./scripts/lint.sh`.
+
+## Success criteria
+
+`heap32[i] = my_heap32[i]` inside an otherwise-eligible numeric `for` loop
+executes a bytecode `Chunk`, returns the same result as the tree-walker for
+both dot and computed, read and write, member access, preserves error-message
+parity with the tree-walker for null/undefined bases, survives a GC collection
+triggered while a member-access result is pending on the operand stack, and
+does not introduce a test262 baseline regression.

--- a/src/interpreter/bytecode/compiler.rs
+++ b/src/interpreter/bytecode/compiler.rs
@@ -1,8 +1,8 @@
 use super::chunk::{Chunk, Constant};
 use super::op::Op;
 use crate::ast::{
-    AssignOp, BinaryOp, Expression, ForInit, Literal, LogicalOp, Pattern, Statement, UnaryOp,
-    UpdateOp, VarKind, VariableDeclaration,
+    AssignOp, BinaryOp, Expression, ForInit, Literal, LogicalOp, MemberProperty, Pattern,
+    Statement, UnaryOp, UpdateOp, VarKind, VariableDeclaration,
 };
 
 #[derive(Debug)]
@@ -241,26 +241,48 @@ impl Compiler {
                 }
                 Ok(())
             }
-            Expression::Assign(op, target, value) => {
-                let Expression::Identifier(name) = target.as_ref() else {
-                    return Err(CompileError::Unsupported("assign target"));
-                };
-                let idx = self.add_name(name)?;
-                self.emit_resolve_name(idx);
-                if *op == AssignOp::Assign {
-                    self.compile_expr(value)?;
-                } else {
-                    self.emit(Op::LoadResolvedName);
-                    self.emit_u16(idx);
-                    self.push_n(1);
-                    self.compile_expr(value)?;
-                    self.emit(Self::compound_binary_op(*op)?);
-                    self.pop_n(2);
-                    self.push_n(1);
+            Expression::Assign(op, target, value) => match target.as_ref() {
+                Expression::Identifier(name) => {
+                    let idx = self.add_name(name)?;
+                    self.emit_resolve_name(idx);
+                    if *op == AssignOp::Assign {
+                        self.compile_expr(value)?;
+                    } else {
+                        self.emit(Op::LoadResolvedName);
+                        self.emit_u16(idx);
+                        self.push_n(1);
+                        self.compile_expr(value)?;
+                        self.emit(Self::compound_binary_op(*op)?);
+                        self.pop_n(2);
+                        self.push_n(1);
+                    }
+                    self.emit_store_resolved_name(idx);
+                    Ok(())
                 }
-                self.emit_store_resolved_name(idx);
-                Ok(())
-            }
+                Expression::Member(obj, prop, _) if *op == AssignOp::Assign => match prop {
+                    MemberProperty::Dot(name) => {
+                        self.compile_expr(obj)?;
+                        let idx = self.add_name(name)?;
+                        self.compile_expr(value)?;
+                        self.emit(Op::SetProp);
+                        self.emit_u16(idx);
+                        self.pop_n(2);
+                        self.push_n(1);
+                        Ok(())
+                    }
+                    MemberProperty::Computed(key) => {
+                        self.compile_expr(obj)?;
+                        self.compile_expr(key)?;
+                        self.compile_expr(value)?;
+                        self.emit(Op::SetElement);
+                        self.pop_n(3);
+                        self.push_n(1);
+                        Ok(())
+                    }
+                    MemberProperty::Private(_) => Err(CompileError::Unsupported("private field")),
+                },
+                _ => Err(CompileError::Unsupported("assign target")),
+            },
             Expression::Update(op, prefix, target) => {
                 let Expression::Identifier(name) = target.as_ref() else {
                     return Err(CompileError::Unsupported("update target"));
@@ -327,6 +349,25 @@ impl Compiler {
                 self.push_n(1);
                 Ok(())
             }
+            Expression::Member(obj, prop, _site_id) => match prop {
+                MemberProperty::Dot(name) => {
+                    self.compile_expr(obj)?;
+                    let idx = self.add_name(name)?;
+                    self.emit(Op::GetProp);
+                    self.emit_u16(idx);
+                    // Stack height unchanged: pop base, push value.
+                    Ok(())
+                }
+                MemberProperty::Computed(key) => {
+                    self.compile_expr(obj)?;
+                    self.compile_expr(key)?;
+                    self.emit(Op::GetElement);
+                    self.pop_n(2);
+                    self.push_n(1);
+                    Ok(())
+                }
+                MemberProperty::Private(_) => Err(CompileError::Unsupported("private field")),
+            },
             _ => Err(CompileError::Unsupported("expression")),
         }
     }

--- a/src/interpreter/bytecode/op.rs
+++ b/src/interpreter/bytecode/op.rs
@@ -44,6 +44,10 @@ pub(crate) enum Op {
     LoadResolvedName = 40,
     StoreResolvedName = 41,
     UpdateName = 42,
+    GetProp = 43,
+    SetProp = 44,
+    GetElement = 45,
+    SetElement = 46,
 }
 
 impl Op {
@@ -92,6 +96,10 @@ impl Op {
             40 => Some(Op::LoadResolvedName),
             41 => Some(Op::StoreResolvedName),
             42 => Some(Op::UpdateName),
+            43 => Some(Op::GetProp),
+            44 => Some(Op::SetProp),
+            45 => Some(Op::GetElement),
+            46 => Some(Op::SetElement),
             _ => None,
         }
     }

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -93,6 +93,162 @@ fn end_to_end_constructor_with_empty_body_returns_this() {
 }
 
 #[test]
+fn end_to_end_member_assignment_in_loop_takes_bytecode_path() {
+    // Motivating case for issue #388 (mandreel's heap-copy loop shape):
+    // a numeric `for` loop whose body is nothing but member/array-element
+    // read + write. Before member-access opcodes landed, `Expression::Member`
+    // had no `compile_expr` case, so this bailed the whole body to the
+    // tree-walker (bc_count == 0) despite being otherwise loop-eligible.
+    let source = "var __r = (function(a, b, n) { \
+        for (var i = 0; i < n; i++) { a[i] = b[i]; } \
+        return a[n - 1]; \
+    })([0, 0, 0], [7, 8, 9], 3);";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(
+        count >= 1,
+        "member access inside the loop should now compile to bytecode"
+    );
+    assert!(matches!(v, JsValue::Number(n) if n == 9.0));
+}
+
+#[test]
+fn end_to_end_dot_read_takes_bytecode_path() {
+    let source = "var __r = (function(o){ return o.x; })({x: 5});";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(count >= 1, "dot read should compile to bytecode");
+    assert!(matches!(v, JsValue::Number(n) if n == 5.0));
+}
+
+#[test]
+fn end_to_end_computed_read_on_plain_array_takes_bytecode_path() {
+    let source = "var __r = (function(a,i){ return a[i]; })([10,20,30], 1);";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(count >= 1, "computed array read should compile to bytecode");
+    assert!(matches!(v, JsValue::Number(n) if n == 20.0));
+}
+
+#[test]
+fn end_to_end_computed_read_on_typed_array_takes_bytecode_path() {
+    let source = "var __r = (function(ta,i){ return ta[i]; })(new Int32Array([1,2,3]), 2);";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(
+        count >= 1,
+        "computed typed-array read should compile to bytecode"
+    );
+    assert!(matches!(v, JsValue::Number(n) if n == 3.0));
+}
+
+#[test]
+fn end_to_end_dot_write_takes_bytecode_path() {
+    let source = "var __r = (function(o){ o.x = 9; return o.x; })({});";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(count >= 1, "dot write should compile to bytecode");
+    assert!(matches!(v, JsValue::Number(n) if n == 9.0));
+}
+
+#[test]
+fn end_to_end_computed_write_on_plain_array_takes_bytecode_path() {
+    let source = "var __r = (function(a,i,v){ a[i] = v; return a[i]; })([1,2,3], 1, 42);";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(
+        count >= 1,
+        "computed array write should compile to bytecode"
+    );
+    assert!(matches!(v, JsValue::Number(n) if n == 42.0));
+}
+
+#[test]
+fn end_to_end_computed_write_on_typed_array_takes_bytecode_path() {
+    let source =
+        "var __r = (function(ta,i,v){ ta[i] = v; return ta[i]; })(new Int32Array(3), 1, 42);";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(
+        count >= 1,
+        "computed typed-array write should compile to bytecode"
+    );
+    assert!(matches!(v, JsValue::Number(n) if n == 42.0));
+}
+
+fn assert_message_parity(source: &str) {
+    let (ast_v, _) = eval_with_mode(source, false);
+    let (bc_v, bc_count) = eval_with_mode(source, true);
+    assert!(
+        bc_count >= 1,
+        "expected the member-access opcodes to compile for {source}"
+    );
+    assert_eq!(
+        format!("{ast_v}"),
+        format!("{bc_v}"),
+        "tree-walker and bytecode paths must throw the exact same message for {source}"
+    );
+}
+
+#[test]
+fn end_to_end_dot_read_null_base_message_matches_tree_walker() {
+    assert_message_parity(
+        "var __r; try { (function(o){ return o.x; })(null); } catch (e) { __r = e.message; }",
+    );
+}
+
+#[test]
+fn end_to_end_computed_read_null_base_message_matches_tree_walker() {
+    // The computed-key null/undefined-base check does NOT interpolate the
+    // key into the message (unlike the Dot case) — this pins that exactly,
+    // per the corrected design in the plan after adversarial review.
+    assert_message_parity(
+        "var __r; try { (function(k){ return null[k]; })(0); } catch (e) { __r = e.message; }",
+    );
+}
+
+#[test]
+fn end_to_end_dot_write_undefined_base_message_matches_tree_walker() {
+    assert_message_parity(
+        "var __r; try { (function(o){ o.x = 1; })(undefined); } catch (e) { __r = e.message; }",
+    );
+}
+
+#[test]
+fn end_to_end_computed_write_null_base_message_matches_tree_walker() {
+    assert_message_parity(
+        "var __r; try { (function(k){ null[k] = 1; })(0); } catch (e) { __r = e.message; }",
+    );
+}
+
+#[test]
+fn end_to_end_member_chain_base_survives_gc_during_rhs_evaluation() {
+    // Two-hop GC-rooting regression (mirrors test262-extra/GC-member-assignment-base-rooting.js,
+    // but exercises the *bytecode* GetProp/SetProp opcodes specifically). `a.base` is read
+    // first, pushing a freshly-allocated, otherwise-unreferenced object onto the VM operand
+    // stack. `a.rhs` is evaluated next as the assignment's RHS — a *separate*, later-dispatched
+    // GetProp opcode whose own getter forces a GC collection ($262.gc()) before the pending
+    // `a.base` result is ever consumed by the final SetProp("value"). A single-hop test (e.g.
+    // a bare `x.value = rhs()` where `x` is a local variable) would pass even if the VM's
+    // whole-stack rooting fix were missing, since `x` stays separately reachable via the
+    // environment/call-frame roots regardless — this shape specifically requires the fix.
+    let source = "
+        var observed = 0;
+        var prototype = { set value(v) { observed = v; } };
+        function makeBase() { return Object.create(prototype); }
+        var __r = (function(a) {
+            a.base.value = a.rhs;
+            return observed;
+        })({
+            get base() { return makeBase(); },
+            get rhs() { $262.gc(); return 42; },
+        });
+    ";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(
+        count >= 1,
+        "the containing function should compile to bytecode"
+    );
+    assert!(
+        matches!(v, JsValue::Number(n) if n == 42.0),
+        "the `a.base` result must survive the nested GC triggered while evaluating `a.rhs`, got {v:?}"
+    );
+}
+
+#[test]
 fn load_const_and_return_yields_number_completion() {
     let chunk = Chunk {
         code: vec![Op::LoadConst as u8, 0, 0, Op::Return as u8],
@@ -616,6 +772,57 @@ fn if_with_unsupported_alternate_bails_to_unsupported() {
             Literal::Number(2.0),
         )))),
     })];
+    match compile_body(&body) {
+        Err(CompileError::Unsupported(_)) => {}
+        other => panic!("expected Err(Unsupported), got {other:?}"),
+    }
+}
+
+#[test]
+fn compound_assign_on_member_bails_to_unsupported() {
+    let source = "var __r = (function(a){ a[0] += 1; return a[0]; })([1]);";
+    let (v, count) = eval_with_mode(source, true);
+    assert_eq!(
+        count, 0,
+        "compound assignment on a member target must bail to the tree-walker"
+    );
+    assert!(matches!(v, JsValue::Number(n) if n == 2.0));
+}
+
+#[test]
+fn update_on_member_bails_to_unsupported() {
+    let source = "var __r = (function(a){ a[0]++; return a[0]; })([1]);";
+    let (v, count) = eval_with_mode(source, true);
+    assert_eq!(
+        count, 0,
+        "update expression on a member target must bail to the tree-walker"
+    );
+    assert!(matches!(v, JsValue::Number(n) if n == 2.0));
+}
+
+#[test]
+fn optional_member_access_bails_to_unsupported() {
+    let source = "var __r = (function(a){ return a?.x; })({x: 3});";
+    let (v, count) = eval_with_mode(source, true);
+    assert_eq!(
+        count, 0,
+        "optional member access must bail to the tree-walker"
+    );
+    assert!(matches!(v, JsValue::Number(n) if n == 3.0));
+}
+
+#[test]
+fn private_field_member_bails_to_unsupported() {
+    use super::compiler::CompileError;
+    use crate::ast::{MemberProperty, PropSiteId};
+    // `this.#x` — private-field access always bails, regardless of what the
+    // base expression is; the `MemberProperty::Private` arm short-circuits
+    // before ever recursing into the base.
+    let body = vec![Statement::Return(Some(Expression::Member(
+        Box::new(Expression::This),
+        MemberProperty::Private("x".to_string()),
+        PropSiteId::UNASSIGNED,
+    )))];
     match compile_body(&body) {
         Err(CompileError::Unsupported(_)) => {}
         other => panic!("expected Err(Unsupported), got {other:?}"),

--- a/src/interpreter/bytecode/vm.rs
+++ b/src/interpreter/bytecode/vm.rs
@@ -18,6 +18,97 @@ fn decode_u16(chunk: &Chunk, pc: usize) -> u16 {
     (hi << 8) | lo
 }
 
+/// Roots every `JsValue::Object` currently on the operand stack, not just the
+/// current opcode's own operands. A value pushed by an earlier `GetProp`/
+/// `GetElement` (e.g. the base of `a.b.value = a.c`) can still be pending on
+/// the stack while a *later* opcode's own getter/proxy-trap/`ToPropertyKey`
+/// coercion runs and reaches a nested `gc_safepoint()` — rooting only this
+/// opcode's own operands would miss that older, still-pending value.
+fn root_operand_stack(interp: &mut Interpreter, stack: &[JsValue]) -> usize {
+    let frame = interp.gc_root_frame();
+    for v in stack {
+        interp.gc_root_value(v);
+    }
+    frame
+}
+
+fn member_get(interp: &mut Interpreter, base: &JsValue, name: &str) -> Completion {
+    if matches!(base, JsValue::Undefined | JsValue::Null) {
+        let err = interp.create_type_error(&format!(
+            "Cannot read properties of {base} (reading '{name}')"
+        ));
+        return Completion::Throw(err);
+    }
+    let obj_val = if matches!(base, JsValue::Object(_)) {
+        base.clone()
+    } else {
+        match interp.to_object(base) {
+            Completion::Normal(v) => v,
+            abrupt => return abrupt,
+        }
+    };
+    let JsValue::Object(o) = &obj_val else {
+        return Completion::Normal(JsValue::Undefined);
+    };
+    interp.get_object_property(o.id, name, &obj_val)
+}
+
+fn member_get_computed(interp: &mut Interpreter, base: &JsValue, key_val: &JsValue) -> Completion {
+    if matches!(base, JsValue::Undefined | JsValue::Null) {
+        let err = interp.create_type_error(&format!(
+            "Cannot read properties of {base} (reading property)"
+        ));
+        return Completion::Throw(err);
+    }
+    let key = match interp.to_property_key(key_val) {
+        Ok(k) => k,
+        Err(e) => return Completion::Throw(e),
+    };
+    let obj_val = if matches!(base, JsValue::Object(_)) {
+        base.clone()
+    } else {
+        match interp.to_object(base) {
+            Completion::Normal(v) => v,
+            abrupt => return abrupt,
+        }
+    };
+    let JsValue::Object(o) = &obj_val else {
+        return Completion::Normal(JsValue::Undefined);
+    };
+    interp.get_object_property(o.id, &key, &obj_val)
+}
+
+fn member_set(
+    interp: &mut Interpreter,
+    base: JsValue,
+    name: &str,
+    rhs: JsValue,
+    strict: bool,
+) -> Result<(), JsValue> {
+    if matches!(base, JsValue::Undefined | JsValue::Null) {
+        return Err(interp.create_type_error(&format!(
+            "Cannot set properties of {base} (setting '{name}')"
+        )));
+    }
+    interp.set_object_with_key(base, name, rhs, strict)
+}
+
+fn member_set_computed(
+    interp: &mut Interpreter,
+    base: JsValue,
+    key_val: &JsValue,
+    rhs: JsValue,
+    strict: bool,
+) -> Result<(), JsValue> {
+    let key = interp.to_property_key(key_val)?;
+    if matches!(base, JsValue::Undefined | JsValue::Null) {
+        return Err(interp.create_type_error(&format!(
+            "Cannot set properties of {base} (setting '{key}')"
+        )));
+    }
+    interp.set_object_with_key(base, &key, rhs, strict)
+}
+
 pub(crate) fn run_chunk(
     interp: &mut Interpreter,
     chunk: &Chunk,
@@ -107,6 +198,58 @@ pub(crate) fn run_chunk(
                 match interp.eval_identifier_update(op, prefix, name, env) {
                     Completion::Normal(value) => stack.push(value),
                     abrupt => return abrupt,
+                }
+            }
+            Op::GetProp => {
+                let idx = decode_u16(chunk, pc);
+                pc += 2;
+                let name = chunk.names[idx as usize].clone();
+                let gc_frame = root_operand_stack(interp, &stack);
+                let base = stack.pop().expect("stack underflow on GetProp");
+                let result = member_get(interp, &base, &name);
+                interp.gc_unroot_frame(gc_frame);
+                match result {
+                    Completion::Normal(v) => stack.push(v),
+                    abrupt => return abrupt,
+                }
+            }
+            Op::GetElement => {
+                let gc_frame = root_operand_stack(interp, &stack);
+                let key_val = stack.pop().expect("stack underflow on GetElement key");
+                let base = stack.pop().expect("stack underflow on GetElement base");
+                let result = member_get_computed(interp, &base, &key_val);
+                interp.gc_unroot_frame(gc_frame);
+                match result {
+                    Completion::Normal(v) => stack.push(v),
+                    abrupt => return abrupt,
+                }
+            }
+            Op::SetProp => {
+                let idx = decode_u16(chunk, pc);
+                pc += 2;
+                let name = chunk.names[idx as usize].clone();
+                let gc_frame = root_operand_stack(interp, &stack);
+                let rhs = stack.pop().expect("stack underflow on SetProp rhs");
+                let base = stack.pop().expect("stack underflow on SetProp base");
+                let strict = env.borrow().strict;
+                let result = member_set(interp, base, &name, rhs.clone(), strict);
+                interp.gc_unroot_frame(gc_frame);
+                match result {
+                    Ok(()) => stack.push(rhs),
+                    Err(e) => return Completion::Throw(e),
+                }
+            }
+            Op::SetElement => {
+                let gc_frame = root_operand_stack(interp, &stack);
+                let rhs = stack.pop().expect("stack underflow on SetElement rhs");
+                let key_val = stack.pop().expect("stack underflow on SetElement key");
+                let base = stack.pop().expect("stack underflow on SetElement base");
+                let strict = env.borrow().strict;
+                let result = member_set_computed(interp, base, &key_val, rhs.clone(), strict);
+                interp.gc_unroot_frame(gc_frame);
+                match result {
+                    Ok(()) => stack.push(rhs),
+                    Err(e) => return Completion::Throw(e),
                 }
             }
             Op::LoadUndefined => {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -4369,7 +4369,7 @@ impl Interpreter {
     }
 
     /// Set a property on an already-evaluated object+key pair (strict controls TypeError on failure).
-    fn set_object_with_key<K: PropertyKeyLike + ?Sized>(
+    pub(super) fn set_object_with_key<K: PropertyKeyLike + ?Sized>(
         &mut self,
         obj_val: JsValue,
         key: &K,


### PR DESCRIPTION
## Summary

- Extends the opt-in bytecode compiler to compile member/array-element **reads** (`a.b`, `a[k]`) and **simple-assignment writes** (`a.b = v`, `a[k] = v`), addressing the specific mandreel-motivated blocker in #388: `for (i=0;i<N;i++) heap32[i]=my_heap32[i]` previously bailed the whole containing function to the tree-walker on any `MemberExpression`.
- Adds 4 new opcodes (`GetProp`/`SetProp`/`GetElement`/`SetElement`) that reuse the tree-walker's shared `property.rs` MOP entry points rather than re-deriving `[[Get]]`/`[[Set]]` semantics.
- **Scope is narrower than #388's own suggested first slice**: no `Call` opcode (its GC-rooting-across-calls, IC-handle-plumbing, and bail-list risks are large enough to warrant a separate follow-up issue/PR — filed as #398) and no compound-assignment/update on member targets (`a[k] += v`, `a[k]++`) — the motivating loop only needs plain assignment, and supporting either would force a stack-layout change (a parallel ref-stack, mirroring `IdentifierRef`) not otherwise justified by the workload.
- The load-bearing new invariant is GC rooting across the operand stack: a value produced by one opcode (e.g. the base of `a.b.value = a.c`) can still be pending on the stack while a *later* opcode's own getter/proxy-trap/`ToPropertyKey` coercion triggers a nested collection. Every new opcode roots the *entire* current operand stack (not just its own operands) before any call that can run arbitrary JS. See `docs/specs/2026-07-25-bytecode-member-access-slice.md` for the full design writeup, including why an earlier per-opcode-only rooting design was insufficient.

This PR is a partial slice toward #388 — it does not close the issue.

**Depends on #401** (unrelated `clippy::items_after_test_module` fix in `regexp.rs`, pre-existing on `main` and blocking `--all-targets -D warnings`): this branch's own CI will show that same pre-existing failure until #401 merges and this branch rebases onto it. Not introduced by this PR.

## Test plan

- [x] `cargo test --release` — 383/383 unit tests passing (incl. new compiler/VM coverage, error-message parity tests, and a two-hop GC-hazard regression test verified to actually discriminate: reverting to a naive per-opcode-only rooting design makes it fail)
- [x] `./scripts/lint.sh` — clean once #401 is merged in (see dependency note above)
- [x] `uv run python scripts/run-test262.py -j 32` — 100.00% (99,568/99,568), 0 regressions
- [x] Release-mode timing comparison on the motivating heap-copy-loop shape (tree-walker vs `--bytecode`): stable ~33% wall-clock reduction (≈9.0s → ≈6.0s across two runs each)
