### PR TITLE
refactor(nan-box): wrap JsBigInt value in Arc<BigInt>

### DIFF
--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -326,7 +326,7 @@ impl Interpreter {
                     })
                     .unwrap_or(0);
                 let expected = match &converted {
-                    JsValue::BigInt(b) => i64::try_from(&b.value).unwrap_or(0),
+                    JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
                     _ => 0,
                 };
                 current == expected
@@ -739,12 +739,12 @@ fn atomic_load_shared(
             })
             .unwrap_or(0);
         let bv = match kind {
-            TypedArrayKind::BigInt64 => JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(val),
-            }),
-            TypedArrayKind::BigUint64 => JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(val as u64),
-            }),
+            TypedArrayKind::BigInt64 => {
+                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(val)))
+            }
+            TypedArrayKind::BigUint64 => {
+                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(val as u64)))
+            }
             _ => JsValue::Number(0.0),
         };
         Completion::Normal(bv)
@@ -801,7 +801,7 @@ fn atomic_store_shared(
 ) {
     if is_bigint {
         let i = match val {
-            JsValue::BigInt(b) => i64::try_from(&b.value).unwrap_or(0),
+            JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
             _ => 0,
         };
         let _ = sab.with_atomic_ptr::<i64, _>(offset, 8, |ptr| unsafe {
@@ -859,11 +859,11 @@ fn atomic_compare_exchange_shared(
 ) -> Completion {
     if is_bigint {
         let exp = match expected {
-            JsValue::BigInt(b) => i64::try_from(&b.value).unwrap_or(0),
+            JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
             _ => 0,
         };
         let rep = match replacement {
-            JsValue::BigInt(b) => i64::try_from(&b.value).unwrap_or(0),
+            JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
             _ => 0,
         };
         let old = sab
@@ -874,12 +874,12 @@ fn atomic_compare_exchange_shared(
             })
             .unwrap_or(0);
         let bv = match kind {
-            TypedArrayKind::BigInt64 => JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(old),
-            }),
-            TypedArrayKind::BigUint64 => JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(old as u64),
-            }),
+            TypedArrayKind::BigInt64 => {
+                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(old)))
+            }
+            TypedArrayKind::BigUint64 => {
+                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(old as u64)))
+            }
             _ => JsValue::Number(0.0),
         };
         Completion::Normal(bv)
@@ -1045,7 +1045,7 @@ fn atomic_rmw_shared(
 ) -> Completion {
     if is_bigint {
         let new_i64 = match converted {
-            JsValue::BigInt(b) => i64::try_from(&b.value).unwrap_or(0),
+            JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
             _ => 0,
         };
         let old = sab
@@ -1067,12 +1067,12 @@ fn atomic_rmw_shared(
             })
             .unwrap_or(0);
         let bv = match kind {
-            TypedArrayKind::BigInt64 => JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(old),
-            }),
-            TypedArrayKind::BigUint64 => JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(old as u64),
-            }),
+            TypedArrayKind::BigInt64 => {
+                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(old)))
+            }
+            TypedArrayKind::BigUint64 => {
+                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(old as u64)))
+            }
             _ => JsValue::Number(0.0),
         };
         Completion::Normal(bv)
@@ -1280,7 +1280,7 @@ fn atomics_rmw(
             let old_bytes = read_bigint_raw_bytes(buf, offset, kind);
             let old_i64 = i64::from_le_bytes(old_bytes);
             let new_i64 = match &converted {
-                JsValue::BigInt(b) => i64::try_from(&b.value).unwrap_or(0),
+                JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
                 _ => 0,
             };
             let result_i64 = bigint_op(old_i64, new_i64);
@@ -1355,14 +1355,10 @@ fn number_from_raw_bytes(kind: TypedArrayKind, raw: &[u8; 8]) -> JsValue {
 fn bigint_from_raw_bytes(kind: TypedArrayKind, raw: &[u8; 8]) -> JsValue {
     let i = i64::from_le_bytes(*raw);
     match kind {
-        TypedArrayKind::BigInt64 => JsValue::BigInt(JsBigInt {
-            value: num_bigint::BigInt::from(i),
-        }),
+        TypedArrayKind::BigInt64 => JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(i))),
         TypedArrayKind::BigUint64 => {
             let u = u64::from_le_bytes(*raw);
-            JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(u),
-            })
+            JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(u)))
         }
         _ => JsValue::Number(0.0),
     }
