### PR TITLE
perf(bytecode): compile direct identifier calls

### DIFF
--- a/docs/specs/2026-07-26-bytecode-direct-call-slice.md
+++ b/docs/specs/2026-07-26-bytecode-direct-call-slice.md
@@ -1,0 +1,173 @@
+# Bytecode direct-call slice
+
+## Context
+
+Issue #388 found that mandreel's hot `render()` path repeatedly calls small
+register-style helper functions, but the bytecode compiler rejects every
+`CallExpression` and therefore falls back for each containing Body. PR #397
+separately covers member/array-element reads and simple-assignment writes.
+This slice covers the remaining call-shaped blocker without duplicating that
+open PR.
+
+The relevant ECMAScript algorithms are Function Calls, `EvaluateCall`, and
+`ArgumentListEvaluation` (§13.3.6 in the checked-in spec). They require callee
+evaluation before arguments, left-to-right argument evaluation, the
+environment record's `WithBaseObject()` as `this` for an identifier resolved
+through `with`, direct-eval handling, callable validation, and proper tail
+calls in strict tail positions.
+
+## Approaches considered
+
+1. **Compile bare identifier calls through the existing universal call
+   dispatcher.** Selected. This covers mandreel's translated helper-call shape
+   (`helper(r0, r1)`) while preserving one call implementation. A callee
+   independently uses bytecode when eligible and otherwise follows the
+   existing AST path, so recursive/transitive eligibility needs no new compile
+   graph.
+2. **Compile arbitrary callee expressions and member calls in one slice.**
+   Rejected. A member call must preserve a property Reference's receiver as
+   `this` and depends on PR #397's property operations. Optional calls, private
+   methods, and `super` add distinct semantics. Combining them would duplicate
+   an open patch and substantially enlarge the correctness surface.
+3. **Add call-site inline-cache probing to the VM immediately.** Rejected for
+   this slice. The AST call IC uses a Body-local `CallSiteId` and mutable
+   `current_ic_handle`. Bytecode dispatch does not yet install its Body's IC
+   handle. The direct bridge is useful without that plumbing, while adding an
+   unchecked slot lookup with a stale handle could panic. IC integration
+   remains follow-up work under #398.
+
+## Eligibility boundary
+
+The compiler accepts:
+
+- `Identifier(args)` calls;
+- any non-spread argument expression already supported by the compiler;
+- calls to native functions, bytecode-eligible user functions, and
+  bytecode-ineligible user functions.
+
+The compiler rejects the entire containing Body for:
+
+- a callee other than an Identifier, including member, optional, `super`, and
+  dynamically selected callees;
+- a bare identifier named `eval`, because it can resolve to the realm's
+  intrinsic direct eval and needs the caller's lexical environment;
+- spread arguments;
+- `new`.
+
+Rejecting every bare `eval` is intentionally conservative: a shadowing
+non-intrinsic function named `eval` could use the ordinary bridge, but the
+compiler cannot prove the runtime binding identity. Falling back preserves
+both direct-eval semantics and shadowed-eval behavior.
+
+## Bytecode and stack layout
+
+Opcode values 43–46 are left reserved for PR #397. This slice adds:
+
+- `LoadCalleeName name_index` (47), which resolves the identifier Reference,
+  loads its value, and pushes both the callable and the Reference-derived
+  `this`;
+- `Call argc` (48), which invokes the existing `call_function` bridge and
+  pushes its result;
+- `ReturnCall argc` (49), which returns a `TailCall` completion in a strict
+  function and otherwise behaves like `Call`.
+
+The operand layout immediately before either call opcode is:
+
+```text
+[..., callee, this, arg0, ..., argN]
+```
+
+`LoadCalleeName` uses `resolve_identifier_ref` followed by
+`get_identifier_value_by_ref`. `IdentifierRef::WithObject(id)` becomes the
+`this` object; other identifier references use `undefined`. Arguments compile
+left to right after both values are on the stack. The call bridge therefore
+matches `EvaluateCall`'s required ordering and keeps a getter-produced callee
+stable while arguments execute.
+
+The opcode stores `argc` as `u16`. Bodies whose call argument count or
+resulting operand height does not fit are ineligible rather than truncated.
+
+## GC rooting
+
+`JsValue::Object` holds an arena id, not an owning pointer, and the tracing GC
+does not scan the VM's Rust `Vec<JsValue>`. Calls make that existing limitation
+immediately unsafe: the callee and earlier arguments remain pending while
+later arguments can call arbitrary JavaScript and collect, and all operands
+must remain live throughout the callee's execution.
+
+The VM now mirrors every object-valued operand-stack entry into
+`gc_temp_roots`:
+
+- pushing a value roots it;
+- a non-calling pop removes its matching root;
+- binary and unary operations retain popped operand roots until coercion
+  finishes, then release them before pushing the result;
+- call operands retain their roots after removal from the operand vector,
+  across the complete nested `call_function`, and are released in reverse
+  stack order after it returns;
+- a frame marker around each `run_chunk` truncates any roots on every normal
+  or abrupt exit.
+
+This is a lifetime invariant rather than a scan before only the `Call` opcode.
+It protects a callee or earlier argument while a later nested call runs, and
+also protects older pending expression operands while name resolution or
+coercion invokes user code. Numeric mandreel operands take only the cheap
+non-object branch and add no root entries.
+
+## Tail calls
+
+The tree-walker returns `Completion::TailCall` for direct calls in strict
+return position so `call_function` can drive recursion iteratively. Compiling
+`return helper(args)` as an ordinary recursive call would turn previously
+catchable/iterative recursion into native Rust recursion.
+
+The compiler therefore emits `ReturnCall` followed by the ordinary `Return`.
+In strict functions, `ReturnCall` returns the tail-call completion before
+invoking the callee. In non-strict functions it invokes normally, pushes the
+result, and the following `Return` completes the caller.
+
+Calls nested in a tail-position conditional, logical RHS, or final sequence
+element remain ineligible for this slice. Calls under a non-tail operator,
+such as `return helper(x) | 0`, use ordinary `Call`; this is important for
+C-to-JavaScript output.
+
+## Completion and error handling
+
+`Completion::Normal(value)` and a defensive `Completion::Return(value)` from
+the bridge become the call expression's pushed result. `Completion::Empty`
+becomes `undefined`. Throws and other abrupt completions propagate out of the
+chunk. Callable validation, proxy and bound-function behavior, the catchable
+call-depth guard, parameter binding, and compiled-versus-AST callee selection
+remain owned by `call_function`.
+
+## Validation
+
+Bytecode unit/end-to-end coverage verifies:
+
+- compiled caller to compiled callee;
+- compiled caller to AST-fallback callee;
+- native calls;
+- calls in a numeric loop;
+- `with`-environment receiver preservation;
+- strict direct-return recursion beyond the normal soft call-depth limit;
+- non-callable error propagation;
+- explicit rejection of direct eval, spread, member calls, and unsupported
+  nested tail positions;
+- a freshly allocated first argument surviving a forced GC in a later
+  argument;
+- a getter-produced callee surviving a forced GC while its argument is
+  evaluated.
+
+The targeted test262 call-expression directory must pass under `--bytecode`,
+and a release-mode isolated loop repeatedly calling a small numeric helper
+must show a wall-clock improvement over the tree-walker before the slice is
+published.
+
+## Success criteria
+
+An otherwise eligible numeric loop containing `helper(args)` executes a
+bytecode Chunk; each helper independently compiles or falls back; call
+ordering, `this`, abrupt completions, direct eval, and strict tail calls match
+the tree-walker; forced collection cannot reclaim pending callees or
+arguments; targeted and full test262 runs have no baseline regression; and
+the isolated call-heavy loop is measurably faster with `--bytecode`.

