### PR TITLE
refactor(interpreter): consolidate loop-body completion into handle_loop_body_completion

### DIFF
--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -1577,23 +1577,11 @@ impl Interpreter {
             if !self.to_boolean_val(&test) {
                 break;
             }
-            match self.exec_statement(&w.body, env) {
-                Completion::Normal(val) => {
-                    v = val;
-                }
-                Completion::Empty => {}
-                Completion::Continue(None, cont_val) => {
-                    if let Some(val) = cont_val {
-                        v = val;
-                    }
-                }
-                Completion::Break(None, break_val) => {
-                    if let Some(val) = break_val {
-                        v = val;
-                    }
-                    return Completion::Normal(v);
-                }
-                other => return other,
+            let comp = self.exec_statement(&w.body, env);
+            match handle_loop_body_completion(comp, &mut v, None) {
+                LoopFlow::Iterate => {}
+                LoopFlow::Break => return Completion::Normal(v),
+                LoopFlow::Propagate(other) => return other,
             }
         }
         Completion::Normal(v)
@@ -1605,23 +1593,11 @@ impl Interpreter {
             self.gc_root_value(&v);
             self.gc_safepoint();
             self.gc_unroot_value(&v);
-            match self.exec_statement(&dw.body, env) {
-                Completion::Normal(val) => {
-                    v = val;
-                }
-                Completion::Empty => {}
-                Completion::Continue(None, cont_val) => {
-                    if let Some(val) = cont_val {
-                        v = val;
-                    }
-                }
-                Completion::Break(None, break_val) => {
-                    if let Some(val) = break_val {
-                        v = val;
-                    }
-                    return Completion::Normal(v);
-                }
-                other => return other,
+            let comp = self.exec_statement(&dw.body, env);
+            match handle_loop_body_completion(comp, &mut v, None) {
+                LoopFlow::Iterate => {}
+                LoopFlow::Break => return Completion::Normal(v),
+                LoopFlow::Propagate(other) => return other,
             }
             let test = match self.eval_expr(&dw.test, env) {
                 Completion::Normal(v) => v,
@@ -1649,28 +1625,11 @@ impl Interpreter {
                     if !self.to_boolean_val(&test) {
                         break;
                     }
-                    match self.exec_statement(&w.body, env) {
-                        Completion::Normal(val) => {
-                            v = val;
-                        }
-                        Completion::Empty => {}
-                        Completion::Continue(None, cont_val) => {
-                            if let Some(val) = cont_val {
-                                v = val;
-                            }
-                        }
-                        Completion::Continue(Some(ref l), cont_val) if l == label => {
-                            if let Some(val) = cont_val {
-                                v = val;
-                            }
-                        }
-                        Completion::Break(None, break_val) => {
-                            if let Some(val) = break_val {
-                                v = val;
-                            }
-                            return Completion::Normal(v);
-                        }
-                        other => return other,
+                    let comp = self.exec_statement(&w.body, env);
+                    match handle_loop_body_completion(comp, &mut v, Some(label)) {
+                        LoopFlow::Iterate => {}
+                        LoopFlow::Break => return Completion::Normal(v),
+                        LoopFlow::Propagate(other) => return other,
                     }
                 }
                 Completion::Normal(v)
@@ -1681,28 +1640,11 @@ impl Interpreter {
                     self.gc_root_value(&v);
                     self.gc_safepoint();
                     self.gc_unroot_value(&v);
-                    match self.exec_statement(&dw.body, env) {
-                        Completion::Normal(val) => {
-                            v = val;
-                        }
-                        Completion::Empty => {}
-                        Completion::Continue(None, cont_val) => {
-                            if let Some(val) = cont_val {
-                                v = val;
-                            }
-                        }
-                        Completion::Continue(Some(ref l), cont_val) if l == label => {
-                            if let Some(val) = cont_val {
-                                v = val;
-                            }
-                        }
-                        Completion::Break(None, break_val) => {
-                            if let Some(val) = break_val {
-                                v = val;
-                            }
-                            return Completion::Normal(v);
-                        }
-                        other => return other,
+                    let comp = self.exec_statement(&dw.body, env);
+                    match handle_loop_body_completion(comp, &mut v, Some(label)) {
+                        LoopFlow::Iterate => {}
+                        LoopFlow::Break => return Completion::Normal(v),
+                        LoopFlow::Propagate(other) => return other,
                     }
                     let test = match self.eval_expr(&dw.test, env) {
                         Completion::Normal(v) => v,
@@ -1790,28 +1732,11 @@ impl Interpreter {
                         break;
                     }
                 }
-                match self.exec_statement(&f.body, &iter_env) {
-                    Completion::Normal(val) => {
-                        v = val;
-                    }
-                    Completion::Empty => {}
-                    Completion::Continue(None, cont_val) => {
-                        if let Some(val) = cont_val {
-                            v = val;
-                        }
-                    }
-                    Completion::Continue(Some(ref l), cont_val) if label == Some(l.as_str()) => {
-                        if let Some(val) = cont_val {
-                            v = val;
-                        }
-                    }
-                    Completion::Break(None, break_val) => {
-                        if let Some(val) = break_val {
-                            v = val;
-                        }
-                        break;
-                    }
-                    other => break 'for_loop other,
+                let comp = self.exec_statement(&f.body, &iter_env);
+                match handle_loop_body_completion(comp, &mut v, label) {
+                    LoopFlow::Iterate => {}
+                    LoopFlow::Break => break,
+                    LoopFlow::Propagate(other) => break 'for_loop other,
                 }
                 // CreatePerIterationEnvironment before update
                 if !per_iteration_bindings.is_empty() {
@@ -2007,30 +1932,10 @@ impl Interpreter {
                         }
                     }
                     let result = self.exec_statement(&fi.body, &for_env);
-                    match result {
-                        Completion::Normal(val) => {
-                            v = val;
-                        }
-                        Completion::Empty => {}
-                        Completion::Continue(None, cont_val) => {
-                            if let Some(val) = cont_val {
-                                v = val;
-                            }
-                        }
-                        Completion::Continue(Some(ref l), cont_val)
-                            if label == Some(l.as_str()) =>
-                        {
-                            if let Some(val) = cont_val {
-                                v = val;
-                            }
-                        }
-                        Completion::Break(None, break_val) => {
-                            if let Some(val) = break_val {
-                                v = val;
-                            }
-                            break 'unroot Completion::Normal(v);
-                        }
-                        other => break 'unroot other,
+                    match handle_loop_body_completion(result, &mut v, label) {
+                        LoopFlow::Iterate => {}
+                        LoopFlow::Break => break 'unroot Completion::Normal(v),
+                        LoopFlow::Propagate(other) => break 'unroot other,
                     }
                 }
             }
@@ -2706,5 +2611,204 @@ impl Interpreter {
             }
             _ => false,
         }
+    }
+}
+
+/// What a loop executor should do after running its body once. Externalises the
+/// per-loop-kind control-flow — `return`, `break`, or `break 'label` — so the
+/// shared body-completion bookkeeping (folding the completion value into the
+/// running loop value, matching labels) lives in exactly one place instead of
+/// being copy-pasted at each loop head.
+#[derive(Debug)]
+enum LoopFlow {
+    /// Keep iterating. The body's completion value has already been folded into
+    /// the running loop value.
+    Iterate,
+    /// Terminate the loop normally; the running loop value is the result.
+    Break,
+    /// An abrupt completion this loop does not consume — the caller propagates
+    /// it in whatever way its control-flow requires.
+    Propagate(Completion),
+}
+
+/// Apply one iteration's body `Completion` to the running loop value `v` and
+/// decide how the loop proceeds. `label` is the loop's own label (`None` for an
+/// unlabelled loop), used to recognise a `continue label;` that targets *this*
+/// loop.
+///
+/// This concentrates the `while` / `do-while` / `for` / `for-in` body protocol.
+/// `for-of` and `switch` are deliberately NOT routed through here: `for-of`
+/// must interleave IteratorClose on every abrupt completion, and `switch` has
+/// no `continue` arm and a different break-value default.
+fn handle_loop_body_completion(comp: Completion, v: &mut JsValue, label: Option<&str>) -> LoopFlow {
+    match comp {
+        Completion::Normal(val) => {
+            *v = val;
+            LoopFlow::Iterate
+        }
+        Completion::Empty => LoopFlow::Iterate,
+        Completion::Continue(None, cont_val) => {
+            if let Some(val) = cont_val {
+                *v = val;
+            }
+            LoopFlow::Iterate
+        }
+        Completion::Continue(Some(l), cont_val) => {
+            if label == Some(l.as_str()) {
+                if let Some(val) = cont_val {
+                    *v = val;
+                }
+                LoopFlow::Iterate
+            } else {
+                LoopFlow::Propagate(Completion::Continue(Some(l), cont_val))
+            }
+        }
+        Completion::Break(None, break_val) => {
+            if let Some(val) = break_val {
+                *v = val;
+            }
+            LoopFlow::Break
+        }
+        other => LoopFlow::Propagate(other),
+    }
+}
+
+#[cfg(test)]
+mod loop_flow_tests {
+    use super::*;
+
+    fn num(x: f64) -> JsValue {
+        JsValue::Number(x)
+    }
+
+    fn is_num(v: &JsValue, x: f64) -> bool {
+        matches!(v, JsValue::Number(n) if *n == x)
+    }
+
+    #[test]
+    fn normal_completion_folds_value_and_iterates() {
+        let mut v = JsValue::Undefined;
+        assert!(matches!(
+            handle_loop_body_completion(Completion::Normal(num(7.0)), &mut v, None),
+            LoopFlow::Iterate
+        ));
+        assert!(is_num(&v, 7.0));
+    }
+
+    #[test]
+    fn empty_completion_iterates_and_preserves_value() {
+        let mut v = num(3.0);
+        assert!(matches!(
+            handle_loop_body_completion(Completion::Empty, &mut v, None),
+            LoopFlow::Iterate
+        ));
+        assert!(is_num(&v, 3.0));
+    }
+
+    #[test]
+    fn unlabelled_continue_with_value_folds_and_iterates() {
+        let mut v = JsValue::Undefined;
+        // A loop's own label is irrelevant to an unlabelled continue.
+        assert!(matches!(
+            handle_loop_body_completion(
+                Completion::Continue(None, Some(num(5.0))),
+                &mut v,
+                Some("l")
+            ),
+            LoopFlow::Iterate
+        ));
+        assert!(is_num(&v, 5.0));
+    }
+
+    #[test]
+    fn unlabelled_continue_without_value_preserves_value() {
+        let mut v = num(9.0);
+        assert!(matches!(
+            handle_loop_body_completion(Completion::Continue(None, None), &mut v, None),
+            LoopFlow::Iterate
+        ));
+        assert!(is_num(&v, 9.0));
+    }
+
+    #[test]
+    fn matching_labelled_continue_folds_and_iterates() {
+        let mut v = JsValue::Undefined;
+        let comp = Completion::Continue(Some("outer".to_string()), Some(num(11.0)));
+        assert!(matches!(
+            handle_loop_body_completion(comp, &mut v, Some("outer")),
+            LoopFlow::Iterate
+        ));
+        assert!(is_num(&v, 11.0));
+    }
+
+    #[test]
+    fn non_matching_labelled_continue_propagates_untouched() {
+        let mut v = num(1.0);
+        let comp = Completion::Continue(Some("outer".to_string()), Some(num(2.0)));
+        match handle_loop_body_completion(comp, &mut v, Some("inner")) {
+            LoopFlow::Propagate(Completion::Continue(Some(l), Some(pv))) => {
+                assert_eq!(l, "outer");
+                assert!(is_num(&pv, 2.0));
+            }
+            other => panic!("expected Propagate(Continue outer), got {other:?}"),
+        }
+        // A continue we don't consume must not disturb our running value.
+        assert!(is_num(&v, 1.0));
+    }
+
+    #[test]
+    fn labelled_continue_in_unlabelled_loop_propagates() {
+        let mut v = num(1.0);
+        let comp = Completion::Continue(Some("outer".to_string()), None);
+        match handle_loop_body_completion(comp, &mut v, None) {
+            LoopFlow::Propagate(Completion::Continue(Some(l), None)) => assert_eq!(l, "outer"),
+            other => panic!("expected Propagate(Continue outer), got {other:?}"),
+        }
+        assert!(is_num(&v, 1.0));
+    }
+
+    #[test]
+    fn unlabelled_break_with_value_folds_and_breaks() {
+        let mut v = JsValue::Undefined;
+        assert!(matches!(
+            handle_loop_body_completion(Completion::Break(None, Some(num(99.0))), &mut v, None),
+            LoopFlow::Break
+        ));
+        assert!(is_num(&v, 99.0));
+    }
+
+    #[test]
+    fn unlabelled_break_without_value_preserves_value_and_breaks() {
+        let mut v = num(44.0);
+        assert!(matches!(
+            handle_loop_body_completion(Completion::Break(None, None), &mut v, None),
+            LoopFlow::Break
+        ));
+        assert!(is_num(&v, 44.0));
+    }
+
+    #[test]
+    fn labelled_break_propagates_untouched() {
+        let mut v = num(1.0);
+        let comp = Completion::Break(Some("outer".to_string()), Some(num(2.0)));
+        match handle_loop_body_completion(comp, &mut v, Some("inner")) {
+            LoopFlow::Propagate(Completion::Break(Some(l), _)) => assert_eq!(l, "outer"),
+            other => panic!("expected Propagate(Break outer), got {other:?}"),
+        }
+        assert!(is_num(&v, 1.0));
+    }
+
+    #[test]
+    fn throw_and_return_propagate_untouched() {
+        let mut v = num(1.0);
+        assert!(matches!(
+            handle_loop_body_completion(Completion::Throw(num(7.0)), &mut v, None),
+            LoopFlow::Propagate(Completion::Throw(_))
+        ));
+        assert!(matches!(
+            handle_loop_body_completion(Completion::Return(num(8.0)), &mut v, None),
+            LoopFlow::Propagate(Completion::Return(_))
+        ));
+        assert!(is_num(&v, 1.0));
     }
 }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -2175,6 +2175,123 @@ fn date_set_utc_full_year_on_invalid_date_seeds_missing_args_from_epoch_not_nan(
     assert_eq!(global_number(&interp, "__d"), 1.0);
 }
 
+// Loop and labelled-statement completion values are the observable surface of
+// the `v = val` folding consolidated into `handle_loop_body_completion`
+// (src/interpreter/exec.rs). These pin the behaviour across the six loop heads
+// migrated to the shared helper, plus the two deliberately-excluded forms
+// (for-of interleaves IteratorClose; switch has no `continue` arm). Expected
+// values are the ECMAScript completion-value semantics, cross-checked against
+// Node — not recomputed from jsse's code.
+mod loop_completion_value_tests {
+    use super::*;
+
+    fn completion_value(source: &str) -> JsValue {
+        let program = parse_program(source);
+        let mut interp = Interpreter::new();
+        match interp.run(&program) {
+            Completion::Normal(v) => v,
+            other => panic!("unexpected completion for `{source}`: {other:?}"),
+        }
+    }
+
+    fn assert_number(source: &str, expected: f64) {
+        match completion_value(source) {
+            JsValue::Number(n) => assert_eq!(n, expected, "completion value of `{source}`"),
+            other => panic!("expected number completion for `{source}`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn while_loop_yields_last_body_value() {
+        assert_number("var i=0; while(i<3){ i++; 42; }", 42.0);
+    }
+
+    #[test]
+    fn do_while_yields_last_body_value() {
+        assert_number("do { 5; } while(false)", 5.0);
+    }
+
+    #[test]
+    fn for_loop_yields_last_body_value() {
+        assert_number("for(var i=0;i<1;i++){ 7; }", 7.0);
+    }
+
+    #[test]
+    fn for_in_yields_last_body_value() {
+        assert_number("for(var k in {a:1,b:2}){ 33; }", 33.0);
+    }
+
+    #[test]
+    fn while_break_with_value_wins() {
+        assert_number(
+            "var n=0; while(n<3){ n++; if(n===2){ 99; break; } 44; }",
+            99.0,
+        );
+    }
+
+    #[test]
+    fn labelled_for_continue_carries_value() {
+        assert_number(
+            "outer: for(var i=0;i<2;i++){ for(var j=0;j<2;j++){ 9; continue outer; } }",
+            9.0,
+        );
+    }
+
+    #[test]
+    fn labelled_while_body_value_after_inner_break() {
+        assert_number(
+            "var o=0; outer: while(o<2){ o++; inner: while(true){ 11; break inner; } 22; }",
+            22.0,
+        );
+    }
+
+    #[test]
+    fn labelled_do_while_continue_then_body_value() {
+        assert_number(
+            "var m=0; outer: do { m++; if(m<3){ 55; continue outer; } 66; } while(m<3)",
+            66.0,
+        );
+    }
+
+    #[test]
+    fn labelled_for_in_continue_carries_value() {
+        assert_number(
+            "outer: for(var k in {a:1,b:2}){ for(var j=0;j<2;j++){ 77; continue outer; } }",
+            77.0,
+        );
+    }
+
+    #[test]
+    fn labelled_break_out_of_for_carries_value() {
+        assert_number(
+            "L: for (var i=0;i<3;i++){ if(i===1){ 71; break L; } }",
+            71.0,
+        );
+    }
+
+    #[test]
+    fn labelled_block_break_yields_value() {
+        assert_number("l: { 1; break l; }", 1.0);
+    }
+
+    // Guard: for-of and switch are deliberately NOT routed through the shared
+    // helper. These pin that the refactor left them unaffected.
+    #[test]
+    fn for_of_completion_value_unaffected() {
+        assert_number("for(var x of [1,2,3]){ x*10; }", 30.0);
+    }
+
+    #[test]
+    fn for_of_break_with_value_unaffected() {
+        assert_number("for(var x of [1,2,3]){ if(x===2){ 88; break; } }", 88.0);
+    }
+
+    #[test]
+    fn switch_break_with_value_unaffected() {
+        assert_number("switch(1){ case 1: 111; break; }", 111.0);
+    }
+}
+
 // §7.1.5 ToIntegerOrInfinity — the combined `? ToIntegerOrInfinity(argument)`
 // coercion method that sits alongside to_number_value / to_string_value / to_index.
 // Expected values are the spec's, not recomputed the way the code does it.


### PR DESCRIPTION
## Goal

An architecture audit (via the `improve-codebase-architecture` skill) surfaced a **shallow, duplicated** protocol in the interpreter: six loop executors each hand-inlined the *same* ~20-line `match` over a loop body's `Completion`. This PR turns that into a **deep module** — a small interface hiding the whole loop-body decision — improving locality (fix-once) and testability.

### The friction

`exec_while`, `exec_do_while`, both arms of `exec_labeled_loop`, `exec_for`, and `exec_for_in` each repeated:

```rust
match self.exec_statement(&body, env) {
    Completion::Normal(val) => { v = val; }
    Completion::Empty => {}
    Completion::Continue(None, cont_val) => { if let Some(val) = cont_val { v = val; } }
    // labeled sites also: Completion::Continue(Some(ref l), _) if l == label => { ... }
    Completion::Break(None, break_val) => { if let Some(val) = break_val { v = val; } <break-action> }
    other => <propagate-action>,
}
```

The arms are structurally identical; only the **break-action** (`return` / `break` / `break 'label`) and **propagate-action** differ. The shared decision — fold the completion value into the running loop value, match *this* loop's label on a labelled `continue`, recognise an unlabelled `break` — had no single home.

### The deepening

Extract a **free function** (no `self` — directly unit-testable):

```rust
fn handle_loop_body_completion(comp: Completion, v: &mut JsValue, label: Option<&str>) -> LoopFlow

enum LoopFlow { Iterate, Break, Propagate(Completion) }
```

`LoopFlow` externalises the per-loop-kind control-flow, so each call site keeps its own `return` / `break` / `break 'label` while the completion bookkeeping lives in one place. The labelled-continue arm is subsumed by the `label: Option<&str>` parameter (`None` for unlabelled loops, which then propagate any labelled `continue` unchanged, exactly as before).

**Deletion test:** PASS — inlining forces six sites to re-derive the arm ordering and label-matching.

### Deliberately excluded

`for-of` and `switch` are **not** routed through the helper:
- `for-of` must interleave **IteratorClose** on every abrupt completion (`gen.return()` on `break`/`throw`/labelled escape).
- `switch` has no `continue` arm and a different break-value default (`update_empty`).

These are a different protocol, not this one. Guard tests pin that they are unaffected.

## Tests (TDD: red → green → refactor)

Written test-first; the legitimate red was the contract test failing to compile before the helper existed.

- **`loop_flow_tests`** (`exec.rs`, 11 tests) — a contract unit test pinning the helper's full decision table: value-folding for Normal/Empty/Continue/Break, label matching, and propagation of `Throw`/`Return`/labelled `break`/non-matching labelled `continue` without disturbing `v`.
- **`loop_completion_value_tests`** (`tests.rs`, 14 tests) — interpreter-level completion values, the observable surface of the `v = val` folding, across **all six** migrated loop heads (incl. labelled `continue`/`break`) **plus the two excluded forms** (`for-of`, `switch`). Expected values are the ECMAScript completion-value semantics, **cross-checked against Node** (non-tautological).

## Verification

- `cargo test` — 439 existing unit tests + 25 new, all green.
- `./scripts/lint.sh` — rustfmt + clippy clean.
- **test262 (tree-walker, the default path)** `language/statements/{while,do-while,for,for-in,for-of,labeled,break,continue,switch}` — **2881/2881 scenarios pass, 0 regressions**.
- **test262 (`--bytecode`)** `language/statements/{while,do-while,for,for-in,labeled,break,continue}` — **1223/1223 pass, 0 regressions** (loops with `break`/`continue` fall back to this tree-walker path; simple loops use the bytecode lowering, which this change does not touch).
- test262 1% full-suite random sample — 3698 scenarios, **0 regressions**. (The sample also reported 7 *new passes* in RegExp/Atomics, unrelated to this change — the baseline `test262-pass.txt` on `main` is stale relative to the current test262 submodule pin.)

## Follow-ups (surfaced by the same audit, not in this PR)

- `arg(args, n)` argument accessor — the `args.get(n).cloned().unwrap_or(JsValue::Undefined)` idiom (371 sites). High volume; needs the full suite to validate, so kept out of this focused change.
- `define_method` adoption gap in `builtins/mod.rs` (~90 open-coded installs).
- GC safepoint-rooting trio → `gc_safepoint_rooted` (7 loop heads).

🤖 Generated with Claude Code