@@ -1380,7 +1376,7 @@ fn number_to_raw_bytes(kind: TypedArrayKind, val: &JsValue) -> [u8; 8] {
 fn bigint_to_raw_bytes(kind: TypedArrayKind, val: &JsValue) -> [u8; 8] {
     match val {
         JsValue::BigInt(b) => {
-            let i = i64::try_from(&b.value).unwrap_or(0);
+            let i = i64::try_from(b.value.as_ref()).unwrap_or(0);
             match kind {
                 TypedArrayKind::BigInt64 => i.to_le_bytes(),
                 TypedArrayKind::BigUint64 => (i as u64).to_le_bytes(),
@@ -1402,7 +1398,7 @@ fn write_number_to_buffer(buf: &mut [u8], offset: usize, kind: TypedArrayKind, v
 
 fn write_bigint_to_buffer(buf: &mut [u8], offset: usize, kind: TypedArrayKind, val: &JsValue) {
     if let JsValue::BigInt(b) = val {
-        let i = i64::try_from(&b.value).unwrap_or(0);
+        let i = i64::try_from(b.value.as_ref()).unwrap_or(0);
         match kind {
             TypedArrayKind::BigInt64 | TypedArrayKind::BigUint64 => {
                 let bytes = i.to_le_bytes();
@@ -1487,14 +1483,12 @@ mod tests {
     }
 
     fn bigint(value: i64) -> JsValue {
-        JsValue::BigInt(JsBigInt {
-            value: num_bigint::BigInt::from(value),
-        })
+        JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(value)))
     }
 
     fn completion_bigint(completion: Completion) -> num_bigint::BigInt {
         match completion {
-            Completion::Normal(JsValue::BigInt(value)) => value.value,
+            Completion::Normal(JsValue::BigInt(value)) => (*value.value).clone(),
             _ => panic!("expected a BigInt normal completion"),
         }
     }

--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -39,13 +39,13 @@ impl Interpreter {
 
         fn this_bigint_value(interp: &Interpreter, this: &JsValue) -> Option<num_bigint::BigInt> {
             match this {
-                JsValue::BigInt(b) => Some(b.value.clone()),
+                JsValue::BigInt(b) => Some((*b.value).clone()),
                 JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|cell| {
                     let b = cell.borrow();
                     if b.class_name == "BigInt"
                         && let Some(JsValue::BigInt(bi)) = &b.primitive_value
                     {
-                        return Some(bi.value.clone());
+                        return Some((*bi.value).clone());
                     }
                     None
                 }),
@@ -103,7 +103,7 @@ impl Interpreter {
                             interp.create_type_error("BigInt.prototype.valueOf requires a BigInt"),
                         );
                     };
-                    Completion::Normal(JsValue::BigInt(JsBigInt { value: n }))
+                    Completion::Normal(JsValue::BigInt(JsBigInt::new(n)))
                 }),
             ),
             (
@@ -121,7 +121,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let bigint_val = JsValue::BigInt(JsBigInt { value: n });
+                    let bigint_val = JsValue::BigInt(JsBigInt::new(n));
                     interp.intl_number_format_format(&nf, &bigint_val)
                 }),
             ),
@@ -151,9 +151,7 @@ impl Interpreter {
                 let val = args.first().cloned().unwrap_or(JsValue::Undefined);
                 match &val {
                     JsValue::BigInt(_) => Completion::Normal(val),
-                    JsValue::Boolean(b) => Completion::Normal(JsValue::BigInt(JsBigInt {
-                        value: num_bigint::BigInt::from(if *b { 1 } else { 0 }),
-                    })),
+                    JsValue::Boolean(b) => Completion::Normal(JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(if *b { 1 } else { 0 })))),
                     JsValue::Number(n) => {
                         if n.is_nan() || n.is_infinite() || *n != n.trunc() {
                             return Completion::Throw(interp.create_error(
@@ -161,16 +159,12 @@ impl Interpreter {
                                 &format!("The number {n} cannot be converted to a BigInt because it is not an integer"),
                             ));
                         }
-                        Completion::Normal(JsValue::BigInt(JsBigInt {
-                            value: f64_to_bigint(*n),
-                        }))
+                        Completion::Normal(JsValue::BigInt(JsBigInt::new(f64_to_bigint(*n))))
                     }
                     JsValue::String(s) => {
                         let text = s.to_rust_string().trim().to_string();
                         if text.is_empty() {
-                            return Completion::Normal(JsValue::BigInt(JsBigInt {
-                                value: num_bigint::BigInt::from(0),
-                            }));
+                            return Completion::Normal(JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(0))));
                         }
                         let parsed = if let Some(hex) =
                             text.strip_prefix("0x").or_else(|| text.strip_prefix("0X"))
@@ -188,7 +182,7 @@ impl Interpreter {
                             text.parse::<num_bigint::BigInt>().ok()
                         };
                         match parsed {
-                            Some(v) => Completion::Normal(JsValue::BigInt(JsBigInt { value: v })),
+                            Some(v) => Completion::Normal(JsValue::BigInt(JsBigInt::new(v))),
                             None => Completion::Throw(interp.create_error(
                                 "SyntaxError",
                                 &format!("Cannot convert {text} to a BigInt"),
@@ -238,16 +232,16 @@ impl Interpreter {
                     unreachable!()
                 };
                 if bits == 0 {
-                    return Completion::Normal(JsValue::BigInt(JsBigInt {
-                        value: num_bigint::BigInt::from(0),
-                    }));
+                    return Completion::Normal(JsValue::BigInt(JsBigInt::new(
+                        num_bigint::BigInt::from(0),
+                    )));
                 }
                 let bit_len = b.value.bits() + 1; // +1 for sign bit
                 if bit_len <= bits {
                     return Completion::Normal(bigint_val);
                 }
                 let modulus = num_bigint::BigInt::from(1) << bits;
-                let mut result = &b.value % &modulus;
+                let mut result = &*b.value % &modulus;
                 if result < num_bigint::BigInt::from(0) {
                     result += &modulus;
                 }
@@ -255,7 +249,7 @@ impl Interpreter {
                 if result >= half {
                     result -= modulus;
                 }
-                Completion::Normal(JsValue::BigInt(JsBigInt { value: result }))
+                Completion::Normal(JsValue::BigInt(JsBigInt::new(result)))
             },
         ));
         let as_uint_n = self.create_function(JsFunction::native(
@@ -279,19 +273,19 @@ impl Interpreter {
                     unreachable!()
                 };
                 if bits == 0 {
-                    return Completion::Normal(JsValue::BigInt(JsBigInt {
-                        value: num_bigint::BigInt::from(0),
-                    }));
+                    return Completion::Normal(JsValue::BigInt(JsBigInt::new(
+                        num_bigint::BigInt::from(0),
+                    )));
                 }
-                if b.value >= num_bigint::BigInt::from(0) && b.value.bits() <= bits {
+                if *b.value >= num_bigint::BigInt::from(0) && b.value.bits() <= bits {
                     return Completion::Normal(bigint_val);
                 }
                 let modulus = num_bigint::BigInt::from(1) << bits;
-                let mut result = &b.value % &modulus;
+                let mut result = &*b.value % &modulus;
                 if result < num_bigint::BigInt::from(0) {
                     result += &modulus;
                 }
-                Completion::Normal(JsValue::BigInt(JsBigInt { value: result }))
+                Completion::Normal(JsValue::BigInt(JsBigInt::new(result)))
             },
         ));
 

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -119,9 +119,7 @@ impl Interpreter {
                     .host_clock_start
                     .map(|start| start.elapsed().as_nanos())
                     .unwrap_or(0);
-                Completion::Normal(JsValue::BigInt(JsBigInt {
-                    value: num_bigint::BigInt::from(ns),
-                }))
+                Completion::Normal(JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(ns))))
             },
         ));
         self.install_host_global("__host_hrtime", hrtime_fn);

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -62,7 +62,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::BigInt(crate::types::JsBigInt { value: ns }))
+                    Completion::Normal(JsValue::BigInt(crate::types::JsBigInt::new(ns)))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -905,7 +905,7 @@ fn parse_instant_string(interp: &mut Interpreter, s: &str) -> Result<BigInt, Com
 
 pub(super) fn to_bigint_arg(interp: &mut Interpreter, val: &JsValue) -> Result<BigInt, Completion> {
     match val {
-        JsValue::BigInt(n) => Ok(n.value.clone()),
+        JsValue::BigInt(n) => Ok((*n.value).clone()),
         JsValue::String(s) => {
             let s_str = s.to_rust_string();
             match s_str.parse::<BigInt>() {

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -1851,9 +1851,7 @@ impl Interpreter {
         });
 
         zdt_getter!("epochNanoseconds", |ns, _tz, _cal| {
-            Completion::Normal(JsValue::BigInt(crate::types::JsBigInt {
-                value: ns.clone(),
-            }))
+            Completion::Normal(JsValue::BigInt(crate::types::JsBigInt::new(ns.clone())))
         });
 
         zdt_getter!("year", |ns, tz, cal| {

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -2953,9 +2953,9 @@ impl Interpreter {
                             }
                             Err(interp.create_type_error("Cannot convert value to a BigInt"))
                         }
-                        JsValue::Boolean(b) => Ok(JsValue::BigInt(JsBigInt {
-                            value: num_bigint::BigInt::from(if *b { 1 } else { 0 }),
-                        })),
+                        JsValue::Boolean(b) => Ok(JsValue::BigInt(JsBigInt::new(
+                            num_bigint::BigInt::from(if *b { 1 } else { 0 }),
+                        ))),
                         JsValue::Number(n) => {
                             // ToBigInt throws TypeError for Number values
                             Err(interp
@@ -2985,7 +2985,7 @@ impl Interpreter {
                                 text.parse::<num_bigint::BigInt>().ok()
                             };
                             match parsed {
-                                Some(v) => Ok(JsValue::BigInt(JsBigInt { value: v })),
+                                Some(v) => Ok(JsValue::BigInt(JsBigInt::new(v))),
                                 None => Err(interp.create_error(
                                     "SyntaxError",
                                     &format!("Cannot convert {} to a BigInt", text),
@@ -5356,9 +5356,7 @@ impl Interpreter {
             } else {
                 i64::from_be_bytes(bytes)
             };
-            JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(v),
-            })
+            JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(v)))
         });
         dv_get_method!("getBigUint64", 8, |buf: &[u8], le: bool| -> JsValue {
             let mut bytes = [0u8; 8];
@@ -5368,9 +5366,7 @@ impl Interpreter {
             } else {
                 u64::from_be_bytes(bytes)
             };
-            JsValue::BigInt(JsBigInt {
-                value: num_bigint::BigInt::from(v),
-            })
+            JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(v)))
         });
         dv_get_method!("getFloat16", 2, |buf: &[u8], le: bool| -> JsValue {
             let bits = if le {
@@ -5652,7 +5648,7 @@ impl Interpreter {
             bigint,
             |buf: &mut [u8], v: &JsValue, le: bool| {
                 let n = match v {
-                    JsValue::BigInt(b) => i64::try_from(&b.value).unwrap_or(0),
+                    JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
                     _ => 0,
                 };
                 let bytes = if le { n.to_le_bytes() } else { n.to_be_bytes() };
@@ -5665,7 +5661,7 @@ impl Interpreter {
             bigint,
             |buf: &mut [u8], v: &JsValue, le: bool| {
                 let n = match v {
-                    JsValue::BigInt(b) => u64::try_from(&b.value).unwrap_or(0),
+                    JsValue::BigInt(b) => u64::try_from(b.value.as_ref()).unwrap_or(0),
                     _ => 0,
                 };
                 let bytes = if le { n.to_le_bytes() } else { n.to_be_bytes() };

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1485,9 +1485,9 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 match numeric {
-                    JsValue::BigInt(b) => Completion::Normal(JsValue::BigInt(JsBigInt {
-                        value: bigint_ops::unary_minus(&b.value),
-                    })),
+                    JsValue::BigInt(b) => Completion::Normal(JsValue::BigInt(JsBigInt::new(
+                        bigint_ops::unary_minus(&b.value),
+                    ))),
                     JsValue::Number(n) => {
                         Completion::Normal(JsValue::Number(number_ops::unary_minus(n)))
                     }
@@ -1505,9 +1505,9 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 match numeric {
-                    JsValue::BigInt(b) => Completion::Normal(JsValue::BigInt(JsBigInt {
-                        value: bigint_ops::bitwise_not(&b.value),
-                    })),
+                    JsValue::BigInt(b) => Completion::Normal(JsValue::BigInt(JsBigInt::new(
+                        bigint_ops::bitwise_not(&b.value),
+                    ))),
                     JsValue::Number(n) => {
                         Completion::Normal(JsValue::Number(number_ops::bitwise_not(n)))
                     }
@@ -1764,20 +1764,18 @@ impl Interpreter {
         };
         match &prim {
             JsValue::BigInt(_) => Ok(prim),
-            JsValue::Boolean(b) => Ok(JsValue::BigInt(crate::types::JsBigInt {
-                value: if *b {
-                    num_bigint::BigInt::from(1)
-                } else {
-                    num_bigint::BigInt::from(0)
-                },
-            })),
+            JsValue::Boolean(b) => Ok(JsValue::BigInt(crate::types::JsBigInt::new(if *b {
+                num_bigint::BigInt::from(1)
+            } else {
+                num_bigint::BigInt::from(0)
+            }))),
             JsValue::String(s) => {
                 let text = s.to_rust_string();
                 let trimmed = text.trim();
                 if trimmed.is_empty() {
-                    return Ok(JsValue::BigInt(crate::types::JsBigInt {
-                        value: num_bigint::BigInt::from(0),
-                    }));
+                    return Ok(JsValue::BigInt(crate::types::JsBigInt::new(
+                        num_bigint::BigInt::from(0),
+                    )));
                 }
                 let parsed = if let Some(hex) = trimmed
                     .strip_prefix("0x")
@@ -1798,7 +1796,7 @@ impl Interpreter {
                     trimmed.parse::<num_bigint::BigInt>().ok()
                 };
                 match parsed {
-                    Some(n) => Ok(JsValue::BigInt(crate::types::JsBigInt { value: n })),
+                    Some(n) => Ok(JsValue::BigInt(crate::types::JsBigInt::new(n))),
                     None => Err(self.create_error(
                         "SyntaxError",
                         &format!("Cannot convert {} to a BigInt", text),
@@ -1947,10 +1945,10 @@ impl Interpreter {
             }
             let n_trunc = n.trunc();
             let n_floor = crate::interpreter::builtins::bigint::f64_to_bigint(n_trunc);
-            if b.value < n_floor {
+            if *b.value < n_floor {
                 return Ok(Some(true));
             }
-            if b.value > n_floor {
+            if *b.value > n_floor {
                 return Ok(Some(false));
             }
             // n_floor == b.value, so result depends on fractional part
@@ -1968,10 +1966,10 @@ impl Interpreter {
             }
             let n_trunc = n.trunc();
             let n_floor = crate::interpreter::builtins::bigint::f64_to_bigint(n_trunc);
-            if n_floor < b.value {
+            if n_floor < *b.value {
                 return Ok(Some(true));
             }
-            if n_floor > b.value {
+            if n_floor > *b.value {
                 return Ok(Some(false));
             }
             // n_floor == b.value, so result depends on fractional part
@@ -1980,15 +1978,13 @@ impl Interpreter {
         // BigInt vs String: try parsing via StringToBigInt
         if let (JsValue::BigInt(_), JsValue::String(s)) = (&lprim, &rprim) {
             if let Some(parsed) = string_to_bigint_for_comparison(&s.to_rust_string()) {
-                return self
-                    .abstract_relational(&lprim, &JsValue::BigInt(JsBigInt { value: parsed }));
+                return self.abstract_relational(&lprim, &JsValue::BigInt(JsBigInt::new(parsed)));
             }
             return Ok(None);
         }
         if let (JsValue::String(s), JsValue::BigInt(_)) = (&lprim, &rprim) {
             if let Some(parsed) = string_to_bigint_for_comparison(&s.to_rust_string()) {
-                return self
-                    .abstract_relational(&JsValue::BigInt(JsBigInt { value: parsed }), &rprim);
+                return self.abstract_relational(&JsValue::BigInt(JsBigInt::new(parsed)), &rprim);
             }
             return Ok(None);
         }
@@ -2022,10 +2018,10 @@ impl Interpreter {
             }
             let n_trunc = n.trunc();
             let n_floor = crate::interpreter::builtins::bigint::f64_to_bigint(n_trunc);
-            if b.value < n_floor {
+            if *b.value < n_floor {
                 return Ok(Some(true));
             }
-            if b.value > n_floor {
+            if *b.value > n_floor {
                 return Ok(Some(false));
             }
             return Ok(Some(n_trunc < *n));
@@ -2042,10 +2038,10 @@ impl Interpreter {
             }
             let n_trunc = n.trunc();
             let n_floor = crate::interpreter::builtins::bigint::f64_to_bigint(n_trunc);
-            if n_floor < b.value {
+            if n_floor < *b.value {
                 return Ok(Some(true));
             }
-            if n_floor > b.value {
+            if n_floor > *b.value {
                 return Ok(Some(false));
             }
             return Ok(Some(*n < n_trunc));
@@ -2216,9 +2212,9 @@ impl Interpreter {
                     };
                     Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
                 } else if let (JsValue::BigInt(a), JsValue::BigInt(b)) = (&lprim, &rprim) {
-                    Completion::Normal(JsValue::BigInt(JsBigInt {
-                        value: bigint_ops::add(&a.value, &b.value),
-                    }))
+                    Completion::Normal(JsValue::BigInt(JsBigInt::new(bigint_ops::add(
+                        &a.value, &b.value,
+                    ))))
                 } else if lprim.is_bigint() || rprim.is_bigint() {
                     Completion::Throw(self.create_type_error(
                         "Cannot mix BigInt and other types, use explicit conversions",
@@ -2242,26 +2238,26 @@ impl Interpreter {
                 };
                 if let (JsValue::BigInt(a), JsValue::BigInt(b)) = (&lnum, &rnum) {
                     match op {
-                        BinaryOp::Sub => Completion::Normal(JsValue::BigInt(JsBigInt {
-                            value: bigint_ops::subtract(&a.value, &b.value),
-                        })),
-                        BinaryOp::Mul => Completion::Normal(JsValue::BigInt(JsBigInt {
-                            value: bigint_ops::multiply(&a.value, &b.value),
-                        })),
+                        BinaryOp::Sub => Completion::Normal(JsValue::BigInt(JsBigInt::new(
+                            bigint_ops::subtract(&a.value, &b.value),
+                        ))),
+                        BinaryOp::Mul => Completion::Normal(JsValue::BigInt(JsBigInt::new(
+                            bigint_ops::multiply(&a.value, &b.value),
+                        ))),
                         BinaryOp::Div => match bigint_ops::divide(&a.value, &b.value) {
-                            Ok(v) => Completion::Normal(JsValue::BigInt(JsBigInt { value: v })),
+                            Ok(v) => Completion::Normal(JsValue::BigInt(JsBigInt::new(v))),
                             Err(_) => Completion::Throw(
                                 self.create_error("RangeError", "Division by zero"),
                             ),
                         },
                         BinaryOp::Mod => match bigint_ops::remainder(&a.value, &b.value) {
-                            Ok(v) => Completion::Normal(JsValue::BigInt(JsBigInt { value: v })),
+                            Ok(v) => Completion::Normal(JsValue::BigInt(JsBigInt::new(v))),
                             Err(_) => Completion::Throw(
                                 self.create_error("RangeError", "Division by zero"),
                             ),
                         },
                         BinaryOp::Exp => match bigint_ops::exponentiate(&a.value, &b.value) {
-                            Ok(v) => Completion::Normal(JsValue::BigInt(JsBigInt { value: v })),
+                            Ok(v) => Completion::Normal(JsValue::BigInt(JsBigInt::new(v))),
                             Err(_) => Completion::Throw(
                                 self.create_error("RangeError", "Exponent must be positive"),
                             ),
@@ -2339,15 +2335,11 @@ impl Interpreter {
                         ));
                     }
                     if let (JsValue::BigInt(a), JsValue::BigInt(b)) = (&lnum, &rnum) {
-                        Completion::Normal(JsValue::BigInt(JsBigInt {
-                            value: match op {
-                                BinaryOp::LShift => bigint_ops::left_shift(&a.value, &b.value),
-                                BinaryOp::RShift => {
-                                    bigint_ops::signed_right_shift(&a.value, &b.value)
-                                }
-                                _ => unreachable!(),
-                            },
-                        }))
+                        Completion::Normal(JsValue::BigInt(JsBigInt::new(match op {
+                            BinaryOp::LShift => bigint_ops::left_shift(&a.value, &b.value),
+                            BinaryOp::RShift => bigint_ops::signed_right_shift(&a.value, &b.value),
+                            _ => unreachable!(),
+                        })))
                     } else {
                         Completion::Throw(self.create_type_error(
                             "Cannot mix BigInt and other types, use explicit conversions",
@@ -2382,14 +2374,12 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 if let (JsValue::BigInt(a), JsValue::BigInt(b)) = (&lnum, &rnum) {
-                    Completion::Normal(JsValue::BigInt(JsBigInt {
-                        value: match op {
-                            BinaryOp::BitAnd => bigint_ops::bitwise_and(&a.value, &b.value),
-                            BinaryOp::BitOr => bigint_ops::bitwise_or(&a.value, &b.value),
-                            BinaryOp::BitXor => bigint_ops::bitwise_xor(&a.value, &b.value),
-                            _ => unreachable!(),
-                        },
-                    }))
+                    Completion::Normal(JsValue::BigInt(JsBigInt::new(match op {
+                        BinaryOp::BitAnd => bigint_ops::bitwise_and(&a.value, &b.value),
+                        BinaryOp::BitOr => bigint_ops::bitwise_or(&a.value, &b.value),
+                        BinaryOp::BitXor => bigint_ops::bitwise_xor(&a.value, &b.value),
+                        _ => unreachable!(),
+                    })))
                 } else if lnum.is_bigint() || rnum.is_bigint() {
                     Completion::Throw(self.create_type_error(
                         "Cannot mix BigInt and other types, use explicit conversions",
@@ -2492,11 +2482,11 @@ impl Interpreter {
             use num_bigint::BigInt;
             let one = BigInt::from(1);
             let new_bigint = match op {
-                UpdateOp::Increment => &b.value + &one,
-                UpdateOp::Decrement => &b.value - &one,
+                UpdateOp::Increment => &*b.value + &one,
+                UpdateOp::Decrement => &*b.value - &one,
             };
             let old_val = JsValue::BigInt(b.clone());
-            let new_val = JsValue::BigInt(JsBigInt { value: new_bigint });
+            let new_val = JsValue::BigInt(JsBigInt::new(new_bigint));
             Ok((old_val, new_val))
         } else if let JsValue::Symbol(_) = numeric {
             Err(self.create_type_error("Cannot convert a Symbol value to a number"))

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -98,7 +98,7 @@ impl Interpreter {
                 } else {
                     s.parse::<BigInt>().unwrap_or_default()
                 };
-                JsValue::BigInt(JsBigInt { value })
+                JsValue::BigInt(JsBigInt::new(value))
             }
             Literal::RegExp(pattern, flags) => {
                 let mut obj = JsObjectData::new();

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -53,7 +53,7 @@ pub(crate) fn to_boolean(val: &JsValue) -> bool {
         JsValue::Boolean(b) => *b,
         JsValue::Number(n) => *n != 0.0 && !n.is_nan(),
         JsValue::String(s) => !s.is_empty(),
-        JsValue::BigInt(b) => b.value != num_bigint::BigInt::from(0),
+        JsValue::BigInt(b) => *b.value != num_bigint::BigInt::from(0),
         JsValue::Symbol(_) | JsValue::Object(_) => true,
     }
 }

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -3390,9 +3390,9 @@ fn typed_array_get_index_shared(
             }
             let mut bytes = [0u8; 8];
             bytes.copy_from_slice(&buf[offset..offset + 8]);
-            JsValue::BigInt(crate::types::JsBigInt {
-                value: num_bigint::BigInt::from(i64::from_ne_bytes(bytes)),
-            })
+            JsValue::BigInt(crate::types::JsBigInt::new(num_bigint::BigInt::from(
+                i64::from_ne_bytes(bytes),
+            )))
         }),
         TypedArrayKind::BigUint64 => sab.with_read(|buf| {
             if offset + 8 > buf.len() {
@@ -3400,9 +3400,9 @@ fn typed_array_get_index_shared(
             }
             let mut bytes = [0u8; 8];
             bytes.copy_from_slice(&buf[offset..offset + 8]);
-            JsValue::BigInt(crate::types::JsBigInt {
-                value: num_bigint::BigInt::from(u64::from_ne_bytes(bytes)),
-            })
+            JsValue::BigInt(crate::types::JsBigInt::new(num_bigint::BigInt::from(
+                u64::from_ne_bytes(bytes),
+            )))
         }),
         TypedArrayKind::Float16 => sab.with_read(|buf| {
             if offset + 2 > buf.len() {
@@ -3497,16 +3497,16 @@ pub(crate) fn typed_array_get_index(ta: &TypedArrayInfo, idx: usize) -> JsValue 
             TypedArrayKind::BigInt64 => {
                 let mut bytes = [0u8; 8];
                 bytes.copy_from_slice(&buf[offset..offset + 8]);
-                JsValue::BigInt(crate::types::JsBigInt {
-                    value: num_bigint::BigInt::from(i64::from_ne_bytes(bytes)),
-                })
+                JsValue::BigInt(crate::types::JsBigInt::new(num_bigint::BigInt::from(
+                    i64::from_ne_bytes(bytes),
+                )))
             }
             TypedArrayKind::BigUint64 => {
                 let mut bytes = [0u8; 8];
                 bytes.copy_from_slice(&buf[offset..offset + 8]);
-                JsValue::BigInt(crate::types::JsBigInt {
-                    value: num_bigint::BigInt::from(u64::from_ne_bytes(bytes)),
-                })
+                JsValue::BigInt(crate::types::JsBigInt::new(num_bigint::BigInt::from(
+                    u64::from_ne_bytes(bytes),
+                )))
             }
             TypedArrayKind::Float16 => {
                 let bits = u16::from_ne_bytes([buf[offset], buf[offset + 1]]);
@@ -3743,7 +3743,7 @@ fn to_uint32(v: &JsValue) -> u32 {
 fn to_bigint64(v: &JsValue) -> i64 {
     match v {
         JsValue::BigInt(b) => {
-            i64::try_from(&b.value).unwrap_or_else(|_| {
+            i64::try_from(b.value.as_ref()).unwrap_or_else(|_| {
                 // Truncate to 64 bits
                 let bytes = b.value.to_signed_bytes_le();
                 let mut result = [0u8; 8];
@@ -3762,7 +3762,7 @@ fn to_bigint64(v: &JsValue) -> i64 {
 }
 fn to_biguint64(v: &JsValue) -> u64 {
     match v {
-        JsValue::BigInt(b) => u64::try_from(&b.value).unwrap_or_else(|_| {
+        JsValue::BigInt(b) => u64::try_from(b.value.as_ref()).unwrap_or_else(|_| {
             let bytes = b.value.to_signed_bytes_le();
             let mut result = [0u8; 8];
             let len = bytes.len().min(8);

--- a/src/types.rs
+++ b/src/types.rs
@@ -357,7 +357,15 @@ impl JsSymbol {
 
 #[derive(Clone, Debug)]
 pub(crate) struct JsBigInt {
-    pub value: num_bigint::BigInt,
+    pub value: Arc<num_bigint::BigInt>,
+}
+
+impl JsBigInt {
+    pub(crate) fn new(value: num_bigint::BigInt) -> Self {
+        Self {
+            value: Arc::new(value),
+        }
+    }
 }
 
 // Placeholder — full object model comes in Phase 5
@@ -1073,11 +1081,9 @@ mod tests {
             description: Some(JsString::from_str("s")),
         };
         assert_eq!(JsValue::symbol(sym).as_symbol().unwrap().id, 1);
-        let big = JsBigInt {
-            value: num_bigint::BigInt::from(42),
-        };
+        let big = JsBigInt::new(num_bigint::BigInt::from(42));
         assert_eq!(
-            JsValue::bigint(big).as_bigint().unwrap().value,
+            *JsValue::bigint(big).as_bigint().unwrap().value,
             num_bigint::BigInt::from(42)
         );
     }
@@ -1106,9 +1112,7 @@ mod tests {
         assert_eq!(sym.with_symbol(|s| s.id), Some(9));
         assert_eq!(JsValue::Null.with_symbol(|s| s.id), None);
 
-        let big = JsValue::BigInt(JsBigInt {
-            value: num_bigint::BigInt::from(5),
-        });
+        let big = JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(5)));
         assert_eq!(
             big.with_bigint(|b| b.clone()),
             Some(num_bigint::BigInt::from(5))
@@ -1122,11 +1126,9 @@ mod tests {
         assert_eq!(s.into_string().unwrap().to_rust_string(), "x");
         assert!(JsValue::Null.into_string().is_none());
 
-        let big = JsValue::BigInt(JsBigInt {
-            value: num_bigint::BigInt::from(11),
-        });
+        let big = JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(11)));
         assert_eq!(
-            big.into_bigint().unwrap().value,
+            *big.into_bigint().unwrap().value,
             num_bigint::BigInt::from(11)
         );
         assert!(JsValue::Number(1.0).into_bigint().is_none());
@@ -1148,9 +1150,7 @@ mod tests {
                 ValueKind::Symbol,
             ),
             (
-                JsValue::BigInt(JsBigInt {
-                    value: num_bigint::BigInt::from(0),
-                }),
+                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(0))),
                 ValueKind::BigInt,
             ),
             (JsValue::object(1), ValueKind::Object),


### PR DESCRIPTION
## Summary

- Wraps `JsBigInt`'s `value` field in `Arc<num_bigint::BigInt>` (per the ratified design in #402/PR #418) instead of storing the `BigInt` by value.
- Adds `JsBigInt::new(value: BigInt)` as the single constructor and updates all 52 construction sites across 10 files to use it.
- Prerequisite for the NaN-boxing migration (epic #69) — NaN-boxed `JsValue` needs to pack BigInt as a pointer into the NaN payload, which requires this indirection to exist first.

Fixes #403

## Test plan

- [x] `cargo build --release` / `cargo check --release --tests` — clean
- [x] `./scripts/lint.sh` (rustfmt + clippy) — clean
- [x] `cargo test --release` — 414 unit tests + host_time_zone + test262_smoke_oracle, all passing
- [x] Full test262 suite (`uv run python scripts/run-test262.py -j 32`) — 99568/99568 (100.00%), 0 regressions
- [x] `uv run python scripts/run-custom-tests.py` — 11/11 passing