--- a/docs/specs/2026-07-26-bytecode-direct-call-slice.md
+++ b/docs/specs/2026-07-26-bytecode-direct-call-slice.md
@@ -95,7 +95,8 @@ immediately unsafe: the callee and earlier arguments remain pending while
 later arguments can call arbitrary JavaScript and collect, and all operands
 must remain live throughout the callee's execution.
 
-The VM now mirrors every object-valued operand-stack entry into
+The VM now mirrors every object-valued operand-stack entry into its dedicated
+`gc_bytecode_roots` stack, which the collector scans alongside
 `gc_temp_roots`:
 
 - pushing a value roots it;
@@ -105,14 +106,19 @@ The VM now mirrors every object-valued operand-stack entry into
 - call operands retain their roots after removal from the operand vector,
   across the complete nested `call_function`, and are released in reverse
   stack order after it returns;
-- a frame marker around each `run_chunk` truncates any roots on every normal
-  or abrupt exit.
+- a frame marker around each `run_chunk` truncates bytecode roots on every
+  normal or abrupt exit.
 
 This is a lifetime invariant rather than a scan before only the `Call` opcode.
 It protects a callee or earlier argument while a later nested call runs, and
 also protects older pending expression operands while name resolution or
 coercion invokes user code. Numeric mandreel operands take only the cheap
 non-object branch and add no root entries.
+
+Keeping operand roots separate is also an ownership invariant. Native callees
+such as host timers may intentionally leave callback roots in
+`gc_temp_roots`; bytecode-frame cleanup must not truncate those persistent
+roots.
 
 ## Tail calls
 
@@ -147,6 +153,7 @@ Bytecode unit/end-to-end coverage verifies:
 - compiled caller to compiled callee;
 - compiled caller to AST-fallback callee;
 - native calls;
+- persistent callback roots installed by native callees;
 - calls in a numeric loop;
 - `with`-environment receiver preservation;
 - strict direct-return recursion beyond the normal soft call-depth limit;

--- a/docs/specs/2026-07-26-bytecode-direct-call-slice.md
+++ b/docs/specs/2026-07-26-bytecode-direct-call-slice.md
@@ -77,12 +77,14 @@ The operand layout immediately before either call opcode is:
 [..., callee, this, arg0, ..., argN]
 ```
 
-`LoadCalleeName` uses `resolve_identifier_ref` followed by
-`get_identifier_value_by_ref`. `IdentifierRef::WithObject(id)` becomes the
-`this` object; other identifier references use `undefined`. Arguments compile
-left to right after both values are on the stack. The call bridge therefore
-matches `EvaluateCall`'s required ordering and keeps a getter-produced callee
-stable while arguments execute.
+`LoadCalleeName` clears the prior receiver marker and uses the same
+single-pass `resolve_identifier` path as the tree-walker. A binding resolved
+through `with` records its object as `this`; other identifier references use
+`undefined`. Keeping resolution and value retrieval in one pass also avoids
+repeating an observable Proxy `has` trap for inherited global bindings.
+Arguments compile left to right after both values are on the stack. The call
+bridge therefore matches `EvaluateCall`'s required ordering and keeps a
+getter-produced callee stable while arguments execute.
 
 The opcode stores `argc` as `u16`. Bodies whose call argument count or
 resulting operand height does not fit are ineligible rather than truncated.
@@ -103,6 +105,9 @@ The VM now mirrors every object-valued operand-stack entry into its dedicated
 - a non-calling pop removes its matching root;
 - binary and unary operations retain popped operand roots until coercion
   finishes, then release them before pushing the result;
+- property operations keep the complete pending stack temporarily rooted
+  across getters, setters, proxy traps, and key coercion, then release the
+  dedicated roots for their consumed operands;
 - call operands retain their roots after removal from the operand vector,
   across the complete nested `call_function`, and are released in reverse
   stack order after it returns;
@@ -156,6 +161,9 @@ Bytecode unit/end-to-end coverage verifies:
 - persistent callback roots installed by native callees;
 - calls in a numeric loop;
 - `with`-environment receiver preservation;
+- global-prototype Proxy bindings invoke their observable `has` trap once,
+  including when the trap result is stateful;
+- member-access loops release consumed base and key roots before chunk exit;
 - strict direct-return recursion beyond the normal soft call-depth limit;
 - non-callable error propagation;
 - explicit rejection of direct eval, spread, member calls, and unsupported

--- a/src/interpreter/bytecode/compiler.rs
+++ b/src/interpreter/bytecode/compiler.rs
@@ -368,8 +368,52 @@ impl Compiler {
                 }
                 MemberProperty::Private(_) => Err(CompileError::Unsupported("private field")),
             },
+            Expression::Call(callee, args, _) => self.compile_call(callee, args, Op::Call),
             _ => Err(CompileError::Unsupported("expression")),
         }
+    }
+
+    fn compile_call(
+        &mut self,
+        callee: &Expression,
+        args: &[Expression],
+        op: Op,
+    ) -> Result<(), CompileError> {
+        let Expression::Identifier(name) = callee else {
+            return Err(CompileError::Unsupported("call callee"));
+        };
+        // A bare `eval` may resolve to the realm's intrinsic eval at runtime,
+        // in which case it needs the caller's lexical environment. Keep the
+        // whole Body on the tree-walker rather than changing direct-eval
+        // semantics.
+        if name == "eval" {
+            return Err(CompileError::Unsupported("direct eval call"));
+        }
+        if args.iter().any(|arg| matches!(arg, Expression::Spread(_))) {
+            return Err(CompileError::Unsupported("spread call argument"));
+        }
+        let argc = u16::try_from(args.len())
+            .map_err(|_| CompileError::Unsupported("call argument count overflow"))?;
+        if usize::from(self.current_stack) + args.len() + 2 > usize::from(u16::MAX) {
+            return Err(CompileError::Unsupported("operand stack overflow"));
+        }
+
+        let name_idx = self.add_name(name)?;
+        self.emit(Op::LoadCalleeName);
+        self.emit_u16(name_idx);
+        // Stack layout consumed by Call/ReturnCall:
+        //   [..., callee, this, arg0, ..., argN]
+        self.push_n(2);
+        for arg in args {
+            self.compile_expr(arg)?;
+        }
+        self.emit(op);
+        self.emit_u16(argc);
+        self.pop_n(argc + 2);
+        if matches!(op, Op::Call | Op::ReturnCall) {
+            self.push_n(1);
+        }
+        Ok(())
     }
 
     fn compile_var_declaration(&mut self, decl: &VariableDeclaration) -> Result<(), CompileError> {
@@ -521,7 +565,16 @@ impl Compiler {
                 self.emit(Op::ReturnUndefined);
                 Ok(())
             }
+            Statement::Return(Some(Expression::Call(callee, args, _))) => {
+                self.compile_call(callee, args, Op::ReturnCall)?;
+                self.emit(Op::Return);
+                self.pop_n(1);
+                Ok(())
+            }
             Statement::Return(Some(expr)) => {
+                if contains_tail_call(expr) {
+                    return Err(CompileError::Unsupported("nested tail call"));
+                }
                 self.compile_expr(expr)?;
                 self.emit(Op::Return);
                 self.pop_n(1);
@@ -548,6 +601,20 @@ impl Compiler {
             max_stack: self.max_stack,
             max_refs: self.max_refs,
         }
+    }
+}
+
+fn contains_tail_call(expr: &Expression) -> bool {
+    match expr {
+        Expression::Call(..) => true,
+        Expression::Conditional(_, consequent, alternate) => {
+            contains_tail_call(consequent) || contains_tail_call(alternate)
+        }
+        Expression::Logical(_, _, rhs) => contains_tail_call(rhs),
+        Expression::Sequence(exprs) | Expression::Comma(exprs) => {
+            exprs.last().is_some_and(contains_tail_call)
+        }
+        _ => false,
     }
 }
 

--- a/src/interpreter/bytecode/op.rs
+++ b/src/interpreter/bytecode/op.rs
@@ -48,6 +48,9 @@ pub(crate) enum Op {
     SetProp = 44,
     GetElement = 45,
     SetElement = 46,
+    LoadCalleeName = 47,
+    Call = 48,
+    ReturnCall = 49,
 }
 
 impl Op {
@@ -100,6 +103,9 @@ impl Op {
             44 => Some(Op::SetProp),
             45 => Some(Op::GetElement),
             46 => Some(Op::SetElement),
+            47 => Some(Op::LoadCalleeName),
+            48 => Some(Op::Call),
+            49 => Some(Op::ReturnCall),
             _ => None,
         }
     }

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -1079,6 +1079,56 @@ fn direct_native_call_takes_bytecode_path() {
 }
 
 #[test]
+fn direct_native_call_preserves_persistent_callback_root() {
+    use crate::parser::Parser;
+
+    let source = "\
+        function makeCallback() { return function() {}; } \
+        function schedule(callback) { return setTimeout(callback, 0); }";
+    let mut parser = Parser::new(source).expect("parser init");
+    let program = parser.parse_program().expect("parse");
+    let mut interp = Interpreter::new();
+    interp.bytecode_enabled = true;
+    assert!(matches!(
+        interp.run(&program),
+        Completion::Normal(_) | Completion::Empty
+    ));
+
+    let make_callback = interp
+        .get_global_var_ref("makeCallback")
+        .expect("makeCallback binding");
+    let callback = match interp.call_function(&make_callback, &JsValue::Undefined, &[]) {
+        Completion::Normal(value) => value,
+        other => panic!("makeCallback failed: {other:?}"),
+    };
+    let JsValue::Object(callback_object) = callback.clone() else {
+        panic!("makeCallback must return a function object");
+    };
+    let schedule = interp
+        .get_global_var_ref("schedule")
+        .expect("schedule binding");
+    assert!(matches!(
+        interp.call_function(&schedule, &JsValue::Undefined, &[callback]),
+        Completion::Normal(_)
+    ));
+    assert!(
+        interp.bytecode_chunks_executed >= 1,
+        "schedule must execute through bytecode"
+    );
+    assert!(
+        interp.gc_bytecode_roots.is_empty(),
+        "bytecode operand roots must be released with the frame"
+    );
+
+    interp.gc.request();
+    interp.gc_safepoint();
+    assert!(
+        interp.get_object_cell(callback_object.id).is_some(),
+        "setTimeout's persistent callback root must survive the bytecode frame"
+    );
+}
+
+#[test]
 fn loop_with_direct_calls_takes_bytecode_path() {
     assert_parity_number(
         "\

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -1032,3 +1032,214 @@ fn loop_with_break_falls_back_to_tree_walker() {
     assert_eq!(count, 0, "break lowering is not part of this slice");
     assert!(matches!(value, JsValue::Number(n) if n == 1.0));
 }
+
+// ----- direct identifier calls -----
+
+#[test]
+fn direct_call_compiles_caller_and_compilable_callee() {
+    let source = "\
+        function addOne(value) { return value + 1; } \
+        var __r = (function(value) { return addOne(value); })(41);";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(
+        bytecode_count >= 2,
+        "caller and callee must both execute bytecode"
+    );
+    assert!(matches!(ast, JsValue::Number(n) if n == 42.0));
+    assert!(matches!(bytecode, JsValue::Number(n) if n == 42.0));
+}
+
+#[test]
+fn direct_call_bridges_to_ineligible_callee() {
+    let source = "\
+        function readObject(value) { var box = { value: value }; return box.value; } \
+        var __r = (function(value) { return readObject(value); })(37);";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert_eq!(
+        bytecode_count, 1,
+        "only the caller should compile; the object/member callee must fall back"
+    );
+    assert!(matches!(ast, JsValue::Number(n) if n == 37.0));
+    assert!(matches!(bytecode, JsValue::Number(n) if n == 37.0));
+}
+
+#[test]
+fn direct_native_call_takes_bytecode_path() {
+    let source = "var __r = (function(value) { return parseInt(value); })('42');";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert_eq!(bytecode_count, 1, "native callee has no bytecode Body");
+    assert!(matches!(ast, JsValue::Number(n) if n == 42.0));
+    assert!(matches!(bytecode, JsValue::Number(n) if n == 42.0));
+}
+
+#[test]
+fn loop_with_direct_calls_takes_bytecode_path() {
+    assert_parity_number(
+        "\
+            function addOne(value) { return value + 1; } \
+            var __r = (function(limit) { \
+                var sum = 0; \
+                for (var i = 0; i < limit; i++) { sum += addOne(i); } \
+                return sum; \
+            })(5);",
+        15.0,
+    );
+}
+
+#[test]
+fn direct_call_preserves_with_base_as_this_value() {
+    let source = "\
+        var scope = { \
+            value: 40, \
+            invoke: function(value) { return this.value + value; } \
+        }; \
+        var runner; \
+        with (scope) { runner = function() { return invoke(2); }; } \
+        var __r = runner();";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(bytecode_count >= 1, "runner must execute through bytecode");
+    assert!(matches!(ast, JsValue::Number(n) if n == 42.0));
+    assert!(matches!(bytecode, JsValue::Number(n) if n == 42.0));
+}
+
+#[test]
+fn pending_argument_survives_gc_during_later_call_argument() {
+    let source = "\
+        var collect = $262.gc; \
+        var observed = 0; \
+        function makeValue() { return { marker: 42 }; } \
+        function consume(value, ignored) { observed = value.marker; } \
+        function run() { consume(makeValue(), collect()); } \
+        run(); \
+        var __r = observed;";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(bytecode_count >= 1, "run must execute through bytecode");
+    assert!(matches!(ast, JsValue::Number(n) if n == 42.0));
+    assert!(matches!(bytecode, JsValue::Number(n) if n == 42.0));
+}
+
+#[test]
+fn pending_with_getter_callee_survives_gc_during_argument() {
+    let source = "\
+        var collect = $262.gc; \
+        var observed = 0; \
+        var scope; \
+        scope = { \
+            get invoke() { \
+                return function(ignored) { observed = this === scope ? 17 : -1; }; \
+            } \
+        }; \
+        var runner; \
+        with (scope) { runner = function() { invoke(collect()); }; } \
+        runner(); \
+        var __r = observed;";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(bytecode_count >= 1, "runner must execute through bytecode");
+    assert!(matches!(ast, JsValue::Number(n) if n == 17.0));
+    assert!(matches!(bytecode, JsValue::Number(n) if n == 17.0));
+}
+
+#[test]
+fn strict_direct_return_call_preserves_tail_calls() {
+    let source = "\
+        function recur(count) { \
+            'use strict'; \
+            if (count === 0) return 42; \
+            return recur(count - 1); \
+        } \
+        var __r = recur(2000);";
+    let (value, bytecode_count) = eval_with_mode(source, true);
+    assert!(
+        bytecode_count >= 2001,
+        "every recursive dispatch must execute bytecode"
+    );
+    assert!(matches!(value, JsValue::Number(n) if n == 42.0));
+}
+
+#[test]
+fn non_callable_direct_call_throws_via_bytecode() {
+    let source = "\
+        var value = 1; \
+        var __r = false; \
+        function run() { return value(); } \
+        try { run(); } catch (error) { __r = error instanceof TypeError; }";
+    let (value, bytecode_count) = eval_with_mode(source, true);
+    assert!(bytecode_count >= 1, "run must execute through bytecode");
+    assert!(matches!(value, JsValue::Boolean(true)));
+}
+
+#[test]
+fn direct_eval_and_spread_calls_remain_ineligible() {
+    use super::compiler::CompileError;
+    use crate::ast::CallSiteId;
+
+    let direct_eval = vec![Statement::Expression(Expression::Call(
+        Box::new(Expression::Identifier("eval".to_string())),
+        vec![Expression::Literal(Literal::String(
+            "var x = 1".encode_utf16().collect(),
+        ))],
+        CallSiteId::UNASSIGNED,
+    ))];
+    assert!(matches!(
+        compile_body(&direct_eval),
+        Err(CompileError::Unsupported(_))
+    ));
+
+    let spread = vec![Statement::Expression(Expression::Call(
+        Box::new(Expression::Identifier("f".to_string())),
+        vec![Expression::Spread(Box::new(Expression::Identifier(
+            "args".to_string(),
+        )))],
+        CallSiteId::UNASSIGNED,
+    ))];
+    assert!(matches!(
+        compile_body(&spread),
+        Err(CompileError::Unsupported(_))
+    ));
+}
+
+#[test]
+fn member_calls_and_nested_tail_positions_remain_ineligible() {
+    use super::compiler::CompileError;
+    use crate::ast::{CallSiteId, LogicalOp, MemberProperty, PropSiteId};
+
+    let member_call = vec![Statement::Expression(Expression::Call(
+        Box::new(Expression::Member(
+            Box::new(Expression::Identifier("object".to_string())),
+            MemberProperty::Dot("method".to_string()),
+            PropSiteId::UNASSIGNED,
+        )),
+        vec![],
+        CallSiteId::UNASSIGNED,
+    ))];
+    assert!(matches!(
+        compile_body(&member_call),
+        Err(CompileError::Unsupported(_))
+    ));
+
+    let nested_tail_call = Expression::Logical(
+        LogicalOp::And,
+        Box::new(Expression::Identifier("condition".to_string())),
+        Box::new(Expression::Call(
+            Box::new(Expression::Identifier("f".to_string())),
+            vec![],
+            CallSiteId::UNASSIGNED,
+        )),
+    );
+    assert!(matches!(
+        compile_body(&[Statement::Return(Some(nested_tail_call))]),
+        Err(CompileError::Unsupported(_))
+    ));
+}

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -1243,6 +1243,74 @@ fn direct_call_preserves_with_base_as_this_value() {
 }
 
 #[test]
+fn direct_call_clears_stale_with_base_before_global_resolution() {
+    let source = "
+        var observed = 0;
+        function recordThis() {
+            'use strict';
+            observed = this === undefined ? 1 : -1;
+        }
+        var runner;
+        with ({ value: 42 }) {
+            runner = function() {
+                var ignored = value;
+                recordThis();
+            };
+        }
+        runner();
+        var __r = observed;
+    ";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(bytecode_count >= 1, "runner must execute through bytecode");
+    assert!(matches!(ast, JsValue::Number(n) if n == 1.0));
+    assert!(
+        matches!(bytecode, JsValue::Number(n) if n == 1.0),
+        "a global call must not inherit a with base from an earlier identifier read"
+    );
+}
+
+#[test]
+fn direct_call_checks_global_proxy_binding_once() {
+    let source = "
+        var hasCount = 0;
+        var callCount = 0;
+        var outcome = 0;
+        var oldPrototype = Object.getPrototypeOf($262.global);
+        var target = { fn: function() { callCount = callCount + 1; } };
+        var proxy = new Proxy(target, {
+            has: function(target, key) {
+                if (key === 'fn') {
+                    hasCount = hasCount + 1;
+                    return hasCount === 1;
+                }
+                return Reflect.has(target, key);
+            },
+        });
+        Object.setPrototypeOf($262.global, proxy);
+        function run() { fn(); }
+        try {
+            run();
+            outcome = 100;
+        } catch (error) {
+            outcome = -100;
+        }
+        Object.setPrototypeOf($262.global, oldPrototype);
+        var __r = outcome + hasCount * 10 + callCount;
+    ";
+    let (ast, ast_count) = eval_with_mode(source, false);
+    let (bytecode, bytecode_count) = eval_with_mode(source, true);
+    assert_eq!(ast_count, 0);
+    assert!(bytecode_count >= 1, "run must execute through bytecode");
+    assert!(matches!(ast, JsValue::Number(n) if n == 111.0));
+    assert!(
+        matches!(bytecode, JsValue::Number(n) if n == 111.0),
+        "bytecode must invoke the stateful global proxy has trap exactly once, got {bytecode:?}"
+    );
+}
+
+#[test]
 fn pending_argument_survives_gc_during_later_call_argument() {
     let source = "\
         var collect = $262.gc; \

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -112,6 +112,54 @@ fn end_to_end_member_assignment_in_loop_takes_bytecode_path() {
 }
 
 #[test]
+fn property_access_loop_releases_consumed_operand_roots() {
+    use crate::parser::Parser;
+
+    let source = "
+        function collect() { $262.gc(); }
+        function make() { return { value: 1 }; }
+        function makeKey() { return ['value']; }
+        function hot(limit) {
+            for (var i = 0; i < limit; i++) {
+                collect();
+                make().value;
+                make()[makeKey()];
+                make().value = 1;
+                make()[makeKey()] = 1;
+            }
+            collect();
+        }
+    ";
+    let mut parser = Parser::new(source).expect("parser init");
+    let program = parser.parse_program().expect("parse");
+    let mut interp = Interpreter::new();
+    interp.bytecode_enabled = true;
+    assert!(matches!(
+        interp.run(&program),
+        Completion::Normal(_) | Completion::Empty
+    ));
+    interp.gc.request();
+    interp.gc_safepoint();
+    let live_before = interp.objects.live_count();
+
+    let hot = interp.get_global_var_ref("hot").expect("hot binding");
+    let chunks_before = interp.bytecode_chunks_executed;
+    assert!(matches!(
+        interp.call_function(&hot, &JsValue::Undefined, &[JsValue::Number(64.0)]),
+        Completion::Normal(_)
+    ));
+    assert!(
+        interp.bytecode_chunks_executed > chunks_before,
+        "the property-access loop must execute through bytecode"
+    );
+    assert_eq!(
+        interp.objects.live_count(),
+        live_before,
+        "consumed property bases and keys must be collectable before the bytecode chunk exits"
+    );
+}
+
+#[test]
 fn end_to_end_dot_read_takes_bytecode_path() {
     let source = "var __r = (function(o){ return o.x; })({x: 5});";
     let (v, count) = eval_with_mode(source, true);

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -249,6 +249,40 @@ fn end_to_end_member_chain_base_survives_gc_during_rhs_evaluation() {
 }
 
 #[test]
+fn end_to_end_getprop_call_argument_survives_gc_during_sibling_arg_evaluation() {
+    // Regression for merging PR #399 (calls) with PR #397 (member access): `GetProp`
+    // pushed its result with a raw `stack.push`, bypassing `push_value`'s
+    // `gc_bytecode_roots` rooting. Harmless while GetProp and Call were compiled by
+    // separate PRs, but the merged VM now compiles `identity(a.child, forceGc())`
+    // end-to-end: `a.child`'s freshly-allocated, otherwise-unreferenced result sits
+    // on the *same chunk's* operand stack as a pending Call argument while the
+    // *second* argument's own nested call runs and forces a GC before the outer
+    // Call consumes it.
+    let source = "
+        function identity(x, _y) { return x; }
+        function forceGc() { $262.gc(); return 0; }
+        var __r = (function(a) {
+            return identity(a.child, forceGc()).tag;
+        })({
+            get child() {
+                var o = Object.create(null);
+                o.tag = 'ok';
+                return o;
+            },
+        });
+    ";
+    let (v, count) = eval_with_mode(source, true);
+    assert!(
+        count >= 1,
+        "the containing function should compile to bytecode"
+    );
+    assert!(
+        matches!(&v, JsValue::String(s) if s.to_string() == "ok"),
+        "GetProp's call-argument result must survive the GC forced while evaluating a sibling call argument, got {v:?}"
+    );
+}
+
+#[test]
 fn load_const_and_return_yields_number_completion() {
     let chunk = Chunk {
         code: vec![Op::LoadConst as u8, 0, 0, Op::Return as u8],

--- a/src/interpreter/bytecode/vm.rs
+++ b/src/interpreter/bytecode/vm.rs
@@ -289,6 +289,7 @@ fn run_chunk_inner(
                 let gc_frame = root_operand_stack(interp, &stack);
                 let base = stack.pop().expect("stack underflow on GetProp");
                 let result = member_get(interp, &base, &name);
+                unroot_stack_value(interp, &base);
                 interp.gc_unroot_frame(gc_frame);
                 match result {
                     Completion::Normal(v) => push_value(interp, &mut stack, v),
@@ -300,6 +301,8 @@ fn run_chunk_inner(
                 let key_val = stack.pop().expect("stack underflow on GetElement key");
                 let base = stack.pop().expect("stack underflow on GetElement base");
                 let result = member_get_computed(interp, &base, &key_val);
+                unroot_stack_value(interp, &key_val);
+                unroot_stack_value(interp, &base);
                 interp.gc_unroot_frame(gc_frame);
                 match result {
                     Completion::Normal(v) => push_value(interp, &mut stack, v),
@@ -313,8 +316,11 @@ fn run_chunk_inner(
                 let gc_frame = root_operand_stack(interp, &stack);
                 let rhs = stack.pop().expect("stack underflow on SetProp rhs");
                 let base = stack.pop().expect("stack underflow on SetProp base");
+                let base_root = base.clone();
                 let strict = env.borrow().strict;
                 let result = member_set(interp, base, &name, rhs.clone(), strict);
+                unroot_stack_value(interp, &rhs);
+                unroot_stack_value(interp, &base_root);
                 interp.gc_unroot_frame(gc_frame);
                 match result {
                     Ok(()) => push_value(interp, &mut stack, rhs),
@@ -326,8 +332,12 @@ fn run_chunk_inner(
                 let rhs = stack.pop().expect("stack underflow on SetElement rhs");
                 let key_val = stack.pop().expect("stack underflow on SetElement key");
                 let base = stack.pop().expect("stack underflow on SetElement base");
+                let base_root = base.clone();
                 let strict = env.borrow().strict;
                 let result = member_set_computed(interp, base, &key_val, rhs.clone(), strict);
+                unroot_stack_value(interp, &rhs);
+                unroot_stack_value(interp, &key_val);
+                unroot_stack_value(interp, &base_root);
                 interp.gc_unroot_frame(gc_frame);
                 match result {
                     Ok(()) => push_value(interp, &mut stack, rhs),

--- a/src/interpreter/bytecode/vm.rs
+++ b/src/interpreter/bytecode/vm.rs
@@ -32,6 +32,38 @@ fn root_operand_stack(interp: &mut Interpreter, stack: &[JsValue]) -> usize {
     frame
 }
 
+fn push_value(interp: &mut Interpreter, stack: &mut Vec<JsValue>, value: JsValue) {
+    interp.gc_root_value(&value);
+    stack.push(value);
+}
+
+fn pop_value(interp: &mut Interpreter, stack: &mut Vec<JsValue>, context: &'static str) -> JsValue {
+    let value = stack.pop().unwrap_or_else(|| panic!("{context}"));
+    interp.gc_unroot_value(&value);
+    value
+}
+
+fn take_call_operands(stack: &mut Vec<JsValue>, argc: usize) -> (JsValue, JsValue, Vec<JsValue>) {
+    assert!(stack.len() >= argc + 2, "stack underflow on call operands");
+    let args = stack.split_off(stack.len() - argc);
+    let this_value = stack.pop().expect("stack underflow on call this");
+    let callee = stack.pop().expect("stack underflow on call callee");
+    (callee, this_value, args)
+}
+
+fn release_call_operands(
+    interp: &mut Interpreter,
+    callee: &JsValue,
+    this_value: &JsValue,
+    args: &[JsValue],
+) {
+    for arg in args.iter().rev() {
+        interp.gc_unroot_value(arg);
+    }
+    interp.gc_unroot_value(this_value);
+    interp.gc_unroot_value(callee);
+}
+
 fn member_get(interp: &mut Interpreter, base: &JsValue, name: &str) -> Completion {
     if matches!(base, JsValue::Undefined | JsValue::Null) {
         let err = interp.create_type_error(&format!(
@@ -113,6 +145,18 @@ pub(crate) fn run_chunk(
     interp: &mut Interpreter,
     chunk: &Chunk,
     env: &EnvRef,
+    this_value: JsValue,
+) -> Completion {
+    let gc_frame = interp.gc_root_frame();
+    let result = run_chunk_inner(interp, chunk, env, this_value);
+    interp.gc_unroot_frame(gc_frame);
+    result
+}
+
+fn run_chunk_inner(
+    interp: &mut Interpreter,
+    chunk: &Chunk,
+    env: &EnvRef,
     _this: JsValue,
 ) -> Completion {
     interp.bytecode_chunks_executed += 1;
@@ -135,7 +179,7 @@ pub(crate) fn run_chunk(
                 let idx = decode_u16(chunk, pc);
                 pc += 2;
                 let v = chunk.constants[idx as usize].to_value();
-                stack.push(v);
+                push_value(interp, &mut stack, v);
             }
             Op::LoadName => {
                 let idx = decode_u16(chunk, pc);
@@ -143,9 +187,30 @@ pub(crate) fn run_chunk(
                 let name = chunk.names[idx as usize].clone();
                 let strict = env.borrow().strict;
                 match interp.resolve_identifier(&name, env, strict) {
-                    Completion::Normal(v) => stack.push(v),
+                    Completion::Normal(v) => push_value(interp, &mut stack, v),
                     abrupt => return abrupt,
                 }
+            }
+            Op::LoadCalleeName => {
+                let idx = decode_u16(chunk, pc);
+                pc += 2;
+                let name = &chunk.names[idx as usize];
+                let id_ref = match interp.resolve_identifier_ref(name, env) {
+                    Ok(id_ref) => id_ref,
+                    Err(error) => return Completion::Throw(error),
+                };
+                let callee = match interp.get_identifier_value_by_ref(name, &id_ref, env) {
+                    Completion::Normal(value) => value,
+                    abrupt => return abrupt,
+                };
+                let this_value = match id_ref {
+                    IdentifierRef::WithObject(id) => JsValue::Object(crate::types::JsObject { id }),
+                    IdentifierRef::Unresolvable | IdentifierRef::SpecificEnv(_) => {
+                        JsValue::Undefined
+                    }
+                };
+                push_value(interp, &mut stack, callee);
+                push_value(interp, &mut stack, this_value);
             }
             Op::ResolveName => {
                 let idx = decode_u16(chunk, pc);
@@ -164,7 +229,7 @@ pub(crate) fn run_chunk(
                     .last()
                     .expect("reference stack underflow on LoadResolvedName");
                 match interp.get_identifier_value_by_ref(name, id_ref, env) {
-                    Completion::Normal(value) => stack.push(value),
+                    Completion::Normal(value) => push_value(interp, &mut stack, value),
                     abrupt => return abrupt,
                 }
             }
@@ -196,7 +261,7 @@ pub(crate) fn run_chunk(
                 };
                 let name = &chunk.names[idx as usize];
                 match interp.eval_identifier_update(op, prefix, name, env) {
-                    Completion::Normal(value) => stack.push(value),
+                    Completion::Normal(value) => push_value(interp, &mut stack, value),
                     abrupt => return abrupt,
                 }
             }
@@ -253,23 +318,55 @@ pub(crate) fn run_chunk(
                 }
             }
             Op::LoadUndefined => {
-                stack.push(JsValue::Undefined);
+                push_value(interp, &mut stack, JsValue::Undefined);
             }
             Op::LoadTrue => {
-                stack.push(JsValue::Boolean(true));
+                push_value(interp, &mut stack, JsValue::Boolean(true));
             }
             Op::LoadFalse => {
-                stack.push(JsValue::Boolean(false));
+                push_value(interp, &mut stack, JsValue::Boolean(false));
             }
             Op::LoadNull => {
-                stack.push(JsValue::Null);
+                push_value(interp, &mut stack, JsValue::Null);
             }
             Op::Return => {
-                let v = stack.pop().unwrap_or(JsValue::Undefined);
+                let v = if stack.is_empty() {
+                    JsValue::Undefined
+                } else {
+                    pop_value(interp, &mut stack, "stack underflow on Return")
+                };
                 return Completion::Return(v);
             }
             Op::ReturnUndefined => {
                 return Completion::Return(JsValue::Undefined);
+            }
+            Op::Call | Op::ReturnCall => {
+                let argc = decode_u16(chunk, pc) as usize;
+                pc += 2;
+                let (callee, this_value, args) = take_call_operands(&mut stack, argc);
+                if op == Op::ReturnCall && env.borrow().strict {
+                    release_call_operands(interp, &callee, &this_value, &args);
+                    return Completion::TailCall {
+                        func: callee,
+                        this: this_value,
+                        args,
+                    };
+                }
+                // The operands remain in gc_temp_roots for the complete
+                // nested invocation even though they have been removed from
+                // the operand Vec. A callee can execute arbitrary JS and hit
+                // any number of safepoints before returning.
+                let result = interp.call_function(&callee, &this_value, &args);
+                release_call_operands(interp, &callee, &this_value, &args);
+                match result {
+                    Completion::Normal(value) | Completion::Return(value) => {
+                        push_value(interp, &mut stack, value);
+                    }
+                    Completion::Empty => {
+                        push_value(interp, &mut stack, JsValue::Undefined);
+                    }
+                    abrupt => return abrupt,
+                }
             }
             Op::Add
             | Op::Sub
@@ -316,8 +413,11 @@ pub(crate) fn run_chunk(
                     Op::UShr => BinaryOp::URShift,
                     _ => unreachable!(),
                 };
-                match interp.eval_binary(bop, &l, &r) {
-                    Completion::Normal(v) => stack.push(v),
+                let result = interp.eval_binary(bop, &l, &r);
+                interp.gc_unroot_value(&r);
+                interp.gc_unroot_value(&l);
+                match result {
+                    Completion::Normal(v) => push_value(interp, &mut stack, v),
                     abrupt => return abrupt,
                 }
             }
@@ -330,13 +430,15 @@ pub(crate) fn run_chunk(
                     Op::BitNot => UnaryOp::BitNot,
                     _ => unreachable!(),
                 };
-                match interp.eval_unary(uop, &v) {
-                    Completion::Normal(r) => stack.push(r),
+                let result = interp.eval_unary(uop, &v);
+                interp.gc_unroot_value(&v);
+                match result {
+                    Completion::Normal(r) => push_value(interp, &mut stack, r),
                     abrupt => return abrupt,
                 }
             }
             Op::Pop => {
-                stack.pop().expect("stack underflow on Pop");
+                pop_value(interp, &mut stack, "stack underflow on Pop");
             }
             Op::Jump => {
                 let offset = decode_i16(chunk, pc) as i32;
@@ -350,7 +452,7 @@ pub(crate) fn run_chunk(
             Op::JumpIfFalse => {
                 let offset = decode_i16(chunk, pc) as i32;
                 pc += 2;
-                let v = stack.pop().expect("stack underflow on JumpIfFalse");
+                let v = pop_value(interp, &mut stack, "stack underflow on JumpIfFalse");
                 if !interp.to_boolean_val(&v) {
                     pc = (pc as i32 + offset) as usize;
                 }
@@ -358,7 +460,7 @@ pub(crate) fn run_chunk(
             Op::JumpIfTrue => {
                 let offset = decode_i16(chunk, pc) as i32;
                 pc += 2;
-                let v = stack.pop().expect("stack underflow on JumpIfTrue");
+                let v = pop_value(interp, &mut stack, "stack underflow on JumpIfTrue");
                 if interp.to_boolean_val(&v) {
                     pc = (pc as i32 + offset) as usize;
                 }

--- a/src/interpreter/bytecode/vm.rs
+++ b/src/interpreter/bytecode/vm.rs
@@ -32,14 +32,31 @@ fn root_operand_stack(interp: &mut Interpreter, stack: &[JsValue]) -> usize {
     frame
 }
 
+fn root_stack_value(interp: &mut Interpreter, value: &JsValue) {
+    if let JsValue::Object(object) = value {
+        interp.gc_bytecode_roots.push(object.id);
+    }
+}
+
+fn unroot_stack_value(interp: &mut Interpreter, value: &JsValue) {
+    if let JsValue::Object(object) = value
+        && let Some(pos) = interp
+            .gc_bytecode_roots
+            .iter()
+            .rposition(|&id| id == object.id)
+    {
+        interp.gc_bytecode_roots.remove(pos);
+    }
+}
+
 fn push_value(interp: &mut Interpreter, stack: &mut Vec<JsValue>, value: JsValue) {
-    interp.gc_root_value(&value);
+    root_stack_value(interp, &value);
     stack.push(value);
 }
 
 fn pop_value(interp: &mut Interpreter, stack: &mut Vec<JsValue>, context: &'static str) -> JsValue {
     let value = stack.pop().unwrap_or_else(|| panic!("{context}"));
-    interp.gc_unroot_value(&value);
+    unroot_stack_value(interp, &value);
     value
 }
 
@@ -58,10 +75,10 @@ fn release_call_operands(
     args: &[JsValue],
 ) {
     for arg in args.iter().rev() {
-        interp.gc_unroot_value(arg);
+        unroot_stack_value(interp, arg);
     }
-    interp.gc_unroot_value(this_value);
-    interp.gc_unroot_value(callee);
+    unroot_stack_value(interp, this_value);
+    unroot_stack_value(interp, callee);
 }
 
 fn member_get(interp: &mut Interpreter, base: &JsValue, name: &str) -> Completion {
@@ -147,9 +164,9 @@ pub(crate) fn run_chunk(
     env: &EnvRef,
     this_value: JsValue,
 ) -> Completion {
-    let gc_frame = interp.gc_root_frame();
+    let gc_frame = interp.gc_bytecode_roots.len();
     let result = run_chunk_inner(interp, chunk, env, this_value);
-    interp.gc_unroot_frame(gc_frame);
+    interp.gc_bytecode_roots.truncate(gc_frame);
     result
 }
 
@@ -274,7 +291,7 @@ fn run_chunk_inner(
                 let result = member_get(interp, &base, &name);
                 interp.gc_unroot_frame(gc_frame);
                 match result {
-                    Completion::Normal(v) => stack.push(v),
+                    Completion::Normal(v) => push_value(interp, &mut stack, v),
                     abrupt => return abrupt,
                 }
             }
@@ -285,7 +302,7 @@ fn run_chunk_inner(
                 let result = member_get_computed(interp, &base, &key_val);
                 interp.gc_unroot_frame(gc_frame);
                 match result {
-                    Completion::Normal(v) => stack.push(v),
+                    Completion::Normal(v) => push_value(interp, &mut stack, v),
                     abrupt => return abrupt,
                 }
             }
@@ -300,7 +317,7 @@ fn run_chunk_inner(
                 let result = member_set(interp, base, &name, rhs.clone(), strict);
                 interp.gc_unroot_frame(gc_frame);
                 match result {
-                    Ok(()) => stack.push(rhs),
+                    Ok(()) => push_value(interp, &mut stack, rhs),
                     Err(e) => return Completion::Throw(e),
                 }
             }
@@ -313,7 +330,7 @@ fn run_chunk_inner(
                 let result = member_set_computed(interp, base, &key_val, rhs.clone(), strict);
                 interp.gc_unroot_frame(gc_frame);
                 match result {
-                    Ok(()) => stack.push(rhs),
+                    Ok(()) => push_value(interp, &mut stack, rhs),
                     Err(e) => return Completion::Throw(e),
                 }
             }
@@ -352,7 +369,7 @@ fn run_chunk_inner(
                         args,
                     };
                 }
-                // The operands remain in gc_temp_roots for the complete
+                // The operands remain in gc_bytecode_roots for the complete
                 // nested invocation even though they have been removed from
                 // the operand Vec. A callee can execute arbitrary JS and hit
                 // any number of safepoints before returning.
@@ -414,8 +431,8 @@ fn run_chunk_inner(
                     _ => unreachable!(),
                 };
                 let result = interp.eval_binary(bop, &l, &r);
-                interp.gc_unroot_value(&r);
-                interp.gc_unroot_value(&l);
+                unroot_stack_value(interp, &r);
+                unroot_stack_value(interp, &l);
                 match result {
                     Completion::Normal(v) => push_value(interp, &mut stack, v),
                     abrupt => return abrupt,
@@ -431,7 +448,7 @@ fn run_chunk_inner(
                     _ => unreachable!(),
                 };
                 let result = interp.eval_unary(uop, &v);
-                interp.gc_unroot_value(&v);
+                unroot_stack_value(interp, &v);
                 match result {
                     Completion::Normal(r) => push_value(interp, &mut stack, r),
                     abrupt => return abrupt,

--- a/src/interpreter/bytecode/vm.rs
+++ b/src/interpreter/bytecode/vm.rs
@@ -212,19 +212,16 @@ fn run_chunk_inner(
                 let idx = decode_u16(chunk, pc);
                 pc += 2;
                 let name = &chunk.names[idx as usize];
-                let id_ref = match interp.resolve_identifier_ref(name, env) {
-                    Ok(id_ref) => id_ref,
-                    Err(error) => return Completion::Throw(error),
+                let strict = env.borrow().strict;
+                interp.last_identifier_with_base = None;
+                let callee_result = interp.resolve_identifier(name, env, strict);
+                let this_value = match interp.last_identifier_with_base.take() {
+                    Some(id) => JsValue::Object(crate::types::JsObject { id }),
+                    None => JsValue::Undefined,
                 };
-                let callee = match interp.get_identifier_value_by_ref(name, &id_ref, env) {
+                let callee = match callee_result {
                     Completion::Normal(value) => value,
                     abrupt => return abrupt,
-                };
-                let this_value = match id_ref {
-                    IdentifierRef::WithObject(id) => JsValue::Object(crate::types::JsObject { id }),
-                    IdentifierRef::Unresolvable | IdentifierRef::SpecificEnv(_) => {
-                        JsValue::Undefined
-                    }
                 };
                 push_value(interp, &mut stack, callee);
                 push_value(interp, &mut stack, this_value);

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -306,6 +306,8 @@ impl Interpreter {
             }
         }
         roots.extend_from_slice(&self.gc_temp_roots);
+        // Values held by active bytecode operand stacks
+        roots.extend_from_slice(&self.gc_bytecode_roots);
         for microtask_roots in self.scheduler.iter_microtask_roots() {
             for val in microtask_roots {
                 Self::collect_value_roots(val, &mut roots);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -113,6 +113,7 @@ pub(crate) struct Interpreter {
     pub(crate) call_stack_envs: Vec<EnvRef>,
     pub(crate) call_stack_frames: Vec<CallFrame>,
     pub(crate) gc_temp_roots: Vec<u64>,
+    pub(crate) gc_bytecode_roots: Vec<u64>,
     // microtask roots are stored inline alongside their jobs in JobScheduler
     pub(crate) class_private_names: Vec<HashMap<String, String>>,
     next_class_brand_id: u64,
@@ -387,6 +388,7 @@ impl Interpreter {
             call_stack_envs: Vec::new(),
             call_stack_frames: Vec::new(),
             gc_temp_roots: Vec::new(),
+            gc_bytecode_roots: Vec::new(),
             class_private_names: Vec::new(),
             next_class_brand_id: 0,
             next_auto_accessor_id: 0,


### PR DESCRIPTION
## Summary

- compile bare identifier calls into the opt-in bytecode VM, bridging through the existing universal call dispatcher so eligible callees compile independently and ineligible/native callees fall back correctly
- preserve callee-before-arguments ordering, `with`-environment receivers, strict proper-tail-call behavior, abrupt completions, and conservative bailouts for direct eval, spread, member, optional, super, and new calls
- keep every object-valued VM operand explicitly GC-rooted while pending or crossing a nested call; forced-GC tests cover both pending arguments and getter-produced callees
- opcode values 43-46 (member-access, from #397) and 47-49 (calls, this PR) now coexist after rebasing onto `main` following #397's merge — see the "Merge with #397" section below

## Performance

An isolated release-mode loop making 2,000,000 small numeric helper calls improved from a 1.32s median on the tree-walker to 0.93s with `--bytecode`, about a 30% wall-clock reduction across five runs per mode.

## Merge with #397 (post-review rebase)

#397 (bytecode member/array-element access) merged into `main` while this PR was open, using exactly the opcode range (43-46) this PR had reserved for it. Rebased onto `main` to resolve:
- `op.rs`/`compiler.rs`: combined both opcode allocations, no semantic overlap.
- `vm.rs`: combined both GC-rooting schemes (`root_operand_stack` from #397, `push_value`/`pop_value`/`gc_bytecode_roots` from this PR) and fixed one real gap the merge exposed — `GetProp`/`GetElement`/`SetProp`/`SetElement` pushed results via a raw `stack.push`, bypassing rooting. Harmless while the two features were separate; a real use-after-collection risk once the merged VM compiles `f(a.b)` end-to-end. Added and verified a regression test for this (`2b927f4`).

Running the full test262 suite with `--bytecode` after the rebase surfaced two pre-existing issues in #397's own bytecode member-access work (confirmed independent of this PR by testing plain `origin/main`), filed rather than fixed here since a correct fix touches shared `[[Set]]` machinery used engine-wide:
- #416 — primitive-base strict-mode `[[Set]]` silently succeeds instead of throwing, newly *reachable* via this PR's call compilation but not caused by it.
- #417 — 7 other test262 scenarios already failing under `--bytecode` on plain `main`.

CI does not run test262 with `--bytecode`, so neither blocks this PR.

## Validation

- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release` (396 unit tests, 3 integration tests, smoke oracle)
- `uv run python scripts/run-custom-tests.py` (11/11)
- `uv run python scripts/run-test262.py --bytecode -j 16 test262/test/language/expressions/call/` (171/171)
- `uv run python scripts/run-test262.py --bytecode -j 32` (99,568/99,568 scenarios; 8 pre-existing/newly-reachable bytecode-only failures tracked in #416/#417, zero regressions in tree-walker mode)

Closes #388