### PR TITLE
refactor(nan-box): migrate core builtins to JsValue accessors

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -38,13 +38,13 @@ fn to_object_val(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, Co
 }
 
 fn length_of_array_like(interp: &mut Interpreter, o: &JsValue) -> Result<usize, Completion> {
-    let len_val = if let JsValue::Object(obj_ref) = o {
-        match interp.get_object_property(obj_ref.id, "length", o) {
+    let len_val = if let Some(obj_id) = o.as_object_id() {
+        match interp.get_object_property(obj_id, "length", o) {
             Completion::Normal(v) => v,
             other => return Err(other),
         }
     } else {
-        JsValue::Undefined
+        JsValue::UNDEFINED
     };
     // ? ToLength(lenProperty) — must propagate errors from ToNumber/ToPrimitive
     let n = match interp.to_number_value(&len_val) {
@@ -59,21 +59,21 @@ fn length_of_array_like(interp: &mut Interpreter, o: &JsValue) -> Result<usize, 
 }
 
 fn get_obj<'a>(interp: &'a Interpreter, o: &JsValue) -> Option<&'a ObjectHandle> {
-    if let JsValue::Object(obj_ref) = o {
-        interp.get_object_cell(obj_ref.id)
+    if let Some(obj_id) = o.as_object_id() {
+        interp.get_object_cell(obj_id)
     } else {
         None
     }
 }
 
 fn obj_get(interp: &mut Interpreter, o: &JsValue, key: &str) -> Result<JsValue, Completion> {
-    if let JsValue::Object(obj_ref) = o {
-        match interp.get_object_property(obj_ref.id, key, o) {
+    if let Some(obj_id) = o.as_object_id() {
+        match interp.get_object_property(obj_id, key, o) {
             Completion::Normal(v) => Ok(v),
             other => Err(other),
         }
     } else {
-        Ok(JsValue::Undefined)
+        Ok(JsValue::UNDEFINED)
     }
 }
 
@@ -84,14 +84,14 @@ fn obj_set_throw(
     key: &str,
     value: JsValue,
 ) -> Result<(), JsValue> {
-    if let JsValue::Object(obj_ref) = o {
+    if let Some(obj_id) = o.as_object_id() {
         // Check for Proxy
-        let is_proxy = interp.get_object_cell(obj_ref.id).is_some_and(|cell| {
+        let is_proxy = interp.get_object_cell(obj_id).is_some_and(|cell| {
             let b = cell.borrow();
             b.is_proxy() || b.is_proxy_revoked()
         });
         if is_proxy {
-            match interp.proxy_set(obj_ref.id, key, value, o) {
+            match interp.proxy_set(obj_id, key, value, o) {
                 Ok(true) => return Ok(()),
                 Ok(false) => {
                     return Err(interp.create_type_error(&format!(
@@ -110,10 +110,10 @@ fn obj_set_throw(
         // honours inherited setters / non-writable data along the way.
         {
             let has_own = interp
-                .get_object_cell(obj_ref.id)
+                .get_object_cell(obj_id)
                 .is_some_and(|cell| cell.borrow().has_own_property(key));
-            if !has_own && interp.has_proxy_in_prototype_chain(obj_ref.id) {
-                return match interp.proxy_set(obj_ref.id, key, value, o) {
+            if !has_own && interp.has_proxy_in_prototype_chain(obj_id) {
+                return match interp.proxy_set(obj_id, key, value, o) {
                     Ok(true) => Ok(()),
                     Ok(false) => Err(interp.create_type_error(&format!(
                         "Cannot assign to read only property '{key}'"
@@ -124,10 +124,10 @@ fn obj_set_throw(
         }
         // Check for setter in prototype chain
         {
-            let desc = interp.get_property_descriptor_on_id(obj_ref.id, key);
+            let desc = interp.get_property_descriptor_on_id(obj_id, key);
             if let Some(ref d) = desc {
                 if let Some(ref setter) = d.set
-                    && !matches!(setter, JsValue::Undefined)
+                    && !(setter).is_undefined()
                 {
                     let setter = setter.clone();
                     let this = o.clone();
@@ -153,7 +153,7 @@ fn obj_set_throw(
         }
         // TypedArray [[Set]]: must call ToNumber/ToBigInt before writing (§10.4.5.5)
         {
-            let ta_info = interp.get_object_cell(obj_ref.id).and_then(|cell| {
+            let ta_info = interp.get_object_cell(obj_id).and_then(|cell| {
                 let b = cell.borrow();
                 b.typed_array_info()
                     .as_ref()
@@ -167,10 +167,10 @@ fn obj_set_throw(
                 } else {
                     {
                         let n = interp.to_number_value(&value)?;
-                        JsValue::Number(n)
+                        JsValue::number(n)
                     }
                 };
-                if let Some(cell) = interp.get_object_cell(obj_ref.id)
+                if let Some(cell) = interp.get_object_cell(obj_id)
                     && let Some(ta) = cell.borrow().typed_array_info()
                     && is_valid_integer_index(ta, index)
                 {
@@ -180,7 +180,7 @@ fn obj_set_throw(
             }
         }
         // Normal set
-        if let Some(cell) = interp.get_object_cell(obj_ref.id) {
+        if let Some(cell) = interp.get_object_cell(obj_id) {
             let needs_error = {
                 let borrow = cell.borrow();
                 !borrow.extensible && !borrow.has_own_property(key)
@@ -204,21 +204,21 @@ pub(crate) fn create_data_property_or_throw<K: PropertyKeyLike + ?Sized>(
     value: JsValue,
 ) -> Result<(), JsValue> {
     let key = key.to_js_property_key();
-    if let JsValue::Object(obj_ref) = o {
+    if let Some(obj_id) = o.as_object_id() {
         // Deferred namespace: trigger evaluation on [[DefineOwnProperty]]
         {
-            let is_deferred_ns = interp.get_object_cell(obj_ref.id).is_some_and(|cell| {
+            let is_deferred_ns = interp.get_object_cell(obj_id).is_some_and(|cell| {
                 cell.borrow()
                     .module_namespace()
                     .is_some_and(|ns| ns.deferred)
             });
             if is_deferred_ns && !Interpreter::is_symbol_like_namespace_key(&key, true) {
-                interp.ensure_deferred_namespace_evaluation(obj_ref.id)?;
+                interp.ensure_deferred_namespace_evaluation(obj_id)?;
             }
         }
         // Check for Proxy defineProperty trap
         let is_proxy = interp
-            .get_object_cell(obj_ref.id)
+            .get_object_cell(obj_id)
             .is_some_and(|cell| cell.borrow().is_proxy());
         if is_proxy {
             // Build descriptor object for proxy trap
@@ -226,13 +226,13 @@ pub(crate) fn create_data_property_or_throw<K: PropertyKeyLike + ?Sized>(
             {
                 let mut borrow = interp.get_object_cell_expect(desc_obj_id).borrow_mut();
                 borrow.set_property_value("value", value);
-                borrow.set_property_value("writable", JsValue::Boolean(true));
-                borrow.set_property_value("enumerable", JsValue::Boolean(true));
-                borrow.set_property_value("configurable", JsValue::Boolean(true));
+                borrow.set_property_value("writable", JsValue::TRUE);
+                borrow.set_property_value("enumerable", JsValue::TRUE);
+                borrow.set_property_value("configurable", JsValue::TRUE);
             }
             let desc_id = desc_obj_id;
-            let desc_val = JsValue::Object(crate::types::JsObject { id: desc_id });
-            return match interp.proxy_define_own_property(obj_ref.id, key.clone(), &desc_val) {
+            let desc_val = JsValue::object(desc_id);
+            return match interp.proxy_define_own_property(obj_id, key.clone(), &desc_val) {
                 Ok(true) => Ok(()),
                 Ok(false) => {
                     Err(interp.create_type_error(&format!("Cannot define property: {key}")))
@@ -240,12 +240,12 @@ pub(crate) fn create_data_property_or_throw<K: PropertyKeyLike + ?Sized>(
                 Err(e) => Err(e),
             };
         }
-        if interp.get_object_cell(obj_ref.id).is_some() {
+        if interp.get_object_cell(obj_id).is_some() {
             // Check extensibility — CreateDataProperty fails when the object is
             // not extensible and lacks an OWN property of this key (an inherited
             // property must not satisfy the check; cf. OrdinaryDefineOwnProperty).
             let (not_extensible, has_own) = {
-                let borrow = interp.get_object_cell_expect(obj_ref.id).borrow();
+                let borrow = interp.get_object_cell_expect(obj_id).borrow();
                 (!borrow.extensible, borrow.has_own_property(&key))
             };
             if not_extensible && !has_own {
@@ -255,7 +255,7 @@ pub(crate) fn create_data_property_or_throw<K: PropertyKeyLike + ?Sized>(
             }
             // Check for non-configurable existing property
             let non_configurable = {
-                let borrow = interp.get_object_cell_expect(obj_ref.id).borrow();
+                let borrow = interp.get_object_cell_expect(obj_id).borrow();
                 borrow
                     .get_own_property(&key)
                     .is_some_and(|desc| desc.configurable == Some(false))
@@ -263,7 +263,7 @@ pub(crate) fn create_data_property_or_throw<K: PropertyKeyLike + ?Sized>(
             if non_configurable {
                 return Err(interp.create_type_error(&format!("Cannot redefine property: {key}")));
             }
-            let cell = interp.get_object_cell_expect(obj_ref.id);
+            let cell = interp.get_object_cell_expect(obj_id);
             interp.gc_write_barrier_value(cell, &value);
             let mut borrow = cell.borrow_mut_untracked();
             if let Some(elems) = borrow.array_elements_mut()
@@ -273,7 +273,7 @@ pub(crate) fn create_data_property_or_throw<K: PropertyKeyLike + ?Sized>(
                     elems[idx] = value.clone();
                 } else {
                     while elems.len() < idx {
-                        elems.push(JsValue::Undefined);
+                        elems.push(JsValue::UNDEFINED);
                     }
                     elems.push(value.clone());
                 }
@@ -282,16 +282,11 @@ pub(crate) fn create_data_property_or_throw<K: PropertyKeyLike + ?Sized>(
                     .properties
                     .get("length")
                     .and_then(|d| d.value.as_ref())
-                    .and_then(|v| {
-                        if let JsValue::Number(n) = v {
-                            Some(*n as usize)
-                        } else {
-                            None
-                        }
-                    })
+                    .and_then(|v| v.as_number())
+                    .map(|n| n as usize)
                     .unwrap_or(0);
                 if idx >= cur_len {
-                    borrow.set_property_value("length", JsValue::Number((idx + 1) as f64));
+                    borrow.set_property_value("length", JsValue::number((idx + 1) as f64));
                 }
             }
             borrow.define_own_property(key, PropertyDescriptor::data_default(value));
@@ -301,8 +296,8 @@ pub(crate) fn create_data_property_or_throw<K: PropertyKeyLike + ?Sized>(
 }
 
 fn obj_has_throw(interp: &mut Interpreter, o: &JsValue, key: &str) -> Result<bool, JsValue> {
-    if let JsValue::Object(obj_ref) = o {
-        interp.proxy_has_property(obj_ref.id, key)
+    if let Some(obj_id) = o.as_object_id() {
+        interp.proxy_has_property(obj_id, key)
     } else {
         Ok(false)
     }
@@ -310,8 +305,9 @@ fn obj_has_throw(interp: &mut Interpreter, o: &JsValue, key: &str) -> Result<boo
 
 // AsyncIteratorClose: call iterator.return() if it exists (best-effort)
 fn close_async_iterator(interp: &mut Interpreter, iterator: &JsValue) {
-    if let JsValue::Object(ref io) = *iterator
-        && let Completion::Normal(return_fn) = interp.get_object_property(io.id, "return", iterator)
+    if let Some(iterator_id) = iterator.as_object_id()
+        && let Completion::Normal(return_fn) =
+            interp.get_object_property(iterator_id, "return", iterator)
         && interp.is_callable(&return_fn)
     {
         let _ = interp.call_function(&return_fn, iterator, &[]);
@@ -347,9 +343,9 @@ fn from_async_gc_root(interp: &mut Interpreter, state: &Rc<RefCell<FromAsyncStat
         &s.reject_fn,
         &s.array_like,
     ] {
-        if let JsValue::Object(o) = val {
-            interp.gc_temp_roots.push(o.id);
-            roots.push(o.id);
+        if let Some(obj_id) = val.as_object_id() {
+            interp.gc_temp_roots.push(obj_id);
+            roots.push(obj_id);
         }
     }
     drop(s);
@@ -377,7 +373,7 @@ fn from_async_collect_roots(state: &Rc<RefCell<FromAsyncState>>) -> Vec<JsValue>
         &s.reject_fn,
         &s.array_like,
     ] {
-        if matches!(val, JsValue::Object(_)) {
+        if (val).is_object() {
             roots.push(val.clone());
         }
     }
@@ -399,7 +395,7 @@ fn from_async_reject(
         close_async_iterator(interp, &iterator);
     }
     from_async_gc_unroot(interp, state);
-    let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[error]);
+    let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[error]);
 }
 
 fn from_async_resolve(interp: &mut Interpreter, state: &Rc<RefCell<FromAsyncState>>) {
@@ -410,11 +406,11 @@ fn from_async_resolve(interp: &mut Interpreter, state: &Rc<RefCell<FromAsyncStat
     drop(s);
     if let Err(e) = set_length_throw(interp, &arr, k as usize) {
         from_async_gc_unroot(interp, state);
-        let _ = interp.call_function(&state.borrow().reject_fn.clone(), &JsValue::Undefined, &[e]);
+        let _ = interp.call_function(&state.borrow().reject_fn.clone(), &JsValue::UNDEFINED, &[e]);
         return;
     }
     from_async_gc_unroot(interp, state);
-    let _ = interp.call_function(&resolve_fn, &JsValue::Undefined, &[arr]);
+    let _ = interp.call_function(&resolve_fn, &JsValue::UNDEFINED, &[arr]);
 }
 
 // Non-blocking Await: wraps value in a promise, then schedules the continuation.
@@ -426,11 +422,7 @@ fn from_async_attach_await(
     close_iter_on_reject: bool,
 ) {
     let promise = interp.promise_resolve_value(value);
-    let promise_id = if let JsValue::Object(ref o) = promise {
-        o.id
-    } else {
-        0
-    };
+    let promise_id = promise.as_object_id().unwrap_or(0);
 
     let pstate = interp.get_promise_state(promise_id);
     match pstate {
@@ -442,7 +434,7 @@ fn from_async_attach_await(
                 roots,
                 Box::new(move |interp| {
                     on_fulfill(interp, value, state_c);
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 }),
             ));
         }
@@ -459,9 +451,9 @@ fn from_async_attach_await(
                 "fromAsyncFulfill".to_string(),
                 1,
                 move |interp, _this, args| {
-                    let v = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let v = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     on_fulfill(interp, v, state_f.clone());
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
 
@@ -469,9 +461,9 @@ fn from_async_attach_await(
                 "fromAsyncReject".to_string(),
                 1,
                 move |interp, _this, args| {
-                    let e = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let e = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     from_async_reject(interp, &state_r, e, close);
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
 
@@ -482,15 +474,15 @@ fn from_async_attach_await(
                     pd.fulfill_reactions.push(PromiseReaction {
                         handler: Some(fulfill_handler),
                         promise_id: None,
-                        resolve: JsValue::Undefined,
-                        reject: JsValue::Undefined,
+                        resolve: JsValue::UNDEFINED,
+                        reject: JsValue::UNDEFINED,
                         reaction_type: PromiseReactionType::Fulfill,
                     });
                     pd.reject_reactions.push(PromiseReaction {
                         handler: Some(reject_handler),
                         promise_id: None,
-                        resolve: JsValue::Undefined,
-                        reject: JsValue::Undefined,
+                        resolve: JsValue::UNDEFINED,
+                        reject: JsValue::UNDEFINED,
                         reaction_type: PromiseReactionType::Reject,
                     });
                 }
@@ -514,23 +506,23 @@ fn from_async_iter_step(interp: &mut Interpreter, state: Rc<RefCell<FromAsyncSta
             let err = interp.create_type_error("Array.fromAsync: too many elements");
             close_async_iterator(interp, &iterator);
             from_async_gc_unroot(interp, &state);
-            let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[err]);
+            let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[err]);
             return;
         }
     }
     let iterator = state.borrow().iterator.clone();
 
-    let next_fn = if let JsValue::Object(ref io) = iterator {
-        match interp.get_object_property(io.id, "next", &iterator) {
+    let next_fn = if let Some(iterator_id) = iterator.as_object_id() {
+        match interp.get_object_property(iterator_id, "next", &iterator) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => {
                 from_async_reject(interp, &state, e, false);
                 return;
             }
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         }
     } else {
-        JsValue::Undefined
+        JsValue::UNDEFINED
     };
 
     let next_result = match interp.call_function(&next_fn, &iterator, &[]) {
@@ -539,7 +531,7 @@ fn from_async_iter_step(interp: &mut Interpreter, state: Rc<RefCell<FromAsyncSta
             from_async_reject(interp, &state, e, false);
             return;
         }
-        _ => JsValue::Undefined,
+        _ => JsValue::UNDEFINED,
     };
 
     from_async_attach_await(interp, &next_result, state, from_async_process_next, true);
@@ -551,8 +543,8 @@ fn from_async_process_next(
     next_result: JsValue,
     state: Rc<RefCell<FromAsyncState>>,
 ) {
-    let done = if let JsValue::Object(ref o) = next_result {
-        match interp.get_object_property(o.id, "done", &next_result) {
+    let done = if let Some(result_id) = next_result.as_object_id() {
+        match interp.get_object_property(result_id, "done", &next_result) {
             Completion::Normal(v) => interp.to_boolean_val(&v),
             _ => false,
         }
@@ -565,17 +557,17 @@ fn from_async_process_next(
         return;
     }
 
-    let value = if let JsValue::Object(ref o) = next_result {
-        match interp.get_object_property(o.id, "value", &next_result) {
+    let value = if let Some(result_id) = next_result.as_object_id() {
+        match interp.get_object_property(result_id, "value", &next_result) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => {
                 from_async_reject(interp, &state, e, true);
                 return;
             }
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         }
     } else {
-        JsValue::Undefined
+        JsValue::UNDEFINED
     };
 
     let has_map = state.borrow().has_map;
@@ -587,13 +579,13 @@ fn from_async_process_next(
         drop(s);
 
         let mapped =
-            match interp.call_function(&map_fn, &this_arg, &[value, JsValue::Number(k as f64)]) {
+            match interp.call_function(&map_fn, &this_arg, &[value, JsValue::number(k as f64)]) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => {
                     from_async_reject(interp, &state, e, true);
                     return;
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
         from_async_attach_await(
             interp,
@@ -638,17 +630,17 @@ fn from_async_arraylike_step(interp: &mut Interpreter, state: Rc<RefCell<FromAsy
     drop(s);
 
     let key_str = k.to_string();
-    let value = if let JsValue::Object(ref o) = array_like {
-        match interp.get_object_property(o.id, &key_str, &array_like) {
+    let value = if let Some(array_like_id) = array_like.as_object_id() {
+        match interp.get_object_property(array_like_id, &key_str, &array_like) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => {
                 from_async_reject(interp, &state, e, false);
                 return;
             }
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         }
     } else {
-        JsValue::Undefined
+        JsValue::UNDEFINED
     };
 
     from_async_attach_await(interp, &value, state, from_async_arraylike_process, false);
@@ -669,13 +661,13 @@ fn from_async_arraylike_process(
         drop(s);
 
         let mapped =
-            match interp.call_function(&map_fn, &this_arg, &[value, JsValue::Number(k as f64)]) {
+            match interp.call_function(&map_fn, &this_arg, &[value, JsValue::number(k as f64)]) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => {
                     from_async_reject(interp, &state, e, false);
                     return;
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
         from_async_attach_await(
             interp,
@@ -714,21 +706,21 @@ fn obj_delete(interp: &mut Interpreter, o: &JsValue, key: &str) {
             && let Ok(idx) = key.parse::<usize>()
             && idx < elems.len()
         {
-            elems[idx] = JsValue::Undefined;
+            elems[idx] = JsValue::UNDEFINED;
         }
     }
 }
 
 // DeletePropertyOrThrow(O, P) - throws TypeError if delete fails
 fn obj_delete_throw(interp: &mut Interpreter, o: &JsValue, key: &str) -> Result<(), JsValue> {
-    if let JsValue::Object(obj_ref) = o {
+    if let Some(obj_id) = o.as_object_id() {
         // Check for Proxy deleteProperty trap
-        let is_proxy = interp.get_object_cell(obj_ref.id).is_some_and(|cell| {
+        let is_proxy = interp.get_object_cell(obj_id).is_some_and(|cell| {
             let b = cell.borrow();
             b.is_proxy() || b.is_proxy_revoked()
         });
         if is_proxy {
-            match interp.proxy_delete_property(obj_ref.id, key) {
+            match interp.proxy_delete_property(obj_id, key) {
                 Ok(true) => return Ok(()),
                 Ok(false) => {
                     return Err(
@@ -739,7 +731,7 @@ fn obj_delete_throw(interp: &mut Interpreter, o: &JsValue, key: &str) -> Result<
             }
         }
         // Check if property is non-configurable
-        let non_configurable = interp.get_object_cell(obj_ref.id).is_some_and(|cell| {
+        let non_configurable = interp.get_object_cell(obj_id).is_some_and(|cell| {
             cell.borrow()
                 .get_own_property(key)
                 .is_some_and(|desc| desc.configurable == Some(false))
@@ -763,7 +755,7 @@ fn set_length(interp: &mut Interpreter, o: &JsValue, len: usize) {
             elems.truncate(len);
         }
         // Don't pre-allocate for sparse arrays
-        borrow.set_property_value("length", JsValue::Number(len as f64));
+        borrow.set_property_value("length", JsValue::number(len as f64));
     }
 }
 
@@ -802,11 +794,11 @@ fn set_length_throw(interp: &mut Interpreter, o: &JsValue, len: usize) -> Result
                 elems.truncate(len);
             }
             // Don't pre-allocate for sparse arrays
-            borrow.set_property_value("length", JsValue::Number(len as f64));
+            borrow.set_property_value("length", JsValue::number(len as f64));
         }
         return Ok(());
     }
-    obj_set_throw(interp, o, "length", JsValue::Number(len as f64))
+    obj_set_throw(interp, o, "length", JsValue::number(len as f64))
 }
 
 fn require_callable(interp: &mut Interpreter, val: &JsValue, msg: &str) -> Result<(), Completion> {
@@ -823,8 +815,8 @@ fn array_species_create(
     original_array: &JsValue,
     length: usize,
 ) -> Result<JsValue, Completion> {
-    let is_array = if let JsValue::Object(o) = original_array {
-        match is_array_check(interp, o.id) {
+    let is_array = if let Some(original_id) = original_array.as_object_id() {
+        match is_array_check(interp, original_id) {
             Ok(v) => v,
             Err(e) => return Err(Completion::Throw(e)),
         }
@@ -846,21 +838,19 @@ fn array_species_create(
         return Ok(arr);
     }
     // Get constructor
-    let mut c = if let JsValue::Object(o) = original_array {
-        match interp.get_object_property(o.id, "constructor", original_array) {
+    let mut c = if let Some(original_id) = original_array.as_object_id() {
+        match interp.get_object_property(original_id, "constructor", original_array) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(Completion::Throw(e)),
             other => return Err(other),
         }
     } else {
-        JsValue::Undefined
+        JsValue::UNDEFINED
     };
     // §9.4.2.3 step 5-6: If C is a constructor from a different realm and
     // equals that realm's intrinsic %Array%, set C to undefined
-    if interp.is_constructor(&c)
-        && let JsValue::Object(co) = &c
-    {
-        let c_realm = match interp.get_function_realm(&JsValue::Object(co.clone())) {
+    if interp.is_constructor(&c) && c.is_object() {
+        let c_realm = match interp.get_function_realm(&c) {
             Ok(r) => r,
             Err(e) => return Err(Completion::Throw(e)),
         };
@@ -875,25 +865,25 @@ fn array_species_create(
             if let Some(ref ra) = realm_array
                 && same_value(&c, ra)
             {
-                c = JsValue::Undefined;
+                c = JsValue::UNDEFINED;
             }
         }
     }
     // If C is Object, get C[@@species]
-    let c = if let JsValue::Object(co) = &c {
+    let c = if let Some(c_id) = c.as_object_id() {
         let sym_key = interp.get_symbol_key("species");
         let species = if let Some(key) = &sym_key {
-            match interp.get_object_property(co.id, key, &c) {
+            match interp.get_object_property(c_id, key, &c) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(Completion::Throw(e)),
                 other => return Err(other),
             }
         } else {
-            JsValue::Undefined
+            JsValue::UNDEFINED
         };
         // If species is null, treat as undefined
-        if matches!(species, JsValue::Null) {
-            JsValue::Undefined
+        if (species).is_null() {
+            JsValue::UNDEFINED
         } else {
             species
         }
@@ -901,7 +891,7 @@ fn array_species_create(
         c
     };
     // If C is undefined, create a default array
-    if matches!(c, JsValue::Undefined) {
+    if (c).is_undefined() {
         if length as u64 > 0xFFFF_FFFF {
             return Err(Completion::Throw(
                 interp.create_range_error("Invalid array length"),
@@ -922,7 +912,7 @@ fn array_species_create(
         ));
     }
     // Construct(C, [length])
-    match interp.construct(&c, &[JsValue::Number(length as f64)]) {
+    match interp.construct(&c, &[JsValue::number(length as f64)]) {
         Completion::Normal(v) => Ok(v),
         Completion::Throw(e) => Err(Completion::Throw(e)),
         other => Err(other),
@@ -941,7 +931,7 @@ impl Interpreter {
             .borrow_mut()
             .insert_property(
                 "length".to_string(),
-                PropertyDescriptor::data(JsValue::Number(0.0), true, false, false),
+                PropertyDescriptor::data(JsValue::number(0.0), true, false, false),
             );
 
         // Array.prototype.push
@@ -963,20 +953,17 @@ impl Interpreter {
             // checks + len.to_string()). Falls through to the slow loop on any
             // guard miss so proxies, array-likes/arguments, frozen/non-writable
             // -length, and sparse arrays keep correct behaviour.
-            if let JsValue::Object(ref obj_ref) = o
-                && let Some(cell) = interp.get_object(obj_ref.id)
+            if let Some(obj_id) = o.as_object_id()
+                && let Some(cell) = interp.get_object(obj_id)
             {
                 let (fast_ok, proto_id) = {
                     let b = cell.borrow();
                     let len_desc = b.properties.get("length");
                     let len_writable = len_desc.map(|d| d.writable != Some(false)).unwrap_or(false);
-                    let desc_len = len_desc.and_then(|d| d.value.as_ref()).and_then(|v| {
-                        if let JsValue::Number(n) = v {
-                            Some(*n as usize)
-                        } else {
-                            None
-                        }
-                    });
+                    let desc_len = len_desc
+                        .and_then(|d| d.value.as_ref())
+                        .and_then(|v| v.as_number())
+                        .map(|n| n as usize);
                     let ok = b.class_name == "Array"
                         && !b.is_proxy()
                         && b.extensible
@@ -987,7 +974,7 @@ impl Interpreter {
                     (ok, b.prototype_id)
                 };
                 // §23.1.3.25 push performs Set, which creates *present* data
-                // properties. In this engine a `JsValue::Undefined` slot in
+                // properties. In this engine a `JsValue::UNDEFINED` slot in
                 // `array_elements` with no `properties` entry is the HOLE
                 // sentinel (see the indexed-write fast path in eval.rs and
                 // `get_own_property_full`), so writing `undefined` straight
@@ -995,7 +982,7 @@ impl Interpreter {
                 // instead of a present element. Bail to the slow path when any
                 // argument is `undefined`; the slow path adds the presence
                 // marker.
-                let has_undefined_arg = args.iter().any(|a| matches!(a, JsValue::Undefined));
+                let has_undefined_arg = args.iter().any(|a| (a).is_undefined());
                 // §23.1.3.25 push performs Set(O, ToString(i), …, true) =
                 // OrdinarySet, which walks the prototype chain. If any
                 // appended index ToString is inherited (setter or data) we
@@ -1030,11 +1017,11 @@ impl Interpreter {
                             elements.push(arg.clone());
                         }
                         if let Some(len_desc) = b.properties.get_mut("length") {
-                            len_desc.value = Some(JsValue::Number(new_len as f64));
+                            len_desc.value = Some(JsValue::number(new_len as f64));
                         }
                         b.shape_id = crate::interpreter::types::fresh_shape_id();
                     }
-                    return Completion::Normal(JsValue::Number(new_len as f64));
+                    return Completion::Normal(JsValue::number(new_len as f64));
                 }
             }
             for arg in args {
@@ -1046,7 +1033,7 @@ impl Interpreter {
             if let Err(e) = set_length_throw(interp, &o, len) {
                 return Completion::Throw(e);
             }
-            Completion::Normal(JsValue::Number(len as f64))
+            Completion::Normal(JsValue::number(len as f64))
         });
 
         // Array.prototype.pop
@@ -1063,7 +1050,7 @@ impl Interpreter {
                 if let Err(e) = set_length_throw(interp, &o, 0) {
                     return Completion::Throw(e);
                 }
-                return Completion::Normal(JsValue::Undefined);
+                return Completion::Normal(JsValue::UNDEFINED);
             }
             let idx = (len - 1).to_string();
             let val = match obj_get(interp, &o, &idx) {
@@ -1093,7 +1080,7 @@ impl Interpreter {
                 if let Err(e) = set_length_throw(interp, &o, 0) {
                     return Completion::Throw(e);
                 }
-                return Completion::Normal(JsValue::Undefined);
+                return Completion::Normal(JsValue::UNDEFINED);
             }
             let first = match obj_get(interp, &o, "0") {
                 Ok(v) => v,
@@ -1173,7 +1160,7 @@ impl Interpreter {
             if let Err(e) = set_length_throw(interp, &o, new_len) {
                 return Completion::Throw(e);
             }
-            Completion::Normal(JsValue::Number(new_len as f64))
+            Completion::Normal(JsValue::number(new_len as f64))
         });
 
         // Array.prototype.indexOf
@@ -1187,9 +1174,9 @@ impl Interpreter {
                 Err(c) => return c,
             };
             if len == 0 {
-                return Completion::Normal(JsValue::Number(-1.0));
+                return Completion::Normal(JsValue::number(-1.0));
             }
-            let search = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let n = if args.len() >= 2 {
                 match interp.to_integer_or_infinity_value(&args[1]) {
                     Ok(v) => v,
@@ -1199,7 +1186,7 @@ impl Interpreter {
                 0.0
             };
             if n >= len as f64 {
-                return Completion::Normal(JsValue::Number(-1.0));
+                return Completion::Normal(JsValue::number(-1.0));
             }
             let k = if n >= 0.0 {
                 n as usize
@@ -1216,14 +1203,14 @@ impl Interpreter {
                             Err(c) => return c,
                         };
                         if strict_equality(&elem, &search) {
-                            return Completion::Normal(JsValue::Number(i as f64));
+                            return Completion::Normal(JsValue::number(i as f64));
                         }
                     }
                     Err(e) => return Completion::Throw(e),
                     _ => {}
                 }
             }
-            Completion::Normal(JsValue::Number(-1.0))
+            Completion::Normal(JsValue::number(-1.0))
         });
 
         // Array.prototype.lastIndexOf
@@ -1237,9 +1224,9 @@ impl Interpreter {
                 Err(c) => return c,
             };
             if len == 0 {
-                return Completion::Normal(JsValue::Number(-1.0));
+                return Completion::Normal(JsValue::number(-1.0));
             }
-            let search = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let n = if args.len() >= 2 {
                 match interp.to_integer_or_infinity_value(&args[1]) {
                     Ok(v) => v,
@@ -1253,7 +1240,7 @@ impl Interpreter {
             } else {
                 let calc = len as f64 + n;
                 if calc < 0.0 {
-                    return Completion::Normal(JsValue::Number(-1.0));
+                    return Completion::Normal(JsValue::number(-1.0));
                 }
                 calc as usize
             };
@@ -1266,14 +1253,14 @@ impl Interpreter {
                             Err(c) => return c,
                         };
                         if strict_equality(&elem, &search) {
-                            return Completion::Normal(JsValue::Number(i as f64));
+                            return Completion::Normal(JsValue::number(i as f64));
                         }
                     }
                     Err(e) => return Completion::Throw(e),
                     _ => {}
                 }
             }
-            Completion::Normal(JsValue::Number(-1.0))
+            Completion::Normal(JsValue::number(-1.0))
         });
 
         // Array.prototype.includes
@@ -1287,9 +1274,9 @@ impl Interpreter {
                 Err(c) => return c,
             };
             if len == 0 {
-                return Completion::Normal(JsValue::Boolean(false));
+                return Completion::Normal(JsValue::boolean(false));
             }
-            let search = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let n = if args.len() >= 2 {
                 match interp.to_integer_or_infinity_value(&args[1]) {
                     Ok(v) => v,
@@ -1310,10 +1297,10 @@ impl Interpreter {
                     Err(c) => return c,
                 };
                 if same_value_zero(&elem, &search) {
-                    return Completion::Normal(JsValue::Boolean(true));
+                    return Completion::Normal(JsValue::boolean(true));
                 }
             }
-            Completion::Normal(JsValue::Boolean(false))
+            Completion::Normal(JsValue::boolean(false))
         });
 
         // Array.prototype.join
@@ -1327,7 +1314,7 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let sep = if let Some(s) = args.first() {
-                if matches!(s, JsValue::Undefined) {
+                if (s).is_undefined() {
                     ",".to_string()
                 } else {
                     match interp.to_string_value(s) {
@@ -1339,12 +1326,9 @@ impl Interpreter {
                 ",".to_string()
             };
 
-            let receiver_id = match &o {
-                JsValue::Object(obj) => obj.id,
-                _ => unreachable!("ToObject must return an object"),
-            };
+            let receiver_id = o.as_object_id().expect("ToObject must return an object");
             if interp.active_array_joins.contains(&receiver_id) {
-                return Completion::Normal(JsValue::String(JsString::from_str("")));
+                return Completion::Normal(JsValue::string(JsString::from_str("")));
             }
 
             interp.active_array_joins.push(receiver_id);
@@ -1364,7 +1348,7 @@ impl Interpreter {
                         }
                     }
                 }
-                Completion::Normal(JsValue::String(JsString::from_str(&parts.join(&sep))))
+                Completion::Normal(JsValue::string(JsString::from_str(&parts.join(&sep))))
             })();
             let popped_receiver = interp.active_array_joins.pop();
             debug_assert_eq!(popped_receiver, Some(receiver_id));
@@ -1389,7 +1373,7 @@ impl Interpreter {
             if let Some(intrinsic_tostring) = interp.realm().object_prototype_tostring.clone() {
                 return interp.call_function(&intrinsic_tostring, &o, &[]);
             }
-            Completion::Normal(JsValue::String(JsString::from_str("[object Array]")))
+            Completion::Normal(JsValue::string(JsString::from_str("[object Array]")))
         });
 
         // Array.prototype.toLocaleString
@@ -1403,8 +1387,8 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let separator = ",";
-            let locales = args.first().cloned().unwrap_or(JsValue::Undefined);
-            let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let locales = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             let pass_args = vec![locales, options];
             let mut parts: Vec<String> = Vec::with_capacity(len);
             for k in 0..len {
@@ -1412,24 +1396,21 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                if matches!(next_element, JsValue::Undefined | JsValue::Null) {
+                if (next_element).is_nullish() {
                     parts.push(String::new());
                 } else {
                     let element_obj = match interp.to_object(&next_element) {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    let JsValue::Object(ref obj_ref) = element_obj else {
-                        unreachable!()
-                    };
-                    let to_locale_str_method = match interp.get_object_property(
-                        obj_ref.id,
-                        "toLocaleString",
-                        &next_element,
-                    ) {
-                        Completion::Normal(v) => v,
-                        other => return other,
-                    };
+                    let obj_id = element_obj
+                        .as_object_id()
+                        .expect("ToObject must return an object");
+                    let to_locale_str_method =
+                        match interp.get_object_property(obj_id, "toLocaleString", &next_element) {
+                            Completion::Normal(v) => v,
+                            other => return other,
+                        };
                     if interp.is_callable(&to_locale_str_method) {
                         match interp.call_function(&to_locale_str_method, &next_element, &pass_args)
                         {
@@ -1445,7 +1426,7 @@ impl Interpreter {
                     }
                 }
             }
-            Completion::Normal(JsValue::String(JsString::from_str(&parts.join(separator))))
+            Completion::Normal(JsValue::string(JsString::from_str(&parts.join(separator))))
         });
 
         // Array.prototype.concat
@@ -1464,22 +1445,22 @@ impl Interpreter {
             let items: Vec<JsValue> = std::iter::once(o).chain(args.iter().cloned()).collect();
             for item in &items {
                 // IsConcatSpreadable (§23.1.3.1.1)
-                let spreadable = if let JsValue::Object(obj_ref) = item {
+                let spreadable = if let Some(item_id) = item.as_object_id() {
                     let sym_key = interp.get_symbol_key("isConcatSpreadable");
                     let spreadable_val = if let Some(key) = &sym_key {
-                        match interp.get_object_property(obj_ref.id, key, item) {
+                        match interp.get_object_property(item_id, key, item) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
                             other => return other,
                         }
                     } else {
-                        JsValue::Undefined
+                        JsValue::UNDEFINED
                     };
-                    if !matches!(spreadable_val, JsValue::Undefined) {
+                    if !(spreadable_val).is_undefined() {
                         interp.to_boolean_val(&spreadable_val)
                     } else {
                         // 4. Return ? IsArray(O)
-                        match is_array_check(interp, obj_ref.id) {
+                        match is_array_check(interp, item_id) {
                             Ok(v) => v,
                             Err(e) => return Completion::Throw(e),
                         }
@@ -1511,8 +1492,8 @@ impl Interpreter {
                             }
                         };
                         if exists {
-                            let val = if let JsValue::Object(obj_ref) = item {
-                                match interp.get_object_property(obj_ref.id, &pk, item) {
+                            let val = if let Some(item_id) = item.as_object_id() {
+                                match interp.get_object_property(item_id, &pk, item) {
                                     Completion::Normal(v) => v,
                                     Completion::Throw(e) => {
                                         interp.gc_unroot_frame(gc_frame);
@@ -1557,7 +1538,7 @@ impl Interpreter {
                     n += 1;
                 }
             }
-            if let Err(e) = obj_set_throw(interp, &a, "length", JsValue::Number(n as f64)) {
+            if let Err(e) = obj_set_throw(interp, &a, "length", JsValue::number(n as f64)) {
                 interp.gc_unroot_frame(gc_frame);
                 return Completion::Throw(e);
             }
@@ -1585,7 +1566,7 @@ impl Interpreter {
             };
             let k = resolve_relative_index(relative_start, len as usize);
             let relative_end = if let Some(v) = args.get(1) {
-                if matches!(v, JsValue::Undefined) {
+                if (v).is_undefined() {
                     len as f64
                 } else {
                     match interp.to_integer_or_infinity_value(v) {
@@ -1631,7 +1612,7 @@ impl Interpreter {
                 }
                 n += 1;
             }
-            if let Err(e) = obj_set_throw(interp, &a, "length", JsValue::Number(n as f64)) {
+            if let Err(e) = obj_set_throw(interp, &a, "length", JsValue::number(n as f64)) {
                 interp.gc_unroot_frame(gc_frame);
                 return Completion::Throw(e);
             }
@@ -1665,7 +1646,7 @@ impl Interpreter {
                         Err(c) => return c,
                     }
                 } else {
-                    JsValue::Undefined
+                    JsValue::UNDEFINED
                 };
                 let upper_exists = match obj_has_throw(interp, &o, &upper_s) {
                     Ok(b) => b,
@@ -1677,7 +1658,7 @@ impl Interpreter {
                         Err(c) => return c,
                     }
                 } else {
-                    JsValue::Undefined
+                    JsValue::UNDEFINED
                 };
                 if lower_exists && upper_exists {
                     if let Err(e) = obj_set_throw(interp, &o, &lower_s, upper_val) {
@@ -1739,13 +1720,13 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) =
                 require_callable(interp, &callback, "forEach callback is not a function")
             {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             for k in 0..len {
                 let pk = k.to_string();
                 match obj_has_throw(interp, &o, &pk) {
@@ -1754,7 +1735,7 @@ impl Interpreter {
                             Ok(v) => v,
                             Err(c) => return c,
                         };
-                        let call_args = vec![kvalue, JsValue::Number(k as f64), o.clone()];
+                        let call_args = vec![kvalue, JsValue::number(k as f64), o.clone()];
                         if let result @ Completion::Throw(_) =
                             interp.call_function(&callback, &this_arg, &call_args)
                         {
@@ -1765,7 +1746,7 @@ impl Interpreter {
                     _ => {}
                 }
             }
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         // Array.prototype.map
@@ -1778,11 +1759,11 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) = require_callable(interp, &callback, "map callback is not a function") {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             let a = match array_species_create(interp, &o, len) {
                 Ok(v) => v,
                 Err(c) => return c,
@@ -1803,7 +1784,7 @@ impl Interpreter {
                         match interp.call_function(
                             &callback,
                             &this_arg,
-                            &[kvalue, JsValue::Number(k as f64), o.clone()],
+                            &[kvalue, JsValue::number(k as f64), o.clone()],
                         ) {
                             Completion::Normal(v) => {
                                 if let Err(e) = create_data_property_or_throw(interp, &a, &pk, v) {
@@ -1838,12 +1819,12 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) = require_callable(interp, &callback, "filter callback is not a function")
             {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             let a = match array_species_create(interp, &o, 0) {
                 Ok(v) => v,
                 Err(c) => return c,
@@ -1865,7 +1846,7 @@ impl Interpreter {
                         match interp.call_function(
                             &callback,
                             &this_arg,
-                            &[kvalue.clone(), JsValue::Number(k as f64), o.clone()],
+                            &[kvalue.clone(), JsValue::number(k as f64), o.clone()],
                         ) {
                             Completion::Normal(v) => {
                                 if interp.to_boolean_val(&v) {
@@ -1908,7 +1889,7 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) = require_callable(interp, &callback, "reduce callback is not a function")
             {
                 return c;
@@ -1955,8 +1936,8 @@ impl Interpreter {
                         };
                         match interp.call_function(
                             &callback,
-                            &JsValue::Undefined,
-                            &[acc, kvalue, JsValue::Number(k as f64), o.clone()],
+                            &JsValue::UNDEFINED,
+                            &[acc, kvalue, JsValue::number(k as f64), o.clone()],
                         ) {
                             Completion::Normal(v) => acc = v,
                             other => return other,
@@ -1980,7 +1961,7 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) =
                 require_callable(interp, &callback, "reduceRight callback is not a function")
             {
@@ -2027,8 +2008,8 @@ impl Interpreter {
                         };
                         match interp.call_function(
                             &callback,
-                            &JsValue::Undefined,
-                            &[acc, kvalue, JsValue::Number(k as f64), o.clone()],
+                            &JsValue::UNDEFINED,
+                            &[acc, kvalue, JsValue::number(k as f64), o.clone()],
                         ) {
                             Completion::Normal(v) => acc = v,
                             other => return other,
@@ -2052,11 +2033,11 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) = require_callable(interp, &callback, "some callback is not a function") {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             for k in 0..len {
                 let pk = k.to_string();
                 match obj_has_throw(interp, &o, &pk) {
@@ -2068,11 +2049,11 @@ impl Interpreter {
                         match interp.call_function(
                             &callback,
                             &this_arg,
-                            &[kvalue, JsValue::Number(k as f64), o.clone()],
+                            &[kvalue, JsValue::number(k as f64), o.clone()],
                         ) {
                             Completion::Normal(v) => {
                                 if interp.to_boolean_val(&v) {
-                                    return Completion::Normal(JsValue::Boolean(true));
+                                    return Completion::Normal(JsValue::boolean(true));
                                 }
                             }
                             other => return other,
@@ -2082,7 +2063,7 @@ impl Interpreter {
                     _ => {}
                 }
             }
-            Completion::Normal(JsValue::Boolean(false))
+            Completion::Normal(JsValue::boolean(false))
         });
 
         // Array.prototype.every
@@ -2095,12 +2076,12 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) = require_callable(interp, &callback, "every callback is not a function")
             {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             for k in 0..len {
                 let pk = k.to_string();
                 match obj_has_throw(interp, &o, &pk) {
@@ -2112,11 +2093,11 @@ impl Interpreter {
                         match interp.call_function(
                             &callback,
                             &this_arg,
-                            &[kvalue, JsValue::Number(k as f64), o.clone()],
+                            &[kvalue, JsValue::number(k as f64), o.clone()],
                         ) {
                             Completion::Normal(v) => {
                                 if !interp.to_boolean_val(&v) {
-                                    return Completion::Normal(JsValue::Boolean(false));
+                                    return Completion::Normal(JsValue::boolean(false));
                                 }
                             }
                             other => return other,
@@ -2126,7 +2107,7 @@ impl Interpreter {
                     _ => {}
                 }
             }
-            Completion::Normal(JsValue::Boolean(true))
+            Completion::Normal(JsValue::boolean(true))
         });
 
         // Array.prototype.find
@@ -2139,12 +2120,12 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) = require_callable(interp, &callback, "find predicate is not a function")
             {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             for k in 0..len {
                 let kvalue = match obj_get(interp, &o, &k.to_string()) {
                     Ok(v) => v,
@@ -2153,7 +2134,7 @@ impl Interpreter {
                 match interp.call_function(
                     &callback,
                     &this_arg,
-                    &[kvalue.clone(), JsValue::Number(k as f64), o.clone()],
+                    &[kvalue.clone(), JsValue::number(k as f64), o.clone()],
                 ) {
                     Completion::Normal(v) => {
                         if interp.to_boolean_val(&v) {
@@ -2163,7 +2144,7 @@ impl Interpreter {
                     other => return other,
                 }
             }
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         // Array.prototype.findIndex
@@ -2176,13 +2157,13 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) =
                 require_callable(interp, &callback, "findIndex predicate is not a function")
             {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             for k in 0..len {
                 let kvalue = match obj_get(interp, &o, &k.to_string()) {
                     Ok(v) => v,
@@ -2191,17 +2172,17 @@ impl Interpreter {
                 match interp.call_function(
                     &callback,
                     &this_arg,
-                    &[kvalue, JsValue::Number(k as f64), o.clone()],
+                    &[kvalue, JsValue::number(k as f64), o.clone()],
                 ) {
                     Completion::Normal(v) => {
                         if interp.to_boolean_val(&v) {
-                            return Completion::Normal(JsValue::Number(k as f64));
+                            return Completion::Normal(JsValue::number(k as f64));
                         }
                     }
                     other => return other,
                 }
             }
-            Completion::Normal(JsValue::Number(-1.0))
+            Completion::Normal(JsValue::number(-1.0))
         });
 
         // Array.prototype.findLast
@@ -2214,13 +2195,13 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) =
                 require_callable(interp, &callback, "findLast predicate is not a function")
             {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             for k in (0..len).rev() {
                 let kvalue = match obj_get(interp, &o, &k.to_string()) {
                     Ok(v) => v,
@@ -2229,7 +2210,7 @@ impl Interpreter {
                 match interp.call_function(
                     &callback,
                     &this_arg,
-                    &[kvalue.clone(), JsValue::Number(k as f64), o.clone()],
+                    &[kvalue.clone(), JsValue::number(k as f64), o.clone()],
                 ) {
                     Completion::Normal(v) => {
                         if interp.to_boolean_val(&v) {
@@ -2239,7 +2220,7 @@ impl Interpreter {
                     other => return other,
                 }
             }
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         // Array.prototype.findLastIndex
@@ -2252,7 +2233,7 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) = require_callable(
                 interp,
                 &callback,
@@ -2260,7 +2241,7 @@ impl Interpreter {
             ) {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             for k in (0..len).rev() {
                 let kvalue = match obj_get(interp, &o, &k.to_string()) {
                     Ok(v) => v,
@@ -2269,17 +2250,17 @@ impl Interpreter {
                 match interp.call_function(
                     &callback,
                     &this_arg,
-                    &[kvalue, JsValue::Number(k as f64), o.clone()],
+                    &[kvalue, JsValue::number(k as f64), o.clone()],
                 ) {
                     Completion::Normal(v) => {
                         if interp.to_boolean_val(&v) {
-                            return Completion::Normal(JsValue::Number(k as f64));
+                            return Completion::Normal(JsValue::number(k as f64));
                         }
                     }
                     other => return other,
                 }
             }
-            Completion::Normal(JsValue::Number(-1.0))
+            Completion::Normal(JsValue::number(-1.0))
         });
 
         // Array.prototype.splice
@@ -2357,7 +2338,7 @@ impl Interpreter {
                 interp,
                 &a,
                 "length",
-                JsValue::Number(actual_delete_count as f64),
+                JsValue::number(actual_delete_count as f64),
             ) {
                 interp.gc_unroot_frame(gc_frame);
                 return Completion::Throw(e);
@@ -2512,7 +2493,7 @@ impl Interpreter {
                 Ok(v) => v as i64,
                 Err(c) => return c,
             };
-            let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let relative_start = if let Some(v) = args.get(1) {
                 match interp.to_integer_or_infinity_value(v) {
                     Ok(n) => n,
@@ -2523,7 +2504,7 @@ impl Interpreter {
             };
             let k = resolve_relative_index(relative_start, len as usize);
             let relative_end = if let Some(v) = args.get(2) {
-                if matches!(v, JsValue::Undefined) {
+                if (v).is_undefined() {
                     len as f64
                 } else {
                     match interp.to_integer_or_infinity_value(v) {
@@ -2551,7 +2532,7 @@ impl Interpreter {
             };
             let compare_fn = args.first().cloned();
             if let Some(ref cf) = compare_fn
-                && !matches!(cf, JsValue::Undefined)
+                && !(cf).is_undefined()
                 && !interp.is_callable(cf)
             {
                 return Completion::Throw(interp.create_type_error("compareFn is not a function"));
@@ -2580,21 +2561,21 @@ impl Interpreter {
                 if sort_error.is_some() {
                     return std::cmp::Ordering::Equal;
                 }
-                if matches!(x, JsValue::Undefined) && matches!(y, JsValue::Undefined) {
+                if (x).is_undefined() && (y).is_undefined() {
                     return std::cmp::Ordering::Equal;
                 }
-                if matches!(x, JsValue::Undefined) {
+                if (x).is_undefined() {
                     return std::cmp::Ordering::Greater;
                 }
-                if matches!(y, JsValue::Undefined) {
+                if (y).is_undefined() {
                     return std::cmp::Ordering::Less;
                 }
                 if let Some(ref cf) = cmp_fn
-                    && !matches!(cf, JsValue::Undefined)
+                    && !(cf).is_undefined()
                     && interp.is_callable(cf)
                 {
                     let result =
-                        interp.call_function(cf, &JsValue::Undefined, &[x.clone(), y.clone()]);
+                        interp.call_function(cf, &JsValue::UNDEFINED, &[x.clone(), y.clone()]);
                     match result {
                         Completion::Normal(v) => {
                             let n = match interp.to_number_value(&v) {
@@ -2663,7 +2644,7 @@ impl Interpreter {
             };
             let compare_fn = args.first().cloned();
             if let Some(ref cf) = compare_fn
-                && !matches!(cf, JsValue::Undefined)
+                && !(cf).is_undefined()
                 && !interp.is_callable(cf)
             {
                 return Completion::Throw(interp.create_type_error("compareFn is not a function"));
@@ -2689,21 +2670,21 @@ impl Interpreter {
                 if sort_error.is_some() {
                     return std::cmp::Ordering::Equal;
                 }
-                if matches!(x, JsValue::Undefined) && matches!(y, JsValue::Undefined) {
+                if (x).is_undefined() && (y).is_undefined() {
                     return std::cmp::Ordering::Equal;
                 }
-                if matches!(x, JsValue::Undefined) {
+                if (x).is_undefined() {
                     return std::cmp::Ordering::Greater;
                 }
-                if matches!(y, JsValue::Undefined) {
+                if (y).is_undefined() {
                     return std::cmp::Ordering::Less;
                 }
                 if let Some(ref cf) = cmp_fn
-                    && !matches!(cf, JsValue::Undefined)
+                    && !(cf).is_undefined()
                     && interp.is_callable(cf)
                 {
                     let result =
-                        interp.call_function(cf, &JsValue::Undefined, &[x.clone(), y.clone()]);
+                        interp.call_function(cf, &JsValue::UNDEFINED, &[x.clone(), y.clone()]);
                     match result {
                         Completion::Normal(v) => {
                             let n = match interp.to_number_value(&v) {
@@ -2764,7 +2745,7 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let depth_num = if let Some(d) = args.first() {
-                if matches!(d, JsValue::Undefined) {
+                if (d).is_undefined() {
                     1.0
                 } else {
                     match interp.to_integer_or_infinity_value(d) {
@@ -2804,8 +2785,8 @@ impl Interpreter {
                             Err(c) => return Err(c),
                         };
                         let should_flatten = if depth > 0 {
-                            if let JsValue::Object(eo) = &elem {
-                                is_array_check(interp, eo.id).map_err(Completion::Throw)?
+                            if let Some(elem_id) = elem.as_object_id() {
+                                is_array_check(interp, elem_id).map_err(Completion::Throw)?
                             } else {
                                 false
                             }
@@ -2848,13 +2829,13 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             if let Err(c) =
                 require_callable(interp, &callback, "flatMap callback is not a function")
             {
                 return c;
             }
-            let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             // Step 5: ArraySpeciesCreate BEFORE iteration (spec order)
             let a = match array_species_create(interp, &o, 0) {
                 Ok(v) => v,
@@ -2877,12 +2858,12 @@ impl Interpreter {
                         let mapped = interp.call_function(
                             &callback,
                             &this_arg,
-                            &[kvalue, JsValue::Number(k as f64), o.clone()],
+                            &[kvalue, JsValue::number(k as f64), o.clone()],
                         );
                         match mapped {
                             Completion::Normal(v) => {
-                                let elem_is_array = if let JsValue::Object(mo) = &v {
-                                    match is_array_check(interp, mo.id) {
+                                let elem_is_array = if let Some(elem_id) = v.as_object_id() {
+                                    match is_array_check(interp, elem_id) {
                                         Ok(b) => b,
                                         Err(e) => {
                                             interp.gc_unroot_frame(gc_frame);
@@ -2988,7 +2969,7 @@ impl Interpreter {
             };
             let from = resolve_relative_index(relative_start, len as usize) as i64;
             let relative_end = if let Some(v) = args.get(2) {
-                if matches!(v, JsValue::Undefined) {
+                if (v).is_undefined() {
                     len as f64
                 } else {
                     match interp.to_integer_or_infinity_value(v) {
@@ -3059,7 +3040,7 @@ impl Interpreter {
                 len + relative_index
             };
             if k < 0 || k >= len {
-                return Completion::Normal(JsValue::Undefined);
+                return Completion::Normal(JsValue::UNDEFINED);
             }
             match obj_get(interp, &o, &(k as usize).to_string()) {
                 Ok(v) => Completion::Normal(v),
@@ -3096,7 +3077,7 @@ impl Interpreter {
             if actual < 0 || actual >= len {
                 return Completion::Throw(interp.create_range_error("Invalid index"));
             }
-            let value = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             let mut result = Vec::with_capacity(len as usize);
             for k in 0..len as usize {
                 if k == actual as usize {
@@ -3116,14 +3097,14 @@ impl Interpreter {
             "isArray".to_string(),
             1,
             |interp, _this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = &val {
-                    match is_array_check(interp, o.id) {
-                        Ok(result) => Completion::Normal(JsValue::Boolean(result)),
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(obj_id) = val.as_object_id() {
+                    match is_array_check(interp, obj_id) {
+                        Ok(result) => Completion::Normal(JsValue::boolean(result)),
                         Err(e) => Completion::Throw(e),
                     }
                 } else {
-                    Completion::Normal(JsValue::Boolean(false))
+                    Completion::Normal(JsValue::FALSE)
                 }
             },
         ));
@@ -3134,11 +3115,11 @@ impl Interpreter {
             1,
             |interp, this_val, args: &[JsValue]| {
                 let c = this_val.clone();
-                let source = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let source = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let map_fn = args.get(1).cloned();
-                let this_arg = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 let mapping = if let Some(ref mf) = map_fn
-                    && !matches!(mf, JsValue::Undefined)
+                    && !(mf).is_undefined()
                 {
                     if !interp.is_callable(mf) {
                         return Completion::Throw(
@@ -3151,7 +3132,7 @@ impl Interpreter {
                 };
 
                 // Check if source is null/undefined
-                if matches!(source, JsValue::Undefined | JsValue::Null) {
+                if (source).is_nullish() {
                     return Completion::Throw(
                         interp.create_type_error("Cannot convert undefined or null to object"),
                     );
@@ -3165,13 +3146,9 @@ impl Interpreter {
                         Completion::Throw(e) => return Completion::Throw(e),
                         other => return other,
                     };
-                    if let JsValue::Object(o) = &obj_val {
-                        match interp.get_object_property(o.id, &key, &source) {
-                            Completion::Normal(v)
-                                if !matches!(v, JsValue::Undefined | JsValue::Null) =>
-                            {
-                                Some(v)
-                            }
+                    if let Some(obj_id) = obj_val.as_object_id() {
+                        match interp.get_object_property(obj_id, &key, &source) {
+                            Completion::Normal(v) if !(v).is_nullish() => Some(v),
                             Completion::Normal(_) => None,
                             Completion::Throw(e) => return Completion::Throw(e),
                             other => return other,
@@ -3242,11 +3219,11 @@ impl Interpreter {
                             match interp.call_function(
                                 map_fn.as_ref().unwrap(),
                                 &this_arg,
-                                &[value, JsValue::Number(k as f64)],
+                                &[value, JsValue::number(k as f64)],
                             ) {
                                 Completion::Normal(v) => v,
                                 other => {
-                                    let _ = interp.iterator_close(&iterator, JsValue::Undefined);
+                                    let _ = interp.iterator_close(&iterator, JsValue::UNDEFINED);
                                     interp.gc_unroot_frame(gc_frame);
                                     return other;
                                 }
@@ -3257,7 +3234,7 @@ impl Interpreter {
                         if let Err(e) =
                             create_data_property_or_throw(interp, &a, &k.to_string(), mapped_value)
                         {
-                            let _ = interp.iterator_close(&iterator, JsValue::Undefined);
+                            let _ = interp.iterator_close(&iterator, JsValue::UNDEFINED);
                             interp.gc_unroot_frame(gc_frame);
                             return Completion::Throw(e);
                         }
@@ -3281,7 +3258,7 @@ impl Interpreter {
                     };
 
                     let a = if interp.is_constructor(&c) {
-                        match interp.construct(&c, &[JsValue::Number(len as f64)]) {
+                        match interp.construct(&c, &[JsValue::number(len as f64)]) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
                                 interp.gc_unroot_frame(gc_frame);
@@ -3309,7 +3286,7 @@ impl Interpreter {
                             match interp.call_function(
                                 map_fn.as_ref().unwrap(),
                                 &this_arg,
-                                &[kvalue, JsValue::Number(k as f64)],
+                                &[kvalue, JsValue::number(k as f64)],
                             ) {
                                 Completion::Normal(v) => v,
                                 other => {
@@ -3345,7 +3322,7 @@ impl Interpreter {
                 let c = this_val.clone();
                 let len = args.len();
                 let a = if interp.is_constructor(&c) {
-                    match interp.construct(&c, &[JsValue::Number(len as f64)]) {
+                    match interp.construct(&c, &[JsValue::number(len as f64)]) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
                         other => return other,
@@ -3373,9 +3350,9 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            if let JsValue::Object(obj_ref) = &o {
+            if let Some(obj_id) = o.as_object_id() {
                 return Completion::Normal(
-                    interp.create_array_iterator(obj_ref.id, IteratorKind::KeyValue),
+                    interp.create_array_iterator(obj_id, IteratorKind::KeyValue),
                 );
             }
             Completion::Throw(interp.create_type_error("entries called on non-object"))
@@ -3387,10 +3364,8 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            if let JsValue::Object(obj_ref) = &o {
-                return Completion::Normal(
-                    interp.create_array_iterator(obj_ref.id, IteratorKind::Key),
-                );
+            if let Some(obj_id) = o.as_object_id() {
+                return Completion::Normal(interp.create_array_iterator(obj_id, IteratorKind::Key));
             }
             Completion::Throw(interp.create_type_error("keys called on non-object"))
         });
@@ -3401,9 +3376,9 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             };
-            if let JsValue::Object(obj_ref) = &o {
+            if let Some(obj_id) = o.as_object_id() {
                 return Completion::Normal(
-                    interp.create_array_iterator(obj_ref.id, IteratorKind::Value),
+                    interp.create_array_iterator(obj_id, IteratorKind::Value),
                 );
             }
             Completion::Throw(interp.create_type_error("values called on non-object"))
@@ -3421,11 +3396,11 @@ impl Interpreter {
             "fromAsync".to_string(),
             1,
             |interp, this, args| {
-                let async_items = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let map_fn = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                let this_arg = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let async_items = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let map_fn = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                let this_arg = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
 
-                let has_map = !matches!(map_fn, JsValue::Undefined);
+                let has_map = !(map_fn).is_undefined();
                 if has_map && !interp.is_callable(&map_fn) {
                     let err = interp.create_type_error("Array.fromAsync mapFn is not a function");
                     return interp.create_rejected_promise(err);
@@ -3437,13 +3412,14 @@ impl Interpreter {
                 let async_sym_key = interp.get_symbol_key("asyncIterator");
                 let mut has_async_iter = false;
                 if let Some(ref key) = async_sym_key {
-                    if let JsValue::Object(ref o) = async_items {
-                        let val = match interp.get_object_property(o.id, key, &async_items) {
+                    if let Some(async_items_id) = async_items.as_object_id() {
+                        let val =
+                            match interp.get_object_property(async_items_id, key, &async_items) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return interp.create_rejected_promise(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
-                        if !matches!(val, JsValue::Undefined | JsValue::Null) {
+                        if !(val).is_nullish() {
                             has_async_iter = true;
                             using_iterator = Some(val);
                         } else {
@@ -3460,9 +3436,9 @@ impl Interpreter {
                 let using_sync_iterator = if !has_async_iter {
                     let sym_key = interp.get_symbol_iterator_key();
                     if let Some(ref key) = sym_key {
-                        if let JsValue::Object(ref o) = async_items {
-                            match interp.get_object_property(o.id, key, &async_items) {
-                                Completion::Normal(v) if !matches!(v, JsValue::Undefined | JsValue::Null) => Some(v),
+                        if let Some(async_items_id) = async_items.as_object_id() {
+                            match interp.get_object_property(async_items_id, key, &async_items) {
+                                Completion::Normal(v) if !(v).is_nullish() => Some(v),
                                 Completion::Throw(e) => return interp.create_rejected_promise(e),
                                 _ => None,
                             }
@@ -3478,7 +3454,7 @@ impl Interpreter {
 
                 // Create a promise for the result
                 let promise = interp.create_promise_object();
-                let promise_id = if let JsValue::Object(ref o) = promise { o.id } else { 0 };
+                let promise_id = promise.as_object_id().unwrap_or(0);
                 let (resolve_fn, reject_fn) = interp.create_resolving_functions(promise_id);
 
                 // Step 7: If usingAsyncIterator is not undefined OR usingSyncIterator is not undefined
@@ -3487,19 +3463,19 @@ impl Interpreter {
                     let iterator = if has_async_iter {
                         if let Some(ref iter_fn) = using_iterator {
                             match interp.call_function(iter_fn, &async_items, &[]) {
-                                Completion::Normal(v) if matches!(v, JsValue::Object(_)) => v,
+                                Completion::Normal(v) if (v).is_object() => v,
                                 Completion::Normal(_) => {
                                     let err = interp.create_type_error("Result of the Symbol.asyncIterator method is not an object");
-                                    let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[err]);
+                                    let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[err]);
                                     return Completion::Normal(promise);
                                 }
                                 Completion::Throw(e) => {
-                                    let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[e]);
+                                    let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
                                     return Completion::Normal(promise);
                                 }
                                 _ => {
                                     let err = interp.create_type_error("is not async iterable");
-                                    let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[err]);
+                                    let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[err]);
                                     return Completion::Normal(promise);
                                 }
                             }
@@ -3511,21 +3487,21 @@ impl Interpreter {
                         match using_sync_iterator {
                             Some(ref iter_fn) => {
                                 match interp.call_function(iter_fn, &async_items, &[]) {
-                                    Completion::Normal(v) if matches!(v, JsValue::Object(_)) => {
+                                    Completion::Normal(v) if (v).is_object() => {
                                         interp.create_async_from_sync_iterator(v)
                                     }
                                     Completion::Normal(_) => {
                                         let err = interp.create_type_error("Result of the Symbol.iterator method is not an object");
-                                        let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[err]);
+                                        let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[err]);
                                         return Completion::Normal(promise);
                                     }
                                     Completion::Throw(e) => {
-                                        let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[e]);
+                                        let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
                                         return Completion::Normal(promise);
                                     }
                                     _ => {
                                         let err = interp.create_type_error("is not iterable");
-                                        let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[err]);
+                                        let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[err]);
                                         return Completion::Normal(promise);
                                     }
                                 }
@@ -3538,9 +3514,9 @@ impl Interpreter {
                     let is_constructor = interp.is_constructor(this);
                     let arr = if is_constructor {
                         match interp.construct(this, &[]) {
-                            Completion::Normal(v) if matches!(v, JsValue::Object(_)) => v,
+                            Completion::Normal(v) if (v).is_object() => v,
                             Completion::Throw(e) => {
-                                let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[e]);
+                                let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
                                 return Completion::Normal(promise);
                             }
                             _ => interp.create_array(vec![]),
@@ -3559,7 +3535,7 @@ impl Interpreter {
                         resolve_fn,
                         reject_fn,
                         is_array_like: false,
-                        array_like: JsValue::Undefined,
+                        array_like: JsValue::UNDEFINED,
                         len: 0,
                         gc_roots: Vec::new(),
                     }));
@@ -3571,19 +3547,19 @@ impl Interpreter {
                     let array_like = match interp.to_object(&async_items) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
-                            let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[e]);
+                            let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
                             return Completion::Normal(promise);
                         }
                         _ => {
                             let err = interp.create_type_error("Cannot convert to object");
-                            let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[err]);
+                            let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[err]);
                             return Completion::Normal(promise);
                         }
                     };
                     let len = match length_of_array_like(interp, &array_like) {
                         Ok(n) => n as u64,
                         Err(Completion::Throw(e)) => {
-                            let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[e]);
+                            let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
                             return Completion::Normal(promise);
                         }
                         Err(_) => 0u64,
@@ -3591,10 +3567,10 @@ impl Interpreter {
 
                     let is_constructor = interp.is_constructor(this);
                     let arr = if is_constructor {
-                        match interp.construct(this, &[JsValue::Number(len as f64)]) {
-                            Completion::Normal(v) if matches!(v, JsValue::Object(_)) => v,
+                        match interp.construct(this, &[JsValue::number(len as f64)]) {
+                            Completion::Normal(v) if (v).is_object() => v,
                             Completion::Throw(e) => {
-                                let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[e]);
+                                let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
                                 return Completion::Normal(promise);
                             }
                             _ => interp.create_array(vec![]),
@@ -3602,14 +3578,14 @@ impl Interpreter {
                     } else {
                         if len > 0xFFFF_FFFF {
                             let e = interp.create_range_error("Invalid array length");
-                            let _ = interp.call_function(&reject_fn, &JsValue::Undefined, &[e]);
+                            let _ = interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
                             return Completion::Normal(promise);
                         }
                         interp.create_array(vec![])
                     };
 
                     let state = Rc::new(RefCell::new(FromAsyncState {
-                        iterator: JsValue::Undefined,
+                        iterator: JsValue::UNDEFINED,
                         arr,
                         k: 0,
                         has_map,
@@ -3632,17 +3608,16 @@ impl Interpreter {
         // Set Array statics on the Array constructor
         let array_val = self.get_global_var("Array");
         if let Some(array_val) = array_val
-            && let JsValue::Object(o) = &array_val
-            && self.get_object_cell(o.id).is_some()
+            && let Some(array_id) = array_val.as_object_id()
+            && self.get_object_cell(array_id).is_some()
         {
-            let array_id = o.id;
             {
                 let mut borrow = self.get_object_cell_expect(array_id).borrow_mut();
                 borrow.insert_builtin("isArray".to_string(), is_array_fn);
                 borrow.insert_builtin("from".to_string(), array_from);
                 borrow.insert_builtin("of".to_string(), array_of);
                 borrow.insert_builtin("fromAsync".to_string(), from_async_fn);
-                let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+                let proto_val = JsValue::object(proto_id);
                 borrow.insert_property(
                     "prototype".to_string(),
                     PropertyDescriptor::data(proto_val, false, false, false),
@@ -3702,10 +3677,10 @@ impl Interpreter {
             for name in names {
                 self.get_object_cell_expect(unscopables_obj_id)
                     .borrow_mut()
-                    .insert_value(name.to_string(), JsValue::Boolean(true));
+                    .insert_value(name.to_string(), JsValue::boolean(true));
             }
             let unscopables_id = unscopables_obj_id;
-            let unscopables_val = JsValue::Object(crate::types::JsObject { id: unscopables_id });
+            let unscopables_val = JsValue::object(unscopables_id);
             self.get_object_cell_expect(proto_id)
                 .borrow_mut()
                 .insert_property(
@@ -3729,11 +3704,11 @@ impl Interpreter {
         }
         obj_data.insert_property(
             "length".to_string(),
-            PropertyDescriptor::data(JsValue::Number(values.len() as f64), true, false, false),
+            PropertyDescriptor::data(JsValue::number(values.len() as f64), true, false, false),
         );
         obj_data.kind = crate::interpreter::types::ObjectKind::Array(values);
         let id = self.alloc_object(obj_data);
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     pub(crate) fn create_array_with_holes(&mut self, items: Vec<Option<JsValue>>) -> JsValue {
@@ -3753,17 +3728,17 @@ impl Interpreter {
                 }
                 None => {
                     // Elision: no own property, but fill array_elements with undefined for indexing
-                    array_elements.push(JsValue::Undefined);
+                    array_elements.push(JsValue::UNDEFINED);
                 }
             }
         }
         obj_data.insert_property(
             "length".to_string(),
-            PropertyDescriptor::data(JsValue::Number(len as f64), true, false, false),
+            PropertyDescriptor::data(JsValue::number(len as f64), true, false, false),
         );
         obj_data.kind = crate::interpreter::types::ObjectKind::Array(array_elements);
         let id = self.alloc_object(obj_data);
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     pub(crate) fn create_array_with_length(&mut self, len: usize) -> JsValue {
@@ -3775,11 +3750,11 @@ impl Interpreter {
         obj_data.class_name = "Array".to_string();
         obj_data.insert_property(
             "length".to_string(),
-            PropertyDescriptor::data(JsValue::Number(len as f64), true, false, false),
+            PropertyDescriptor::data(JsValue::number(len as f64), true, false, false),
         );
         // Use a small Vec for sparse arrays — don't pre-allocate huge arrays
         obj_data.kind = crate::interpreter::types::ObjectKind::Array(Vec::new());
         let id = self.alloc_object(obj_data);
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 }

--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -38,19 +38,21 @@ impl Interpreter {
             .class_name = "BigInt".to_string();
 
         fn this_bigint_value(interp: &Interpreter, this: &JsValue) -> Option<num_bigint::BigInt> {
-            match this {
-                JsValue::BigInt(b) => Some((*b.value).clone()),
-                JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|cell| {
-                    let b = cell.borrow();
-                    if b.class_name == "BigInt"
-                        && let Some(JsValue::BigInt(bi)) = &b.primitive_value
-                    {
-                        return Some((*bi.value).clone());
-                    }
-                    None
-                }),
-                _ => None,
+            if let Some(bigint) = this.with_bigint(Clone::clone) {
+                return Some(bigint);
             }
+            let object_id = this.as_object_id()?;
+            interp.get_object_cell(object_id).and_then(|cell| {
+                let object = cell.borrow();
+                if object.class_name == "BigInt" {
+                    object
+                        .primitive_value
+                        .as_ref()
+                        .and_then(|value| value.with_bigint(Clone::clone))
+                } else {
+                    None
+                }
+            })
         }
 
         #[allow(clippy::type_complexity)]
@@ -91,7 +93,7 @@ impl Interpreter {
                     } else {
                         bigint_to_string_radix(&n, radix)
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&s)))
+                    Completion::Normal(JsValue::from_str(&s))
                 }),
             ),
             (
@@ -103,7 +105,7 @@ impl Interpreter {
                             interp.create_type_error("BigInt.prototype.valueOf requires a BigInt"),
                         );
                     };
-                    Completion::Normal(JsValue::BigInt(JsBigInt::new(n)))
+                    Completion::Normal(JsValue::bigint(JsBigInt::new(n)))
                 }),
             ),
             (
@@ -115,13 +117,13 @@ impl Interpreter {
                             "BigInt.prototype.toLocaleString requires a BigInt",
                         ));
                     };
-                    let locales = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let nf = match interp.intl_construct_number_format(&locales, &options) {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let bigint_val = JsValue::BigInt(JsBigInt::new(n));
+                    let bigint_val = JsValue::bigint(JsBigInt::new(n));
                     interp.intl_number_format_format(&nf, &bigint_val)
                 }),
             ),
@@ -148,65 +150,71 @@ impl Interpreter {
                         interp.create_type_error("BigInt is not a constructor"),
                     );
                 }
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                match &val {
-                    JsValue::BigInt(_) => Completion::Normal(val),
-                    JsValue::Boolean(b) => Completion::Normal(JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(if *b { 1 } else { 0 })))),
-                    JsValue::Number(n) => {
-                        if n.is_nan() || n.is_infinite() || *n != n.trunc() {
-                            return Completion::Throw(interp.create_error(
-                                "RangeError",
-                                &format!("The number {n} cannot be converted to a BigInt because it is not an integer"),
-                            ));
-                        }
-                        Completion::Normal(JsValue::BigInt(JsBigInt::new(f64_to_bigint(*n))))
-                    }
-                    JsValue::String(s) => {
-                        let text = s.to_rust_string().trim().to_string();
-                        if text.is_empty() {
-                            return Completion::Normal(JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(0))));
-                        }
-                        let parsed = if let Some(hex) =
-                            text.strip_prefix("0x").or_else(|| text.strip_prefix("0X"))
-                        {
-                            num_bigint::BigInt::parse_bytes(hex.as_bytes(), 16)
-                        } else if let Some(oct) =
-                            text.strip_prefix("0o").or_else(|| text.strip_prefix("0O"))
-                        {
-                            num_bigint::BigInt::parse_bytes(oct.as_bytes(), 8)
-                        } else if let Some(bin) =
-                            text.strip_prefix("0b").or_else(|| text.strip_prefix("0B"))
-                        {
-                            num_bigint::BigInt::parse_bytes(bin.as_bytes(), 2)
-                        } else {
-                            text.parse::<num_bigint::BigInt>().ok()
-                        };
-                        match parsed {
-                            Some(v) => Completion::Normal(JsValue::BigInt(JsBigInt::new(v))),
-                            None => Completion::Throw(interp.create_error(
-                                "SyntaxError",
-                                &format!("Cannot convert {text} to a BigInt"),
-                            )),
-                        }
-                    }
-                    JsValue::Object(_) => {
-                        let prim = match interp.to_primitive(&val, "number") {
-                            Ok(v) => v,
-                            Err(e) => return Completion::Throw(e),
-                        };
-                        let args = [prim];
-                        let bigint_fn = interp.get_global_var("BigInt");
-                        if let Some(bigint_fn) = bigint_fn {
-                            return interp.call_function(&bigint_fn, &JsValue::Undefined, &args);
-                        }
-                        Completion::Throw(
-                            interp.create_type_error("Cannot convert value to a BigInt"),
-                        )
-                    }
-                    _ => Completion::Throw(
-                        interp.create_type_error("Cannot convert value to a BigInt"),
-                    ),
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if val.is_bigint() {
+                    return Completion::Normal(val);
                 }
+                if let Some(boolean) = val.as_boolean() {
+                    return Completion::Normal(JsValue::bigint(JsBigInt::new(
+                        num_bigint::BigInt::from(if boolean { 1 } else { 0 }),
+                    )));
+                }
+                if let Some(number) = val.as_number() {
+                    if number.is_nan() || number.is_infinite() || number != number.trunc() {
+                        return Completion::Throw(interp.create_error(
+                            "RangeError",
+                            &format!("The number {number} cannot be converted to a BigInt because it is not an integer"),
+                        ));
+                    }
+                    return Completion::Normal(JsValue::bigint(JsBigInt::new(f64_to_bigint(
+                        number,
+                    ))));
+                }
+                if let Some(string) = val.as_string() {
+                    let text = string.to_rust_string().trim().to_string();
+                    if text.is_empty() {
+                        return Completion::Normal(JsValue::bigint(JsBigInt::new(
+                            num_bigint::BigInt::from(0),
+                        )));
+                    }
+                    let parsed = if let Some(hex) =
+                        text.strip_prefix("0x").or_else(|| text.strip_prefix("0X"))
+                    {
+                        num_bigint::BigInt::parse_bytes(hex.as_bytes(), 16)
+                    } else if let Some(oct) =
+                        text.strip_prefix("0o").or_else(|| text.strip_prefix("0O"))
+                    {
+                        num_bigint::BigInt::parse_bytes(oct.as_bytes(), 8)
+                    } else if let Some(bin) =
+                        text.strip_prefix("0b").or_else(|| text.strip_prefix("0B"))
+                    {
+                        num_bigint::BigInt::parse_bytes(bin.as_bytes(), 2)
+                    } else {
+                        text.parse::<num_bigint::BigInt>().ok()
+                    };
+                    return match parsed {
+                        Some(value) => Completion::Normal(JsValue::bigint(JsBigInt::new(value))),
+                        None => Completion::Throw(interp.create_error(
+                            "SyntaxError",
+                            &format!("Cannot convert {text} to a BigInt"),
+                        )),
+                    };
+                }
+                if val.is_object() {
+                    let prim = match interp.to_primitive(&val, "number") {
+                        Ok(value) => value,
+                        Err(error) => return Completion::Throw(error),
+                    };
+                    let args = [prim];
+                    let bigint_fn = interp.get_global_var("BigInt");
+                    if let Some(bigint_fn) = bigint_fn {
+                        return interp.call_function(&bigint_fn, &JsValue::UNDEFINED, &args);
+                    }
+                    return Completion::Throw(
+                        interp.create_type_error("Cannot convert value to a BigInt"),
+                    );
+                }
+                Completion::Throw(interp.create_type_error("Cannot convert value to a BigInt"))
             }),
         );
 
@@ -216,32 +224,34 @@ impl Interpreter {
             2,
             |interp, _this, args| {
                 // Step 1: Let bits be ? ToIndex(bits).
-                let bits_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let bits_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let bits = match interp.to_index(&bits_val) {
-                    Completion::Normal(JsValue::Number(n)) => n as u64,
-                    Completion::Normal(_) => unreachable!(),
+                    Completion::Normal(value) => value
+                        .as_number()
+                        .expect("ToIndex returns a Number completion")
+                        as u64,
                     other => return other,
                 };
                 // Step 2: Let bigint be ? ToBigInt(bigint).
-                let bigint_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let bigint_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let bigint_val = match interp.to_bigint_value(&bigint_val) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 };
-                let JsValue::BigInt(ref b) = bigint_val else {
-                    unreachable!()
-                };
+                let bigint = bigint_val
+                    .as_bigint()
+                    .expect("ToBigInt returns a BigInt value");
                 if bits == 0 {
-                    return Completion::Normal(JsValue::BigInt(JsBigInt::new(
+                    return Completion::Normal(JsValue::bigint(JsBigInt::new(
                         num_bigint::BigInt::from(0),
                     )));
                 }
-                let bit_len = b.value.bits() + 1; // +1 for sign bit
+                let bit_len = bigint.value.bits() + 1; // +1 for sign bit
                 if bit_len <= bits {
                     return Completion::Normal(bigint_val);
                 }
                 let modulus = num_bigint::BigInt::from(1) << bits;
-                let mut result = &*b.value % &modulus;
+                let mut result = &*bigint.value % &modulus;
                 if result < num_bigint::BigInt::from(0) {
                     result += &modulus;
                 }
@@ -249,7 +259,7 @@ impl Interpreter {
                 if result >= half {
                     result -= modulus;
                 }
-                Completion::Normal(JsValue::BigInt(JsBigInt::new(result)))
+                Completion::Normal(JsValue::bigint(JsBigInt::new(result)))
             },
         ));
         let as_uint_n = self.create_function(JsFunction::native(
@@ -257,43 +267,45 @@ impl Interpreter {
             2,
             |interp, _this, args| {
                 // Step 1: Let bits be ? ToIndex(bits).
-                let bits_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let bits_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let bits = match interp.to_index(&bits_val) {
-                    Completion::Normal(JsValue::Number(n)) => n as u64,
-                    Completion::Normal(_) => unreachable!(),
+                    Completion::Normal(value) => value
+                        .as_number()
+                        .expect("ToIndex returns a Number completion")
+                        as u64,
                     other => return other,
                 };
                 // Step 2: Let bigint be ? ToBigInt(bigint).
-                let bigint_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let bigint_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let bigint_val = match interp.to_bigint_value(&bigint_val) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 };
-                let JsValue::BigInt(ref b) = bigint_val else {
-                    unreachable!()
-                };
+                let bigint = bigint_val
+                    .as_bigint()
+                    .expect("ToBigInt returns a BigInt value");
                 if bits == 0 {
-                    return Completion::Normal(JsValue::BigInt(JsBigInt::new(
+                    return Completion::Normal(JsValue::bigint(JsBigInt::new(
                         num_bigint::BigInt::from(0),
                     )));
                 }
-                if *b.value >= num_bigint::BigInt::from(0) && b.value.bits() <= bits {
+                if *bigint.value >= num_bigint::BigInt::from(0) && bigint.value.bits() <= bits {
                     return Completion::Normal(bigint_val);
                 }
                 let modulus = num_bigint::BigInt::from(1) << bits;
-                let mut result = &*b.value % &modulus;
+                let mut result = &*bigint.value % &modulus;
                 if result < num_bigint::BigInt::from(0) {
                     result += &modulus;
                 }
-                Completion::Normal(JsValue::BigInt(JsBigInt::new(result)))
+                Completion::Normal(JsValue::bigint(JsBigInt::new(result)))
             },
         ));
 
         if let Some(bigint_val) = self.get_global_var("BigInt")
-            && let JsValue::Object(o) = &bigint_val
-            && let Some(bigint_cell) = self.get_object_cell(o.id)
+            && let Some(bigint_id) = bigint_val.as_object_id()
+            && let Some(bigint_cell) = self.get_object_cell(bigint_id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             bigint_cell.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),

--- a/src/interpreter/builtins/collections.rs
+++ b/src/interpreter/builtins/collections.rs
@@ -14,14 +14,14 @@ fn this_map(
     this: &JsValue,
     method: &str,
 ) -> Result<(u64, ObjectHandle), Completion> {
-    if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+    if let Some(o) = (this).as_object_id()
+        && let Some(obj) = interp.get_object(o)
         && {
             let b = obj.borrow();
             b.map_data().is_some() && b.class_name == "Map"
         }
     {
-        return Ok((o.id, obj));
+        return Ok((o, obj));
     }
     Err(Completion::Throw(interp.create_type_error(&format!(
         "Map.prototype.{method} requires a Map"
@@ -36,14 +36,14 @@ fn this_set(
     this: &JsValue,
     method: &str,
 ) -> Result<(u64, ObjectHandle), Completion> {
-    if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object(o.id)
+    if let Some(o) = (this).as_object_id()
+        && let Some(obj) = interp.get_object(o)
         && {
             let b = obj.borrow();
             b.set_data().is_some() && b.class_name != "WeakSet"
         }
     {
-        return Ok((o.id, obj));
+        return Ok((o, obj));
     }
     Err(Completion::Throw(interp.create_type_error(&format!(
         "Set.prototype.{method} requires a Set"
@@ -69,8 +69,8 @@ impl Interpreter {
         self.define_to_string_tag(map_iter_proto_id, "Map Iterator");
 
         self.define_method(map_iter_proto_id, "next", 0, |interp, this, _args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object(o)
             {
                 let state = obj.borrow().iterator_state().cloned();
                 if let Some(IteratorState::MapIterator {
@@ -82,7 +82,7 @@ impl Interpreter {
                 {
                     if done {
                         return Completion::Normal(
-                            interp.create_iter_result_object(JsValue::Undefined, true),
+                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                         );
                     }
                     if let Some(map_obj) = interp.get_object(map_id) {
@@ -124,7 +124,7 @@ impl Interpreter {
                             },
                         );
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 }
             }
@@ -170,7 +170,7 @@ impl Interpreter {
                     done: false,
                 });
             let id = interp.alloc_object(obj_data);
-            JsValue::Object(crate::types::JsObject { id })
+            JsValue::object(id)
         }
 
         // Map.prototype.entries
@@ -214,33 +214,33 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let entries = obj.borrow().map_data().cloned().unwrap();
-            let key = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             for entry in entries.iter().flatten() {
                 if same_value_zero(&entry.0, &key) {
                     return Completion::Normal(entry.1.clone());
                 }
             }
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         // Map.prototype.set
         self.define_method(proto_id, "set", 2, |interp, this, args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let has_map = {
                     let b = obj.borrow();
                     b.map_data().is_some() && b.class_name == "Map"
                 };
                 if has_map {
-                    let mut key = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let value = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let mut key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     // Normalize -0 to +0
-                    if let JsValue::Number(n) = &key
-                        && *n == 0.0
-                        && n.is_sign_negative()
+                    if key
+                        .as_number()
+                        .is_some_and(|number| number == 0.0 && number.is_sign_negative())
                     {
-                        key = JsValue::Number(0.0);
+                        key = JsValue::number(0.0);
                     }
                     interp.gc_write_barrier_value(obj, &key);
                     interp.gc_write_barrier_value(obj, &value);
@@ -267,13 +267,13 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let entries = obj.borrow().map_data().cloned().unwrap();
-            let key = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             for entry in entries.iter().flatten() {
                 if same_value_zero(&entry.0, &key) {
-                    return Completion::Normal(JsValue::Boolean(true));
+                    return Completion::Normal(JsValue::boolean(true));
                 }
             }
-            Completion::Normal(JsValue::Boolean(false))
+            Completion::Normal(JsValue::boolean(false))
         });
 
         // Map.prototype.delete
@@ -282,17 +282,17 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let key = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let mut borrowed = obj.borrow_mut_untracked();
             let entries = borrowed.map_data_mut().unwrap();
             for entry in entries.iter_mut() {
                 let matches = entry.as_ref().is_some_and(|e| same_value_zero(&e.0, &key));
                 if matches {
                     *entry = None;
-                    return Completion::Normal(JsValue::Boolean(true));
+                    return Completion::Normal(JsValue::boolean(true));
                 }
             }
-            Completion::Normal(JsValue::Boolean(false))
+            Completion::Normal(JsValue::boolean(false))
         });
 
         // Map.prototype.clear
@@ -303,39 +303,46 @@ impl Interpreter {
             };
             obj.borrow_mut_untracked().kind =
                 crate::interpreter::types::ObjectKind::Map(Vec::new());
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         // Map.prototype.forEach
-        self.define_method(proto_id, "forEach", 1,
-            |interp, this, args| {
-                let (_id, obj) = match this_map(interp, this, "forEach") {
-                    Ok(t) => t,
-                    Err(c) => return c,
-                };
-                let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&callback, JsValue::Object(co) if interp.get_object(co.id).is_some_and(|o| o.borrow().callable.is_some())) {
-                    let err = interp.create_type_error("Map.prototype.forEach callback is not a function");
-                    return Completion::Throw(err);
-                }
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                let mut i = 0;
-                loop {
-                    let entry = {
-                        let borrowed = obj.borrow();
-                        let entries = borrowed.map_data().unwrap();
-                        if i >= entries.len() { break; }
-                        entries[i].clone()
-                    };
-                    if let Some((k, v)) = entry {
-                        let result = interp.call_function(&callback, &this_arg, &[v, k, this.clone()]);
-                        if result.is_abrupt() { return result; }
+        self.define_method(proto_id, "forEach", 1, |interp, this, args| {
+            let (_id, obj) = match this_map(interp, this, "forEach") {
+                Ok(t) => t,
+                Err(c) => return c,
+            };
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if !callback.as_object_id().is_some_and(|callback_id| {
+                interp
+                    .get_object(callback_id)
+                    .is_some_and(|object| object.borrow().callable.is_some())
+            }) {
+                let err =
+                    interp.create_type_error("Map.prototype.forEach callback is not a function");
+                return Completion::Throw(err);
+            }
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            let mut i = 0;
+            loop {
+                let entry = {
+                    let borrowed = obj.borrow();
+                    let entries = borrowed.map_data().unwrap();
+                    if i >= entries.len() {
+                        break;
                     }
-                    i += 1;
+                    entries[i].clone()
+                };
+                if let Some((k, v)) = entry {
+                    let result = interp.call_function(&callback, &this_arg, &[v, k, this.clone()]);
+                    if result.is_abrupt() {
+                        return result;
+                    }
                 }
-                Completion::Normal(JsValue::Undefined)
-            },
-        );
+                i += 1;
+            }
+            Completion::Normal(JsValue::UNDEFINED)
+        });
 
         // Map.prototype.size (getter)
         self.define_getter(proto_id, "size", |interp, this, _args| {
@@ -350,7 +357,7 @@ impl Interpreter {
                 .iter()
                 .filter(|e| e.is_some())
                 .count();
-            Completion::Normal(JsValue::Number(count as f64))
+            Completion::Normal(JsValue::number(count as f64))
         });
 
         // Map.prototype.getOrInsert
@@ -359,14 +366,14 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let mut key = args.first().cloned().unwrap_or(JsValue::Undefined);
-            let value = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let mut key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             // CanonicalizeKeyedCollectionKey: normalize -0 to +0
-            if let JsValue::Number(n) = &key
-                && *n == 0.0
-                && n.is_sign_negative()
+            if key
+                .as_number()
+                .is_some_and(|number| number == 0.0 && number.is_sign_negative())
             {
-                key = JsValue::Number(0.0);
+                key = JsValue::number(0.0);
             }
             // Search existing entries
             {
@@ -388,63 +395,68 @@ impl Interpreter {
         });
 
         // Map.prototype.getOrInsertComputed
-        self.define_method(proto_id, "getOrInsertComputed", 2,
-            |interp, this, args| {
-                let (_id, obj) = match this_map(interp, this, "getOrInsertComputed") {
-                    Ok(t) => t,
-                    Err(c) => return c,
-                };
-                let mut key = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let callbackfn = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                // Step 3: IsCallable check BEFORE anything else
-                if !matches!(&callbackfn, JsValue::Object(co) if interp.get_object_cell(co.id).is_some_and(|o| o.borrow().callable.is_some())) {
-                    let err = interp.create_type_error("callbackfn is not a function");
-                    return Completion::Throw(err);
-                }
-                // CanonicalizeKeyedCollectionKey: normalize -0 to +0
-                if let JsValue::Number(n) = &key
-                    && *n == 0.0 && n.is_sign_negative() {
-                        key = JsValue::Number(0.0);
+        self.define_method(proto_id, "getOrInsertComputed", 2, |interp, this, args| {
+            let (_id, obj) = match this_map(interp, this, "getOrInsertComputed") {
+                Ok(t) => t,
+                Err(c) => return c,
+            };
+            let mut key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let callbackfn = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            // Step 3: IsCallable check BEFORE anything else
+            if !callbackfn.as_object_id().is_some_and(|callback_id| {
+                interp
+                    .get_object_cell(callback_id)
+                    .is_some_and(|object| object.borrow().callable.is_some())
+            }) {
+                let err = interp.create_type_error("callbackfn is not a function");
+                return Completion::Throw(err);
+            }
+            // CanonicalizeKeyedCollectionKey: normalize -0 to +0
+            if key
+                .as_number()
+                .is_some_and(|number| number == 0.0 && number.is_sign_negative())
+            {
+                key = JsValue::number(0.0);
+            }
+            // Step 5: Search existing entries
+            {
+                let borrowed = obj.borrow();
+                let entries = borrowed.map_data().unwrap();
+                for entry in entries.iter().flatten() {
+                    if same_value_zero(&entry.0, &key) {
+                        return Completion::Normal(entry.1.clone());
                     }
-                // Step 5: Search existing entries
-                {
-                    let borrowed = obj.borrow();
-                    let entries = borrowed.map_data().unwrap();
-                    for entry in entries.iter().flatten() {
-                        if same_value_zero(&entry.0, &key) {
-                            return Completion::Normal(entry.1.clone());
-                        }
+                }
+            }
+            // Step 6: Call(callbackfn, undefined, « key »)
+            let value = match interp.call_function(&callbackfn, &JsValue::UNDEFINED, &[key.clone()])
+            {
+                Completion::Normal(v) => v,
+                other => return other,
+            };
+            // Step 7: Re-check if key was inserted by callback
+            {
+                interp.gc_write_barrier_value(&obj, &key);
+                interp.gc_write_barrier_value(&obj, &value);
+                let mut borrowed = obj.borrow_mut_untracked();
+                let entries = borrowed.map_data_mut().unwrap();
+                for entry in entries.iter_mut().flatten() {
+                    if same_value_zero(&entry.0, &key) {
+                        entry.1 = value.clone();
+                        return Completion::Normal(value);
                     }
                 }
-                // Step 6: Call(callbackfn, undefined, « key »)
-                let value = match interp.call_function(&callbackfn, &JsValue::Undefined, &[key.clone()]) {
-                    Completion::Normal(v) => v,
-                    other => return other,
-                };
-                // Step 7: Re-check if key was inserted by callback
-                {
-                    interp.gc_write_barrier_value(&obj, &key);
-                    interp.gc_write_barrier_value(&obj, &value);
-                    let mut borrowed = obj.borrow_mut_untracked();
-                    let entries = borrowed.map_data_mut().unwrap();
-                    for entry in entries.iter_mut().flatten() {
-                        if same_value_zero(&entry.0, &key) {
-                            entry.1 = value.clone();
-                            return Completion::Normal(value);
-                        }
-                    }
-                    // Step 8-9: Not found, append
-                    entries.push(Some((key, value.clone())));
-                }
-                Completion::Normal(value)
-            },
-        );
+                // Step 8-9: Not found, append
+                entries.push(Some((key, value.clone())));
+            }
+            Completion::Normal(value)
+        });
 
         // @@toStringTag
         self.define_to_string_tag(proto_id, "Map");
 
         // constructor property
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
 
         // Map constructor
         let map_proto_clone_id = proto_id;
@@ -458,26 +470,36 @@ impl Interpreter {
                 }
 
                 // OrdinaryCreateFromConstructor — realm-aware prototype
-                let proto = match interp.get_prototype_from_new_target_realm(|realm| {
-                    realm.map_prototype
-                }) {
-                    Ok(p) => p.unwrap_or(map_proto_clone_id),
-                    Err(e) => return Completion::Throw(e),
-                };
+                let proto =
+                    match interp.get_prototype_from_new_target_realm(|realm| realm.map_prototype) {
+                        Ok(p) => p.unwrap_or(map_proto_clone_id),
+                        Err(e) => return Completion::Throw(e),
+                    };
                 let obj_id = interp.create_object_id();
-                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
-                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "Map".to_string();
-                interp.get_object_cell_expect(obj_id).borrow_mut().kind = crate::interpreter::types::ObjectKind::Map(Vec::new());
-                let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Map".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().kind =
+                    crate::interpreter::types::ObjectKind::Map(Vec::new());
+                let this_val = JsValue::object(obj_id);
 
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !iterable.is_undefined() && !iterable.is_null() {
                     // Step 7a: Get adder = Get(map, "set") — must invoke getters
                     let adder = match interp.get_object_property(obj_id, "set", &this_val) {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object_cell(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
+                    if !adder.as_object_id().is_some_and(|adder_id| {
+                        interp
+                            .get_object_cell(adder_id)
+                            .is_some_and(|object| object.borrow().callable.is_some())
+                    }) {
                         let err = interp.create_type_error("Map.prototype.set is not a function");
                         return Completion::Throw(err);
                     }
@@ -505,14 +527,18 @@ impl Interpreter {
                         };
 
                         // value should be [key, value] — must be Object
-                        if !matches!(&value, JsValue::Object(_)) {
+                        if !value.is_object() {
                             let err = interp.create_type_error("Iterator value is not an object");
                             let _ = interp.iterator_close(&iterator, err.clone());
                             return Completion::Throw(err);
                         }
 
                         // Get(nextItem, "0") — invoke getters, close on abrupt
-                        let val_id = if let JsValue::Object(vo) = &value { vo.id } else { unreachable!() };
+                        let val_id = if let Some(vo) = value.as_object_id() {
+                            vo
+                        } else {
+                            unreachable!()
+                        };
                         let k = match interp.get_object_property(val_id, "0", &value) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
@@ -548,8 +574,8 @@ impl Interpreter {
         ));
 
         // Set Map.prototype on ctor, ctor on prototype
-        if let JsValue::Object(ctor_obj) = &map_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_obj) = map_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_obj)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -564,8 +590,8 @@ impl Interpreter {
             );
 
         // Map[Symbol.species] getter
-        if let JsValue::Object(ref ctor_ref) = map_ctor
-            && let Some(ctor_obj) = self.get_object(ctor_ref.id)
+        if let Some(ctor_ref) = (map_ctor).as_object_id()
+            && let Some(ctor_obj) = self.get_object(ctor_ref)
         {
             let species_getter = self.create_function(JsFunction::native(
                 "get [Symbol.species]".to_string(),
@@ -586,21 +612,23 @@ impl Interpreter {
         }
 
         // Map.groupBy static method
-        if let JsValue::Object(ref ctor_ref) = map_ctor
-            && let Some(ctor_obj) = self.get_object(ctor_ref.id)
+        if let Some(ctor_ref) = (map_ctor).as_object_id()
+            && let Some(ctor_obj) = self.get_object(ctor_ref)
         {
             let map_proto_for_groupby = proto_id;
             let group_by_fn = self.create_function(JsFunction::native(
                 "groupBy".to_string(),
                 2,
                 move |interp, _this, args| {
-                    let items = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let callback = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let items = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let callback = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                     // 1. Validate callback is callable
-                    if !matches!(&callback, JsValue::Object(o) if interp.get_object_cell(o.id)
-                        .map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
-                    {
+                    if !callback.as_object_id().is_some_and(|callback_id| {
+                        interp
+                            .get_object_cell(callback_id)
+                            .is_some_and(|object| object.borrow().callable.is_some())
+                    }) {
                         return Completion::Throw(
                             interp.create_type_error("callbackfn is not a function"),
                         );
@@ -627,7 +655,7 @@ impl Interpreter {
                         .borrow_mut()
                         .kind = crate::interpreter::types::ObjectKind::Map(Vec::new());
                     let result_id = result_map_id;
-                    let result_val = JsValue::Object(crate::types::JsObject { id: result_id });
+                    let result_val = JsValue::object(result_id);
 
                     // 4. Iterate and group
                     let mut k: u64 = 0;
@@ -645,18 +673,18 @@ impl Interpreter {
                         // Call callback with (value, index)
                         let key_val = match interp.call_function(
                             &callback,
-                            &JsValue::Undefined,
-                            &[value.clone(), JsValue::Number(k as f64)],
+                            &JsValue::UNDEFINED,
+                            &[value.clone(), JsValue::number(k as f64)],
                         ) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
 
                         // Per spec: If key is -0, set key to +0
-                        let key_val = if let JsValue::Number(n) = &key_val {
-                            if *n == 0.0 {
-                                JsValue::Number(0.0)
+                        let key_val = if let Some(number) = key_val.as_number() {
+                            if number == 0.0 {
+                                JsValue::number(0.0)
                             } else {
                                 key_val
                             }
@@ -681,9 +709,9 @@ impl Interpreter {
                             if let Some(idx) = existing_idx {
                                 // Append to existing array
                                 if let Some((_, arr_val)) = entries[idx].as_ref()
-                                    && let JsValue::Object(arr_obj) = arr_val
+                                    && let Some(arr_obj) = (arr_val).as_object_id()
                                 {
-                                    let arr_id = arr_obj.id;
+                                    let arr_id = arr_obj;
                                     drop(borrowed);
                                     if let Some(arr) = interp.get_object(arr_id) {
                                         let len_val = interp.get_property_on_id(arr_id, "length");
@@ -691,7 +719,7 @@ impl Interpreter {
                                         arr.borrow_mut().insert_builtin(len.to_string(), value);
                                         arr.borrow_mut().insert_builtin(
                                             "length".to_string(),
-                                            JsValue::Number((len + 1) as f64),
+                                            JsValue::number((len + 1) as f64),
                                         );
                                     }
                                 }
@@ -745,8 +773,8 @@ impl Interpreter {
         self.define_to_string_tag(set_iter_proto_id, "Set Iterator");
 
         self.define_method(set_iter_proto_id, "next", 0, |interp, this, _args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object(o)
             {
                 let state = obj.borrow().iterator_state().cloned();
                 if let Some(IteratorState::SetIterator {
@@ -758,7 +786,7 @@ impl Interpreter {
                 {
                     if done {
                         return Completion::Normal(
-                            interp.create_iter_result_object(JsValue::Undefined, true),
+                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                         );
                     }
                     if let Some(set_obj) = interp.get_object(set_id) {
@@ -800,7 +828,7 @@ impl Interpreter {
                             },
                         );
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 }
             }
@@ -845,7 +873,7 @@ impl Interpreter {
                     done: false,
                 });
             let id = interp.alloc_object(obj_data);
-            JsValue::Object(crate::types::JsObject { id })
+            JsValue::object(id)
         }
 
         // Set.prototype.values
@@ -884,12 +912,12 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let mut value = args.first().cloned().unwrap_or(JsValue::Undefined);
-            if let JsValue::Number(n) = &value
-                && *n == 0.0
-                && n.is_sign_negative()
+            let mut value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if value
+                .as_number()
+                .is_some_and(|number| number == 0.0 && number.is_sign_negative())
             {
-                value = JsValue::Number(0.0);
+                value = JsValue::number(0.0);
             }
             interp.gc_write_barrier_value(&obj, &value);
             let mut borrowed = obj.borrow_mut_untracked();
@@ -910,13 +938,13 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let entries = obj.borrow().set_data().cloned().unwrap();
-            let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             for entry in entries.iter().flatten() {
                 if same_value_zero(entry, &value) {
-                    return Completion::Normal(JsValue::Boolean(true));
+                    return Completion::Normal(JsValue::boolean(true));
                 }
             }
-            Completion::Normal(JsValue::Boolean(false))
+            Completion::Normal(JsValue::boolean(false))
         });
 
         // Set.prototype.delete
@@ -925,17 +953,17 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let mut borrowed = obj.borrow_mut_untracked();
             let entries = borrowed.set_data_mut().unwrap();
             for entry in entries.iter_mut() {
                 let matches = entry.as_ref().is_some_and(|e| same_value_zero(e, &value));
                 if matches {
                     *entry = None;
-                    return Completion::Normal(JsValue::Boolean(true));
+                    return Completion::Normal(JsValue::boolean(true));
                 }
             }
-            Completion::Normal(JsValue::Boolean(false))
+            Completion::Normal(JsValue::boolean(false))
         });
 
         // Set.prototype.clear
@@ -946,39 +974,47 @@ impl Interpreter {
             };
             obj.borrow_mut_untracked().kind =
                 crate::interpreter::types::ObjectKind::Set(Vec::new());
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         // Set.prototype.forEach
-        self.define_method(proto_id, "forEach", 1,
-            |interp, this, args| {
-                let (_id, obj) = match this_set(interp, this, "forEach") {
-                    Ok(t) => t,
-                    Err(c) => return c,
-                };
-                let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&callback, JsValue::Object(co) if interp.get_object(co.id).is_some_and(|o| o.borrow().callable.is_some())) {
-                    let err = interp.create_type_error("Set.prototype.forEach callback is not a function");
-                    return Completion::Throw(err);
-                }
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                let mut i = 0;
-                loop {
-                    let entry = {
-                        let borrowed = obj.borrow();
-                        let entries = borrowed.set_data().unwrap();
-                        if i >= entries.len() { break; }
-                        entries[i].clone()
-                    };
-                    if let Some(v) = entry {
-                        let result = interp.call_function(&callback, &this_arg, &[v.clone(), v, this.clone()]);
-                        if result.is_abrupt() { return result; }
+        self.define_method(proto_id, "forEach", 1, |interp, this, args| {
+            let (_id, obj) = match this_set(interp, this, "forEach") {
+                Ok(t) => t,
+                Err(c) => return c,
+            };
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if !callback.as_object_id().is_some_and(|callback_id| {
+                interp
+                    .get_object(callback_id)
+                    .is_some_and(|object| object.borrow().callable.is_some())
+            }) {
+                let err =
+                    interp.create_type_error("Set.prototype.forEach callback is not a function");
+                return Completion::Throw(err);
+            }
+            let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            let mut i = 0;
+            loop {
+                let entry = {
+                    let borrowed = obj.borrow();
+                    let entries = borrowed.set_data().unwrap();
+                    if i >= entries.len() {
+                        break;
                     }
-                    i += 1;
+                    entries[i].clone()
+                };
+                if let Some(v) = entry {
+                    let result =
+                        interp.call_function(&callback, &this_arg, &[v.clone(), v, this.clone()]);
+                    if result.is_abrupt() {
+                        return result;
+                    }
                 }
-                Completion::Normal(JsValue::Undefined)
-            },
-        );
+                i += 1;
+            }
+            Completion::Normal(JsValue::UNDEFINED)
+        });
 
         // Set.prototype.size (getter)
         self.define_getter(proto_id, "size", |interp, this, _args| {
@@ -993,7 +1029,7 @@ impl Interpreter {
                 .iter()
                 .filter(|e| e.is_some())
                 .count();
-            Completion::Normal(JsValue::Number(count as f64))
+            Completion::Normal(JsValue::number(count as f64))
         });
 
         // ES2025 Set methods
@@ -1003,16 +1039,15 @@ impl Interpreter {
             interp: &mut Interpreter,
             obj: &JsValue,
         ) -> Result<SetRecord, JsValue> {
-            let o_id = match obj {
-                JsValue::Object(o) => o.id,
-                _ => return Err(interp.create_type_error("GetSetRecord requires an object")),
-            };
+            let o_id = obj
+                .as_object_id()
+                .ok_or_else(|| interp.create_type_error("GetSetRecord requires an object"))?;
 
             // Get size via property access (invokes getters)
             let raw_size = match interp.get_object_property(o_id, "size", obj) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             let size = interp.to_number_coerce(&raw_size);
             if size.is_nan() {
@@ -1027,7 +1062,7 @@ impl Interpreter {
             let has = match interp.get_object_property(o_id, "has", obj) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if !interp.is_callable(&has) {
                 return Err(
@@ -1039,7 +1074,7 @@ impl Interpreter {
             let keys = match interp.get_object_property(o_id, "keys", obj) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if !interp.is_callable(&keys) {
                 return Err(
@@ -1060,15 +1095,14 @@ impl Interpreter {
                 Completion::Normal(v) => v,
                 other => return Err(other),
             };
-            if !matches!(&keys_iter, JsValue::Object(_)) {
+            if !keys_iter.is_object() {
                 return Err(Completion::Throw(
                     interp.create_type_error("keys() must return an object"),
                 ));
             }
-            let iter_id = match &keys_iter {
-                JsValue::Object(io) => io.id,
-                _ => unreachable!(),
-            };
+            let iter_id = keys_iter
+                .as_object_id()
+                .expect("keys iterator must be an object");
             // Read next ONCE (per spec GetIterator)
             let next_fn = match interp.get_object_property(iter_id, "next", &keys_iter) {
                 Completion::Normal(v) => v,
@@ -1087,14 +1121,9 @@ impl Interpreter {
                 Completion::Normal(v) => v,
                 other => return Err(other),
             };
-            let result_id = match &next_result {
-                JsValue::Object(ro) => ro.id,
-                _ => {
-                    return Err(Completion::Throw(
-                        interp.create_type_error("Iterator result is not an object"),
-                    ));
-                }
-            };
+            let result_id = next_result.as_object_id().ok_or_else(|| {
+                Completion::Throw(interp.create_type_error("Iterator result is not an object"))
+            })?;
             let done = match interp.get_object_property(result_id, "done", &next_result) {
                 Completion::Normal(v) => interp.to_boolean_val(&v),
                 other => return Err(other),
@@ -1110,11 +1139,11 @@ impl Interpreter {
         }
 
         fn canonicalize_key(val: JsValue) -> JsValue {
-            if let JsValue::Number(n) = &val
-                && *n == 0.0
-                && n.is_sign_negative()
+            if val
+                .as_number()
+                .is_some_and(|number| number == 0.0 && number.is_sign_negative())
             {
-                return JsValue::Number(0.0);
+                return JsValue::number(0.0);
             }
             val
         }
@@ -1136,7 +1165,7 @@ impl Interpreter {
             interp.get_object_cell_expect(new_obj_id).borrow_mut().kind =
                 crate::interpreter::types::ObjectKind::Set(entries);
             let id = new_obj_id;
-            Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+            Completion::Normal(JsValue::object(id))
         }
 
         // Set.prototype.union
@@ -1145,7 +1174,7 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let other_rec = match spec_get_set_record(interp, &other) {
                 Ok(r) => r,
                 Err(e) => return Completion::Throw(e),
@@ -1181,7 +1210,7 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let other_rec = match spec_get_set_record(interp, &other) {
                 Ok(r) => r,
                 Err(e) => return Completion::Throw(e),
@@ -1250,7 +1279,7 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let other_rec = match spec_get_set_record(interp, &other) {
                 Ok(r) => r,
                 Err(e) => return Completion::Throw(e),
@@ -1306,7 +1335,7 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let other_rec = match spec_get_set_record(interp, &other) {
                 Ok(r) => r,
                 Err(e) => return Completion::Throw(e),
@@ -1352,7 +1381,7 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let other_rec = match spec_get_set_record(interp, &other) {
                 Ok(r) => r,
                 Err(e) => return Completion::Throw(e),
@@ -1360,7 +1389,7 @@ impl Interpreter {
             let entries = obj.borrow().set_data().cloned().unwrap();
             let this_size = entries.iter().filter(|e| e.is_some()).count();
             if this_size as f64 > other_rec.size {
-                return Completion::Normal(JsValue::Boolean(false));
+                return Completion::Normal(JsValue::boolean(false));
             }
             // Iterate live set data (re-read each iteration for mutation support)
             let mut i = 0;
@@ -1380,11 +1409,11 @@ impl Interpreter {
                         other => return other,
                     };
                     if !interp.to_boolean_val(&has_result) {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                 }
             }
-            Completion::Normal(JsValue::Boolean(true))
+            Completion::Normal(JsValue::boolean(true))
         });
 
         // Set.prototype.isSupersetOf
@@ -1393,7 +1422,7 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let other_rec = match spec_get_set_record(interp, &other) {
                 Ok(r) => r,
                 Err(e) => return Completion::Throw(e),
@@ -1401,7 +1430,7 @@ impl Interpreter {
             let entries = obj.borrow().set_data().cloned().unwrap();
             let this_size = entries.iter().filter(|e| e.is_some()).count();
             if (this_size as f64) < other_rec.size {
-                return Completion::Normal(JsValue::Boolean(false));
+                return Completion::Normal(JsValue::boolean(false));
             }
             let (keys_iter, next_fn) = match get_keys_iterator(interp, &other_rec.keys, &other) {
                 Ok(r) => r,
@@ -1415,11 +1444,11 @@ impl Interpreter {
                 };
                 let current = obj.borrow().set_data().cloned().unwrap_or_default();
                 if !set_data_has(&current, &value) {
-                    interp.iterator_close(&keys_iter, JsValue::Undefined);
-                    return Completion::Normal(JsValue::Boolean(false));
+                    interp.iterator_close(&keys_iter, JsValue::UNDEFINED);
+                    return Completion::Normal(JsValue::boolean(false));
                 }
             }
-            Completion::Normal(JsValue::Boolean(true))
+            Completion::Normal(JsValue::boolean(true))
         });
 
         // Set.prototype.isDisjointFrom
@@ -1428,7 +1457,7 @@ impl Interpreter {
                 Ok(t) => t,
                 Err(c) => return c,
             };
-            let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let other_rec = match spec_get_set_record(interp, &other) {
                 Ok(r) => r,
                 Err(e) => return Completion::Throw(e),
@@ -1454,7 +1483,7 @@ impl Interpreter {
                             other => return other,
                         };
                         if interp.to_boolean_val(&has_result) {
-                            return Completion::Normal(JsValue::Boolean(false));
+                            return Completion::Normal(JsValue::boolean(false));
                         }
                     }
                 }
@@ -1472,18 +1501,18 @@ impl Interpreter {
                     };
                     let current = obj.borrow().set_data().cloned().unwrap_or_default();
                     if set_data_has(&current, &value) {
-                        interp.iterator_close(&keys_iter, JsValue::Undefined);
-                        return Completion::Normal(JsValue::Boolean(false));
+                        interp.iterator_close(&keys_iter, JsValue::UNDEFINED);
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                 }
             }
-            Completion::Normal(JsValue::Boolean(true))
+            Completion::Normal(JsValue::boolean(true))
         });
 
         // @@toStringTag
         self.define_to_string_tag(proto_id, "Set");
 
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
 
         // Set constructor
         let set_proto_clone_id = proto_id;
@@ -1497,37 +1526,55 @@ impl Interpreter {
                 }
 
                 // OrdinaryCreateFromConstructor — realm-aware prototype
-                let proto = match interp.get_prototype_from_new_target_realm(|realm| {
-                    realm.set_prototype
-                }) {
-                    Ok(p) => p.unwrap_or(set_proto_clone_id),
-                    Err(e) => return Completion::Throw(e),
-                };
+                let proto =
+                    match interp.get_prototype_from_new_target_realm(|realm| realm.set_prototype) {
+                        Ok(p) => p.unwrap_or(set_proto_clone_id),
+                        Err(e) => return Completion::Throw(e),
+                    };
                 let obj_id = interp.create_object_id();
-                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
-                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "Set".to_string();
-                interp.get_object_cell_expect(obj_id).borrow_mut().kind = crate::interpreter::types::ObjectKind::Set(Vec::new());
-                let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "Set".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().kind =
+                    crate::interpreter::types::ObjectKind::Set(Vec::new());
+                let this_val = JsValue::object(obj_id);
 
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !iterable.is_undefined() && !iterable.is_null() {
                     // §24.2.1.1 step 7a: Let adder be ? Get(set, "add").
                     let adder = match interp.get_object_property(obj_id, "add", &this_val) {
                         Completion::Normal(v) => v,
                         c => return c,
                     };
-                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object_cell(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
+                    if !adder.as_object_id().is_some_and(|adder_id| {
+                        interp
+                            .get_object_cell(adder_id)
+                            .is_some_and(|object| object.borrow().callable.is_some())
+                    }) {
                         let err = interp.create_type_error("Set.prototype.add is not a function");
                         return Completion::Throw(err);
                     }
 
                     let iter_key = interp.get_symbol_iterator_key();
                     let iterator_fn = if let Some(ref key) = iter_key {
-                        if let JsValue::Object(io) = &iterable {
-                            let v = interp.get_property_on_id(io.id, key);
-                            if v.is_undefined() { JsValue::Undefined } else { v }
-                        } else { JsValue::Undefined }
-                    } else { JsValue::Undefined };
+                        if let Some(io) = iterable.as_object_id() {
+                            let v = interp.get_property_on_id(io, key);
+                            if v.is_undefined() {
+                                JsValue::UNDEFINED
+                            } else {
+                                v
+                            }
+                        } else {
+                            JsValue::UNDEFINED
+                        }
+                    } else {
+                        JsValue::UNDEFINED
+                    };
 
                     if iterator_fn.is_undefined() {
                         let err = interp.create_type_error("object is not iterable");
@@ -1540,9 +1587,11 @@ impl Interpreter {
                     };
 
                     loop {
-                        let next_fn = if let JsValue::Object(io) = &iterator {
-                            interp.get_property_on_id(io.id, "next")
-                        } else { JsValue::Undefined };
+                        let next_fn = if let Some(io) = iterator.as_object_id() {
+                            interp.get_property_on_id(io, "next")
+                        } else {
+                            JsValue::UNDEFINED
+                        };
 
                         let next_result = match interp.call_function(&next_fn, &iterator, &[]) {
                             Completion::Normal(v) => v,
@@ -1550,23 +1599,29 @@ impl Interpreter {
                         };
 
                         // Use getter-aware property access for done/value
-                        let done = if let JsValue::Object(ro) = &next_result {
-                            match interp.get_object_property(ro.id, "done", &next_result) {
+                        let done = if let Some(ro) = next_result.as_object_id() {
+                            match interp.get_object_property(ro, "done", &next_result) {
                                 Completion::Normal(v) => interp.to_boolean_val(&v),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 other => return other,
                             }
-                        } else { false };
-                        if done { break; }
+                        } else {
+                            false
+                        };
+                        if done {
+                            break;
+                        }
                         // Per IteratorStepValue, if accessing .value throws, the error
                         // propagates directly without closing the iterator.
-                        let value = if let JsValue::Object(ro) = &next_result {
-                            match interp.get_object_property(ro.id, "value", &next_result) {
+                        let value = if let Some(ro) = next_result.as_object_id() {
+                            match interp.get_object_property(ro, "value", &next_result) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 other => return other,
                             }
-                        } else { JsValue::Undefined };
+                        } else {
+                            JsValue::UNDEFINED
+                        };
 
                         match interp.call_function(&adder, &this_val, &[value]) {
                             Completion::Normal(_) => {}
@@ -1583,8 +1638,8 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(ctor_obj) = &set_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_obj) = set_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_obj)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -1599,8 +1654,8 @@ impl Interpreter {
             );
 
         // Set[Symbol.species] getter
-        if let JsValue::Object(ref ctor_ref) = set_ctor
-            && let Some(ctor_obj) = self.get_object(ctor_ref.id)
+        if let Some(ctor_ref) = (set_ctor).as_object_id()
+            && let Some(ctor_obj) = self.get_object(ctor_ref)
         {
             let species_getter = self.create_function(JsFunction::native(
                 "get [Symbol.species]".to_string(),
@@ -1642,22 +1697,22 @@ impl Interpreter {
 
         // WeakMap.prototype.get
         self.define_method(proto_id, "get", 1, |interp, this, args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let is_weakmap = obj.borrow().class_name == "WeakMap";
                 let map_data = obj.borrow().map_data().cloned();
                 if is_weakmap && let Some(entries) = map_data {
-                    let key = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if !interp.can_be_held_weakly(&key) {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     for entry in entries.iter().flatten() {
                         if strict_equality(&entry.0, &key) {
                             return Completion::Normal(entry.1.clone());
                         }
                     }
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
             }
             let err = interp.create_type_error("WeakMap.prototype.get requires a WeakMap");
@@ -1666,17 +1721,17 @@ impl Interpreter {
 
         // WeakMap.prototype.set
         self.define_method(proto_id, "set", 2, |interp, this, args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let has_map = obj.borrow().map_data().is_some();
                 if has_map && obj.borrow().class_name == "WeakMap" {
-                    let key = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if !interp.can_be_held_weakly(&key) {
                         let err = interp.create_type_error("Invalid value used as weak map key");
                         return Completion::Throw(err);
                     }
-                    let value = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     interp.gc_write_barrier_value(obj, &key);
                     interp.gc_write_barrier_value(obj, &value);
                     let mut borrowed = obj.borrow_mut_untracked();
@@ -1697,22 +1752,22 @@ impl Interpreter {
 
         // WeakMap.prototype.has
         self.define_method(proto_id, "has", 1, |interp, this, args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let is_weakmap = obj.borrow().class_name == "WeakMap";
                 let map_data = obj.borrow().map_data().cloned();
                 if is_weakmap && let Some(entries) = map_data {
-                    let key = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if !interp.can_be_held_weakly(&key) {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     for entry in entries.iter().flatten() {
                         if strict_equality(&entry.0, &key) {
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                     }
-                    return Completion::Normal(JsValue::Boolean(false));
+                    return Completion::Normal(JsValue::boolean(false));
                 }
             }
             let err = interp.create_type_error("WeakMap.prototype.has requires a WeakMap");
@@ -1721,15 +1776,15 @@ impl Interpreter {
 
         // WeakMap.prototype.delete
         self.define_method(proto_id, "delete", 1, |interp, this, args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let is_weakmap = obj.borrow().class_name == "WeakMap";
                 let has_map = obj.borrow().map_data().is_some();
                 if is_weakmap && has_map {
-                    let key = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if !interp.can_be_held_weakly(&key) {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     let mut borrowed = obj.borrow_mut_untracked();
                     let entries = borrowed.map_data_mut().unwrap();
@@ -1737,10 +1792,10 @@ impl Interpreter {
                         let matches = entry.as_ref().is_some_and(|e| strict_equality(&e.0, &key));
                         if matches {
                             *entry = None;
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                     }
-                    return Completion::Normal(JsValue::Boolean(false));
+                    return Completion::Normal(JsValue::boolean(false));
                 }
             }
             let err = interp.create_type_error("WeakMap.prototype.delete requires a WeakMap");
@@ -1749,14 +1804,14 @@ impl Interpreter {
 
         // WeakMap.prototype.getOrInsert
         self.define_method(proto_id, "getOrInsert", 2, |interp, this, args| {
-            if let JsValue::Object(o) = &this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = this.as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let is_weakmap =
                     obj.borrow().map_data().is_some() && obj.borrow().class_name == "WeakMap";
                 if is_weakmap {
-                    let key = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let value = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     if !interp.can_be_held_weakly(&key) {
                         let err = interp.create_type_error("Invalid value used as weak map key");
                         return Completion::Throw(err);
@@ -1783,71 +1838,69 @@ impl Interpreter {
         });
 
         // WeakMap.prototype.getOrInsertComputed
-        self.define_method(proto_id, "getOrInsertComputed", 2,
-            |interp, this, args| {
-                if let JsValue::Object(o) = &this
-                    && let Some(obj) = interp.get_object_cell(o.id)
-                {
-                    let is_weakmap = obj.borrow().map_data().is_some()
-                        && obj.borrow().class_name == "WeakMap";
-                    if is_weakmap {
-                        let key = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        let callbackfn = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                        if !interp.can_be_held_weakly(&key) {
-                            let err = interp
-                                .create_type_error("Invalid value used as weak map key");
-                            return Completion::Throw(err);
-                        }
-                        let is_callable = matches!(&callbackfn, JsValue::Object(co)
-                            if interp.get_object_cell(co.id).is_some_and(|ob| ob.borrow().callable.is_some()));
-                        if !is_callable {
-                            let err = interp
-                                .create_type_error("callbackfn is not a function");
-                            return Completion::Throw(err);
-                        }
-                        {
-                            let borrowed = obj.borrow();
-                            let entries = borrowed.map_data().unwrap();
-                            for entry in entries.iter().flatten() {
-                                if strict_equality(&entry.0, &key) {
-                                    return Completion::Normal(entry.1.clone());
-                                }
-                            }
-                        }
-                        let value = match interp.call_function(
-                            &callbackfn,
-                            &JsValue::Undefined,
-                            std::slice::from_ref(&key),
-                        ) {
-                            Completion::Normal(v) => v,
-                            other => return other,
-                        };
-                        let obj = interp.get_object_cell(o.id).unwrap();
-                        interp.gc_write_barrier_value(obj, &key);
-                        interp.gc_write_barrier_value(obj, &value);
-                        let mut borrowed = obj.borrow_mut_untracked();
-                        let entries = borrowed.map_data_mut().unwrap();
-                        for entry in entries.iter_mut().flatten() {
-                            if strict_equality(&entry.0, &key) {
-                                entry.1 = value.clone();
-                                return Completion::Normal(value);
-                            }
-                        }
-                        entries.push(Some((key, value.clone())));
-                        return Completion::Normal(value);
+        self.define_method(proto_id, "getOrInsertComputed", 2, |interp, this, args| {
+            if let Some(o) = this.as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
+            {
+                let is_weakmap =
+                    obj.borrow().map_data().is_some() && obj.borrow().class_name == "WeakMap";
+                if is_weakmap {
+                    let key = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let callbackfn = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    if !interp.can_be_held_weakly(&key) {
+                        let err = interp.create_type_error("Invalid value used as weak map key");
+                        return Completion::Throw(err);
                     }
+                    let is_callable = callbackfn.as_object_id().is_some_and(|callback_id| {
+                        interp
+                            .get_object_cell(callback_id)
+                            .is_some_and(|object| object.borrow().callable.is_some())
+                    });
+                    if !is_callable {
+                        let err = interp.create_type_error("callbackfn is not a function");
+                        return Completion::Throw(err);
+                    }
+                    {
+                        let borrowed = obj.borrow();
+                        let entries = borrowed.map_data().unwrap();
+                        for entry in entries.iter().flatten() {
+                            if strict_equality(&entry.0, &key) {
+                                return Completion::Normal(entry.1.clone());
+                            }
+                        }
+                    }
+                    let value = match interp.call_function(
+                        &callbackfn,
+                        &JsValue::UNDEFINED,
+                        std::slice::from_ref(&key),
+                    ) {
+                        Completion::Normal(v) => v,
+                        other => return other,
+                    };
+                    let obj = interp.get_object_cell(o).unwrap();
+                    interp.gc_write_barrier_value(obj, &key);
+                    interp.gc_write_barrier_value(obj, &value);
+                    let mut borrowed = obj.borrow_mut_untracked();
+                    let entries = borrowed.map_data_mut().unwrap();
+                    for entry in entries.iter_mut().flatten() {
+                        if strict_equality(&entry.0, &key) {
+                            entry.1 = value.clone();
+                            return Completion::Normal(value);
+                        }
+                    }
+                    entries.push(Some((key, value.clone())));
+                    return Completion::Normal(value);
                 }
-                let err = interp.create_type_error(
-                    "WeakMap.prototype.getOrInsertComputed requires a WeakMap",
-                );
-                Completion::Throw(err)
-            },
-        );
+            }
+            let err = interp
+                .create_type_error("WeakMap.prototype.getOrInsertComputed requires a WeakMap");
+            Completion::Throw(err)
+        });
 
         // @@toStringTag
         self.define_to_string_tag(proto_id, "WeakMap");
 
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
 
         // WeakMap constructor
         let weakmap_proto_clone_id = proto_id;
@@ -1861,37 +1914,57 @@ impl Interpreter {
                 }
 
                 // OrdinaryCreateFromConstructor — realm-aware prototype
-                let proto = match interp.get_prototype_from_new_target_realm(|realm| {
-                    realm.weakmap_prototype
-                }) {
+                let proto = match interp
+                    .get_prototype_from_new_target_realm(|realm| realm.weakmap_prototype)
+                {
                     Ok(p) => p.unwrap_or(weakmap_proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
                 let obj_id = interp.create_object_id();
-                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
-                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "WeakMap".to_string();
-                interp.get_object_cell_expect(obj_id).borrow_mut().kind = crate::interpreter::types::ObjectKind::Map(Vec::new());
-                let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "WeakMap".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().kind =
+                    crate::interpreter::types::ObjectKind::Map(Vec::new());
+                let this_val = JsValue::object(obj_id);
 
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !iterable.is_undefined() && !iterable.is_null() {
                     // §24.3.1.1 step 7a: Let adder be ? Get(map, "set").
                     let adder = match interp.get_object_property(obj_id, "set", &this_val) {
                         Completion::Normal(v) => v,
                         c => return c,
                     };
-                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object_cell(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
-                        let err = interp.create_type_error("WeakMap.prototype.set is not a function");
+                    if !adder.as_object_id().is_some_and(|adder_id| {
+                        interp
+                            .get_object_cell(adder_id)
+                            .is_some_and(|object| object.borrow().callable.is_some())
+                    }) {
+                        let err =
+                            interp.create_type_error("WeakMap.prototype.set is not a function");
                         return Completion::Throw(err);
                     }
 
                     let iter_key = interp.get_symbol_iterator_key();
                     let iterator_fn = if let Some(ref key) = iter_key {
-                        if let JsValue::Object(io) = &iterable {
-                            let v = interp.get_property_on_id(io.id, key);
-                            if v.is_undefined() { JsValue::Undefined } else { v }
-                        } else { JsValue::Undefined }
-                    } else { JsValue::Undefined };
+                        if let Some(io) = iterable.as_object_id() {
+                            let v = interp.get_property_on_id(io, key);
+                            if v.is_undefined() {
+                                JsValue::UNDEFINED
+                            } else {
+                                v
+                            }
+                        } else {
+                            JsValue::UNDEFINED
+                        }
+                    } else {
+                        JsValue::UNDEFINED
+                    };
 
                     if iterator_fn.is_undefined() {
                         let err = interp.create_type_error("object is not iterable");
@@ -1904,9 +1977,11 @@ impl Interpreter {
                     };
 
                     loop {
-                        let next_fn = if let JsValue::Object(io) = &iterator {
-                            interp.get_property_on_id(io.id, "next")
-                        } else { JsValue::Undefined };
+                        let next_fn = if let Some(io) = iterator.as_object_id() {
+                            interp.get_property_on_id(io, "next")
+                        } else {
+                            JsValue::UNDEFINED
+                        };
 
                         let next_result = match interp.call_function(&next_fn, &iterator, &[]) {
                             Completion::Normal(v) => v,
@@ -1916,36 +1991,42 @@ impl Interpreter {
                         // IteratorStep: access .done via getter-aware Get (not raw get_property)
                         // Per spec, if accessing .done throws, the error propagates directly
                         // without closing the iterator.
-                        let done = if let JsValue::Object(ro) = &next_result {
-                            match interp.get_object_property(ro.id, "done", &next_result) {
+                        let done = if let Some(ro) = next_result.as_object_id() {
+                            match interp.get_object_property(ro, "done", &next_result) {
                                 Completion::Normal(d) => interp.to_boolean_val(&d),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 _ => false,
                             }
-                        } else { false };
+                        } else {
+                            false
+                        };
 
-                        if done { break; }
+                        if done {
+                            break;
+                        }
 
                         // §24.3.1.1 step 9d: Get value via Get (invokes getters).
                         // If accessing .value throws, the error propagates without closing the iterator.
-                        let value = if let JsValue::Object(ro) = &next_result {
-                            match interp.get_object_property(ro.id, "value", &next_result) {
+                        let value = if let Some(ro) = next_result.as_object_id() {
+                            match interp.get_object_property(ro, "value", &next_result) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 other => return other,
                             }
-                        } else { JsValue::Undefined };
+                        } else {
+                            JsValue::UNDEFINED
+                        };
 
                         // §24.3.1.1 step 9e: If value is not Object, close iterator + throw
-                        if !matches!(&value, JsValue::Object(_)) {
+                        if !value.is_object() {
                             let err = interp.create_type_error("Iterator value is not an object");
                             let e2 = interp.iterator_close(&iterator, err);
                             return Completion::Throw(e2);
                         }
 
                         // Get key and value from the [key, value] pair
-                        let (k, v) = if let JsValue::Object(vo) = &value {
-                            let k = match interp.get_object_property(vo.id, "0", &value) {
+                        let (k, v) = if let Some(vo) = value.as_object_id() {
+                            let k = match interp.get_object_property(vo, "0", &value) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => {
                                     let e2 = interp.iterator_close(&iterator, e);
@@ -1953,7 +2034,7 @@ impl Interpreter {
                                 }
                                 other => return other,
                             };
-                            let v = match interp.get_object_property(vo.id, "1", &value) {
+                            let v = match interp.get_object_property(vo, "1", &value) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => {
                                     let e2 = interp.iterator_close(&iterator, e);
@@ -1982,8 +2063,8 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(ctor_obj) = &weakmap_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_obj) = weakmap_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_obj)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -2018,13 +2099,13 @@ impl Interpreter {
 
         // WeakSet.prototype.add
         self.define_method(proto_id, "add", 1, |interp, this, args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let has_set =
                     obj.borrow().set_data().is_some() && obj.borrow().class_name == "WeakSet";
                 if has_set {
-                    let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if !interp.can_be_held_weakly(&value) {
                         let err = interp.create_type_error("Invalid value used in weak set");
                         return Completion::Throw(err);
@@ -2047,22 +2128,22 @@ impl Interpreter {
 
         // WeakSet.prototype.has
         self.define_method(proto_id, "has", 1, |interp, this, args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let is_weakset = obj.borrow().class_name == "WeakSet";
                 let set_data = obj.borrow().set_data().cloned();
                 if is_weakset && let Some(entries) = set_data {
-                    let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if !interp.can_be_held_weakly(&value) {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     for entry in entries.iter().flatten() {
                         if strict_equality(entry, &value) {
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                     }
-                    return Completion::Normal(JsValue::Boolean(false));
+                    return Completion::Normal(JsValue::boolean(false));
                 }
             }
             let err = interp.create_type_error("WeakSet.prototype.has requires a WeakSet");
@@ -2071,15 +2152,15 @@ impl Interpreter {
 
         // WeakSet.prototype.delete
         self.define_method(proto_id, "delete", 1, |interp, this, args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let is_weakset = obj.borrow().class_name == "WeakSet";
                 let has_set = obj.borrow().set_data().is_some();
                 if is_weakset && has_set {
-                    let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if !interp.can_be_held_weakly(&value) {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     let mut borrowed = obj.borrow_mut_untracked();
                     let entries = borrowed.set_data_mut().unwrap();
@@ -2087,10 +2168,10 @@ impl Interpreter {
                         let matches = entry.as_ref().is_some_and(|e| strict_equality(e, &value));
                         if matches {
                             *entry = None;
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                     }
-                    return Completion::Normal(JsValue::Boolean(false));
+                    return Completion::Normal(JsValue::boolean(false));
                 }
             }
             let err = interp.create_type_error("WeakSet.prototype.delete requires a WeakSet");
@@ -2100,7 +2181,7 @@ impl Interpreter {
         // @@toStringTag
         self.define_to_string_tag(proto_id, "WeakSet");
 
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
 
         // WeakSet constructor
         let weakset_proto_clone_id = proto_id;
@@ -2114,37 +2195,57 @@ impl Interpreter {
                 }
 
                 // OrdinaryCreateFromConstructor — realm-aware prototype
-                let proto = match interp.get_prototype_from_new_target_realm(|realm| {
-                    realm.weakset_prototype
-                }) {
+                let proto = match interp
+                    .get_prototype_from_new_target_realm(|realm| realm.weakset_prototype)
+                {
                     Ok(p) => p.unwrap_or(weakset_proto_clone_id),
                     Err(e) => return Completion::Throw(e),
                 };
                 let obj_id = interp.create_object_id();
-                interp.get_object_cell_expect(obj_id).borrow_mut().prototype_id = Some(proto);
-                interp.get_object_cell_expect(obj_id).borrow_mut().class_name = "WeakSet".to_string();
-                interp.get_object_cell_expect(obj_id).borrow_mut().kind = crate::interpreter::types::ObjectKind::Set(Vec::new());
-                let this_val = JsValue::Object(crate::types::JsObject { id: obj_id });
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .prototype_id = Some(proto);
+                interp
+                    .get_object_cell_expect(obj_id)
+                    .borrow_mut()
+                    .class_name = "WeakSet".to_string();
+                interp.get_object_cell_expect(obj_id).borrow_mut().kind =
+                    crate::interpreter::types::ObjectKind::Set(Vec::new());
+                let this_val = JsValue::object(obj_id);
 
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !iterable.is_undefined() && !iterable.is_null() {
                     // §24.4.1.1 step 7a: Let adder be ? Get(set, "add").
                     let adder = match interp.get_object_property(obj_id, "add", &this_val) {
                         Completion::Normal(v) => v,
                         c => return c,
                     };
-                    if !matches!(&adder, JsValue::Object(ao) if interp.get_object_cell(ao.id).is_some_and(|o| o.borrow().callable.is_some())) {
-                        let err = interp.create_type_error("WeakSet.prototype.add is not a function");
+                    if !adder.as_object_id().is_some_and(|adder_id| {
+                        interp
+                            .get_object_cell(adder_id)
+                            .is_some_and(|object| object.borrow().callable.is_some())
+                    }) {
+                        let err =
+                            interp.create_type_error("WeakSet.prototype.add is not a function");
                         return Completion::Throw(err);
                     }
 
                     let iter_key = interp.get_symbol_iterator_key();
                     let iterator_fn = if let Some(ref key) = iter_key {
-                        if let JsValue::Object(io) = &iterable {
-                            let v = interp.get_property_on_id(io.id, key);
-                            if v.is_undefined() { JsValue::Undefined } else { v }
-                        } else { JsValue::Undefined }
-                    } else { JsValue::Undefined };
+                        if let Some(io) = iterable.as_object_id() {
+                            let v = interp.get_property_on_id(io, key);
+                            if v.is_undefined() {
+                                JsValue::UNDEFINED
+                            } else {
+                                v
+                            }
+                        } else {
+                            JsValue::UNDEFINED
+                        }
+                    } else {
+                        JsValue::UNDEFINED
+                    };
 
                     if iterator_fn.is_undefined() {
                         let err = interp.create_type_error("object is not iterable");
@@ -2157,39 +2258,47 @@ impl Interpreter {
                     };
 
                     loop {
-                        let next_fn = if let JsValue::Object(io) = &iterator {
-                            interp.get_property_on_id(io.id, "next")
-                        } else { JsValue::Undefined };
+                        let next_fn = if let Some(io) = iterator.as_object_id() {
+                            interp.get_property_on_id(io, "next")
+                        } else {
+                            JsValue::UNDEFINED
+                        };
 
                         let next_result = match interp.call_function(&next_fn, &iterator, &[]) {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
 
-                        if !matches!(next_result, JsValue::Object(_)) {
-                            return Completion::Throw(interp.create_type_error("Iterator result is not an object"));
+                        if !(next_result).is_object() {
+                            return Completion::Throw(
+                                interp.create_type_error("Iterator result is not an object"),
+                            );
                         }
 
                         // Use getter-aware property access for done/value.
                         // Per IteratorStepValue, errors from .done/.value propagate
                         // directly without closing the iterator.
-                        let done = if let JsValue::Object(ro) = &next_result {
-                            match interp.get_object_property(ro.id, "done", &next_result) {
+                        let done = if let Some(ro) = next_result.as_object_id() {
+                            match interp.get_object_property(ro, "done", &next_result) {
                                 Completion::Normal(d) => interp.to_boolean_val(&d),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 _ => false,
                             }
-                        } else { false };
-                        if done { break; }
+                        } else {
+                            false
+                        };
+                        if done {
+                            break;
+                        }
 
-                        let value = if let JsValue::Object(ro) = &next_result {
-                            match interp.get_object_property(ro.id, "value", &next_result) {
+                        let value = if let Some(ro) = next_result.as_object_id() {
+                            match interp.get_object_property(ro, "value", &next_result) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 other => return other,
                             }
                         } else {
-                            JsValue::Undefined
+                            JsValue::UNDEFINED
                         };
 
                         // §24.4.1.1 step 9f-g: Call adder, IteratorClose on failure
@@ -2208,8 +2317,8 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(ctor_obj) = &weakset_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_obj) = weakset_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_obj)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -2246,13 +2355,13 @@ impl Interpreter {
         self.define_method(proto_id, "deref", 0, |interp, this, _args| {
             // Require this to be an object with [[WeakRefTarget]] internal slot
             // (indicated by class_name == "WeakRef" AND primitive_value.is_some())
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let b = obj.borrow();
                 if b.class_name == "WeakRef" && b.primitive_value.is_some() {
                     return Completion::Normal(
-                        b.primitive_value.clone().unwrap_or(JsValue::Undefined),
+                        b.primitive_value.clone().unwrap_or(JsValue::UNDEFINED),
                     );
                 }
             }
@@ -2273,7 +2382,7 @@ impl Interpreter {
                     let err = interp.create_type_error("Constructor WeakRef requires 'new'");
                     return Completion::Throw(err);
                 }
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !interp.can_be_held_weakly(&target) {
                     return Completion::Throw(interp.create_type_error(
                         "WeakRef: target must be an object or non-registered symbol",
@@ -2302,21 +2411,16 @@ impl Interpreter {
                     .borrow_mut()
                     .primitive_value = Some(target);
                 let id = obj_id;
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
 
-        if let JsValue::Object(ref ctor_obj) = weakref_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_obj) = (weakref_ctor).as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_obj)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject { id: proto_id }),
-                    false,
-                    false,
-                    false,
-                ),
+                PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
             );
         }
 
@@ -2349,8 +2453,8 @@ impl Interpreter {
         // FinalizationRegistry.prototype.register
         self.define_method(proto_id, "register", 2,
             |interp, this, args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = (this).as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     // Check [[Cells]] internal slot: class_name + map_data.is_some()
                     let has_cells = {
@@ -2359,42 +2463,42 @@ impl Interpreter {
                             && b.finalization_registry().is_some()
                     };
                     if has_cells {
-                        let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         if !interp.can_be_held_weakly(&target) {
                             return Completion::Throw(interp.create_type_error(
                                 "FinalizationRegistry.register: target must be an object or non-registered symbol",
                             ));
                         }
-                        let held_value = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                        let held_value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                         // SameValue(target, heldValue) => TypeError
                         if same_value(&target, &held_value) {
                             return Completion::Throw(interp.create_type_error(
                                 "FinalizationRegistry.register: target and heldValue must not be the same",
                             ));
                         }
-                        let unregister_token = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                        let unregister_token = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                         // If CanBeHeldWeakly(unregisterToken) is false:
                         //   If unregisterToken is not undefined, throw TypeError
                         if !interp.can_be_held_weakly(&unregister_token)
-                            && !matches!(unregister_token, JsValue::Undefined) {
+                            && !(unregister_token).is_undefined() {
                                 return Completion::Throw(interp.create_type_error(
                                     "FinalizationRegistry.register: unregisterToken must be an object, non-registered symbol, or undefined",
                                 ));
                             }
                         // Store cell: map_data stores (target, heldValue), set_data stores unregisterToken
-                        let token_entry = if matches!(unregister_token, JsValue::Undefined) {
+                        let token_entry = if (unregister_token).is_undefined() {
                             None
                         } else {
                             Some(unregister_token)
                         };
-                        if let Some(obj_rc) = interp.get_object_cell(o.id)
+                        if let Some(obj_rc) = interp.get_object_cell(o)
                             && let Some((cells, tokens)) =
                                 obj_rc.borrow_mut().finalization_registry_mut()
                         {
                             cells.push(Some((target, held_value)));
                             tokens.push(token_entry);
                         }
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                 }
                 Completion::Throw(interp.create_type_error(
@@ -2406,8 +2510,8 @@ impl Interpreter {
         // FinalizationRegistry.prototype.unregister
         self.define_method(proto_id, "unregister", 1,
             |interp, this, args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = (this).as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     let has_cells = {
                         let b = obj.borrow();
@@ -2415,7 +2519,7 @@ impl Interpreter {
                             && b.finalization_registry().is_some()
                     };
                     if has_cells {
-                        let token = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let token = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         if !interp.can_be_held_weakly(&token) {
                             return Completion::Throw(interp.create_type_error(
                                 "FinalizationRegistry.unregister: unregisterToken must be an object or non-registered symbol",
@@ -2423,7 +2527,7 @@ impl Interpreter {
                         }
                         // Remove cells whose unregisterToken matches
                         let mut removed = false;
-                        if let Some(obj_rc) = interp.get_object_cell(o.id)
+                        if let Some(obj_rc) = interp.get_object_cell(o)
                             && let Some((cells, tokens)) =
                                 obj_rc.borrow_mut().finalization_registry_mut()
                         {
@@ -2440,7 +2544,7 @@ impl Interpreter {
                                 }
                             }
                         }
-                        return Completion::Normal(JsValue::Boolean(removed));
+                        return Completion::Normal(JsValue::boolean(removed));
                     }
                 }
                 Completion::Throw(interp.create_type_error(
@@ -2451,15 +2555,15 @@ impl Interpreter {
 
         // FinalizationRegistry.prototype.cleanupSome
         self.define_method(proto_id, "cleanupSome", 0, |interp, this, _args| {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = (this).as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let has_cells = {
                     let b = obj.borrow();
                     b.class_name == "FinalizationRegistry" && b.finalization_registry().is_some()
                 };
                 if has_cells {
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
             }
             Completion::Throw(interp.create_type_error(
@@ -2480,14 +2584,14 @@ impl Interpreter {
                         interp.create_type_error("Constructor FinalizationRegistry requires 'new'"),
                     );
                 }
-                let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&callback, JsValue::Object(_)) {
+                let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !callback.is_object() {
                     return Completion::Throw(interp.create_type_error(
                         "FinalizationRegistry requires a callable cleanup callback",
                     ));
                 }
-                if let JsValue::Object(ref o) = callback
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = (callback).as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                     && obj.borrow().callable.is_none()
                 {
                     return Completion::Throw(interp.create_type_error(
@@ -2523,21 +2627,16 @@ impl Interpreter {
                         tokens: Vec::new(),
                     };
                 let id = obj_id;
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
 
-        if let JsValue::Object(ref ctor_obj) = fr_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_obj) = (fr_ctor).as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_obj)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject { id: proto_id }),
-                    false,
-                    false,
-                    false,
-                ),
+                PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
             );
         }
 

--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -23,14 +23,12 @@ fn date_to_locale_string(
     defaults: &str,
 ) -> Completion {
     fn this_time_value_locale(interp: &Interpreter, this: &JsValue) -> Option<f64> {
-        if let JsValue::Object(o) = this
-            && let Some(obj) = interp.get_object_cell(o.id)
+        if let Some(object_id) = this.as_object_id()
+            && let Some(obj) = interp.get_object_cell(object_id)
         {
-            let b = obj.borrow();
-            if b.class_name == "Date"
-                && let Some(JsValue::Number(t)) = &b.primitive_value
-            {
-                return Some(*t);
+            let object = obj.borrow();
+            if object.class_name == "Date" {
+                return object.primitive_value.as_ref().and_then(JsValue::as_number);
             }
         }
         None
@@ -45,20 +43,20 @@ fn date_to_locale_string(
     };
 
     if tv.is_nan() {
-        return Completion::Normal(JsValue::String(JsString::from_str("Invalid Date")));
+        return Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")));
     }
 
-    let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-    let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+    let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+    let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
     // ToDateTimeOptions(options, required, defaults)
-    let options_obj_id = if matches!(options_arg, JsValue::Undefined) {
+    let options_obj_id = if (options_arg).is_undefined() {
         interp.create_object_id()
     } else {
         match interp.to_object(&options_arg) {
             Completion::Normal(v) => {
-                if let JsValue::Object(o) = &v {
-                    if let Some(src) = interp.get_object_cell(o.id) {
+                if let Some(object_id) = v.as_object_id() {
+                    if let Some(src) = interp.get_object_cell(object_id) {
                         let pds: Vec<(JsPropertyKey, PropertyDescriptor)> = src
                             .borrow()
                             .properties
@@ -130,7 +128,7 @@ fn date_to_locale_string(
     }
 
     if need_defaults {
-        let numeric = JsValue::String(JsString::from_str("numeric"));
+        let numeric = JsValue::string(JsString::from_str("numeric"));
         if defaults == "date" || defaults == "all" {
             interp
                 .get_object_cell_expect(options_obj_id)
@@ -179,13 +177,13 @@ fn date_to_locale_string(
         }
     }
 
-    let opt_val = JsValue::Object(crate::types::JsObject { id: options_obj_id });
+    let opt_val = JsValue::object(options_obj_id);
 
     // Use the built-in DateTimeFormat constructor directly (not through user-visible Intl property)
     let dtf_val = match interp.realm().intl_date_time_format_ctor.clone() {
         Some(v) => v,
         None => {
-            return Completion::Normal(JsValue::String(JsString::from_str(&format_date_string(
+            return Completion::Normal(JsValue::string(JsString::from_str(&format_date_string(
                 tv,
             ))));
         }
@@ -195,26 +193,26 @@ fn date_to_locale_string(
     let dtf_instance = match interp.construct(&dtf_val, &[locales_arg, opt_val]) {
         Completion::Normal(v) => v,
         Completion::Throw(e) => return Completion::Throw(e),
-        _ => return Completion::Normal(JsValue::Undefined),
+        _ => return Completion::Normal(JsValue::UNDEFINED),
     };
 
     // Get the format function from the DateTimeFormat instance
-    if let JsValue::Object(dtf_obj) = &dtf_instance {
-        let format_val = match interp.get_object_property(dtf_obj.id, "format", &dtf_instance) {
+    if let Some(dtf_id) = dtf_instance.as_object_id() {
+        let format_val = match interp.get_object_property(dtf_id, "format", &dtf_instance) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Completion::Throw(e),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
 
         // Call format(tv)
-        let date_val = JsValue::Number(tv);
+        let date_val = JsValue::number(tv);
         match interp.call_function(&format_val, &dtf_instance, &[date_val]) {
             Completion::Normal(v) => Completion::Normal(v),
             Completion::Throw(e) => Completion::Throw(e),
-            _ => Completion::Normal(JsValue::Undefined),
+            _ => Completion::Normal(JsValue::UNDEFINED),
         }
     } else {
-        Completion::Normal(JsValue::String(JsString::from_str(&format_date_string(tv))))
+        Completion::Normal(JsValue::string(JsString::from_str(&format_date_string(tv))))
     }
 }
 
@@ -227,14 +225,12 @@ impl Interpreter {
         // Date.prototype does NOT have [[DateValue]] per spec
 
         fn this_time_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(object_id) = this.as_object_id()
+                && let Some(obj) = interp.get_object_cell(object_id)
             {
-                let b = obj.borrow();
-                if b.class_name == "Date"
-                    && let Some(JsValue::Number(t)) = &b.primitive_value
-                {
-                    return Some(*t);
+                let object = obj.borrow();
+                if object.class_name == "Date" {
+                    return object.primitive_value.as_ref().and_then(JsValue::as_number);
                 }
             }
             None
@@ -252,7 +248,7 @@ impl Interpreter {
         ) -> Completion {
             match this_time_value(interp, this) {
                 Some(t) => {
-                    Completion::Normal(JsValue::Number(date_field_value(t, local, component)))
+                    Completion::Normal(JsValue::number(date_field_value(t, local, component)))
                 }
                 None => {
                     let e = interp.create_type_error("this is not a Date object");
@@ -262,10 +258,10 @@ impl Interpreter {
         }
 
         fn set_date_value(interp: &Interpreter, this: &JsValue, v: f64) {
-            if let JsValue::Object(o) = this
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(object_id) = this.as_object_id()
+                && let Some(obj) = interp.get_object_cell(object_id)
             {
-                obj.borrow_mut().primitive_value = Some(JsValue::Number(v));
+                obj.borrow_mut().primitive_value = Some(JsValue::number(v));
             }
         }
 
@@ -300,7 +296,7 @@ impl Interpreter {
         ) -> Completion {
             let v = make_date_clipped(day, time, is_local);
             set_date_value(interp, this, v);
-            Completion::Normal(JsValue::Number(v))
+            Completion::Normal(JsValue::number(v))
         }
 
         // Getter methods
@@ -428,7 +424,7 @@ impl Interpreter {
                     };
                     let v = time_clip(v);
                     set_date_value(interp, this, v);
-                    Completion::Normal(JsValue::Number(v))
+                    Completion::Normal(JsValue::number(v))
                 }),
             ),
             (
@@ -444,7 +440,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let lt = local_time(t);
                     let time =
@@ -465,7 +461,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let time = make_time(hour_from_time(t), min_from_time(t), sec_from_time(t), ms);
                     finish_set(interp, this, day(t), time, false)
@@ -493,7 +489,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let lt = local_time(t);
                     let time = make_time(hour_from_time(lt), min_from_time(lt), s, ms);
@@ -522,7 +518,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let time = make_time(hour_from_time(t), min_from_time(t), s, ms);
                     finish_set(interp, this, day(t), time, false)
@@ -559,7 +555,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let lt = local_time(t);
                     let time = make_time(hour_from_time(lt), m, s, ms);
@@ -597,7 +593,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let time = make_time(hour_from_time(t), m, s, ms);
                     finish_set(interp, this, day(t), time, false)
@@ -643,7 +639,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let lt = local_time(t);
                     let time = make_time(h, m, s, ms);
@@ -690,7 +686,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let time = make_time(h, m, s, ms);
                     finish_set(interp, this, day(t), time, false)
@@ -709,7 +705,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let lt = local_time(t);
                     let new_date = make_day(year_from_time(lt), month_from_time(lt), dt);
@@ -729,7 +725,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let new_date = make_day(year_from_time(t), month_from_time(t), dt);
                     finish_set(interp, this, new_date, time_within_day(t), false)
@@ -757,7 +753,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let lt = local_time(t);
                     let new_date = make_day(year_from_time(lt), m, dt);
@@ -786,7 +782,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     let new_date = make_day(year_from_time(t), m, dt);
                     finish_set(interp, this, new_date, time_within_day(t), false)
@@ -850,9 +846,9 @@ impl Interpreter {
                 0,
                 Rc::new(|interp, this, _args| match this_time_value(interp, this) {
                     Some(t) if t.is_nan() => {
-                        Completion::Normal(JsValue::String(JsString::from_str("Invalid Date")))
+                        Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")))
                     }
-                    Some(t) => Completion::Normal(JsValue::String(JsString::from_str(
+                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
                         &format_date_string(t),
                     ))),
                     None => {
@@ -866,9 +862,9 @@ impl Interpreter {
                 0,
                 Rc::new(|interp, this, _args| match this_time_value(interp, this) {
                     Some(t) if t.is_nan() => {
-                        Completion::Normal(JsValue::String(JsString::from_str("Invalid Date")))
+                        Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")))
                     }
-                    Some(t) => Completion::Normal(JsValue::String(JsString::from_str(
+                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
                         &format_date_only_string(t),
                     ))),
                     None => {
@@ -882,9 +878,9 @@ impl Interpreter {
                 0,
                 Rc::new(|interp, this, _args| match this_time_value(interp, this) {
                     Some(t) if t.is_nan() => {
-                        Completion::Normal(JsValue::String(JsString::from_str("Invalid Date")))
+                        Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")))
                     }
-                    Some(t) => Completion::Normal(JsValue::String(JsString::from_str(
+                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
                         &format_time_only_string(t),
                     ))),
                     None => {
@@ -901,7 +897,7 @@ impl Interpreter {
                         let e = interp.create_range_error("Invalid time value");
                         Completion::Throw(e)
                     }
-                    Some(t) => Completion::Normal(JsValue::String(JsString::from_str(
+                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
                         &format_iso_string(t),
                     ))),
                     None => {
@@ -915,9 +911,9 @@ impl Interpreter {
                 0,
                 Rc::new(|interp, this, _args| match this_time_value(interp, this) {
                     Some(t) if t.is_nan() => {
-                        Completion::Normal(JsValue::String(JsString::from_str("Invalid Date")))
+                        Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")))
                     }
-                    Some(t) => Completion::Normal(JsValue::String(JsString::from_str(
+                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
                         &format_utc_string(t),
                     ))),
                     None => {
@@ -938,24 +934,22 @@ impl Interpreter {
                     let o = match interp.to_object(this) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => return Completion::Normal(JsValue::Undefined),
+                        _ => return Completion::Normal(JsValue::UNDEFINED),
                     };
                     let tv = match interp.to_primitive(&o, "number") {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
-                    if let JsValue::Number(n) = &tv
-                        && !n.is_finite()
-                    {
-                        return Completion::Normal(JsValue::Null);
+                    if tv.as_number().is_some_and(|number| !number.is_finite()) {
+                        return Completion::Normal(JsValue::NULL);
                     }
-                    if let JsValue::Object(obj_ref) = &o {
-                        let to_iso = interp.get_object_property(obj_ref.id, "toISOString", &o);
+                    if let Some(object_id) = o.as_object_id() {
+                        let to_iso = interp.get_object_property(object_id, "toISOString", &o);
                         match to_iso {
                             Completion::Normal(func) => {
-                                if let JsValue::Object(fo) = &func
+                                if let Some(function_id) = func.as_object_id()
                                     && interp
-                                        .get_object_cell(fo.id)
+                                        .get_object_cell(function_id)
                                         .map(|obj| obj.borrow().callable.is_some())
                                         .unwrap_or(false)
                                 {
@@ -1031,7 +1025,7 @@ impl Interpreter {
                             },
                         );
                     let id = obj_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 }),
             ),
         ];
@@ -1055,10 +1049,10 @@ impl Interpreter {
             "[Symbol.toPrimitive]".to_string(),
             1,
             |interp, this, args| {
-                let JsValue::Object(_) = this else {
+                if !this.is_object() {
                     let e = interp.create_type_error("this is not an object");
                     return Completion::Throw(e);
-                };
+                }
                 let hint = args.first().map(to_js_string).unwrap_or_default();
                 let try_first = match hint.as_str() {
                     "string" | "default" => "string",
@@ -1070,7 +1064,7 @@ impl Interpreter {
                 };
                 // Inline OrdinaryToPrimitive to avoid infinite recursion
                 // (to_primitive() checks @@toPrimitive which would call us again)
-                let JsValue::Object(o) = this else {
+                let Some(object_id) = this.as_object_id() else {
                     return Completion::Normal(this.clone());
                 };
                 let methods = if try_first == "string" {
@@ -1079,20 +1073,21 @@ impl Interpreter {
                     ["valueOf", "toString"]
                 };
                 for method_name in &methods {
-                    let method_val = match interp.get_object_property(o.id, method_name, this) {
+                    let method_val = match interp.get_object_property(object_id, method_name, this)
+                    {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
-                    if let JsValue::Object(fo) = &method_val
+                    if let Some(function_id) = method_val.as_object_id()
                         && interp
-                            .get_object_cell(fo.id)
+                            .get_object_cell(function_id)
                             .map(|o| o.borrow().callable.is_some())
                             .unwrap_or(false)
                     {
                         let result = interp.call_function(&method_val, this, &[]);
                         match result {
-                            Completion::Normal(v) if !matches!(v, JsValue::Object(_)) => {
+                            Completion::Normal(v) if !(v).is_object() => {
                                 return Completion::Normal(v);
                             }
                             Completion::Throw(e) => return Completion::Throw(e),
@@ -1121,7 +1116,7 @@ impl Interpreter {
             move |interp, this, args| {
                 if interp.new_target.is_none() {
                     let t = now_ms();
-                    return Completion::Normal(JsValue::String(JsString::from_str(
+                    return Completion::Normal(JsValue::string(JsString::from_str(
                         &format_date_string(t),
                     )));
                 }
@@ -1130,23 +1125,23 @@ impl Interpreter {
                     now_ms()
                 } else if args.len() == 1 {
                     let v = &args[0];
-                    if let JsValue::Object(o) = v
-                        && let Some(obj) = interp.get_object_cell(o.id)
+                    if let Some(object_id) = v.as_object_id()
+                        && let Some(obj) = interp.get_object_cell(object_id)
                         && obj.borrow().class_name == "Date"
-                        && obj.borrow().primitive_value.is_some()
+                        && let Some(time) = obj
+                            .borrow()
+                            .primitive_value
+                            .as_ref()
+                            .and_then(JsValue::as_number)
                     {
-                        if let Some(JsValue::Number(t)) = obj.borrow().primitive_value.clone() {
-                            t
-                        } else {
-                            f64::NAN
-                        }
+                        time
                     } else {
                         // ToPrimitive(value) with hint "default"
                         let prim = match interp.to_primitive(v, "default") {
                             Ok(p) => p,
                             Err(e) => return Completion::Throw(e),
                         };
-                        if let JsValue::String(_) = &prim {
+                        if prim.is_string() {
                             parse_date_string(&to_js_string(&prim))
                         } else {
                             match interp.to_number_value(&prim) {
@@ -1217,8 +1212,8 @@ impl Interpreter {
                     time_clip(utc_time(make_date(d, time)))
                 };
 
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     // OrdinaryCreateFromConstructor — realm-aware prototype
                     let proto = match interp
@@ -1227,30 +1222,29 @@ impl Interpreter {
                         Ok(p) => p.unwrap_or(date_proto_clone_id),
                         Err(e) => return Completion::Throw(e),
                     };
-                    let mut b = interp.get_object_cell_expect(o.id).borrow_mut();
+                    let mut b = interp.get_object_cell_expect(object_id).borrow_mut();
                     b.class_name = "Date".to_string();
-                    b.primitive_value = Some(JsValue::Number(time_val));
+                    b.primitive_value = Some(JsValue::number(time_val));
                     b.prototype_id = Some(proto);
                 }
                 Completion::Normal(this.clone())
             },
         ));
 
-        if let JsValue::Object(o) = &date_ctor
-            && self.get_object_cell(o.id).is_some()
+        if let Some(date_ctor_id) = date_ctor.as_object_id()
+            && self.get_object_cell(date_ctor_id).is_some()
         {
-            let date_ctor_id = o.id;
             self.get_object_cell_expect(date_ctor_id)
                 .borrow_mut()
                 .insert_property(
                     "length".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(7.0), false, false, true),
+                    PropertyDescriptor::data(JsValue::number(7.0), false, false, true),
                 );
 
             let now_fn = self.create_function(JsFunction::native(
                 "now".to_string(),
                 0,
-                |_interp, _this, _args| Completion::Normal(JsValue::Number(now_ms().floor())),
+                |_interp, _this, _args| Completion::Normal(JsValue::number(now_ms().floor())),
             ));
             self.get_object_cell_expect(date_ctor_id)
                 .borrow_mut()
@@ -1267,7 +1261,7 @@ impl Interpreter {
                         },
                         None => String::new(),
                     };
-                    Completion::Normal(JsValue::Number(parse_date_string(&s)))
+                    Completion::Normal(JsValue::number(parse_date_string(&s)))
                 },
             ));
             self.get_object_cell_expect(date_ctor_id)
@@ -1339,14 +1333,14 @@ impl Interpreter {
                     };
                     let d = make_day(yr, m, dt);
                     let time = make_time(h, min, s, ms);
-                    Completion::Normal(JsValue::Number(time_clip(make_date(d, time))))
+                    Completion::Normal(JsValue::number(time_clip(make_date(d, time))))
                 },
             ));
             self.get_object_cell_expect(date_ctor_id)
                 .borrow_mut()
                 .insert_builtin("UTC".to_string(), utc_fn);
 
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             self.get_object_cell_expect(date_ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -1394,7 +1388,7 @@ impl Interpreter {
                 };
                 if y.is_nan() {
                     set_date_value(interp, this, f64::NAN);
-                    return Completion::Normal(JsValue::Number(f64::NAN));
+                    return Completion::Normal(JsValue::number(f64::NAN));
                 }
                 let yi = y as i64;
                 let yr = if (0..=99).contains(&yi) {
@@ -1432,16 +1426,9 @@ impl Interpreter {
     pub(crate) fn create_error(&mut self, name: &str, msg: &str) -> JsValue {
         let ctor = self.get_global_var(name);
         let error_proto_id: Option<u64> = ctor.and_then(|v| {
-            if let JsValue::Object(o) = &v {
-                let pv = self.get_property_on_id(o.id, "prototype");
-                if let JsValue::Object(p) = &pv {
-                    Some(p.id)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
+            let constructor_id = v.as_object_id()?;
+            self.get_property_on_id(constructor_id, "prototype")
+                .as_object_id()
         });
         let obj_id = self.create_object_id();
         {
@@ -1452,15 +1439,15 @@ impl Interpreter {
             }
             o.insert_builtin(
                 "message".to_string(),
-                JsValue::String(JsString::from_str(msg)),
+                JsValue::string(JsString::from_str(msg)),
             );
             o.insert_builtin(
                 "name".to_string(),
-                JsValue::String(JsString::from_str(name)),
+                JsValue::string(JsString::from_str(name)),
             );
         }
         let id = obj_id;
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 }
 

--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -16,7 +16,7 @@ impl Interpreter {
                 .insert_property(
                     key,
                     PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str("DisposableStack")),
+                        JsValue::string(JsString::from_str("DisposableStack")),
                         false,
                         false,
                         true,
@@ -43,8 +43,8 @@ impl Interpreter {
 
         // get disposed
         self.define_getter(ds_proto_id, "disposed", |interp, this, _args| {
-            let disposed = if let JsValue::Object(o) = this {
-                interp.get_object_cell(o.id).and_then(|cell| {
+            let disposed = if let Some(object_id) = this.as_object_id() {
+                interp.get_object_cell(object_id).and_then(|cell| {
                     let b = cell.borrow();
                     if b.class_name == "DisposableStack"
                         && let Some(ds) = b.disposable_stack()
@@ -58,7 +58,7 @@ impl Interpreter {
                 None
             };
             match disposed {
-                Some(d) => Completion::Normal(JsValue::Boolean(d)),
+                Some(d) => Completion::Normal(JsValue::boolean(d)),
                 None => Completion::Throw(interp.create_type_error(
                     "DisposableStack.prototype.disposed called on non-DisposableStack",
                 )),
@@ -70,9 +70,9 @@ impl Interpreter {
             "use".to_string(),
             1,
             |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     enum Probe {
                         NotStack,
@@ -80,7 +80,7 @@ impl Interpreter {
                         Active,
                     }
                     let probe = {
-                        let b = interp.get_object_cell_expect(o.id).borrow();
+                        let b = interp.get_object_cell_expect(object_id).borrow();
                         if b.class_name != "DisposableStack" {
                             Probe::NotStack
                         } else {
@@ -104,10 +104,10 @@ impl Interpreter {
                         }
                         Probe::Active => {}
                     }
-                    if matches!(value, JsValue::Null | JsValue::Undefined) {
+                    if (value).is_nullish() {
                         return Completion::Normal(value);
                     }
-                    if !matches!(value, JsValue::Object(_)) {
+                    if !(value).is_object() {
                         return Completion::Throw(
                             interp.create_type_error("Using requires an object or null/undefined"),
                         );
@@ -115,10 +115,10 @@ impl Interpreter {
                     // GetMethod(V, @@dispose) - uses get_object_property to invoke getters
                     let method =
                         if let Some(key) = interp.get_symbol_key("dispose") {
-                            if let JsValue::Object(vo) = &value {
-                                match interp.get_object_property(vo.id, &key, &value) {
+                            if let Some(value_id) = value.as_object_id() {
+                                match interp.get_object_property(value_id, &key, &value) {
                                     Completion::Normal(m) => {
-                                        if matches!(m, JsValue::Undefined | JsValue::Null) {
+                                        if (m).is_nullish() {
                                             return Completion::Throw(interp.create_type_error(
                                                 "Object does not have a [Symbol.dispose] method",
                                             ));
@@ -126,7 +126,7 @@ impl Interpreter {
                                         m
                                     }
                                     Completion::Throw(e) => return Completion::Throw(e),
-                                    _ => JsValue::Undefined,
+                                    _ => JsValue::UNDEFINED,
                                 }
                             } else {
                                 return Completion::Throw(interp.create_type_error(
@@ -148,7 +148,7 @@ impl Interpreter {
                         hint: DisposeHint::Sync,
                         dispose_method: method,
                     };
-                    if let Some(cell) = interp.get_object_cell(o.id) {
+                    if let Some(cell) = interp.get_object_cell(object_id) {
                         let mut b = cell.borrow_mut();
                         if let Some(ds) = b.disposable_stack_mut() {
                             ds.stack.push(resource);
@@ -168,10 +168,10 @@ impl Interpreter {
             "adopt".to_string(),
             2,
             |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let on_dispose = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let on_dispose = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     enum Probe {
                         AlreadyDisposed,
@@ -179,7 +179,7 @@ impl Interpreter {
                         Active,
                     }
                     let probe = {
-                        let b = interp.get_object_cell_expect(o.id).borrow();
+                        let b = interp.get_object_cell_expect(object_id).borrow();
                         match b.disposable_stack() {
                             Some(ds) if ds.disposed => Probe::AlreadyDisposed,
                             Some(_) => Probe::Active,
@@ -213,17 +213,17 @@ impl Interpreter {
                         move |interp2, _this2, _args2| {
                             interp2.call_function(
                                 &wrapper_dispose,
-                                &JsValue::Undefined,
+                                &JsValue::UNDEFINED,
                                 std::slice::from_ref(&wrapper_val),
                             )
                         },
                     ));
                     let resource = DisposableResource {
-                        value: JsValue::Undefined,
+                        value: JsValue::UNDEFINED,
                         hint: DisposeHint::Sync,
                         dispose_method: wrapper_fn,
                     };
-                    if let Some(cell) = interp.get_object_cell(o.id) {
+                    if let Some(cell) = interp.get_object_cell(object_id) {
                         let mut b = cell.borrow_mut();
                         if let Some(ds) = b.disposable_stack_mut() {
                             ds.stack.push(resource);
@@ -243,9 +243,9 @@ impl Interpreter {
             "defer".to_string(),
             1,
             |interp, this, args| {
-                let on_dispose = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                let on_dispose = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     enum Probe {
                         AlreadyDisposed,
@@ -253,7 +253,7 @@ impl Interpreter {
                         Active,
                     }
                     let probe = {
-                        let b = interp.get_object_cell_expect(o.id).borrow();
+                        let b = interp.get_object_cell_expect(object_id).borrow();
                         match b.disposable_stack() {
                             Some(ds) if ds.disposed => Probe::AlreadyDisposed,
                             Some(_) => Probe::Active,
@@ -279,17 +279,17 @@ impl Interpreter {
                         );
                     }
                     let resource = DisposableResource {
-                        value: JsValue::Undefined,
+                        value: JsValue::UNDEFINED,
                         hint: DisposeHint::Sync,
                         dispose_method: on_dispose,
                     };
-                    if let Some(cell) = interp.get_object_cell(o.id) {
+                    if let Some(cell) = interp.get_object_cell(object_id) {
                         let mut b = cell.borrow_mut();
                         if let Some(ds) = b.disposable_stack_mut() {
                             ds.stack.push(resource);
                         }
                     }
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 Completion::Throw(interp.create_type_error("Not a DisposableStack"))
             },
@@ -303,8 +303,8 @@ impl Interpreter {
             "move".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     enum Probe {
                         NotStack,
@@ -312,7 +312,7 @@ impl Interpreter {
                         Moved(Vec<DisposableResource>),
                     }
                     let probe = {
-                        let cell = interp.get_object_cell_expect(o.id);
+                        let cell = interp.get_object_cell_expect(object_id);
                         let mut b = cell.borrow_mut();
                         if b.class_name != "DisposableStack" {
                             Probe::NotStack
@@ -346,14 +346,14 @@ impl Interpreter {
                     {
                         // Get DisposableStack prototype
                         if let Some(ctor_val) = interp.get_global_var("DisposableStack")
-                            && let JsValue::Object(ctor) = &ctor_val
+                            && let Some(constructor_id) = ctor_val.as_object_id()
                         {
-                            let proto_val = interp.get_property_on_id(ctor.id, "prototype");
-                            if let JsValue::Object(p) = &proto_val {
+                            let proto_val = interp.get_property_on_id(constructor_id, "prototype");
+                            if let Some(prototype_id) = proto_val.as_object_id() {
                                 interp
                                     .get_object_cell_expect(new_obj_id)
                                     .borrow_mut()
-                                    .prototype_id = Some(p.id);
+                                    .prototype_id = Some(prototype_id);
                             }
                         }
                     }
@@ -368,7 +368,7 @@ impl Interpreter {
                         );
                     }
                     let id = new_obj_id;
-                    return Completion::Normal(JsValue::Object(crate::types::JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error("Not a DisposableStack"))
             },
@@ -415,7 +415,7 @@ impl Interpreter {
                         );
                     }
                     let id = obj_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 },
             ),
         );
@@ -428,19 +428,14 @@ impl Interpreter {
         }
         {
             if let Some(ctor_val) = self.get_global_var("DisposableStack")
-                && let JsValue::Object(o) = &ctor_val
-                && let Some(ctor_obj) = self.get_object_cell(o.id)
+                && let Some(constructor_id) = ctor_val.as_object_id()
+                && let Some(ctor_obj) = self.get_object_cell(constructor_id)
             {
                 let proto_id = ds_proto_id;
                 // prototype property: { writable: false, enumerable: false, configurable: false }
                 ctor_obj.borrow_mut().insert_property(
                     "prototype".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::Object(crate::types::JsObject { id: proto_id }),
-                        false,
-                        false,
-                        false,
-                    ),
+                    PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                 );
             }
         }
@@ -451,8 +446,8 @@ impl Interpreter {
         this: &JsValue,
         _is_async: bool,
     ) -> Completion {
-        if let JsValue::Object(o) = this
-            && self.get_object_cell(o.id).is_some()
+        if let Some(object_id) = this.as_object_id()
+            && self.get_object_cell(object_id).is_some()
         {
             enum Probe {
                 NotStack,
@@ -460,7 +455,7 @@ impl Interpreter {
                 Active(Vec<DisposableResource>),
             }
             let probe = {
-                let cell = self.get_object_cell_expect(o.id);
+                let cell = self.get_object_cell_expect(object_id);
                 let mut b = cell.borrow_mut();
                 if b.class_name != "DisposableStack" {
                     Probe::NotStack
@@ -482,7 +477,7 @@ impl Interpreter {
                 Probe::NotStack => {
                     return Completion::Throw(self.create_type_error("Not a DisposableStack"));
                 }
-                Probe::AlreadyDisposed => return Completion::Normal(JsValue::Undefined),
+                Probe::AlreadyDisposed => return Completion::Normal(JsValue::UNDEFINED),
                 Probe::Active(s) => s,
             };
 
@@ -508,7 +503,7 @@ impl Interpreter {
             if let Some(err) = current_error {
                 Completion::Throw(err)
             } else {
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             }
         } else {
             Completion::Throw(self.create_type_error(
@@ -532,7 +527,7 @@ impl Interpreter {
                 .insert_property(
                     key,
                     PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str("AsyncDisposableStack")),
+                        JsValue::string(JsString::from_str("AsyncDisposableStack")),
                         false,
                         false,
                         true,
@@ -552,7 +547,7 @@ impl Interpreter {
                 // returned as `Normal`, which would let the caller keep
                 // evaluating in expression position.
                 match result {
-                    Completion::Normal(_) => interp.create_resolved_promise(JsValue::Undefined),
+                    Completion::Normal(_) => interp.create_resolved_promise(JsValue::UNDEFINED),
                     Completion::Throw(e) => interp.create_rejected_promise(e),
                     other => other,
                 }
@@ -574,8 +569,8 @@ impl Interpreter {
 
         // get disposed
         self.define_getter(ads_proto_id, "disposed", |interp, this, _args| {
-            let disposed = if let JsValue::Object(o) = this {
-                interp.get_object_cell(o.id).and_then(|cell| {
+            let disposed = if let Some(object_id) = this.as_object_id() {
+                interp.get_object_cell(object_id).and_then(|cell| {
                     let b = cell.borrow();
                     if b.class_name == "AsyncDisposableStack"
                         && let Some(ds) = b.disposable_stack()
@@ -589,7 +584,7 @@ impl Interpreter {
                 None
             };
             match disposed {
-                Some(d) => Completion::Normal(JsValue::Boolean(d)),
+                Some(d) => Completion::Normal(JsValue::boolean(d)),
                 None => Completion::Throw(interp.create_type_error(
                     "AsyncDisposableStack.prototype.disposed called on non-AsyncDisposableStack",
                 )),
@@ -601,9 +596,9 @@ impl Interpreter {
             "use".to_string(),
             1,
             |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     enum Probe {
                         NotStack,
@@ -611,7 +606,7 @@ impl Interpreter {
                         Active,
                     }
                     let probe = {
-                        let b = interp.get_object_cell_expect(o.id).borrow();
+                        let b = interp.get_object_cell_expect(object_id).borrow();
                         if b.class_name != "AsyncDisposableStack" {
                             Probe::NotStack
                         } else {
@@ -635,13 +630,13 @@ impl Interpreter {
                         }
                         Probe::Active => {}
                     }
-                    if matches!(value, JsValue::Null | JsValue::Undefined) {
+                    if (value).is_nullish() {
                         let resource = DisposableResource {
                             value: value.clone(),
                             hint: DisposeHint::Async,
-                            dispose_method: JsValue::Undefined,
+                            dispose_method: JsValue::UNDEFINED,
                         };
-                        if let Some(obj2) = interp.get_object_cell(o.id)
+                        if let Some(obj2) = interp.get_object_cell(object_id)
                             && let Some(ds) = obj2.borrow_mut().disposable_stack_mut()
                         {
                             ds.stack.push(resource);
@@ -649,33 +644,33 @@ impl Interpreter {
                         return Completion::Normal(value);
                     }
                     // Try Symbol.asyncDispose first, then Symbol.dispose
-                    let mut method = JsValue::Undefined;
+                    let mut method = JsValue::UNDEFINED;
                     let mut hint = DisposeHint::Async;
                     if let Some(key) = interp.get_symbol_key("asyncDispose")
-                        && let JsValue::Object(vo) = &value
+                        && let Some(value_id) = value.as_object_id()
                     {
-                        let m = match interp.get_object_property(vo.id, &key, &value) {
+                        let m = match interp.get_object_property(value_id, &key, &value) {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        if !matches!(m, JsValue::Undefined | JsValue::Null) {
+                        if !(m).is_nullish() {
                             method = m;
                         }
                     }
-                    if matches!(method, JsValue::Undefined)
+                    if (method).is_undefined()
                         && let Some(key) = interp.get_symbol_key("dispose")
-                        && let JsValue::Object(vo) = &value
+                        && let Some(value_id) = value.as_object_id()
                     {
-                        let m = match interp.get_object_property(vo.id, &key, &value) {
+                        let m = match interp.get_object_property(value_id, &key, &value) {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        if !matches!(m, JsValue::Undefined | JsValue::Null) {
+                        if !(m).is_nullish() {
                             method = m;
                             hint = DisposeHint::Sync;
                         }
                     }
-                    if matches!(method, JsValue::Undefined) {
+                    if (method).is_undefined() {
                         return Completion::Throw(
                             interp.create_type_error("Object is not disposable"),
                         );
@@ -690,7 +685,7 @@ impl Interpreter {
                         hint,
                         dispose_method: method,
                     };
-                    if let Some(cell) = interp.get_object_cell(o.id) {
+                    if let Some(cell) = interp.get_object_cell(object_id) {
                         let mut b = cell.borrow_mut();
                         if let Some(ds) = b.disposable_stack_mut() {
                             ds.stack.push(resource);
@@ -710,10 +705,10 @@ impl Interpreter {
             "adopt".to_string(),
             2,
             |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let on_dispose = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let on_dispose = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     enum Probe {
                         AlreadyDisposed,
@@ -721,7 +716,7 @@ impl Interpreter {
                         Active,
                     }
                     let probe = {
-                        let b = interp.get_object_cell_expect(o.id).borrow();
+                        let b = interp.get_object_cell_expect(object_id).borrow();
                         match b.disposable_stack() {
                             Some(ds) if ds.disposed => Probe::AlreadyDisposed,
                             Some(_) => Probe::Active,
@@ -754,17 +749,17 @@ impl Interpreter {
                         move |interp2, _this2, _args2| {
                             interp2.call_function(
                                 &wrapper_dispose,
-                                &JsValue::Undefined,
+                                &JsValue::UNDEFINED,
                                 std::slice::from_ref(&wrapper_val),
                             )
                         },
                     ));
                     let resource = DisposableResource {
-                        value: JsValue::Undefined,
+                        value: JsValue::UNDEFINED,
                         hint: DisposeHint::Async,
                         dispose_method: wrapper_fn,
                     };
-                    if let Some(cell) = interp.get_object_cell(o.id) {
+                    if let Some(cell) = interp.get_object_cell(object_id) {
                         let mut b = cell.borrow_mut();
                         if let Some(ds) = b.disposable_stack_mut() {
                             ds.stack.push(resource);
@@ -784,9 +779,9 @@ impl Interpreter {
             "defer".to_string(),
             1,
             |interp, this, args| {
-                let on_dispose = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                let on_dispose = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     enum Probe {
                         AlreadyDisposed,
@@ -794,7 +789,7 @@ impl Interpreter {
                         Active,
                     }
                     let probe = {
-                        let b = interp.get_object_cell_expect(o.id).borrow();
+                        let b = interp.get_object_cell_expect(object_id).borrow();
                         match b.disposable_stack() {
                             Some(ds) if ds.disposed => Probe::AlreadyDisposed,
                             Some(_) => Probe::Active,
@@ -820,17 +815,17 @@ impl Interpreter {
                         );
                     }
                     let resource = DisposableResource {
-                        value: JsValue::Undefined,
+                        value: JsValue::UNDEFINED,
                         hint: DisposeHint::Async,
                         dispose_method: on_dispose,
                     };
-                    if let Some(cell) = interp.get_object_cell(o.id) {
+                    if let Some(cell) = interp.get_object_cell(object_id) {
                         let mut b = cell.borrow_mut();
                         if let Some(ds) = b.disposable_stack_mut() {
                             ds.stack.push(resource);
                         }
                     }
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
             },
@@ -844,8 +839,8 @@ impl Interpreter {
             "move".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && interp.get_object_cell(o.id).is_some()
+                if let Some(object_id) = this.as_object_id()
+                    && interp.get_object_cell(object_id).is_some()
                 {
                     enum Probe {
                         NotStack,
@@ -853,7 +848,7 @@ impl Interpreter {
                         Moved(Vec<DisposableResource>),
                     }
                     let probe = {
-                        let cell = interp.get_object_cell_expect(o.id);
+                        let cell = interp.get_object_cell_expect(object_id);
                         let mut b = cell.borrow_mut();
                         if b.class_name != "AsyncDisposableStack" {
                             Probe::NotStack
@@ -903,7 +898,7 @@ impl Interpreter {
                         );
                     }
                     let id = new_obj_id;
-                    return Completion::Normal(JsValue::Object(crate::types::JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
             },
@@ -952,7 +947,7 @@ impl Interpreter {
                         );
                     }
                     let id = obj_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 },
             ),
         );
@@ -965,27 +960,22 @@ impl Interpreter {
         }
         {
             if let Some(ctor_val) = self.get_global_var("AsyncDisposableStack")
-                && let JsValue::Object(o) = &ctor_val
-                && let Some(ctor_obj) = self.get_object_cell(o.id)
+                && let Some(constructor_id) = ctor_val.as_object_id()
+                && let Some(ctor_obj) = self.get_object_cell(constructor_id)
             {
                 let proto_id = ads_proto_id;
                 // prototype property: { writable: false, enumerable: false, configurable: false }
                 ctor_obj.borrow_mut().insert_property(
                     "prototype".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::Object(crate::types::JsObject { id: proto_id }),
-                        false,
-                        false,
-                        false,
-                    ),
+                    PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                 );
             }
         }
     }
 
     fn async_disposable_stack_dispose(&mut self, this: &JsValue) -> Completion {
-        if let JsValue::Object(o) = this
-            && self.get_object_cell(o.id).is_some()
+        if let Some(object_id) = this.as_object_id()
+            && self.get_object_cell(object_id).is_some()
         {
             enum Probe {
                 NotStack,
@@ -993,7 +983,7 @@ impl Interpreter {
                 Active(Vec<DisposableResource>),
             }
             let probe = {
-                let cell = self.get_object_cell_expect(o.id);
+                let cell = self.get_object_cell_expect(object_id);
                 let mut b = cell.borrow_mut();
                 if b.class_name != "AsyncDisposableStack" {
                     Probe::NotStack
@@ -1017,7 +1007,7 @@ impl Interpreter {
                         self.create_type_error("Not an AsyncDisposableStack"),
                     );
                 }
-                Probe::AlreadyDisposed => return Completion::Normal(JsValue::Undefined),
+                Probe::AlreadyDisposed => return Completion::Normal(JsValue::UNDEFINED),
                 Probe::Active(s) => s,
             };
 
@@ -1025,9 +1015,7 @@ impl Interpreter {
             let mut needs_await = false;
             let mut has_awaited = false;
             for resource in stack.iter().rev() {
-                if resource.hint == DisposeHint::Async
-                    && matches!(resource.dispose_method, JsValue::Undefined)
-                {
+                if resource.hint == DisposeHint::Async && (resource.dispose_method).is_undefined() {
                     needs_await = true;
                     continue;
                 }
@@ -1058,7 +1046,7 @@ impl Interpreter {
             if needs_await && !has_awaited {
                 // The final await may have run a job that called `__host_exit`
                 // (issue #242): propagate the `Completion::Exit` abruptly.
-                if let Completion::Exit(code) = self.await_value(&JsValue::Undefined) {
+                if let Completion::Exit(code) = self.await_value(&JsValue::UNDEFINED) {
                     return Completion::Exit(code);
                 }
             }
@@ -1066,7 +1054,7 @@ impl Interpreter {
             if let Some(err) = current_error {
                 Completion::Throw(err)
             } else {
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             }
         } else {
             Completion::Throw(self.create_type_error("Not an AsyncDisposableStack"))

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -377,7 +377,7 @@ impl Interpreter {
                 self.realm().object_prototype;
             self.get_object_cell_expect(fp_id).borrow_mut().callable =
                 Some(JsFunction::native(String::new(), 0, |_, _, _| {
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 }));
             self.get_object_cell_expect(fp_id).borrow_mut().class_name = "Function".to_string();
             self.realm_mut().function_prototype = Some(fp_id);
@@ -386,19 +386,19 @@ impl Interpreter {
         // Create %ThrowTypeError% intrinsic (§10.2.4) — must exist before anything uses it
         {
             let thrower = self.create_thrower_function();
-            if let JsValue::Object(ref o) = thrower
-                && let Some(obj) = self.get_object_cell(o.id)
+            if let Some(thrower_id) = thrower.as_object_id()
+                && let Some(obj) = self.get_object_cell(thrower_id)
             {
                 let mut b = obj.borrow_mut();
                 b.extensible = false;
                 b.insert_property(
                     "length".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(0.0), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(0.0), false, false, false),
                 );
                 b.insert_property(
                     "name".to_string(),
                     PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str("")),
+                        JsValue::string(JsString::from_str("")),
                         false,
                         false,
                         false,
@@ -416,14 +416,14 @@ impl Interpreter {
                 |_interp, _this, args| {
                     let parts: Vec<String> = args.iter().map(|v| format!("{v}")).collect();
                     println!("{}", parts.join(" "));
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             self.get_object_cell_expect(console_id)
                 .borrow_mut()
                 .insert_builtin("log".to_string(), log_fn);
         }
-        let console_val = JsValue::Object(crate::types::JsObject { id: console_id });
+        let console_val = JsValue::object(console_id);
         self.realm()
             .global_env
             .borrow_mut()
@@ -441,7 +441,7 @@ impl Interpreter {
                 |_interp, _this, args| {
                     let parts: Vec<String> = args.iter().map(|v| format!("{v}")).collect();
                     println!("{}", parts.join(" "));
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             self.realm()
@@ -459,14 +459,14 @@ impl Interpreter {
             "setTimeout",
             BindingKind::Var,
             JsFunction::native("setTimeout".to_string(), 2, |interp, _this, args| {
-                let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !interp.is_callable(&callback) {
                     return Completion::Throw(
                         interp.create_type_error("setTimeout callback must be callable"),
                     );
                 }
 
-                let delay_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let delay_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let delay_num = match interp.to_number_value(&delay_val) {
                     Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
@@ -497,7 +497,7 @@ impl Interpreter {
                         .unwrap()
                         .push(Box::new(move |interp: &mut Interpreter| {
                             let _ =
-                                interp.call_function(&callback, &JsValue::Undefined, &timer_args);
+                                interp.call_function(&callback, &JsValue::UNDEFINED, &timer_args);
                             interp.gc_unroot_value(&callback);
                             for arg in &timer_args {
                                 interp.gc_unroot_value(arg);
@@ -507,7 +507,7 @@ impl Interpreter {
                     completion_cvar.notify_one();
                 });
 
-                Completion::Normal(JsValue::Number(0.0))
+                Completion::Normal(JsValue::number(0.0))
             }),
         );
 
@@ -518,8 +518,8 @@ impl Interpreter {
                 "Error",
                 BindingKind::Var,
                 JsFunction::constructor(error_name.clone(), 1, move |interp, this, args| {
-                    let msg_raw = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let msg_raw = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                     // OrdinaryCreateFromConstructor — realm-aware prototype
                     let proto = match interp
@@ -528,19 +528,19 @@ impl Interpreter {
                         Ok(p) => p,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let msg_str = if !matches!(msg_raw, JsValue::Undefined) {
+                    let msg_str = if !(msg_raw).is_undefined() {
                         match interp.to_string_value(&msg_raw) {
-                            Ok(s) => Some(JsValue::String(JsString::from_str(&s))),
+                            Ok(s) => Some(JsValue::string(JsString::from_str(&s))),
                             Err(e) => return Completion::Throw(e),
                         }
                     } else {
                         None
                     };
                     // §20.5.8.1 InstallErrorCause — use proxy-aware HasProperty
-                    let cause_val = if let JsValue::Object(opts) = &options {
-                        match interp.proxy_has_property(opts.id, "cause") {
+                    let cause_val = if let Some(options_id) = options.as_object_id() {
+                        match interp.proxy_has_property(options_id, "cause") {
                             Ok(true) => {
-                                match interp.get_object_property(opts.id, "cause", &options) {
+                                match interp.get_object_property(options_id, "cause", &options) {
                                     Completion::Normal(v) => Some(v),
                                     c => return c,
                                 }
@@ -571,9 +571,9 @@ impl Interpreter {
                     // OrdinaryCreateFromConstructor. A plain [[Call]] (e.g.
                     // `Error.call(obj, msg)`) must not mutate an arbitrary `this`.
                     if interp.new_target.is_some()
-                        && let JsValue::Object(o) = this
+                        && let Some(this_id) = this.as_object_id()
                     {
-                        if let Some(obj) = interp.get_object_cell(o.id) {
+                        if let Some(obj) = interp.get_object_cell(this_id) {
                             let mut o = obj.borrow_mut();
                             init_error!(o);
                         }
@@ -585,15 +585,15 @@ impl Interpreter {
                         init_error!(o);
                     }
                     let id = obj_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 }),
             );
             // Mark Error constructor as deferred_construct so construct_with_new_target
             // doesn't do an early prototype lookup (the constructor body handles it via
             // get_prototype_from_new_target_realm, per spec §20.5.1.1 step 2).
             if let Some(error_val) = self.get_global_var("Error")
-                && let JsValue::Object(o) = &error_val
-                && let Some(func_obj) = self.get_object(o.id)
+                && let Some(error_id) = error_val.as_object_id()
+                && let Some(func_obj) = self.get_object(error_id)
             {
                 func_obj.borrow_mut().deferred_construct = true;
             }
@@ -602,15 +602,10 @@ impl Interpreter {
         // Get Error.prototype for inheritance
         let error_prototype_id: Option<u64> = {
             if let Some(error_val) = self.get_global_var("Error")
-                && let JsValue::Object(o) = &error_val
+                && let Some(ctor_id) = error_val.as_object_id()
             {
-                let ctor_id = o.id;
                 let proto_val = self.get_property_on_id(ctor_id, "prototype");
-                if let JsValue::Object(p) = &proto_val {
-                    Some(p.id)
-                } else {
-                    None
-                }
+                proto_val.as_object_id()
             } else {
                 None
             }
@@ -625,19 +620,19 @@ impl Interpreter {
                 0,
                 |interp, this_val, _args| {
                     // §20.5.3.4 step 2: If Type(O) is not Object, throw TypeError
-                    if let JsValue::Object(o) = this_val {
-                        let name_val = interp.get_object_property(o.id, "name", this_val);
+                    if let Some(this_id) = this_val.as_object_id() {
+                        let name_val = interp.get_object_property(this_id, "name", this_val);
                         let name = match name_val {
-                            Completion::Normal(JsValue::Undefined) => "Error".to_string(),
+                            Completion::Normal(v) if v.is_undefined() => "Error".to_string(),
                             Completion::Normal(v) => match interp.to_js_string(&v) {
                                 Ok(s) => s.to_rust_string(),
                                 Err(e) => return Completion::Throw(e),
                             },
                             other => return other,
                         };
-                        let msg_val = interp.get_object_property(o.id, "message", this_val);
+                        let msg_val = interp.get_object_property(this_id, "message", this_val);
                         let msg = match msg_val {
-                            Completion::Normal(JsValue::Undefined) => String::new(),
+                            Completion::Normal(v) if v.is_undefined() => String::new(),
                             Completion::Normal(v) => match interp.to_js_string(&v) {
                                 Ok(s) => s.to_rust_string(),
                                 Err(e) => return Completion::Throw(e),
@@ -645,11 +640,11 @@ impl Interpreter {
                             other => return other,
                         };
                         return if name.is_empty() {
-                            Completion::Normal(JsValue::String(JsString::from_str(&msg)))
+                            Completion::Normal(JsValue::string(JsString::from_str(&msg)))
                         } else if msg.is_empty() {
-                            Completion::Normal(JsValue::String(JsString::from_str(&name)))
+                            Completion::Normal(JsValue::string(JsString::from_str(&name)))
                         } else {
-                            Completion::Normal(JsValue::String(JsString::from_str(&format!(
+                            Completion::Normal(JsValue::string(JsString::from_str(&format!(
                                 "{name}: {msg}"
                             ))))
                         };
@@ -663,11 +658,11 @@ impl Interpreter {
                 .insert_builtin("toString".to_string(), tostring_fn);
             ep.borrow_mut().insert_builtin(
                 "name".to_string(),
-                JsValue::String(JsString::from_str("Error")),
+                JsValue::string(JsString::from_str("Error")),
             );
             ep.borrow_mut().insert_builtin(
                 "message".to_string(),
-                JsValue::String(JsString::from_str("")),
+                JsValue::string(JsString::from_str("")),
             );
 
             // error-stack-accessor: Error.prototype.stack is an own accessor of
@@ -678,13 +673,10 @@ impl Interpreter {
                 0,
                 |interp, this_val, _args| {
                     // 2. If E is not an Object, throw a TypeError exception.
-                    let o_id = match this_val {
-                        JsValue::Object(o) => o.id,
-                        _ => {
-                            return Completion::Throw(interp.create_type_error(
-                                "Error.prototype.stack getter called on non-object",
-                            ));
-                        }
+                    let Some(o_id) = this_val.as_object_id() else {
+                        return Completion::Throw(interp.create_type_error(
+                            "Error.prototype.stack getter called on non-object",
+                        ));
                     };
                     // 3. If E does not have an [[ErrorData]] internal slot,
                     //    return undefined. [[ErrorData]] is modeled as
@@ -694,10 +686,10 @@ impl Interpreter {
                         .get_object(o_id)
                         .is_some_and(|obj| obj.borrow().class_name.contains("Error"));
                     if !has_error_data {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     // 4. Return an implementation-defined trace string.
-                    Completion::Normal(JsValue::String(JsString::from_str("")))
+                    Completion::Normal(JsValue::string(JsString::from_str("")))
                 },
             ));
             // Capture %Error.prototype% per-realm for the SameValue check.
@@ -706,19 +698,16 @@ impl Interpreter {
                 "set stack".to_string(),
                 1,
                 move |interp, this_val, args| {
-                    let v = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let v = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     // 2. If E is not an Object, throw a TypeError exception.
-                    let o_id = match this_val {
-                        JsValue::Object(o) => o.id,
-                        _ => {
-                            return Completion::Throw(interp.create_type_error(
-                                "Error.prototype.stack setter called on non-object",
-                            ));
-                        }
+                    let Some(o_id) = this_val.as_object_id() else {
+                        return Completion::Throw(interp.create_type_error(
+                            "Error.prototype.stack setter called on non-object",
+                        ));
                     };
                     // 3. If v is not a String, throw a TypeError exception.
                     //    (A String wrapper object is not a String value.)
-                    if !matches!(v, JsValue::String(_)) {
+                    if !(v).is_string() {
                         return Completion::Throw(interp.create_type_error(
                             "Error.prototype.stack setter requires a string value",
                         ));
@@ -740,18 +729,18 @@ impl Interpreter {
                             Ok(d) => d,
                             Err(e) => return Completion::Throw(e),
                         };
-                        if matches!(desc, JsValue::Undefined) {
+                        if (desc).is_undefined() {
                             // 4a. CreateDataPropertyOrThrow (fires defineProperty trap).
                             return match array::create_data_property_or_throw(
                                 interp, this_val, "stack", v,
                             ) {
-                                Ok(()) => Completion::Normal(JsValue::Undefined),
+                                Ok(()) => Completion::Normal(JsValue::UNDEFINED),
                                 Err(e) => Completion::Throw(e),
                             };
                         }
                         // 5a. Set(this, "stack", v, true) (fires set trap).
                         return match interp.set_object_property(o_id, "stack", v, this_val) {
-                            Ok(true) => Completion::Normal(JsValue::Undefined),
+                            Ok(true) => Completion::Normal(JsValue::UNDEFINED),
                             Ok(false) => Completion::Throw(
                                 interp.create_type_error("Cannot set property 'stack'"),
                             ),
@@ -766,13 +755,13 @@ impl Interpreter {
                         None => {
                             match array::create_data_property_or_throw(interp, this_val, "stack", v)
                             {
-                                Ok(()) => Completion::Normal(JsValue::Undefined),
+                                Ok(()) => Completion::Normal(JsValue::UNDEFINED),
                                 Err(e) => Completion::Throw(e),
                             }
                         }
                         // 5a. Set(this, "stack", v, true) with receiver == this.
                         Some(_) => match interp.set_object_property(o_id, "stack", v, this_val) {
-                            Ok(true) => Completion::Normal(JsValue::Undefined),
+                            Ok(true) => Completion::Normal(JsValue::UNDEFINED),
                             Ok(false) => Completion::Throw(
                                 interp.create_type_error("Cannot set property 'stack'"),
                             ),
@@ -799,21 +788,21 @@ impl Interpreter {
                 "isError".to_string(),
                 1,
                 |interp, _this, args| {
-                    let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(o) = &arg
-                        && let Some(obj) = interp.get_object(o.id)
+                    let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(arg_id) = arg.as_object_id()
+                        && let Some(obj) = interp.get_object(arg_id)
                     {
                         let cn = &obj.borrow().class_name;
                         if cn.contains("Error") {
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                     }
-                    Completion::Normal(JsValue::Boolean(false))
+                    Completion::Normal(JsValue::boolean(false))
                 },
             ));
             if let Some(error_ctor) = self.get_global_var("Error")
-                && let JsValue::Object(o) = &error_ctor
-                && let Some(obj) = self.get_object(o.id)
+                && let Some(error_ctor_id) = error_ctor.as_object_id()
+                && let Some(obj) = self.get_object(error_ctor_id)
             {
                 obj.borrow_mut()
                     .insert_builtin("isError".to_string(), is_error_fn);
@@ -830,25 +819,25 @@ impl Interpreter {
                     "Test262Error".to_string(),
                     1,
                     move |interp, this, args| {
-                        let msg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let msg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         // Only box into `this` when invoked via [[Construct]] — a plain
                         // [[Call]] (e.g. `Test262Error.call(obj, msg)`) must not mutate
                         // an arbitrary `this`.
                         if interp.new_target.is_some()
-                            && let JsValue::Object(o) = this
+                            && let Some(this_id) = this.as_object_id()
                         {
-                            if let Some(obj) = interp.get_object(o.id) {
+                            if let Some(obj) = interp.get_object(this_id) {
                                 let mut o = obj.borrow_mut();
                                 o.class_name = "Test262Error".to_string();
                                 if let Some(ref ep) = error_proto_clone {
                                     o.prototype_id = Some(ep.borrow().id.unwrap());
                                 }
-                                if !matches!(msg, JsValue::Undefined) {
+                                if !(msg).is_undefined() {
                                     o.insert_builtin("message".to_string(), msg);
                                 }
                                 o.insert_builtin(
                                     "name".to_string(),
-                                    JsValue::String(JsString::from_str("Test262Error")),
+                                    JsValue::string(JsString::from_str("Test262Error")),
                                 );
                             }
                             return Completion::Normal(this.clone());
@@ -860,16 +849,16 @@ impl Interpreter {
                             if let Some(ref ep) = error_proto_clone {
                                 o.prototype_id = Some(ep.borrow().id.unwrap());
                             }
-                            if !matches!(msg, JsValue::Undefined) {
+                            if !(msg).is_undefined() {
                                 o.insert_builtin("message".to_string(), msg);
                             }
                             o.insert_builtin(
                                 "name".to_string(),
-                                JsValue::String(JsString::from_str("Test262Error")),
+                                JsValue::string(JsString::from_str("Test262Error")),
                             );
                         }
                         let id = obj_id;
-                        Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                        Completion::Normal(JsValue::object(id))
                     },
                 ),
             );
@@ -897,13 +886,13 @@ impl Interpreter {
                 .borrow_mut()
                 .insert_builtin(
                     "name".to_string(),
-                    JsValue::String(JsString::from_str(name)),
+                    JsValue::string(JsString::from_str(name)),
                 );
             self.get_object_cell_expect(native_proto_id)
                 .borrow_mut()
                 .insert_builtin(
                     "message".to_string(),
-                    JsValue::String(JsString::from_str("")),
+                    JsValue::string(JsString::from_str("")),
                 );
 
             // Store native error prototype on realm
@@ -925,8 +914,8 @@ impl Interpreter {
                 name,
                 BindingKind::Var,
                 JsFunction::constructor(error_name.clone(), 1, move |interp, this, args| {
-                    let msg_raw = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let msg_raw = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                     // OrdinaryCreateFromConstructor — realm-aware prototype
                     let proto = match interp.get_prototype_from_new_target_realm(|realm| {
@@ -944,19 +933,19 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
 
-                    let msg_str = if !matches!(msg_raw, JsValue::Undefined) {
+                    let msg_str = if !(msg_raw).is_undefined() {
                         match interp.to_string_value(&msg_raw) {
-                            Ok(s) => Some(JsValue::String(JsString::from_str(&s))),
+                            Ok(s) => Some(JsValue::string(JsString::from_str(&s))),
                             Err(e) => return Completion::Throw(e),
                         }
                     } else {
                         None
                     };
                     // §20.5.8.1 InstallErrorCause — use proxy-aware HasProperty
-                    let cause_val = if let JsValue::Object(opts) = &options {
-                        match interp.proxy_has_property(opts.id, "cause") {
+                    let cause_val = if let Some(options_id) = options.as_object_id() {
+                        match interp.proxy_has_property(options_id, "cause") {
                             Ok(true) => {
-                                match interp.get_object_property(opts.id, "cause", &options) {
+                                match interp.get_object_property(options_id, "cause", &options) {
                                     Completion::Normal(v) => Some(v),
                                     c => return c,
                                 }
@@ -985,9 +974,9 @@ impl Interpreter {
                     // OrdinaryCreateFromConstructor. A plain [[Call]] (e.g.
                     // `TypeError.call(obj, msg)`) must not mutate an arbitrary `this`.
                     if interp.new_target.is_some()
-                        && let JsValue::Object(o) = this
+                        && let Some(this_id) = this.as_object_id()
                     {
-                        if let Some(obj) = interp.get_object(o.id) {
+                        if let Some(obj) = interp.get_object(this_id) {
                             let mut o = obj.borrow_mut();
                             init_native_error!(o);
                         }
@@ -999,7 +988,7 @@ impl Interpreter {
                         init_native_error!(o);
                     }
                     let id = obj_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 }),
             );
 
@@ -1012,18 +1001,13 @@ impl Interpreter {
             // Set constructor's .prototype to the per-type prototype
             {
                 if let Some(ctor_val) = self.get_global_var(name)
-                    && let JsValue::Object(o) = &ctor_val
-                    && let Some(ctor_obj) = self.get_object(o.id)
+                    && let Some(ctor_id) = ctor_val.as_object_id()
+                    && let Some(ctor_obj) = self.get_object(ctor_id)
                 {
                     let proto_id = native_proto_id;
                     ctor_obj.borrow_mut().insert_property(
                         "prototype".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::Object(crate::types::JsObject { id: proto_id }),
-                            false,
-                            false,
-                            false,
-                        ),
+                        PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                     );
                     ctor_obj.borrow_mut().deferred_construct = true;
                 }
@@ -1042,13 +1026,13 @@ impl Interpreter {
                 .borrow_mut()
                 .insert_builtin(
                     "name".to_string(),
-                    JsValue::String(JsString::from_str("SuppressedError")),
+                    JsValue::string(JsString::from_str("SuppressedError")),
                 );
             self.get_object_cell_expect(suppressed_proto_id)
                 .borrow_mut()
                 .insert_builtin(
                     "message".to_string(),
-                    JsValue::String(JsString::from_str("")),
+                    JsValue::string(JsString::from_str("")),
                 );
 
             self.realm_mut().suppressed_error_prototype = Some(suppressed_proto_id);
@@ -1057,9 +1041,9 @@ impl Interpreter {
                 "SuppressedError".to_string(),
                 3,
                 move |interp, _this, args| {
-                    let error_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let suppressed_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    let msg_raw = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                    let error_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let suppressed_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    let msg_raw = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
 
                     // OrdinaryCreateFromConstructor — realm-aware prototype
                     let proto = match interp.get_prototype_from_new_target_realm(|realm| {
@@ -1070,9 +1054,9 @@ impl Interpreter {
                     };
                     // Extract msg_str BEFORE the mut borrow on obj's RefCell
                     // (lifetime is tied to &interp; can't hold across &mut interp).
-                    let msg_str = if !matches!(msg_raw, JsValue::Undefined) {
+                    let msg_str = if !(msg_raw).is_undefined() {
                         match interp.to_string_value(&msg_raw) {
-                            Ok(s) => Some(JsValue::String(JsString::from_str(&s))),
+                            Ok(s) => Some(JsValue::string(JsString::from_str(&s))),
                             Err(e) => return Completion::Throw(e),
                         }
                     } else {
@@ -1093,7 +1077,7 @@ impl Interpreter {
                         o.insert_builtin("suppressed".to_string(), suppressed_val.clone());
                     }
                     let id = obj_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 },
             ));
 
@@ -1101,18 +1085,13 @@ impl Interpreter {
                 .borrow_mut()
                 .insert_builtin("constructor".to_string(), suppressed_ctor.clone());
 
-            if let JsValue::Object(ref ctor_ref) = suppressed_ctor
-                && let Some(ctor_obj) = self.get_object(ctor_ref.id)
+            if let Some(ctor_id) = suppressed_ctor.as_object_id()
+                && let Some(ctor_obj) = self.get_object(ctor_id)
             {
                 let proto_id = suppressed_proto_id;
                 ctor_obj.borrow_mut().insert_property(
                     "prototype".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::Object(crate::types::JsObject { id: proto_id }),
-                        false,
-                        false,
-                        false,
-                    ),
+                    PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                 );
             }
 
@@ -1135,13 +1114,13 @@ impl Interpreter {
                 .borrow_mut()
                 .insert_builtin(
                     "name".to_string(),
-                    JsValue::String(JsString::from_str("AggregateError")),
+                    JsValue::string(JsString::from_str("AggregateError")),
                 );
             self.get_object_cell_expect(agg_proto_id)
                 .borrow_mut()
                 .insert_builtin(
                     "message".to_string(),
-                    JsValue::String(JsString::from_str("")),
+                    JsValue::string(JsString::from_str("")),
                 );
             let agg_proto_clone_id = agg_proto_id;
             self.realm_mut().aggregate_error_prototype = Some(agg_proto_id);
@@ -1152,9 +1131,9 @@ impl Interpreter {
                     "AggregateError".to_string(),
                     2,
                     move |interp, this, args| {
-                        let errors_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        let msg_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                        let options = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                        let errors_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                        let msg_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                        let options = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
 
                         // OrdinaryCreateFromConstructor — realm-aware prototype
                         let proto = match interp.get_prototype_from_new_target_realm(|realm| {
@@ -1165,9 +1144,9 @@ impl Interpreter {
                         };
 
                         // §20.5.7.1 step 3: ToString(message) BEFORE iterating errors
-                        let msg_str = if !matches!(msg_raw, JsValue::Undefined) {
+                        let msg_str = if !(msg_raw).is_undefined() {
                             match interp.to_string_value(&msg_raw) {
-                                Ok(s) => Some(JsValue::String(JsString::from_str(&s))),
+                                Ok(s) => Some(JsValue::string(JsString::from_str(&s))),
                                 Err(e) => return Completion::Throw(e),
                             }
                         } else {
@@ -1181,10 +1160,11 @@ impl Interpreter {
                         };
                         let errors_arr = interp.create_array(errors_vec);
                         // §20.5.8.1 InstallErrorCause — use proxy-aware HasProperty
-                        let cause_val = if let JsValue::Object(opts) = &options {
-                            match interp.proxy_has_property(opts.id, "cause") {
+                        let cause_val = if let Some(options_id) = options.as_object_id() {
+                            match interp.proxy_has_property(options_id, "cause") {
                                 Ok(true) => {
-                                    match interp.get_object_property(opts.id, "cause", &options) {
+                                    match interp.get_object_property(options_id, "cause", &options)
+                                    {
                                         Completion::Normal(v) => Some(v),
                                         c => return c,
                                     }
@@ -1215,9 +1195,9 @@ impl Interpreter {
                         // `AggregateError.call(obj, errors, msg)`) must not mutate an
                         // arbitrary `this`.
                         if interp.new_target.is_some()
-                            && let JsValue::Object(o) = this
+                            && let Some(this_id) = this.as_object_id()
                         {
-                            if let Some(obj) = interp.get_object(o.id) {
+                            if let Some(obj) = interp.get_object(this_id) {
                                 let mut o = obj.borrow_mut();
                                 init_agg_error!(o);
                             }
@@ -1229,7 +1209,7 @@ impl Interpreter {
                             init_agg_error!(o);
                         }
                         let id = obj_id;
-                        Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                        Completion::Normal(JsValue::object(id))
                     },
                 ),
             );
@@ -1242,18 +1222,13 @@ impl Interpreter {
             }
             {
                 if let Some(ctor_val) = self.get_global_var("AggregateError")
-                    && let JsValue::Object(o) = &ctor_val
-                    && let Some(ctor_obj) = self.get_object(o.id)
+                    && let Some(ctor_id) = ctor_val.as_object_id()
+                    && let Some(ctor_obj) = self.get_object(ctor_id)
                 {
                     let proto_id = agg_proto_id;
                     ctor_obj.borrow_mut().insert_property(
                         "prototype".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::Object(crate::types::JsObject { id: proto_id }),
-                            false,
-                            false,
-                            false,
-                        ),
+                        PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                     );
                 }
             }
@@ -1268,29 +1243,32 @@ impl Interpreter {
                 // the active function (Object), return OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%")
                 if let Some(ref nt) = interp.new_target.clone() {
                     // Check if new_target is different from the Object constructor itself
-                    let object_fn = interp.get_global_var("Object").unwrap_or(JsValue::Undefined);
-                    let nt_is_object = matches!((&object_fn, nt), (JsValue::Object(a), JsValue::Object(b)) if a.id == b.id);
+                    let object_fn = interp
+                        .get_global_var("Object")
+                        .unwrap_or(JsValue::UNDEFINED);
+                    let nt_is_object = object_fn
+                        .as_object_id()
+                        .zip(nt.as_object_id())
+                        .is_some_and(|(object_id, new_target_id)| object_id == new_target_id);
                     if !nt_is_object {
                         // OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%")
                         let default_proto = interp.realm().object_prototype;
                         let new_obj_rc_id = interp.create_object_id();
                         let no_id = new_obj_rc_id;
-                        interp.apply_new_target_prototype(no_id, default_proto, |realm| realm.object_prototype);
-                        let new_obj_val = JsValue::Object(crate::types::JsObject { id: no_id });
+                        interp.apply_new_target_prototype(no_id, default_proto, |realm| {
+                            realm.object_prototype
+                        });
+                        let new_obj_val = JsValue::object(no_id);
                         return Completion::Normal(new_obj_val);
                     }
                 }
                 match args.first() {
-                    Some(val) if matches!(val, JsValue::Object(_)) => {
-                        Completion::Normal(val.clone())
-                    }
-                    Some(val) if !matches!(val, JsValue::Undefined | JsValue::Null) => {
-                        interp.to_object(val)
-                    }
+                    Some(val) if (val).is_object() => Completion::Normal(val.clone()),
+                    Some(val) if !(val).is_nullish() => interp.to_object(val),
                     _ => {
                         let obj_id = interp.create_object_id();
                         let id = obj_id;
-                        Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                        Completion::Normal(JsValue::object(id))
                     }
                 }
             }),
@@ -1304,9 +1282,9 @@ impl Interpreter {
             BindingKind::Var,
             JsFunction::constructor("Array".to_string(), 1, |interp, _this, args| {
                 let arr = if args.len() == 1
-                    && let JsValue::Number(n) = &args[0]
+                    && let Some(n) = args[0].as_number()
                 {
-                    let len = *n;
+                    let len = n;
                     let uint32_len = len as u32;
                     if (uint32_len as f64) != len {
                         let err = interp.create_range_error("Invalid array length");
@@ -1316,9 +1294,9 @@ impl Interpreter {
                 } else {
                     interp.create_array(args.to_vec())
                 };
-                if let JsValue::Object(ref o) = arr {
+                if let Some(array_id) = arr.as_object_id() {
                     let default_proto_id = interp.realm().array_prototype;
-                    interp.apply_new_target_prototype(o.id, default_proto_id, |realm| {
+                    interp.apply_new_target_prototype(array_id, default_proto_id, |realm| {
                         realm.array_prototype
                     });
                 }
@@ -1337,7 +1315,7 @@ impl Interpreter {
                         return Completion::Throw(err);
                     }
                     let desc = if let Some(v) = args.first() {
-                        if matches!(v, JsValue::Undefined) {
+                        if (v).is_undefined() {
                             None
                         } else {
                             match interp.to_string_value(v) {
@@ -1350,14 +1328,14 @@ impl Interpreter {
                     };
                     let id = interp.next_symbol_id;
                     interp.next_symbol_id += 1;
-                    Completion::Normal(JsValue::Symbol(crate::types::JsSymbol {
+                    Completion::Normal(JsValue::symbol(crate::types::JsSymbol {
                         id,
                         description: desc,
                     }))
                 },
             ));
-            if let JsValue::Object(ref o) = symbol_fn
-                && let Some(obj) = self.get_object(o.id)
+            if let Some(symbol_id) = symbol_fn.as_object_id()
+                && let Some(obj) = self.get_object(symbol_id)
             {
                 let well_known = [
                     ("iterator", "Symbol.iterator"),
@@ -1378,7 +1356,7 @@ impl Interpreter {
                 ];
                 for (name, desc) in well_known {
                     let sym_val = if let Some(existing) = self.well_known_symbols.get(name) {
-                        JsValue::Symbol(existing.clone())
+                        JsValue::symbol(existing.clone())
                     } else {
                         let id = self.next_symbol_id;
                         self.next_symbol_id += 1;
@@ -1388,7 +1366,7 @@ impl Interpreter {
                         };
                         self.well_known_symbols
                             .insert(name.to_string(), sym.clone());
-                        JsValue::Symbol(sym)
+                        JsValue::symbol(sym)
                     };
                     obj.borrow_mut().insert_property(
                         name.to_string(),
@@ -1410,7 +1388,7 @@ impl Interpreter {
                             "undefined".to_string()
                         };
                         if let Some(existing) = interp.global_symbol_registry.get(&key) {
-                            return Completion::Normal(JsValue::Symbol(existing.clone()));
+                            return Completion::Normal(JsValue::symbol(existing.clone()));
                         }
                         let id = interp.next_symbol_id;
                         interp.next_symbol_id += 1;
@@ -1419,7 +1397,7 @@ impl Interpreter {
                             description: Some(JsString::from_str(&key)),
                         };
                         interp.global_symbol_registry.insert(key, sym.clone());
-                        Completion::Normal(JsValue::Symbol(sym))
+                        Completion::Normal(JsValue::symbol(sym))
                     }),
                     false,
                 ));
@@ -1430,19 +1408,19 @@ impl Interpreter {
                     "keyFor".to_string(),
                     1,
                     Rc::new(|interp, _this, args| {
-                        let Some(JsValue::Symbol(sym)) = args.first() else {
+                        let Some(sym) = args.first().and_then(JsValue::as_symbol) else {
                             let err = interp
                                 .create_type_error("Symbol.keyFor requires a symbol argument");
                             return Completion::Throw(err);
                         };
                         for (key, reg_sym) in &interp.global_symbol_registry {
                             if reg_sym.id == sym.id {
-                                return Completion::Normal(JsValue::String(JsString::from_str(
+                                return Completion::Normal(JsValue::string(JsString::from_str(
                                     key,
                                 )));
                             }
                         }
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     }),
                     false,
                 ));
@@ -1472,7 +1450,7 @@ impl Interpreter {
                     let val = &args[0];
                     // §22.1.1.1 step 2a: only when NewTarget is undefined AND value is Symbol
                     if interp.new_target.is_none()
-                        && let JsValue::Symbol(sym) = val
+                        && let Some(sym) = val.as_symbol()
                     {
                         let desc = if let Some(desc) = &sym.description {
                             format!("Symbol({desc})")
@@ -1480,8 +1458,8 @@ impl Interpreter {
                             "Symbol()".to_string()
                         };
                         JsString::from_str(&desc)
-                    } else if let JsValue::String(s) = val {
-                        s.clone()
+                    } else if let Some(s) = val.as_string() {
+                        s
                     } else {
                         // §22.1.1.1 step 2b: ToString(value) — throws TypeError for Symbol
                         match interp.to_string_value(val) {
@@ -1493,8 +1471,8 @@ impl Interpreter {
                 // §22.1.1.1 step 3: only box into `this` when invoked via [[Construct]].
                 // A plain [[Call]] (e.g. `String.call(obj, x)`) must not mutate `this`.
                 if interp.new_target.is_some()
-                    && let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(this_id) = this.as_object_id()
+                    && let Some(obj) = interp.get_object(this_id)
                 {
                     let proto = match interp
                         .get_prototype_from_new_target_realm(|realm| realm.string_prototype)
@@ -1505,10 +1483,10 @@ impl Interpreter {
                     if let Some(proto_rc) = proto {
                         obj.borrow_mut().prototype_id = Some(proto_rc);
                     }
-                    obj.borrow_mut().primitive_value = Some(JsValue::String(js_str.clone()));
+                    obj.borrow_mut().primitive_value = Some(JsValue::string(js_str.clone()));
                     obj.borrow_mut().class_name = "String".to_string();
                 }
-                Completion::Normal(JsValue::String(js_str))
+                Completion::Normal(JsValue::string(js_str))
             }),
         );
         self.setup_string_prototype();
@@ -1519,30 +1497,30 @@ impl Interpreter {
                 "raw".to_string(),
                 1,
                 |interp, _this, args| {
-                    let template = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let template = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let template_obj = match interp.to_object(&template) {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    let raw_val = if let JsValue::Object(o) = &template_obj {
-                        match interp.get_object_property(o.id, "raw", &template_obj) {
+                    let raw_val = if let Some(template_id) = template_obj.as_object_id() {
+                        match interp.get_object_property(template_id, "raw", &template_obj) {
                             Completion::Normal(v) => v,
                             other => return other,
                         }
                     } else {
-                        JsValue::Undefined
+                        JsValue::UNDEFINED
                     };
                     let raw_obj = match interp.to_object(&raw_val) {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    let len = if let JsValue::Object(o) = &raw_obj {
-                        let length_val = match interp.get_object_property(o.id, "length", &raw_obj)
-                        {
-                            Completion::Normal(v) => v,
-                            Completion::Throw(e) => return Completion::Throw(e),
-                            other => return other,
-                        };
+                    let len = if let Some(raw_id) = raw_obj.as_object_id() {
+                        let length_val =
+                            match interp.get_object_property(raw_id, "length", &raw_obj) {
+                                Completion::Normal(v) => v,
+                                Completion::Throw(e) => return Completion::Throw(e),
+                                other => return other,
+                            };
                         let n = match interp.to_number_value(&length_val) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
@@ -1556,19 +1534,19 @@ impl Interpreter {
                         0
                     };
                     if len == 0 {
-                        return Completion::Normal(JsValue::String(JsString::from_str("")));
+                        return Completion::Normal(JsValue::string(JsString::from_str("")));
                     }
                     let subs = &args[1..];
                     let mut result = String::new();
                     for i in 0..len {
-                        let next_seg = if let JsValue::Object(o) = &raw_obj {
-                            match interp.get_object_property(o.id, &i.to_string(), &raw_obj) {
+                        let next_seg = if let Some(raw_id) = raw_obj.as_object_id() {
+                            match interp.get_object_property(raw_id, &i.to_string(), &raw_obj) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 other => return other,
                             }
                         } else {
-                            JsValue::Undefined
+                            JsValue::UNDEFINED
                         };
                         let seg_str = match interp.to_string_value(&next_seg) {
                             Ok(s) => s,
@@ -1583,12 +1561,12 @@ impl Interpreter {
                             result.push_str(&sub_str);
                         }
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::string(JsString::from_str(&result)))
                 },
             ));
             if let Some(string_ctor) = self.get_global_var("String")
-                && let JsValue::Object(o) = &string_ctor
-                && let Some(obj) = self.get_object(o.id)
+                && let Some(string_ctor_id) = string_ctor.as_object_id()
+                && let Some(obj) = self.get_object(string_ctor_id)
             {
                 obj.borrow_mut().insert_builtin("raw".to_string(), raw_fn);
             }
@@ -1599,8 +1577,8 @@ impl Interpreter {
             "Number",
             BindingKind::Var,
             JsFunction::constructor("Number".to_string(), 1, |interp, this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Number(0.0));
-                let n = if let JsValue::BigInt(ref b) = val {
+                let val = args.first().cloned().unwrap_or(JsValue::number(0.0));
+                let n = if let Some(b) = val.as_bigint() {
                     let s = b.value.to_string();
                     s.parse::<f64>().unwrap_or(f64::INFINITY)
                 } else {
@@ -1612,8 +1590,8 @@ impl Interpreter {
                 // §21.1.1.1 step 3: only box into `this` when invoked via [[Construct]].
                 // A plain [[Call]] (e.g. `Number.call(obj, x)`) must not mutate `this`.
                 if interp.new_target.is_some()
-                    && let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(this_id) = this.as_object_id()
+                    && let Some(obj) = interp.get_object(this_id)
                 {
                     // OrdinaryCreateFromConstructor — realm-aware prototype
                     let proto = match interp
@@ -1623,13 +1601,13 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     let mut b = obj.borrow_mut();
-                    b.primitive_value = Some(JsValue::Number(n));
+                    b.primitive_value = Some(JsValue::number(n));
                     b.class_name = "Number".to_string();
                     if let Some(p) = proto {
                         b.prototype_id = Some(p);
                     }
                 }
-                Completion::Normal(JsValue::Number(n))
+                Completion::Normal(JsValue::number(n))
             }),
         );
 
@@ -1639,59 +1617,59 @@ impl Interpreter {
                 "isFinite".to_string(),
                 1,
                 |_interp, _this, args| {
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let result = matches!(&val, JsValue::Number(n) if n.is_finite());
-                    Completion::Normal(JsValue::Boolean(result))
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let result = val.as_number().is_some_and(f64::is_finite);
+                    Completion::Normal(JsValue::boolean(result))
                 },
             ));
             let is_nan_fn = self.create_function(JsFunction::native(
                 "isNaN".to_string(),
                 1,
                 |_interp, _this, args| {
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let result = matches!(&val, JsValue::Number(n) if n.is_nan());
-                    Completion::Normal(JsValue::Boolean(result))
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let result = val.as_number().is_some_and(f64::is_nan);
+                    Completion::Normal(JsValue::boolean(result))
                 },
             ));
             let is_integer_fn = self.create_function(JsFunction::native(
                 "isInteger".to_string(),
                 1,
                 |_interp, _this, args| {
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let result = if let JsValue::Number(n) = &val {
-                        n.is_finite() && *n == n.trunc()
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let result = if let Some(n) = val.as_number() {
+                        n.is_finite() && n == n.trunc()
                     } else {
                         false
                     };
-                    Completion::Normal(JsValue::Boolean(result))
+                    Completion::Normal(JsValue::boolean(result))
                 },
             ));
             let is_safe_fn = self.create_function(JsFunction::native(
                 "isSafeInteger".to_string(),
                 1,
                 |_interp, _this, args| {
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let result = if let JsValue::Number(n) = &val {
-                        n.is_finite() && *n == n.trunc() && n.abs() <= 9007199254740991.0
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let result = if let Some(n) = val.as_number() {
+                        n.is_finite() && n == n.trunc() && n.abs() <= 9007199254740991.0
                     } else {
                         false
                     };
-                    Completion::Normal(JsValue::Boolean(result))
+                    Completion::Normal(JsValue::boolean(result))
                 },
             ));
             if let Some(num_val) = self.get_global_var("Number")
-                && let JsValue::Object(o) = &num_val
-                && let Some(num_obj) = self.get_object(o.id)
+                && let Some(number_id) = num_val.as_object_id()
+                && let Some(num_obj) = self.get_object(number_id)
             {
                 let mut n = num_obj.borrow_mut();
                 n.insert_property(
                     "POSITIVE_INFINITY".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(f64::INFINITY), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(f64::INFINITY), false, false, false),
                 );
                 n.insert_property(
                     "NEGATIVE_INFINITY".to_string(),
                     PropertyDescriptor::data(
-                        JsValue::Number(f64::NEG_INFINITY),
+                        JsValue::number(f64::NEG_INFINITY),
                         false,
                         false,
                         false,
@@ -1699,24 +1677,24 @@ impl Interpreter {
                 );
                 n.insert_property(
                     "MAX_VALUE".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(f64::MAX), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(f64::MAX), false, false, false),
                 );
                 n.insert_property(
                     "MIN_VALUE".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(5e-324_f64), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(5e-324_f64), false, false, false),
                 );
                 n.insert_property(
                     "NaN".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(f64::NAN), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(f64::NAN), false, false, false),
                 );
                 n.insert_property(
                     "EPSILON".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(f64::EPSILON), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(f64::EPSILON), false, false, false),
                 );
                 n.insert_property(
                     "MAX_SAFE_INTEGER".to_string(),
                     PropertyDescriptor::data(
-                        JsValue::Number(9007199254740991.0),
+                        JsValue::number(9007199254740991.0),
                         false,
                         false,
                         false,
@@ -1725,7 +1703,7 @@ impl Interpreter {
                 n.insert_property(
                     "MIN_SAFE_INTEGER".to_string(),
                     PropertyDescriptor::data(
-                        JsValue::Number(-9007199254740991.0),
+                        JsValue::number(-9007199254740991.0),
                         false,
                         false,
                         false,
@@ -1743,13 +1721,13 @@ impl Interpreter {
             "Boolean",
             BindingKind::Var,
             JsFunction::constructor("Boolean".to_string(), 1, |interp, this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let b = interp.to_boolean_val(&val);
                 // §21.3.1.1 step 2: only box into `this` when invoked via [[Construct]].
                 // A plain [[Call]] (e.g. `Boolean.call(obj, x)`) must not mutate `this`.
                 if interp.new_target.is_some()
-                    && let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                    && let Some(this_id) = this.as_object_id()
+                    && let Some(obj) = interp.get_object(this_id)
                 {
                     // OrdinaryCreateFromConstructor — realm-aware prototype
                     let proto = match interp
@@ -1759,13 +1737,13 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     let mut bo = obj.borrow_mut();
-                    bo.primitive_value = Some(JsValue::Boolean(b));
+                    bo.primitive_value = Some(JsValue::boolean(b));
                     bo.class_name = "Boolean".to_string();
                     if let Some(p) = proto {
                         bo.prototype_id = Some(p);
                     }
                 }
-                Completion::Normal(JsValue::Boolean(b))
+                Completion::Normal(JsValue::boolean(b))
             }),
         );
 
@@ -1789,12 +1767,12 @@ impl Interpreter {
             "parseInt",
             BindingKind::Var,
             JsFunction::native("parseInt".to_string(), 2, |interp, _this, args| {
-                let input = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let input = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let s = match interp.to_string_value(&input) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
                 };
-                let radix_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let radix_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // §19.2.5 step 6: Let R be 𝔽(? ToInt32(radix))
                 let radix_num = match interp.to_number_value(&radix_val) {
                     Ok(n) => n,
@@ -1817,7 +1795,7 @@ impl Interpreter {
                     }
                 }
                 if !(2..=36).contains(&radix) {
-                    return Completion::Normal(JsValue::Number(f64::NAN));
+                    return Completion::Normal(JsValue::number(f64::NAN));
                 }
                 let s = if radix == 16 {
                     s.strip_prefix("0x")
@@ -1843,12 +1821,12 @@ impl Interpreter {
                     result = result * (radix as f64) + (digit as f64);
                 }
                 if !found_digit {
-                    return Completion::Normal(JsValue::Number(f64::NAN));
+                    return Completion::Normal(JsValue::number(f64::NAN));
                 }
                 if negative {
                     result = -result;
                 }
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             }),
         );
 
@@ -1856,21 +1834,21 @@ impl Interpreter {
             "parseFloat",
             BindingKind::Var,
             JsFunction::native("parseFloat".to_string(), 1, |interp, _this, args| {
-                let input = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let input = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let s = match interp.to_string_value(&input) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
                 };
                 let s = s.trim_matches(crate::interpreter::helpers::is_ecma_whitespace);
                 if s.is_empty() {
-                    return Completion::Normal(JsValue::Number(f64::NAN));
+                    return Completion::Normal(JsValue::number(f64::NAN));
                 }
                 // Handle Infinity/-Infinity
                 if s.starts_with("Infinity") || s.starts_with("+Infinity") {
-                    return Completion::Normal(JsValue::Number(f64::INFINITY));
+                    return Completion::Normal(JsValue::number(f64::INFINITY));
                 }
                 if s.starts_with("-Infinity") {
-                    return Completion::Normal(JsValue::Number(f64::NEG_INFINITY));
+                    return Completion::Normal(JsValue::number(f64::NEG_INFINITY));
                 }
                 // Find longest valid float prefix
                 let mut end = 0;
@@ -1909,11 +1887,11 @@ impl Interpreter {
                 let _ = (has_dot, has_e);
                 let prefix = &s[..end];
                 if prefix.is_empty() || prefix == "+" || prefix == "-" {
-                    return Completion::Normal(JsValue::Number(f64::NAN));
+                    return Completion::Normal(JsValue::number(f64::NAN));
                 }
                 match prefix.parse::<f64>() {
-                    Ok(n) => Completion::Normal(JsValue::Number(n)),
-                    Err(_) => Completion::Normal(JsValue::Number(f64::NAN)),
+                    Ok(n) => Completion::Normal(JsValue::number(n)),
+                    Err(_) => Completion::Normal(JsValue::number(f64::NAN)),
                 }
             }),
         );
@@ -1923,8 +1901,8 @@ impl Interpreter {
             let parse_int = self.get_global_var("parseInt");
             let parse_float = self.get_global_var("parseFloat");
             if let Some(num_val) = self.get_global_var("Number")
-                && let JsValue::Object(o) = &num_val
-                && let Some(num_obj) = self.get_object_cell(o.id)
+                && let Some(number_id) = num_val.as_object_id()
+                && let Some(num_obj) = self.get_object_cell(number_id)
             {
                 let mut n = num_obj.borrow_mut();
                 if let Some(pi) = parse_int {
@@ -1940,12 +1918,12 @@ impl Interpreter {
             "isNaN",
             BindingKind::Var,
             JsFunction::native("isNaN".to_string(), 1, |interp, _this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let n = match interp.to_number_value(&val) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 };
-                Completion::Normal(JsValue::Boolean(n.is_nan()))
+                Completion::Normal(JsValue::boolean(n.is_nan()))
             }),
         );
 
@@ -1953,12 +1931,12 @@ impl Interpreter {
             "isFinite",
             BindingKind::Var,
             JsFunction::native("isFinite".to_string(), 1, |interp, _this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let n = match interp.to_number_value(&val) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 };
-                Completion::Normal(JsValue::Boolean(n.is_finite()))
+                Completion::Normal(JsValue::boolean(n.is_finite()))
             }),
         );
 
@@ -1966,14 +1944,14 @@ impl Interpreter {
             "encodeURI",
             BindingKind::Var,
             JsFunction::native("encodeURI".to_string(), 1, |interp, _this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let code_units = match interp.to_js_string(&val) {
                     Ok(s) => s.code_units,
                     Err(e) => return Completion::Throw(e),
                 };
                 match encode_uri_string(&code_units, true) {
                     Ok(encoded) => {
-                        Completion::Normal(JsValue::String(JsString::from_str(&encoded)))
+                        Completion::Normal(JsValue::string(JsString::from_str(&encoded)))
                     }
                     Err(msg) => Completion::Throw(interp.create_error("URIError", &msg)),
                 }
@@ -1987,14 +1965,14 @@ impl Interpreter {
                 "encodeURIComponent".to_string(),
                 1,
                 |interp, _this, args| {
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let code_units = match interp.to_js_string(&val) {
                         Ok(s) => s.code_units,
                         Err(e) => return Completion::Throw(e),
                     };
                     match encode_uri_string(&code_units, false) {
                         Ok(encoded) => {
-                            Completion::Normal(JsValue::String(JsString::from_str(&encoded)))
+                            Completion::Normal(JsValue::string(JsString::from_str(&encoded)))
                         }
                         Err(msg) => Completion::Throw(interp.create_error("URIError", &msg)),
                     }
@@ -2006,13 +1984,13 @@ impl Interpreter {
             "decodeURI",
             BindingKind::Var,
             JsFunction::native("decodeURI".to_string(), 1, |interp, _this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let code_units = match interp.to_js_string(&val) {
                     Ok(s) => s.code_units.to_vec(),
                     Err(e) => return Completion::Throw(e),
                 };
                 match decode_uri_string(&code_units, true) {
-                    Ok(decoded) => Completion::Normal(JsValue::String(JsString::from_vec(decoded))),
+                    Ok(decoded) => Completion::Normal(JsValue::string(JsString::from_vec(decoded))),
                     Err(msg) => Completion::Throw(interp.create_error("URIError", &msg)),
                 }
             }),
@@ -2025,14 +2003,14 @@ impl Interpreter {
                 "decodeURIComponent".to_string(),
                 1,
                 |interp, _this, args| {
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let code_units = match interp.to_js_string(&val) {
                         Ok(s) => s.code_units.to_vec(),
                         Err(e) => return Completion::Throw(e),
                     };
                     match decode_uri_string(&code_units, false) {
                         Ok(decoded) => {
-                            Completion::Normal(JsValue::String(JsString::from_vec(decoded)))
+                            Completion::Normal(JsValue::string(JsString::from_vec(decoded)))
                         }
                         Err(msg) => Completion::Throw(interp.create_error("URIError", &msg)),
                     }
@@ -2045,7 +2023,7 @@ impl Interpreter {
             "escape",
             BindingKind::Var,
             JsFunction::native("escape".to_string(), 1, |interp, _this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let s = match interp.to_string_value(&val) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
@@ -2075,7 +2053,7 @@ impl Interpreter {
                         }
                     }
                 }
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::string(JsString::from_str(&result)))
             }),
         );
 
@@ -2084,7 +2062,7 @@ impl Interpreter {
             "unescape",
             BindingKind::Var,
             JsFunction::native("unescape".to_string(), 1, |interp, _this, args| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let s = match interp.to_string_value(&val) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
@@ -2123,7 +2101,7 @@ impl Interpreter {
                     }
                     i += 1;
                 }
-                Completion::Normal(JsValue::String(JsString::from_vec(result)))
+                Completion::Normal(JsValue::string(JsString::from_vec(result)))
             }),
         );
 
@@ -2146,7 +2124,7 @@ impl Interpreter {
             for (name, val) in math_consts {
                 m.insert_property(
                     name.to_string(),
-                    PropertyDescriptor::data(JsValue::Number(*val), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(*val), false, false, false),
                 );
             }
         }
@@ -2185,8 +2163,8 @@ impl Interpreter {
                 name.to_string(),
                 1,
                 move |interp, _this, args| {
-                    let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::Undefined));
-                    Completion::Normal(JsValue::Number(op(x)))
+                    let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::UNDEFINED));
+                    Completion::Normal(JsValue::number(op(x)))
                 },
             ));
             self.get_object_cell_expect(math_obj_id)
@@ -2198,7 +2176,7 @@ impl Interpreter {
             "round".to_string(),
             1,
             |interp, _this, args| {
-                let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::Undefined));
+                let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::UNDEFINED));
                 let result = if x.is_nan() || x.is_infinite() || x == 0.0 {
                     x
                 } else if (-0.5..0.0).contains(&x) {
@@ -2210,7 +2188,7 @@ impl Interpreter {
                 } else {
                     (x + 0.5).floor()
                 };
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2222,7 +2200,7 @@ impl Interpreter {
             2,
             |interp, _this, args| {
                 if args.is_empty() {
-                    return Completion::Normal(JsValue::Number(f64::NEG_INFINITY));
+                    return Completion::Normal(JsValue::number(f64::NEG_INFINITY));
                 }
                 // Coerce all args first (spec step 2), propagating errors
                 let mut coerced = Vec::with_capacity(args.len());
@@ -2235,7 +2213,7 @@ impl Interpreter {
                 let mut result = f64::NEG_INFINITY;
                 for n in coerced {
                     if n.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     // +0 is considered greater than -0
                     if n > result
@@ -2247,7 +2225,7 @@ impl Interpreter {
                         result = n;
                     }
                 }
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2258,7 +2236,7 @@ impl Interpreter {
             2,
             |interp, _this, args| {
                 if args.is_empty() {
-                    return Completion::Normal(JsValue::Number(f64::INFINITY));
+                    return Completion::Normal(JsValue::number(f64::INFINITY));
                 }
                 // Coerce all args first (spec step 2), propagating errors
                 let mut coerced = Vec::with_capacity(args.len());
@@ -2271,7 +2249,7 @@ impl Interpreter {
                 let mut result = f64::INFINITY;
                 for n in coerced {
                     if n.is_nan() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
                     // -0 is considered less than +0
                     if n < result
@@ -2283,7 +2261,7 @@ impl Interpreter {
                         result = n;
                     }
                 }
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2293,9 +2271,9 @@ impl Interpreter {
             "pow".to_string(),
             2,
             |interp, _this, args| {
-                let base = interp.to_number_coerce(args.first().unwrap_or(&JsValue::Undefined));
-                let exp = interp.to_number_coerce(args.get(1).unwrap_or(&JsValue::Undefined));
-                Completion::Normal(JsValue::Number(number_ops::exponentiate(base, exp)))
+                let base = interp.to_number_coerce(args.first().unwrap_or(&JsValue::UNDEFINED));
+                let exp = interp.to_number_coerce(args.get(1).unwrap_or(&JsValue::UNDEFINED));
+                Completion::Normal(JsValue::number(number_ops::exponentiate(base, exp)))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2305,7 +2283,7 @@ impl Interpreter {
             "random".to_string(),
             0,
             |interp, _this, _args| {
-                Completion::Normal(JsValue::Number(interp.realm_mut().math_random()))
+                Completion::Normal(JsValue::number(interp.realm_mut().math_random()))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2317,9 +2295,9 @@ impl Interpreter {
             "atan2".to_string(),
             2,
             |interp, _this, args| {
-                let y = interp.to_number_coerce(args.first().unwrap_or(&JsValue::Undefined));
-                let x = interp.to_number_coerce(args.get(1).unwrap_or(&JsValue::Undefined));
-                Completion::Normal(JsValue::Number(y.atan2(x)))
+                let y = interp.to_number_coerce(args.first().unwrap_or(&JsValue::UNDEFINED));
+                let x = interp.to_number_coerce(args.get(1).unwrap_or(&JsValue::UNDEFINED));
+                Completion::Normal(JsValue::number(y.atan2(x)))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2332,7 +2310,7 @@ impl Interpreter {
             2,
             |interp, _this, args| {
                 if args.is_empty() {
-                    return Completion::Normal(JsValue::Number(0.0));
+                    return Completion::Normal(JsValue::number(0.0));
                 }
                 // Step 1-2: coerce all args to numbers first, propagating errors
                 let mut coerced = Vec::with_capacity(args.len());
@@ -2347,7 +2325,7 @@ impl Interpreter {
                 let mut sum = 0.0f64;
                 for n in &coerced {
                     if n.is_infinite() {
-                        return Completion::Normal(JsValue::Number(f64::INFINITY));
+                        return Completion::Normal(JsValue::number(f64::INFINITY));
                     }
                     if n.is_nan() {
                         has_nan = true;
@@ -2356,9 +2334,9 @@ impl Interpreter {
                     }
                 }
                 if has_nan {
-                    return Completion::Normal(JsValue::Number(f64::NAN));
+                    return Completion::Normal(JsValue::number(f64::NAN));
                 }
-                Completion::Normal(JsValue::Number(sum.sqrt()))
+                Completion::Normal(JsValue::number(sum.sqrt()))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2371,7 +2349,7 @@ impl Interpreter {
             1,
             |_interp, _this, args| {
                 let x = args.first().map(to_number).unwrap_or(f64::NAN);
-                Completion::Normal(JsValue::Number(x.log2()))
+                Completion::Normal(JsValue::number(x.log2()))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2382,7 +2360,7 @@ impl Interpreter {
             1,
             |_interp, _this, args| {
                 let x = args.first().map(to_number).unwrap_or(f64::NAN);
-                Completion::Normal(JsValue::Number(x.log10()))
+                Completion::Normal(JsValue::number(x.log10()))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2394,8 +2372,8 @@ impl Interpreter {
             "fround".to_string(),
             1,
             |interp, _this, args| {
-                let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::Undefined));
-                Completion::Normal(JsValue::Number((x as f32) as f64))
+                let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::UNDEFINED));
+                Completion::Normal(JsValue::number((x as f32) as f64))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2407,9 +2385,9 @@ impl Interpreter {
             "clz32".to_string(),
             1,
             |interp, _this, args| {
-                let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::Undefined));
+                let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::UNDEFINED));
                 let n = number_ops::to_uint32(x);
-                Completion::Normal(JsValue::Number(n.leading_zeros() as f64))
+                Completion::Normal(JsValue::number(n.leading_zeros() as f64))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2425,7 +2403,7 @@ impl Interpreter {
                 let b = args.get(1).map(to_number).unwrap_or(0.0);
                 let ia = number_ops::to_int32(a);
                 let ib = number_ops::to_int32(b);
-                Completion::Normal(JsValue::Number(ia.wrapping_mul(ib) as f64))
+                Completion::Normal(JsValue::number(ia.wrapping_mul(ib) as f64))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2449,8 +2427,8 @@ impl Interpreter {
                 name.to_string(),
                 1,
                 move |interp, _this, args| {
-                    let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::Undefined));
-                    Completion::Normal(JsValue::Number(op(x)))
+                    let x = interp.to_number_coerce(args.first().unwrap_or(&JsValue::UNDEFINED));
+                    Completion::Normal(JsValue::number(op(x)))
                 },
             ));
             self.get_object_cell_expect(math_obj_id)
@@ -2463,12 +2441,12 @@ impl Interpreter {
             "f16round".to_string(),
             1,
             |interp, _this, args| {
-                let x = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let x = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let n = match interp.to_number_value(&x) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 };
-                Completion::Normal(JsValue::Number(f64_to_f16_to_f64(n)))
+                Completion::Normal(JsValue::number(f64_to_f16_to_f64(n)))
             },
         ));
         self.get_object_cell_expect(math_obj_id)
@@ -2480,7 +2458,7 @@ impl Interpreter {
             "sumPrecise".to_string(),
             1,
             |interp, _this, args| {
-                let items = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let items = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let iterator = match interp.get_iterator(&items) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
@@ -2499,18 +2477,15 @@ impl Interpreter {
                     let value = match interp.iterator_value(&next) {
                         Ok(v) => v,
                         Err(e) => {
-                            interp.iterator_close(&iterator, JsValue::Undefined);
+                            interp.iterator_close(&iterator, JsValue::UNDEFINED);
                             return Completion::Throw(e);
                         }
                     };
-                    let n = match &value {
-                        JsValue::Number(n) => *n,
-                        _ => {
-                            interp.iterator_close(&iterator, JsValue::Undefined);
-                            return Completion::Throw(interp.create_type_error(
-                                "Math.sumPrecise requires all values to be Numbers",
-                            ));
-                        }
+                    let Some(n) = value.as_number() else {
+                        interp.iterator_close(&iterator, JsValue::UNDEFINED);
+                        return Completion::Throw(interp.create_type_error(
+                            "Math.sumPrecise requires all values to be Numbers",
+                        ));
                     };
                     if n.is_nan() {
                         has_nan = true;
@@ -2530,19 +2505,19 @@ impl Interpreter {
                     }
                 }
                 if has_nan || (pos_inf > 0 && neg_inf > 0) {
-                    return Completion::Normal(JsValue::Number(f64::NAN));
+                    return Completion::Normal(JsValue::number(f64::NAN));
                 }
                 if pos_inf > 0 {
-                    return Completion::Normal(JsValue::Number(f64::INFINITY));
+                    return Completion::Normal(JsValue::number(f64::INFINITY));
                 }
                 if neg_inf > 0 {
-                    return Completion::Normal(JsValue::Number(f64::NEG_INFINITY));
+                    return Completion::Normal(JsValue::number(f64::NEG_INFINITY));
                 }
                 let result = sum_precise_shewchuk(&finite_vals);
                 if result == 0.0 && !has_non_neg_zero {
-                    Completion::Normal(JsValue::Number(-0.0))
+                    Completion::Normal(JsValue::number(-0.0))
                 } else {
-                    Completion::Normal(JsValue::Number(result))
+                    Completion::Normal(JsValue::number(result))
                 }
             },
         ));
@@ -2553,7 +2528,7 @@ impl Interpreter {
         // @@toStringTag
         self.define_to_string_tag(math_obj_id, "Math");
 
-        let math_val = JsValue::Object(crate::types::JsObject { id: math_id });
+        let math_val = JsValue::object(math_id);
         self.realm()
             .global_env
             .borrow_mut()
@@ -2579,8 +2554,8 @@ impl Interpreter {
                     result
                 },
             ));
-            if let JsValue::Object(ref o) = eval_fn {
-                self.realm_mut().builtin_eval_id = Some(o.id);
+            if let Some(eval_id) = eval_fn.as_object_id() {
+                self.realm_mut().builtin_eval_id = Some(eval_id);
             }
             let global_env = self.realm().global_env.clone();
             global_env.borrow_mut().declare("eval", BindingKind::Var);
@@ -2591,7 +2566,7 @@ impl Interpreter {
             "$DONOTEVALUATE",
             BindingKind::Var,
             JsFunction::native("$DONOTEVALUATE".to_string(), 0, |_interp, _this, _args| {
-                Completion::Throw(JsValue::String(JsString::from_str(
+                Completion::Throw(JsValue::string(JsString::from_str(
                     "Test262: $DONOTEVALUATE was called",
                 )))
             }),
@@ -2717,8 +2692,8 @@ impl Interpreter {
                             Err(e) => return Completion::Throw(e),
                         };
                         if let Some(p) = proto
-                            && let JsValue::Object(fo) = &result
-                            && let Some(fobj) = interp.get_object_cell(fo.id)
+                            && let Some(result_id) = result.as_object_id()
+                            && let Some(fobj) = interp.get_object_cell(result_id)
                         {
                             fobj.borrow_mut().prototype_id = Some(p);
                         }
@@ -2731,8 +2706,8 @@ impl Interpreter {
                 },
             ));
             // Parse-before-getprototype: body is parsed before prototype lookup
-            if let JsValue::Object(ref fo) = fn_ctor_fn
-                && let Some(func_obj) = self.get_object_cell(fo.id)
+            if let Some(function_id) = fn_ctor_fn.as_object_id()
+                && let Some(func_obj) = self.get_object_cell(function_id)
             {
                 func_obj.borrow_mut().deferred_construct = true;
             }
@@ -2754,14 +2729,14 @@ impl Interpreter {
                 if !b.properties.contains_key("length") {
                     b.insert_property(
                         "length".to_string(),
-                        PropertyDescriptor::data(JsValue::Number(0.0), false, false, true),
+                        PropertyDescriptor::data(JsValue::number(0.0), false, false, true),
                     );
                 }
                 if !b.properties.contains_key("name") {
                     b.insert_property(
                         "name".to_string(),
                         PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str("")),
+                            JsValue::string(JsString::from_str("")),
                             false,
                             false,
                             true,
@@ -2770,24 +2745,24 @@ impl Interpreter {
                 }
             } else {
                 let func_val = self.get_global_var("Function");
-                if let Some(JsValue::Object(fo)) = func_val {
-                    let pv = self.get_property_on_id(fo.id, "prototype");
-                    if let JsValue::Object(pr) = pv
-                        && let Some(proto_obj) = self.get_object_cell(pr.id)
+                if let Some(function_id) = func_val.and_then(|v| v.as_object_id()) {
+                    let pv = self.get_property_on_id(function_id, "prototype");
+                    if let Some(proto_id) = pv.as_object_id()
+                        && let Some(proto_obj) = self.get_object_cell(proto_id)
                     {
                         proto_obj.borrow_mut().callable = Some(JsFunction::native(
                             "".to_string(),
                             0,
-                            |_interp, _this, _args| Completion::Normal(JsValue::Undefined),
+                            |_interp, _this, _args| Completion::Normal(JsValue::UNDEFINED),
                         ));
                         proto_obj.borrow_mut().insert_property(
                             "length".to_string(),
-                            PropertyDescriptor::data(JsValue::Number(0.0), false, false, true),
+                            PropertyDescriptor::data(JsValue::number(0.0), false, false, true),
                         );
                         proto_obj.borrow_mut().insert_property(
                             "name".to_string(),
                             PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str("")),
+                                JsValue::string(JsString::from_str("")),
                                 false,
                                 false,
                                 true,
@@ -2801,8 +2776,8 @@ impl Interpreter {
         // Store Function.prototype for use as [[Prototype]] of all function objects
         {
             let func_val = self.get_global_var("Function");
-            if let Some(JsValue::Object(fo)) = func_val
-                && let Some(func_data) = self.get_object(fo.id)
+            if let Some(function_id) = func_val.and_then(|v| v.as_object_id())
+                && let Some(func_data) = self.get_object(function_id)
             {
                 // Use the early-created function_prototype if available, otherwise
                 // fall back to the auto-created one from create_function
@@ -2810,22 +2785,22 @@ impl Interpreter {
                     && let Some(existing_fp) = self.get_object(existing_fp_id)
                 {
                     // Replace the Function constructor's .prototype with our early object
-                    let fp_val = JsValue::Object(crate::types::JsObject { id: existing_fp_id });
+                    let fp_val = JsValue::object(existing_fp_id);
                     func_data.borrow_mut().insert_property(
                         "prototype".to_string(),
                         PropertyDescriptor::data(fp_val, true, false, false),
                     );
                     // Set constructor back-link
-                    let func_obj_val = JsValue::Object(crate::types::JsObject { id: fo.id });
+                    let func_obj_val = JsValue::object(function_id);
                     existing_fp.borrow_mut().insert_property(
                         "constructor".to_string(),
                         PropertyDescriptor::data(func_obj_val, true, false, true),
                     );
                     existing_fp.clone()
                 } else {
-                    let pv = self.get_property_on_id(fo.id, "prototype");
-                    if let JsValue::Object(pr) = pv {
-                        self.get_object(pr.id).unwrap()
+                    let pv = self.get_property_on_id(function_id, "prototype");
+                    if let Some(proto_id) = pv.as_object_id() {
+                        self.get_object(proto_id).unwrap()
                     } else {
                         unreachable!()
                     }
@@ -2848,7 +2823,7 @@ impl Interpreter {
                             "[Symbol.hasInstance]".to_string(),
                             1,
                             |interp, this_val, args| {
-                                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                                 interp.ordinary_has_instance(this_val, &arg)
                             },
                         ));
@@ -2886,9 +2861,8 @@ impl Interpreter {
                             "get caller".to_string(),
                             0,
                             |interp: &mut Interpreter, this_val: &JsValue, _args: &[JsValue]| {
-                                let this_id = match this_val {
-                                    JsValue::Object(o) => o.id,
-                                    _ => return Completion::Normal(JsValue::Null),
+                                let Some(this_id) = this_val.as_object_id() else {
+                                    return Completion::Normal(JsValue::NULL);
                                 };
                                 let this_realm_id = interp
                                     .function_realm_map
@@ -2905,11 +2879,11 @@ impl Interpreter {
                                 }
                                 let idx = match found_idx {
                                     Some(i) => i,
-                                    None => return Completion::Normal(JsValue::Null),
+                                    None => return Completion::Normal(JsValue::NULL),
                                 };
                                 // Scan backwards from idx, skipping eval frames
                                 if idx == 0 {
-                                    return Completion::Normal(JsValue::Null);
+                                    return Completion::Normal(JsValue::NULL);
                                 }
                                 for i in (0..idx).rev() {
                                     let frame = &interp.call_stack_frames[i];
@@ -2926,7 +2900,7 @@ impl Interpreter {
                                         .unwrap_or(interp.current_realm_id);
                                     // Do not leak cross-realm caller function objects.
                                     if caller_realm_id != this_realm_id {
-                                        return Completion::Normal(JsValue::Null);
+                                        return Completion::Normal(JsValue::NULL);
                                     }
                                     // Check if the caller is strict — return null for strict callers
                                     if let Some(obj) = interp.get_object(frame.func_obj_id)
@@ -2934,15 +2908,11 @@ impl Interpreter {
                                             &obj.borrow().callable
                                         && *is_strict
                                     {
-                                        return Completion::Normal(JsValue::Null);
+                                        return Completion::Normal(JsValue::NULL);
                                     }
-                                    return Completion::Normal(JsValue::Object(
-                                        crate::types::JsObject {
-                                            id: frame.func_obj_id,
-                                        },
-                                    ));
+                                    return Completion::Normal(JsValue::object(frame.func_obj_id));
                                 }
-                                Completion::Normal(JsValue::Null)
+                                Completion::Normal(JsValue::NULL)
                             },
                         ));
                         self.realm_mut().sloppy_caller_getter = Some(caller_getter);
@@ -2954,9 +2924,8 @@ impl Interpreter {
                             "get arguments".to_string(),
                             0,
                             |interp: &mut Interpreter, this_val: &JsValue, _args: &[JsValue]| {
-                                let this_id = match this_val {
-                                    JsValue::Object(o) => o.id,
-                                    _ => return Completion::Normal(JsValue::Null),
+                                let Some(this_id) = this_val.as_object_id() else {
+                                    return Completion::Normal(JsValue::NULL);
                                 };
                                 // Walk call_stack_frames from top to find this function's activation
                                 for i in (0..interp.call_stack_frames.len()).rev() {
@@ -2966,7 +2935,7 @@ impl Interpreter {
                                         );
                                     }
                                 }
-                                Completion::Normal(JsValue::Null)
+                                Completion::Normal(JsValue::NULL)
                             },
                         ));
                         self.realm_mut().sloppy_arguments_getter = Some(args_getter);
@@ -3009,8 +2978,8 @@ impl Interpreter {
                         .map(|b| b.value.clone())
                         .collect();
                     for val in &bindings {
-                        if let JsValue::Object(o) = val
-                            && let Some(obj) = self.get_object_cell(o.id)
+                        if let Some(obj_id) = val.as_object_id()
+                            && let Some(obj) = self.get_object_cell(obj_id)
                         {
                             fix_callable(obj, &fp);
                             // Level 2: properties of global bindings (static methods, .prototype)
@@ -3021,11 +2990,11 @@ impl Interpreter {
                                 .flat_map(collect_pd_objects)
                                 .collect();
                             for pv in &level2_vals {
-                                if let JsValue::Object(po) = pv
-                                    && let Some(pobj) = self.get_object_cell(po.id)
+                                if let Some(property_id) = pv.as_object_id()
+                                    && let Some(pobj) = self.get_object_cell(property_id)
                                 {
                                     // Don't set fp's own [[Prototype]] to itself
-                                    if Some(po.id) != fp_id {
+                                    if Some(property_id) != fp_id {
                                         fix_callable(pobj, &fp);
                                     }
                                     // Level 3: always walk into properties (including fp's own)
@@ -3036,11 +3005,11 @@ impl Interpreter {
                                         .flat_map(collect_pd_objects)
                                         .collect();
                                     for pv3 in &level3_vals {
-                                        if let JsValue::Object(po3) = pv3 {
-                                            if Some(po3.id) == fp_id {
+                                        if let Some(property_id) = pv3.as_object_id() {
+                                            if Some(property_id) == fp_id {
                                                 continue;
                                             }
-                                            if let Some(pobj3) = self.get_object_cell(po3.id) {
+                                            if let Some(pobj3) = self.get_object_cell(property_id) {
                                                 fix_callable(pobj3, &fp);
                                             }
                                         }
@@ -3102,11 +3071,11 @@ impl Interpreter {
                             .flat_map(collect_pd_objects)
                             .collect();
                         for pv in &prop_vals {
-                            if let JsValue::Object(po) = pv {
-                                if Some(po.id) == fp_id {
+                            if let Some(property_id) = pv.as_object_id() {
+                                if Some(property_id) == fp_id {
                                     continue;
                                 }
-                                if let Some(pobj) = self.get_object_cell(po.id) {
+                                if let Some(pobj) = self.get_object_cell(property_id) {
                                     fix_callable(pobj, &fp);
                                 }
                             }
@@ -3114,8 +3083,12 @@ impl Interpreter {
                     }
 
                     // Fix %ThrowTypeError% prototype (§10.2.4 step 11)
-                    if let Some(JsValue::Object(ref te)) = self.realm().throw_type_error
-                        && let Some(te_obj) = self.get_object_cell(te.id)
+                    if let Some(thrower_id) = self
+                        .realm()
+                        .throw_type_error
+                        .as_ref()
+                        .and_then(JsValue::as_object_id)
+                        && let Some(te_obj) = self.get_object_cell(thrower_id)
                     {
                         te_obj.borrow_mut().prototype_id = Some(fp.borrow().id.unwrap());
                     }
@@ -3127,11 +3100,8 @@ impl Interpreter {
         // Must happen after the Function.prototype retroactive fix above
         {
             let error_ctor_obj = self.get_global_var("Error").and_then(|v| {
-                if let JsValue::Object(o) = &v {
-                    self.get_object(o.id)
-                } else {
-                    None
-                }
+                v.as_object_id()
+                    .and_then(|error_id| self.get_object(error_id))
             });
             if let Some(err_data) = error_ctor_obj {
                 for name in [
@@ -3145,8 +3115,8 @@ impl Interpreter {
                     "AggregateError",
                 ] {
                     let ctor_val = self.get_global_var(name);
-                    if let Some(JsValue::Object(o)) = ctor_val
-                        && let Some(ctor_obj) = self.get_object_cell(o.id)
+                    if let Some(ctor_id) = ctor_val.and_then(|v| v.as_object_id())
+                        && let Some(ctor_obj) = self.get_object_cell(ctor_id)
                     {
                         ctor_obj.borrow_mut().prototype_id = Some(err_data.borrow().id.unwrap());
                     }
@@ -3164,10 +3134,11 @@ impl Interpreter {
 
             // [[Prototype]] = Function.prototype_id
             if let Some(func_val) = self.get_global_var("Function")
-                && let JsValue::Object(func_obj) = func_val
-                && let JsValue::Object(func_proto_obj) =
-                    self.get_property_on_id(func_obj.id, "prototype")
-                && let Some(func_proto) = self.get_object_cell(func_proto_obj.id)
+                && let Some(function_id) = func_val.as_object_id()
+                && let Some(function_proto_id) = self
+                    .get_property_on_id(function_id, "prototype")
+                    .as_object_id()
+                && let Some(func_proto) = self.get_object_cell(function_proto_id)
             {
                 self.get_object_cell_expect(af_proto_id)
                     .borrow_mut()
@@ -3284,13 +3255,13 @@ impl Interpreter {
                         };
                         let fn_val = interp.create_function(js_func);
                         // Apply GetPrototypeFromConstructor(newTarget, "%AsyncFunction.prototype%")
-                        if let JsValue::Object(ref fo) = fn_val {
+                        if let Some(function_id) = fn_val.as_object_id() {
                             let proto = interp.get_prototype_from_new_target_realm(|realm| {
                                 realm.async_function_prototype
                             });
                             match proto {
                                 Ok(Some(proto_rc)) => {
-                                    if let Some(fo_obj) = interp.get_object_cell(fo.id) {
+                                    if let Some(fo_obj) = interp.get_object_cell(function_id) {
                                         fo_obj.borrow_mut().prototype_id = Some(proto_rc);
                                     }
                                 }
@@ -3307,17 +3278,17 @@ impl Interpreter {
                 },
             ));
             // Wire up AsyncFunction.prototype and constructor property
-            if let JsValue::Object(af_obj) = &af_ctor
-                && let Some(af) = self.get_object(af_obj.id)
+            if let Some(async_function_id) = af_ctor.as_object_id()
+                && let Some(af) = self.get_object(async_function_id)
             {
                 // Parse-before-getprototype: body is parsed before prototype lookup
                 af.borrow_mut().deferred_construct = true;
                 // §27.7.1 %AsyncFunction% inherits from %Function%
                 let function_ctor = self
                     .get_global_var("Function")
-                    .unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(fc) = &function_ctor
-                    && let Some(fc_obj) = self.get_object_cell(fc.id)
+                    .unwrap_or(JsValue::UNDEFINED);
+                if let Some(function_id) = function_ctor.as_object_id()
+                    && let Some(fc_obj) = self.get_object_cell(function_id)
                 {
                     af.borrow_mut().prototype_id = Some(fc_obj.borrow().id.unwrap());
                 }
@@ -3325,12 +3296,7 @@ impl Interpreter {
                 // Set AsyncFunction.prototype_id
                 af.borrow_mut().insert_property(
                     "prototype".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::Object(crate::types::JsObject { id: proto_id }),
-                        false,
-                        false,
-                        false,
-                    ),
+                    PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                 );
                 // Set constructor back-reference on AsyncFunction.prototype_id
                 af_proto.borrow_mut().insert_property(
@@ -3442,13 +3408,13 @@ impl Interpreter {
                         };
                         let fn_val = interp.create_function(js_func);
                         // Apply GetPrototypeFromConstructor(newTarget, "%GeneratorFunction.prototype%")
-                        if let JsValue::Object(ref fo) = fn_val {
+                        if let Some(function_id) = fn_val.as_object_id() {
                             let proto = interp.get_prototype_from_new_target_realm(|realm| {
                                 realm.generator_function_prototype
                             });
                             match proto {
                                 Ok(Some(proto_rc)) => {
-                                    if let Some(fo_obj) = interp.get_object_cell(fo.id) {
+                                    if let Some(fo_obj) = interp.get_object_cell(function_id) {
                                         fo_obj.borrow_mut().prototype_id = Some(proto_rc);
                                     }
                                 }
@@ -3466,16 +3432,16 @@ impl Interpreter {
                 },
             ));
             // Wire up GeneratorFunction.prototype and constructor property
-            if let JsValue::Object(gf_obj) = &gf_ctor
-                && let Some(gf) = self.get_object(gf_obj.id)
+            if let Some(generator_function_id) = gf_ctor.as_object_id()
+                && let Some(gf) = self.get_object(generator_function_id)
             {
                 gf.borrow_mut().deferred_construct = true;
                 // §27.3.1 %GeneratorFunction% inherits from %Function%
                 let function_ctor = self
                     .get_global_var("Function")
-                    .unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(fc) = &function_ctor
-                    && let Some(fc_obj) = self.get_object_cell(fc.id)
+                    .unwrap_or(JsValue::UNDEFINED);
+                if let Some(function_id) = function_ctor.as_object_id()
+                    && let Some(fc_obj) = self.get_object_cell(function_id)
                 {
                     gf.borrow_mut().prototype_id = Some(fc_obj.borrow().id.unwrap());
                 }
@@ -3483,12 +3449,7 @@ impl Interpreter {
                 // Set GeneratorFunction.prototype_id
                 gf.borrow_mut().insert_property(
                     "prototype".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::Object(crate::types::JsObject { id: proto_id }),
-                        false,
-                        false,
-                        false,
-                    ),
+                    PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                 );
                 // Set constructor back-reference on GeneratorFunction.prototype_id
                 gf_proto.borrow_mut().insert_property(
@@ -3602,13 +3563,13 @@ impl Interpreter {
                         };
                         let fn_val = interp.create_function(js_func);
                         // Apply GetPrototypeFromConstructor(newTarget, "%AsyncGeneratorFunction.prototype%")
-                        if let JsValue::Object(ref fo) = fn_val {
+                        if let Some(function_id) = fn_val.as_object_id() {
                             let proto = interp.get_prototype_from_new_target_realm(|realm| {
                                 realm.async_generator_function_prototype
                             });
                             match proto {
                                 Ok(Some(proto_rc)) => {
-                                    if let Some(fo_obj) = interp.get_object_cell(fo.id) {
+                                    if let Some(fo_obj) = interp.get_object_cell(function_id) {
                                         fo_obj.borrow_mut().prototype_id = Some(proto_rc);
                                     }
                                 }
@@ -3626,16 +3587,16 @@ impl Interpreter {
                 },
             ));
             // Wire up AsyncGeneratorFunction.prototype and constructor property
-            if let JsValue::Object(agf_obj) = &agf_ctor
-                && let Some(agf) = self.get_object(agf_obj.id)
+            if let Some(async_generator_function_id) = agf_ctor.as_object_id()
+                && let Some(agf) = self.get_object(async_generator_function_id)
             {
                 agf.borrow_mut().deferred_construct = true;
                 // §27.4.1 %AsyncGeneratorFunction% inherits from %Function%
                 let function_ctor = self
                     .get_global_var("Function")
-                    .unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(fc) = &function_ctor
-                    && let Some(fc_obj) = self.get_object_cell(fc.id)
+                    .unwrap_or(JsValue::UNDEFINED);
+                if let Some(function_id) = function_ctor.as_object_id()
+                    && let Some(fc_obj) = self.get_object_cell(function_id)
                 {
                     agf.borrow_mut().prototype_id = Some(fc_obj.borrow().id.unwrap());
                 }
@@ -3643,12 +3604,7 @@ impl Interpreter {
                 // Set AsyncGeneratorFunction.prototype_id
                 agf.borrow_mut().insert_property(
                     "prototype".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::Object(crate::types::JsObject { id: proto_id }),
-                        false,
-                        false,
-                        false,
-                    ),
+                    PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                 );
                 // Set constructor back-reference on AsyncGeneratorFunction.prototype_id
                 agf_proto.borrow_mut().insert_property(
@@ -3664,53 +3620,55 @@ impl Interpreter {
             "stringify".to_string(),
             3,
             |interp, _this, args: &[JsValue]| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let replacer_arg = args.get(1).cloned();
-                let space_arg = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let space_arg = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // Process space argument per spec (ToNumber for Number objects, ToString for String objects)
                 let mut space_val = space_arg;
-                if let JsValue::Object(o) = &space_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(space_id) = space_val.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(space_id)
                 {
                     let cn = obj.borrow().class_name.clone();
                     if cn == "Number" {
                         match interp.to_number_value(&space_val) {
-                            Ok(n) => space_val = JsValue::Number(n),
+                            Ok(n) => space_val = JsValue::number(n),
                             Err(e) => return Completion::Throw(e),
                         }
                     } else if cn == "String" {
                         match interp.to_string_value(&space_val) {
-                            Ok(s) => space_val = JsValue::String(JsString::from_str(&s)),
+                            Ok(s) => space_val = JsValue::string(JsString::from_str(&s)),
                             Err(e) => return Completion::Throw(e),
                         }
                     }
                 }
-                let gap = match &space_val {
-                    JsValue::Number(n) => {
-                        let count = (*n as i64).clamp(0, 10) as usize;
-                        " ".repeat(count)
+                let gap = if let Some(n) = space_val.as_number() {
+                    let count = (n as i64).clamp(0, 10) as usize;
+                    " ".repeat(count)
+                } else if let Some(s) = space_val.as_string() {
+                    let rs = s.to_rust_string();
+                    if rs.len() > 10 {
+                        rs[..10].to_string()
+                    } else {
+                        rs
                     }
-                    JsValue::String(s) => {
-                        let rs = s.to_rust_string();
-                        if rs.len() > 10 {
-                            rs[..10].to_string()
-                        } else {
-                            rs
-                        }
-                    }
-                    _ => String::new(),
+                } else {
+                    String::new()
                 };
 
-                let replacer = if matches!(&replacer_arg, Some(JsValue::Undefined) | None) {
+                let replacer_is_undefined = match &replacer_arg {
+                    Some(value) => value.is_undefined(),
+                    None => true,
+                };
+                let replacer = if replacer_is_undefined {
                     None
                 } else {
                     replacer_arg
                 };
 
                 match json_stringify_full(interp, &val, &replacer, &gap) {
-                    Ok(Some(s)) => Completion::Normal(JsValue::String(JsString::from_str(&s))),
-                    Ok(None) => Completion::Normal(JsValue::Undefined),
+                    Ok(Some(s)) => Completion::Normal(JsValue::string(JsString::from_str(&s))),
+                    Ok(None) => Completion::Normal(JsValue::UNDEFINED),
                     Err(e) => Completion::Throw(e),
                 }
             },
@@ -3719,21 +3677,22 @@ impl Interpreter {
             "parse".to_string(),
             2,
             |interp, _this, args: &[JsValue]| {
-                let raw = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let raw = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let s = match interp.to_string_value(&raw) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
                 };
                 let reviver = args.get(1).cloned();
 
-                let has_reviver = if let Some(JsValue::Object(rev_obj)) = &reviver {
-                    interp
-                        .get_object_cell(rev_obj.id)
-                        .map(|o| o.borrow().callable.is_some())
-                        .unwrap_or(false)
-                } else {
-                    false
-                };
+                let has_reviver =
+                    if let Some(reviver_id) = reviver.as_ref().and_then(JsValue::as_object_id) {
+                        interp
+                            .get_object_cell(reviver_id)
+                            .map(|o| o.borrow().callable.is_some())
+                            .unwrap_or(false)
+                    } else {
+                        false
+                    };
 
                 if has_reviver {
                     let (result, smap) = json_parse_value_with_source(interp, &s);
@@ -3755,8 +3714,7 @@ impl Interpreter {
                             } else {
                                 Some(smap)
                             };
-                            let wrapper_val =
-                                JsValue::Object(crate::types::JsObject { id: wrapper_id });
+                            let wrapper_val = JsValue::object(wrapper_id);
                             json_internalize(
                                 interp,
                                 &wrapper_val,
@@ -3776,7 +3734,7 @@ impl Interpreter {
             "rawJSON".to_string(),
             1,
             |interp, _this, args: &[JsValue]| {
-                let raw = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let raw = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let text = match interp.to_string_value(&raw) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
@@ -3818,7 +3776,7 @@ impl Interpreter {
                 {
                     let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                     let desc = PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str(&text)),
+                        JsValue::string(JsString::from_str(&text)),
                         false,
                         true,
                         false,
@@ -3836,20 +3794,20 @@ impl Interpreter {
                     .borrow_mut()
                     .is_raw_json = true;
                 let id = obj_id;
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
         let json_is_raw_json = self.create_function(JsFunction::native(
             "isRawJSON".to_string(),
             1,
             |interp, _this, args: &[JsValue]| {
-                let val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = &val
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(value_id) = val.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(value_id)
                 {
-                    return Completion::Normal(JsValue::Boolean(obj.borrow().is_raw_json));
+                    return Completion::Normal(JsValue::boolean(obj.borrow().is_raw_json));
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(json_obj_id)
@@ -3866,7 +3824,7 @@ impl Interpreter {
             .insert_builtin("isRawJSON".to_string(), json_is_raw_json);
         // @@toStringTag
         self.define_to_string_tag(json_obj_id, "JSON");
-        let json_val = JsValue::Object(crate::types::JsObject { id: json_obj_id });
+        let json_val = JsValue::object(json_obj_id);
         self.realm()
             .global_env
             .borrow_mut()
@@ -3877,7 +3835,7 @@ impl Interpreter {
         // String.fromCharCode
         {
             let string_ctor = self.get_global_var("String");
-            if let Some(JsValue::Object(ref o)) = string_ctor {
+            if let Some(string_ctor_id) = string_ctor.and_then(|v| v.as_object_id()) {
                 let from_char_code = self.create_function(JsFunction::native(
                     "fromCharCode".to_string(),
                     1,
@@ -3904,7 +3862,7 @@ impl Interpreter {
                             };
                             code_units.push(cu);
                         }
-                        Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
+                        Completion::Normal(JsValue::string(JsString::from_vec(code_units)))
                     },
                 ));
                 let from_code_point = self.create_function(JsFunction::native(
@@ -3942,10 +3900,10 @@ impl Interpreter {
                                 code_units.push(cp as u16);
                             }
                         }
-                        Completion::Normal(JsValue::String(JsString::from_vec(code_units)))
+                        Completion::Normal(JsValue::string(JsString::from_vec(code_units)))
                     },
                 ));
-                if let Some(obj) = self.get_object_cell(o.id) {
+                if let Some(obj) = self.get_object_cell(string_ctor_id) {
                     obj.borrow_mut()
                         .insert_builtin("fromCharCode".to_string(), from_char_code);
                     obj.borrow_mut()
@@ -3981,7 +3939,7 @@ impl Interpreter {
 
         // globalThis - create a global object
         let global_obj_id = self.create_object_id();
-        let global_val = JsValue::Object(crate::types::JsObject { id: global_obj_id });
+        let global_val = JsValue::object(global_obj_id);
         self.realm()
             .global_env
             .borrow_mut()
@@ -4086,7 +4044,7 @@ impl Interpreter {
                 );
         }
         // Also set globalThis on itself
-        let gt_val = JsValue::Object(crate::types::JsObject { id: global_obj_id });
+        let gt_val = JsValue::object(global_obj_id);
         self.get_object_cell_expect(global_obj_id)
             .borrow_mut()
             .insert_property(
@@ -4122,8 +4080,8 @@ impl Interpreter {
             .filter_map(|name| self.get_global_var(name))
             .collect();
         for ctor_val in &ctor_vals {
-            if let JsValue::Object(o) = ctor_val
-                && let Some(ctor_obj) = self.get_object_cell(o.id)
+            if let Some(ctor_id) = ctor_val.as_object_id()
+                && let Some(ctor_obj) = self.get_object_cell(ctor_id)
             {
                 let proto_val = ctor_obj.borrow().get_property_value("prototype");
                 if let Some(val) = proto_val {
@@ -4177,14 +4135,14 @@ impl Interpreter {
             .global_env
             .borrow()
             .get("Object")
-            .unwrap_or(JsValue::Undefined);
-        if let JsValue::Object(ref o) = obj_func_val
-            && let Some(obj_func) = self.get_object(o.id)
+            .unwrap_or(JsValue::UNDEFINED);
+        if let Some(object_id) = obj_func_val.as_object_id()
+            && let Some(obj_func) = self.get_object(object_id)
         {
             // Get prototype property
             let proto_val = obj_func.borrow().get_property_value("prototype");
-            if let Some(JsValue::Object(ref proto_ref)) = proto_val
-                && let Some(proto_obj) = self.get_object(proto_ref.id)
+            if let Some(proto_id) = proto_val.as_ref().and_then(JsValue::as_object_id)
+                && let Some(proto_obj) = self.get_object(proto_id)
             {
                 self.realm_mut().object_prototype = Some(proto_obj.borrow().id.unwrap());
                 // Object.prototype is an immutable prototype exotic object (§10.4.7)
@@ -4202,11 +4160,11 @@ impl Interpreter {
                     "Test262Error",
                 ] {
                     if let Some(error_val) = self.get_global_var(name)
-                        && let JsValue::Object(o) = &error_val
+                        && let Some(error_id) = error_val.as_object_id()
                     {
-                        let pv = self.get_property_on_id(o.id, "prototype");
-                        if let JsValue::Object(p) = &pv
-                            && let Some(ep) = self.get_object(p.id)
+                        let pv = self.get_property_on_id(error_id, "prototype");
+                        if let Some(error_proto_id) = pv.as_object_id()
+                            && let Some(ep) = self.get_object(error_proto_id)
                             && ep.borrow().prototype_id.is_none()
                         {
                             ep.borrow_mut().prototype_id = Some(proto_obj.borrow().id.unwrap());
@@ -4220,7 +4178,7 @@ impl Interpreter {
                     1,
                     |interp, this_val, args| {
                         // Step 1: ToPropertyKey(V) first
-                        let key_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let key_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let key = match interp.to_property_key(&key_val) {
                             Ok(k) => k,
                             Err(e) => return Completion::Throw(e),
@@ -4230,18 +4188,17 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        if let JsValue::Object(ref obj_ref) = o {
-                            match interp.proxy_get_own_property_descriptor(obj_ref.id, &key) {
+                        if let Some(obj_id) = o.as_object_id() {
+                            match interp.proxy_get_own_property_descriptor(obj_id, &key) {
                                 Ok(desc_val) => {
-                                    return Completion::Normal(JsValue::Boolean(!matches!(
-                                        desc_val,
-                                        JsValue::Undefined
-                                    )));
+                                    return Completion::Normal(JsValue::boolean(
+                                        !(desc_val).is_undefined(),
+                                    ));
                                 }
                                 Err(e) => return Completion::Throw(e),
                             }
                         }
-                        Completion::Normal(JsValue::Boolean(false))
+                        Completion::Normal(JsValue::boolean(false))
                     },
                 ));
                 proto_obj
@@ -4253,13 +4210,13 @@ impl Interpreter {
                     "toString".to_string(),
                     0,
                     |interp, this_val, _args| {
-                        if matches!(this_val, JsValue::Undefined) {
-                            return Completion::Normal(JsValue::String(JsString::from_str(
+                        if (this_val).is_undefined() {
+                            return Completion::Normal(JsValue::string(JsString::from_str(
                                 "[object Undefined]",
                             )));
                         }
-                        if matches!(this_val, JsValue::Null) {
-                            return Completion::Normal(JsValue::String(JsString::from_str(
+                        if (this_val).is_null() {
+                            return Completion::Normal(JsValue::string(JsString::from_str(
                                 "[object Null]",
                             )));
                         }
@@ -4267,15 +4224,15 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        if let JsValue::Object(ref obj_ref) = o {
+                        if let Some(obj_id) = o.as_object_id() {
                             // Step 4: IsArray (recursive for proxies)
-                            let is_array = match is_array_value(interp, obj_ref.id) {
+                            let is_array = match is_array_value(interp, obj_id) {
                                 Ok(v) => v,
                                 Err(e) => return Completion::Throw(e),
                             };
                             let builtin_tag = if is_array {
                                 "Array"
-                            } else if let Some(obj) = interp.get_object(obj_ref.id) {
+                            } else if let Some(obj) = interp.get_object(obj_id) {
                                 let ob = obj.borrow();
                                 if ob.class_name == "Arguments" {
                                     "Arguments"
@@ -4311,18 +4268,19 @@ impl Interpreter {
                             };
                             // Step 15: Let tag be ? Get(O, @@toStringTag).
                             let tag_key = JsPropertyKey::well_known_symbol("toStringTag");
-                            let tag_result = interp.get_object_property(obj_ref.id, &tag_key, &o);
+                            let tag_result = interp.get_object_property(obj_id, &tag_key, &o);
                             let tag = match tag_result {
-                                Completion::Normal(JsValue::String(s)) => s.to_string(),
-                                Completion::Normal(_) => builtin_tag.to_string(),
+                                Completion::Normal(value) => value
+                                    .as_string()
+                                    .map_or_else(|| builtin_tag.to_string(), |s| s.to_string()),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 _ => builtin_tag.to_string(),
                             };
-                            Completion::Normal(JsValue::String(JsString::from_str(&format!(
+                            Completion::Normal(JsValue::string(JsString::from_str(&format!(
                                 "[object {tag}]"
                             ))))
                         } else {
-                            Completion::Normal(JsValue::String(JsString::from_str(
+                            Completion::Normal(JsValue::string(JsString::from_str(
                                 "[object Object]",
                             )))
                         }
@@ -4360,10 +4318,10 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        if let JsValue::Object(ref obj_ref) = obj {
+                        if let Some(obj_id) = obj.as_object_id() {
                             // [[Get]] with receiver = O (the original value, possibly primitive)
                             let to_string_fn =
-                                match interp.get_object_property(obj_ref.id, "toString", &o) {
+                                match interp.get_object_property(obj_id, "toString", &o) {
                                     Completion::Normal(v) => v,
                                     other => return other,
                                 };
@@ -4384,7 +4342,7 @@ impl Interpreter {
                     "propertyIsEnumerable".to_string(),
                     1,
                     |interp, this_val, args| {
-                        let key_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let key_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let key = match interp.to_property_key(&key_val) {
                             Ok(k) => k,
                             Err(e) => return Completion::Throw(e),
@@ -4393,25 +4351,25 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        if let JsValue::Object(ref obj_ref) = o {
+                        if let Some(obj_id) = o.as_object_id() {
                             // Use proxy-aware [[GetOwnProperty]]
-                            match interp.proxy_get_own_property_descriptor(obj_ref.id, &key) {
+                            match interp.proxy_get_own_property_descriptor(obj_id, &key) {
                                 Ok(desc_val) => {
-                                    if matches!(desc_val, JsValue::Undefined) {
-                                        return Completion::Normal(JsValue::Boolean(false));
+                                    if (desc_val).is_undefined() {
+                                        return Completion::Normal(JsValue::boolean(false));
                                     }
                                     // Convert result to PropertyDescriptor to check enumerable
                                     if let Ok(desc) = interp.to_property_descriptor(&desc_val) {
-                                        return Completion::Normal(JsValue::Boolean(
+                                        return Completion::Normal(JsValue::boolean(
                                             desc.enumerable != Some(false),
                                         ));
                                     }
-                                    return Completion::Normal(JsValue::Boolean(false));
+                                    return Completion::Normal(JsValue::boolean(false));
                                 }
                                 Err(e) => return Completion::Throw(e),
                             }
                         }
-                        Completion::Normal(JsValue::Boolean(false))
+                        Completion::Normal(JsValue::boolean(false))
                     },
                 ));
                 proto_obj
@@ -4423,16 +4381,15 @@ impl Interpreter {
                     "isPrototypeOf".to_string(),
                     1,
                     |interp, this_val, args| {
-                        let mut v = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        if !matches!(v, JsValue::Object(_)) {
-                            return Completion::Normal(JsValue::Boolean(false));
+                        let mut v = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                        if !(v).is_object() {
+                            return Completion::Normal(JsValue::boolean(false));
                         }
                         let o = match interp.to_object(this_val) {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        while let JsValue::Object(ref vo) = v {
-                            let v_id = vo.id;
+                        while let Some(v_id) = v.as_object_id() {
                             // Use proxy-aware [[GetPrototypeOf]]
                             let proto = if let Some(obj) = interp.get_object(v_id) {
                                 if obj.borrow().is_proxy() || obj.borrow().is_proxy_revoked() {
@@ -4444,25 +4401,27 @@ impl Interpreter {
                                     match obj.borrow().prototype_id {
                                         Some(p) => {
                                             let pid = p;
-                                            JsValue::Object(crate::types::JsObject { id: pid })
+                                            JsValue::object(pid)
                                         }
-                                        None => JsValue::Null,
+                                        None => JsValue::NULL,
                                     }
                                 }
                             } else {
                                 break;
                             };
-                            if matches!(proto, JsValue::Null) {
+                            if (proto).is_null() {
                                 break;
                             }
-                            if let (JsValue::Object(po), JsValue::Object(oo)) = (&proto, &o)
-                                && po.id == oo.id
+                            if proto
+                                .as_object_id()
+                                .zip(o.as_object_id())
+                                .is_some_and(|(proto_id, object_id)| proto_id == object_id)
                             {
-                                return Completion::Normal(JsValue::Boolean(true));
+                                return Completion::Normal(JsValue::boolean(true));
                             }
                             v = proto;
                         }
-                        Completion::Normal(JsValue::Boolean(false))
+                        Completion::Normal(JsValue::boolean(false))
                     },
                 ));
                 proto_obj
@@ -4479,15 +4438,18 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        let getter = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                        if !matches!(&getter, JsValue::Object(o) if interp.get_object_cell(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
-                        {
+                        let getter = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                        let getter_is_callable = getter
+                            .as_object_id()
+                            .and_then(|id| interp.get_object_cell(id))
+                            .is_some_and(|obj| obj.borrow().callable.is_some());
+                        if !getter_is_callable {
                             return Completion::Throw(
                                 interp.create_type_error("Getter must be a function"),
                             );
                         }
                         // ToPropertyKey(P)
-                        let key_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let key_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let key = match interp.to_property_key(&key_val) {
                             Ok(k) => k,
                             Err(e) => return Completion::Throw(e),
@@ -4501,23 +4463,34 @@ impl Interpreter {
                             enumerable: Some(true),
                             configurable: Some(true),
                         };
-                        if let JsValue::Object(ref obj_ref) = o {
-                            let is_proxy = interp.get_object_cell(obj_ref.id)
-                                .map(|obj| { let b = obj.borrow(); b.is_proxy() || b.is_proxy_revoked() })
+                        if let Some(obj_id) = o.as_object_id() {
+                            let is_proxy = interp
+                                .get_object_cell(obj_id)
+                                .map(|obj| {
+                                    let b = obj.borrow();
+                                    b.is_proxy() || b.is_proxy_revoked()
+                                })
                                 .unwrap_or(false);
                             if is_proxy {
                                 let desc_val = interp.from_property_descriptor(&desc);
-                                match interp.proxy_define_own_property(obj_ref.id, key, &desc_val) {
+                                match interp.proxy_define_own_property(obj_id, key, &desc_val) {
                                     Ok(true) => {}
-                                    Ok(false) => return Completion::Throw(interp.create_type_error("Cannot define property")),
+                                    Ok(false) => {
+                                        return Completion::Throw(
+                                            interp.create_type_error("Cannot define property"),
+                                        );
+                                    }
                                     Err(e) => return Completion::Throw(e),
                                 }
-                            } else if let Some(obj) = interp.get_object(obj_ref.id)
-                                && !obj.borrow_mut().define_own_property(key, desc) {
-                                    return Completion::Throw(interp.create_type_error("Cannot define property"));
-                                }
+                            } else if let Some(obj) = interp.get_object(obj_id)
+                                && !obj.borrow_mut().define_own_property(key, desc)
+                            {
+                                return Completion::Throw(
+                                    interp.create_type_error("Cannot define property"),
+                                );
+                            }
                         }
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     },
                 ));
                 proto_obj
@@ -4534,14 +4507,17 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        let setter = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                        if !matches!(&setter, JsValue::Object(o) if interp.get_object_cell(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
-                        {
+                        let setter = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                        let setter_is_callable = setter
+                            .as_object_id()
+                            .and_then(|id| interp.get_object_cell(id))
+                            .is_some_and(|obj| obj.borrow().callable.is_some());
+                        if !setter_is_callable {
                             return Completion::Throw(
                                 interp.create_type_error("Setter must be a function"),
                             );
                         }
-                        let key_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let key_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let key = match interp.to_property_key(&key_val) {
                             Ok(k) => k,
                             Err(e) => return Completion::Throw(e),
@@ -4554,23 +4530,34 @@ impl Interpreter {
                             enumerable: Some(true),
                             configurable: Some(true),
                         };
-                        if let JsValue::Object(ref obj_ref) = o {
-                            let is_proxy = interp.get_object_cell(obj_ref.id)
-                                .map(|obj| { let b = obj.borrow(); b.is_proxy() || b.is_proxy_revoked() })
+                        if let Some(obj_id) = o.as_object_id() {
+                            let is_proxy = interp
+                                .get_object_cell(obj_id)
+                                .map(|obj| {
+                                    let b = obj.borrow();
+                                    b.is_proxy() || b.is_proxy_revoked()
+                                })
                                 .unwrap_or(false);
                             if is_proxy {
                                 let desc_val = interp.from_property_descriptor(&desc);
-                                match interp.proxy_define_own_property(obj_ref.id, key, &desc_val) {
+                                match interp.proxy_define_own_property(obj_id, key, &desc_val) {
                                     Ok(true) => {}
-                                    Ok(false) => return Completion::Throw(interp.create_type_error("Cannot define property")),
+                                    Ok(false) => {
+                                        return Completion::Throw(
+                                            interp.create_type_error("Cannot define property"),
+                                        );
+                                    }
                                     Err(e) => return Completion::Throw(e),
                                 }
-                            } else if let Some(obj) = interp.get_object(obj_ref.id)
-                                && !obj.borrow_mut().define_own_property(key, desc) {
-                                    return Completion::Throw(interp.create_type_error("Cannot define property"));
-                                }
+                            } else if let Some(obj) = interp.get_object(obj_id)
+                                && !obj.borrow_mut().define_own_property(key, desc)
+                            {
+                                return Completion::Throw(
+                                    interp.create_type_error("Cannot define property"),
+                                );
+                            }
                         }
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     },
                 ));
                 proto_obj
@@ -4587,26 +4574,25 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        let key_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let key_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let key = match interp.to_property_key(&key_val) {
                             Ok(k) => k,
                             Err(e) => return Completion::Throw(e),
                         };
-                        while let JsValue::Object(ref o) = current {
-                            let obj_id = o.id;
+                        while let Some(obj_id) = current.as_object_id() {
                             // Step 4a: O.[[GetOwnProperty]](key) (proxy-aware)
                             let desc_val =
                                 match interp.proxy_get_own_property_descriptor(obj_id, &key) {
                                     Ok(v) => v,
                                     Err(e) => return Completion::Throw(e),
                                 };
-                            if !matches!(desc_val, JsValue::Undefined) {
+                            if !(desc_val).is_undefined() {
                                 if let Ok(desc) = interp.to_property_descriptor(&desc_val)
                                     && let Some(g) = desc.get
                                 {
                                     return Completion::Normal(g);
                                 }
-                                return Completion::Normal(JsValue::Undefined);
+                                return Completion::Normal(JsValue::UNDEFINED);
                             }
                             // Step 4c: O.[[GetPrototypeOf]]() (proxy-aware)
                             let is_proxy = interp
@@ -4625,19 +4611,19 @@ impl Interpreter {
                                 match obj.borrow().prototype_id {
                                     Some(p) => {
                                         let pid = p;
-                                        JsValue::Object(crate::types::JsObject { id: pid })
+                                        JsValue::object(pid)
                                     }
-                                    None => JsValue::Null,
+                                    None => JsValue::NULL,
                                 }
                             } else {
                                 break;
                             };
-                            if matches!(proto, JsValue::Null) {
+                            if (proto).is_null() {
                                 break;
                             }
                             current = proto;
                         }
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     },
                 ));
                 proto_obj
@@ -4654,25 +4640,24 @@ impl Interpreter {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        let key_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let key_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let key = match interp.to_property_key(&key_val) {
                             Ok(k) => k,
                             Err(e) => return Completion::Throw(e),
                         };
-                        while let JsValue::Object(ref o) = current {
-                            let obj_id = o.id;
+                        while let Some(obj_id) = current.as_object_id() {
                             let desc_val =
                                 match interp.proxy_get_own_property_descriptor(obj_id, &key) {
                                     Ok(v) => v,
                                     Err(e) => return Completion::Throw(e),
                                 };
-                            if !matches!(desc_val, JsValue::Undefined) {
+                            if !(desc_val).is_undefined() {
                                 if let Ok(desc) = interp.to_property_descriptor(&desc_val)
                                     && let Some(s) = desc.set
                                 {
                                     return Completion::Normal(s);
                                 }
-                                return Completion::Normal(JsValue::Undefined);
+                                return Completion::Normal(JsValue::UNDEFINED);
                             }
                             let is_proxy = interp
                                 .get_object_cell(obj_id)
@@ -4690,19 +4675,19 @@ impl Interpreter {
                                 match obj.borrow().prototype_id {
                                     Some(p) => {
                                         let pid = p;
-                                        JsValue::Object(crate::types::JsObject { id: pid })
+                                        JsValue::object(pid)
                                     }
-                                    None => JsValue::Null,
+                                    None => JsValue::NULL,
                                 }
                             } else {
                                 break;
                             };
-                            if matches!(proto, JsValue::Null) {
+                            if (proto).is_null() {
                                 break;
                             }
                             current = proto;
                         }
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     },
                 ));
                 proto_obj
@@ -4718,11 +4703,11 @@ impl Interpreter {
                         let obj_val = match interp.to_object(this_val) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => return Completion::Normal(JsValue::Undefined),
+                            _ => return Completion::Normal(JsValue::UNDEFINED),
                         };
                         // 2. Return ? O.[[GetPrototypeOf]]()
-                        if let JsValue::Object(ref o) = obj_val
-                            && let Some(obj) = interp.get_object(o.id)
+                        if let Some(obj_id) = obj_val.as_object_id()
+                            && let Some(obj) = interp.get_object(obj_id)
                         {
                             // Proxy getPrototypeOf trap
                             let res = {
@@ -4730,20 +4715,18 @@ impl Interpreter {
                                 _b.is_proxy() || _b.is_proxy_revoked()
                             };
                             if res {
-                                match interp.proxy_get_prototype_of(o.id) {
+                                match interp.proxy_get_prototype_of(obj_id) {
                                     Ok(v) => return Completion::Normal(v),
                                     Err(e) => return Completion::Throw(e),
                                 }
                             }
                             return if let Some(pid) = obj.borrow().prototype_id {
-                                Completion::Normal(JsValue::Object(crate::types::JsObject {
-                                    id: pid,
-                                }))
+                                Completion::Normal(JsValue::object(pid))
                             } else {
-                                Completion::Normal(JsValue::Null)
+                                Completion::Normal(JsValue::NULL)
                             };
                         }
-                        Completion::Normal(JsValue::Null)
+                        Completion::Normal(JsValue::NULL)
                     },
                 ));
                 let proto_setter = self.create_function(JsFunction::native(
@@ -4751,58 +4734,55 @@ impl Interpreter {
                     1,
                     |interp, this_val, args| {
                         // 1. Let O be ? RequireObjectCoercible(this value).
-                        if matches!(this_val, JsValue::Undefined | JsValue::Null) {
+                        if (this_val).is_nullish() {
                             return Completion::Throw(interp.create_type_error(
                                 "Cannot convert undefined or null to object",
                             ));
                         }
-                        let proto = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let proto = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         // 2. If Type(proto) is neither Object nor Null, return undefined.
-                        if !matches!(proto, JsValue::Object(_) | JsValue::Null) {
-                            return Completion::Normal(JsValue::Undefined);
+                        if !proto.is_object() && !proto.is_null() {
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
                         // 3. If Type(O) is not Object, return undefined.
-                        if !matches!(this_val, JsValue::Object(_)) {
-                            return Completion::Normal(JsValue::Undefined);
+                        if !(this_val).is_object() {
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
                         // 4. Let status be ? O.[[SetPrototypeOf]](proto).
-                        if let JsValue::Object(o) = this_val
-                            && let Some(obj) = interp.get_object(o.id) {
+                        if let Some(this_id) = this_val.as_object_id()
+                            && let Some(obj) = interp.get_object(this_id) {
                                 let res = { let _b = obj.borrow(); _b.is_proxy() || _b.is_proxy_revoked() }; if res {
-                                    match interp.proxy_set_prototype_of(o.id, &proto) {
+                                    match interp.proxy_set_prototype_of(this_id, &proto) {
                                         Ok(success) => {
                                             if !success {
                                                 return Completion::Throw(interp.create_type_error(
                                                     "Object.prototype.__proto__: proxy setPrototypeOf returned false",
                                                 ));
                                             }
-                                            return Completion::Normal(JsValue::Undefined);
+                                            return Completion::Normal(JsValue::UNDEFINED);
                                         }
                                         Err(e) => return Completion::Throw(e),
                                     }
                                 }
                                 // OrdinarySetPrototypeOf: SameValue(V, current) check
                                 let current_proto_id = obj.borrow().prototype_id;
-                                let same = match (current_proto_id, &proto) {
-                                    (None, JsValue::Null) => true,
-                                    (Some(cid), JsValue::Object(p)) => cid == p.id,
-                                    _ => false,
-                                };
+                                let same = current_proto_id.is_none() && proto.is_null()
+                                    || current_proto_id
+                                        .zip(proto.as_object_id())
+                                        .is_some_and(|(current_id, proto_id)| current_id == proto_id);
                                 if same {
-                                    return Completion::Normal(JsValue::Undefined);
+                                    return Completion::Normal(JsValue::UNDEFINED);
                                 }
                                 if !obj.borrow().extensible {
                                     return Completion::Throw(interp.create_type_error(
                                         "Object is not extensible",
                                     ));
                                 }
-                                match &proto {
-                                    JsValue::Null => {
-                                        obj.borrow_mut().prototype_id = None;
-                                    }
-                                    JsValue::Object(p) => {
+                                if proto.is_null() {
+                                    obj.borrow_mut().prototype_id = None;
+                                } else if let Some(proto_id) = proto.as_object_id() {
                                         let obj_id = obj.borrow().id;
-                                        let mut check = Some(p.id);
+                                        let mut check = Some(proto_id);
                                         while let Some(c_id) = check {
                                             if Some(c_id) == obj_id {
                                                 return Completion::Throw(
@@ -4813,12 +4793,10 @@ impl Interpreter {
                                             }
                                             check = interp.get_object_cell_expect(c_id).borrow().prototype_id;
                                         }
-                                        obj.borrow_mut().prototype_id = Some(p.id);
-                                    }
-                                    _ => {}
+                                        obj.borrow_mut().prototype_id = Some(proto_id);
                                 }
                             }
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     },
                 ));
                 proto_obj.borrow_mut().insert_property(
@@ -4837,30 +4815,30 @@ impl Interpreter {
                 "defineProperty".to_string(),
                 3,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if !matches!(target, JsValue::Object(_)) {
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if !(target).is_object() {
                         return Completion::Throw(interp.create_type_error(
                             "Object.defineProperty called on non-object",
                         ));
                     }
-                    let key_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let key_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let key = match interp.to_property_key(&key_raw) {
                         Ok(s) => s,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let desc_val = args.get(2).cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = target
-                        && let Some(obj) = interp.get_object(o.id)
+                    let desc_val = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(target_id) = target.as_object_id()
+                        && let Some(obj) = interp.get_object(target_id)
                     {
                         // Deferred namespace: trigger evaluation on [[DefineOwnProperty]]
                         {
                             let is_deferred_ns = obj.borrow().module_namespace().is_some_and(|ns| ns.deferred);
                             if is_deferred_ns && !Interpreter::is_symbol_like_namespace_key(&key, true)
-                                && let Err(e) = interp.ensure_deferred_namespace_evaluation(o.id) {
+                                && let Err(e) = interp.ensure_deferred_namespace_evaluation(target_id) {
                                     return Completion::Throw(e);
                                 }
                         }
-                        let obj = interp.get_object(o.id).unwrap();
+                        let obj = interp.get_object(target_id).unwrap();
                         // Proxy defineProperty trap
                         let res = { let _b = obj.borrow(); _b.is_proxy() || _b.is_proxy_revoked() }; if res {
                             // Re-parse descriptor so proxy trap gets a fresh copy with coerced booleans
@@ -4869,7 +4847,7 @@ impl Interpreter {
                                 Err(Some(e)) => return Completion::Throw(e),
                                 Err(None) => desc_val.clone(),
                             };
-                            match interp.proxy_define_own_property(o.id, key, &reparsed_desc) {
+                            match interp.proxy_define_own_property(target_id, key, &reparsed_desc) {
                                 Ok(success) => {
                                     if !success {
                                         return Completion::Throw(interp.create_type_error(
@@ -4902,7 +4880,7 @@ impl Interpreter {
                                 let is_array = obj.borrow().class_name == "Array";
                                 let is_ta = obj.borrow().typed_array_info().is_some();
                                 if is_array {
-                                    match interp.array_define_own_property(o.id as usize, &key, desc) {
+                                    match interp.array_define_own_property(target_id as usize, &key, desc) {
                                         Ok(true) => {}
                                         Ok(false) => {
                                             return Completion::Throw(interp.create_type_error(
@@ -4912,7 +4890,7 @@ impl Interpreter {
                                         Err(e) => return Completion::Throw(e),
                                     }
                                 } else if is_ta {
-                                    match interp.typed_array_define_own_property(o.id, &key, &desc) {
+                                    match interp.typed_array_define_own_property(target_id, &key, &desc) {
                                         Ok(Some(true)) => {}
                                         Ok(Some(false)) => {
                                             return Completion::Throw(interp.create_type_error(
@@ -4950,51 +4928,52 @@ impl Interpreter {
                 "getOwnPropertyDescriptor".to_string(),
                 2,
                 |interp, _this, args| {
-                    let target_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let target = match interp.to_object(&target_arg) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => return Completion::Normal(JsValue::Undefined),
+                        _ => return Completion::Normal(JsValue::UNDEFINED),
                     };
-                    let key_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let key_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let key = match interp.to_property_key(&key_raw) {
                         Ok(s) => s,
                         Err(e) => return Completion::Throw(e),
                     };
-                    if let JsValue::Object(ref o) = target {
+                    if let Some(target_id) = target.as_object_id() {
                         // Deferred namespace: trigger evaluation on [[GetOwnProperty]] with non-symbol-like key
                         {
-                            let deferred_ns = interp.get_object_cell(o.id).and_then(|obj| {
+                            let deferred_ns = interp.get_object_cell(target_id).and_then(|obj| {
                                 let b = obj.borrow();
                                 b.module_namespace().map(|ns| ns.deferred)
                             });
                             if deferred_ns == Some(true)
                                 && !Interpreter::is_symbol_like_namespace_key(&key, true)
-                                && let Err(e) = interp.ensure_deferred_namespace_evaluation(o.id)
+                                && let Err(e) =
+                                    interp.ensure_deferred_namespace_evaluation(target_id)
                             {
                                 return Completion::Throw(e);
                             }
                         }
                         // Proxy getOwnPropertyDescriptor trap
-                        if let Some(obj) = interp.get_object_cell(o.id)
+                        if let Some(obj) = interp.get_object_cell(target_id)
                             && {
                                 let _b = obj.borrow();
                                 _b.is_proxy() || _b.is_proxy_revoked()
                             }
                         {
-                            match interp.proxy_get_own_property_descriptor(o.id, &key) {
+                            match interp.proxy_get_own_property_descriptor(target_id, &key) {
                                 Ok(v) => return Completion::Normal(v),
                                 Err(e) => return Completion::Throw(e),
                             }
                         }
                         // Module namespace [[GetOwnProperty]] (§10.4.6.4): live binding
                         let is_ns = interp
-                            .get_object_cell(o.id)
+                            .get_object_cell(target_id)
                             .map(|obj| obj.borrow().module_namespace().is_some())
                             .unwrap_or(false);
                         if is_ns {
                             let is_export = interp
-                                .get_object(o.id)
+                                .get_object(target_id)
                                 .and_then(|obj| {
                                     let b = obj.borrow();
                                     let ns = b.module_namespace()?;
@@ -5004,12 +4983,15 @@ impl Interpreter {
                                 })
                                 .unwrap_or(false);
                             if is_export {
-                                let live_val =
-                                    match interp.get_object_property(o.id, &key, &target.clone()) {
-                                        Completion::Normal(v) => v,
-                                        Completion::Throw(e) => return Completion::Throw(e),
-                                        other => return other,
-                                    };
+                                let live_val = match interp.get_object_property(
+                                    target_id,
+                                    &key,
+                                    &target.clone(),
+                                ) {
+                                    Completion::Normal(v) => v,
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    other => return other,
+                                };
                                 let desc = crate::interpreter::types::PropertyDescriptor {
                                     value: Some(live_val),
                                     writable: Some(true),
@@ -5021,20 +5003,20 @@ impl Interpreter {
                                 return Completion::Normal(interp.from_property_descriptor(&desc));
                             }
                             // Non-export key on namespace (e.g. Symbol.toStringTag): fall through
-                            if let Some(obj) = interp.get_object(o.id)
+                            if let Some(obj) = interp.get_object(target_id)
                                 && let Some(desc) = obj.borrow().get_own_property(&key)
                             {
                                 return Completion::Normal(interp.from_property_descriptor(&desc));
                             }
-                            return Completion::Normal(JsValue::Undefined);
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
-                        if let Some(obj) = interp.get_object(o.id)
+                        if let Some(obj) = interp.get_object(target_id)
                             && let Some(desc) = obj.borrow().get_own_property(&key)
                         {
                             return Completion::Normal(interp.from_property_descriptor(&desc));
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             obj_func
@@ -5046,13 +5028,12 @@ impl Interpreter {
                 "keys".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_val = match interp.to_object(&target) {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    if let JsValue::Object(ref o) = obj_val {
-                        let obj_id = o.id;
+                    if let Some(obj_id) = obj_val.as_object_id() {
                         // [[OwnPropertyKeys]] for all keys
                         let all_keys = match interp.proxy_own_keys(obj_id) {
                             Ok(k) => k,
@@ -5067,7 +5048,8 @@ impl Interpreter {
                             && let Some(obj) = interp.get_object_cell(obj_id)
                         {
                             let b = obj.borrow();
-                            if let Some(JsValue::String(ref s)) = b.primitive_value {
+                            if let Some(s) = b.primitive_value.as_ref().and_then(JsValue::as_string)
+                            {
                                 for i in 0..s.len() {
                                     extra_str_keys.push(JsPropertyKey::from(i.to_string()));
                                 }
@@ -5076,15 +5058,15 @@ impl Interpreter {
                         let mut result = Vec::new();
                         // Add extra char index keys first (string wrapper exotic)
                         for k in &extra_str_keys {
-                            result.push(JsValue::String(k.to_js_string()));
+                            result.push(JsValue::string(k.to_js_string()));
                         }
                         // [[OwnPropertyKeys]] already supplies the required order for ordinary
                         // objects and preserves the trap order for proxies.
                         for kv in &all_keys {
-                            if let JsValue::String(s) = kv {
-                                let key = JsPropertyKey::from_js_string(s);
+                            if let Some(s) = kv.as_string() {
+                                let key = JsPropertyKey::from_js_string(&s);
                                 if !extra_str_keys.contains(&key) {
-                                    result.push(JsValue::String(s.clone()));
+                                    result.push(JsValue::string(s));
                                 }
                             }
                         }
@@ -5092,17 +5074,17 @@ impl Interpreter {
                         let mut enum_keys: Vec<JsValue> = Vec::new();
                         // Extra char index keys are always enumerable (string exotic)
                         for k in &extra_str_keys {
-                            enum_keys.push(JsValue::String(k.to_js_string()));
+                            enum_keys.push(JsValue::string(k.to_js_string()));
                         }
                         for kv in result.iter().skip(extra_str_keys.len()) {
-                            if let JsValue::String(s) = kv {
-                                let k = JsPropertyKey::from_js_string(s);
+                            if let Some(s) = kv.as_string() {
+                                let k = JsPropertyKey::from_js_string(&s);
                                 let desc_val =
                                     match interp.proxy_get_own_property_descriptor(obj_id, &k) {
                                         Ok(v) => v,
                                         Err(e) => return Completion::Throw(e),
                                     };
-                                if matches!(desc_val, JsValue::Undefined) {
+                                if (desc_val).is_undefined() {
                                     continue;
                                 }
                                 if let Ok(desc) = interp.to_property_descriptor(&desc_val)
@@ -5126,9 +5108,8 @@ impl Interpreter {
                 "freeze".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = target {
-                        let obj_id = o.id;
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(obj_id) = target.as_object_id() {
                         let is_proxy = interp
                             .get_object_cell(obj_id)
                             .map(|obj| {
@@ -5160,7 +5141,7 @@ impl Interpreter {
                                         Ok(v) => v,
                                         Err(e) => return Completion::Throw(e),
                                     };
-                                if matches!(desc_val, JsValue::Undefined) {
+                                if (desc_val).is_undefined() {
                                     continue;
                                 }
                                 let desc = match interp.to_property_descriptor(&desc_val) {
@@ -5272,15 +5253,15 @@ impl Interpreter {
                 "getPrototypeOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     // ES6 §19.1.2.9: Let obj = ? ToObject(O)
                     let obj_val = match interp.to_object(&target) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
                         other => return other,
                     };
-                    if let JsValue::Object(ref o) = obj_val
-                        && let Some(obj) = interp.get_object(o.id)
+                    if let Some(obj_id) = obj_val.as_object_id()
+                        && let Some(obj) = interp.get_object(obj_id)
                     {
                         // Proxy getPrototypeOf trap
                         let res = {
@@ -5288,18 +5269,16 @@ impl Interpreter {
                             _b.is_proxy() || _b.is_proxy_revoked()
                         };
                         if res {
-                            match interp.proxy_get_prototype_of(o.id) {
+                            match interp.proxy_get_prototype_of(obj_id) {
                                 Ok(v) => return Completion::Normal(v),
                                 Err(e) => return Completion::Throw(e),
                             }
                         }
                         if let Some(id) = obj.borrow().prototype_id {
-                            return Completion::Normal(JsValue::Object(crate::types::JsObject {
-                                id,
-                            }));
+                            return Completion::Normal(JsValue::object(id));
                         }
                     }
-                    Completion::Normal(JsValue::Null)
+                    Completion::Normal(JsValue::NULL)
                 },
             ));
             obj_func
@@ -5311,8 +5290,8 @@ impl Interpreter {
                 "create".to_string(),
                 2,
                 |interp, _this, args| {
-                    let proto_arg = args.first().cloned().unwrap_or(JsValue::Null);
-                    if !matches!(&proto_arg, JsValue::Object(_) | JsValue::Null) {
+                    let proto_arg = args.first().cloned().unwrap_or(JsValue::NULL);
+                    if !proto_arg.is_object() && !proto_arg.is_null() {
                         return Completion::Throw(
                             interp.create_type_error(
                                 "Object prototype may only be an Object or null",
@@ -5320,34 +5299,31 @@ impl Interpreter {
                         );
                     }
                     let new_obj_id = interp.create_object_id();
-                    match &proto_arg {
-                        JsValue::Object(o) => {
-                            interp
-                                .get_object_cell_expect(new_obj_id)
-                                .borrow_mut()
-                                .prototype_id = Some(o.id);
-                        }
-                        JsValue::Null => {
-                            interp
-                                .get_object_cell_expect(new_obj_id)
-                                .borrow_mut()
-                                .prototype_id = None;
-                        }
-                        _ => unreachable!(),
+                    if let Some(proto_id) = proto_arg.as_object_id() {
+                        interp
+                            .get_object_cell_expect(new_obj_id)
+                            .borrow_mut()
+                            .prototype_id = Some(proto_id);
+                    } else if proto_arg.is_null() {
+                        interp
+                            .get_object_cell_expect(new_obj_id)
+                            .borrow_mut()
+                            .prototype_id = None;
+                    } else {
+                        unreachable!()
                     }
                     let id = new_obj_id;
-                    let target = JsValue::Object(crate::types::JsObject { id });
+                    let target = JsValue::object(id);
 
-                    let props_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    if !matches!(props_arg, JsValue::Undefined) {
+                    let props_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    if !(props_arg).is_undefined() {
                         // ObjectDefineProperties(target, props_arg)
                         let props_obj_val = match interp.to_object(&props_arg) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => return Completion::Normal(target),
                         };
-                        if let JsValue::Object(ref d) = props_obj_val {
-                            let d_id = d.id;
+                        if let Some(d_id) = props_obj_val.as_object_id() {
                             let all_keys = match interp.proxy_own_keys(d_id) {
                                 Ok(k) => k,
                                 Err(e) => return Completion::Throw(e),
@@ -5360,7 +5336,7 @@ impl Interpreter {
                                         Ok(v) => v,
                                         Err(e) => return Completion::Throw(e),
                                     };
-                                if matches!(desc_check, JsValue::Undefined) {
+                                if (desc_check).is_undefined() {
                                     continue;
                                 }
                                 if let Ok(chk) = interp.to_property_descriptor(&desc_check)
@@ -5409,13 +5385,12 @@ impl Interpreter {
                 "entries".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_val = match interp.to_object(&target) {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    if let JsValue::Object(o) = &obj_val {
-                        let obj_id = o.id;
+                    if let Some(obj_id) = obj_val.as_object_id() {
                         // EnumerableOwnProperties: call [[OwnPropertyKeys]], then [[GetOwnProperty]] once per string key
                         let all_keys = match interp.proxy_own_keys(obj_id) {
                             Ok(k) => k,
@@ -5423,7 +5398,7 @@ impl Interpreter {
                         };
                         let mut pairs = Vec::new();
                         for key_val in all_keys {
-                            let JsValue::String(key_string) = key_val else {
+                            let Some(key_string) = key_val.as_string() else {
                                 continue;
                             };
                             let k = JsPropertyKey::from_js_string(&key_string);
@@ -5432,7 +5407,7 @@ impl Interpreter {
                                     Ok(v) => v,
                                     Err(e) => return Completion::Throw(e),
                                 };
-                            if matches!(desc_val, JsValue::Undefined) {
+                            if (desc_val).is_undefined() {
                                 continue;
                             }
                             if let Ok(desc) = interp.to_property_descriptor(&desc_val) {
@@ -5446,7 +5421,7 @@ impl Interpreter {
                                 Completion::Normal(v) => v,
                                 other => return other,
                             };
-                            pairs.push(interp.create_array(vec![JsValue::String(key_string), val]));
+                            pairs.push(interp.create_array(vec![JsValue::string(key_string), val]));
                         }
                         let arr = interp.create_array(pairs);
                         return Completion::Normal(arr);
@@ -5463,13 +5438,12 @@ impl Interpreter {
                 "values".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_val = match interp.to_object(&target) {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    if let JsValue::Object(o) = &obj_val {
-                        let obj_id = o.id;
+                    if let Some(obj_id) = obj_val.as_object_id() {
                         // EnumerableOwnProperties: call [[OwnPropertyKeys]], then [[GetOwnProperty]] once per string key
                         let all_keys = match interp.proxy_own_keys(obj_id) {
                             Ok(k) => k,
@@ -5477,7 +5451,7 @@ impl Interpreter {
                         };
                         let mut values = Vec::new();
                         for key_val in all_keys {
-                            let JsValue::String(key_string) = key_val else {
+                            let Some(key_string) = key_val.as_string() else {
                                 continue;
                             };
                             let k = JsPropertyKey::from_js_string(&key_string);
@@ -5486,7 +5460,7 @@ impl Interpreter {
                                     Ok(v) => v,
                                     Err(e) => return Completion::Throw(e),
                                 };
-                            if matches!(desc_val, JsValue::Undefined) {
+                            if (desc_val).is_undefined() {
                                 continue;
                             }
                             if let Ok(desc) = interp.to_property_descriptor(&desc_val) {
@@ -5517,19 +5491,17 @@ impl Interpreter {
                 "assign".to_string(),
                 2,
                 |interp, _this, args| {
-                    let target_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let target = match interp.to_object(&target_arg) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => return Completion::Normal(JsValue::Undefined),
+                        _ => return Completion::Normal(JsValue::UNDEFINED),
                     };
-                    let t_id = if let JsValue::Object(ref o) = target {
-                        o.id
-                    } else {
+                    let Some(t_id) = target.as_object_id() else {
                         return Completion::Normal(target);
                     };
                     for source in args.iter().skip(1) {
-                        if matches!(source, JsValue::Undefined | JsValue::Null) {
+                        if (source).is_nullish() {
                             continue;
                         }
                         let src_obj_val = match interp.to_object(source) {
@@ -5537,9 +5509,7 @@ impl Interpreter {
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => continue,
                         };
-                        let s_id = if let JsValue::Object(ref o) = src_obj_val {
-                            o.id
-                        } else {
+                        let Some(s_id) = src_obj_val.as_object_id() else {
                             continue;
                         };
                         let raw_keys = match interp.proxy_own_keys(s_id) {
@@ -5556,7 +5526,7 @@ impl Interpreter {
                                 Err(e) => return Completion::Throw(e),
                             };
                             // If descriptor is undefined or not enumerable, skip
-                            if matches!(desc_obj, JsValue::Undefined) {
+                            if (desc_obj).is_undefined() {
                                 continue;
                             }
                             let desc = interp.to_property_descriptor(&desc_obj);
@@ -5572,7 +5542,7 @@ impl Interpreter {
                             {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
                             // [[Set]] on target with Throw=true
                             match interp.proxy_set(t_id, &key_str, val, &target) {
@@ -5600,10 +5570,13 @@ impl Interpreter {
                 "groupBy".to_string(),
                 2,
                 |interp, _this, args| {
-                    let items = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let callback = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    if !matches!(&callback, JsValue::Object(o) if interp.get_object_cell(o.id).map(|obj| obj.borrow().callable.is_some()).unwrap_or(false))
-                    {
+                    let items = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let callback = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    let callback_is_callable = callback
+                        .as_object_id()
+                        .and_then(|id| interp.get_object_cell(id))
+                        .is_some_and(|obj| obj.borrow().callable.is_some());
+                    if !callback_is_callable {
                         return Completion::Throw(
                             interp.create_type_error("callbackfn is not a function"),
                         );
@@ -5613,9 +5586,12 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     let result_obj_id = interp.create_object_id();
-                    interp.get_object_cell_expect(result_obj_id).borrow_mut().prototype_id = None;
+                    interp
+                        .get_object_cell_expect(result_obj_id)
+                        .borrow_mut()
+                        .prototype_id = None;
                     let result_id = result_obj_id;
-                    let result_val = JsValue::Object(crate::types::JsObject { id: result_id });
+                    let result_val = JsValue::object(result_id);
                     let mut k: u64 = 0;
                     loop {
                         let next = match interp.iterator_step(&iterator) {
@@ -5629,12 +5605,12 @@ impl Interpreter {
                         };
                         let key_val = match interp.call_function(
                             &callback,
-                            &JsValue::Undefined,
-                            &[value.clone(), JsValue::Number(k as f64)],
+                            &JsValue::UNDEFINED,
+                            &[value.clone(), JsValue::number(k as f64)],
                         ) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         // ToPropertyKey (with error propagation)
                         let key_str = match interp.to_property_key(&key_val) {
@@ -5647,21 +5623,32 @@ impl Interpreter {
                         };
                         if let Some(obj) = interp.get_object(result_id) {
                             let existing = interp.get_property_on_id(result_id, &key_str);
-                            if let JsValue::Object(ref arr_o) = existing
-                                && let Some(arr) = interp.get_object(arr_o.id)
+                            if let Some(array_id) = existing.as_object_id()
+                                && let Some(arr) = interp.get_object(array_id)
                             {
-                                let len_val = interp.get_property_on_id(arr_o.id, "length");
+                                let len_val = interp.get_property_on_id(array_id, "length");
                                 let len = to_number(&len_val) as usize;
                                 // Use enumerable property insertion
-                                arr.borrow_mut().insert_property(len.to_string(), PropertyDescriptor::data(value, true, true, true));
+                                arr.borrow_mut().insert_property(
+                                    len.to_string(),
+                                    PropertyDescriptor::data(value, true, true, true),
+                                );
                                 arr.borrow_mut().insert_property(
                                     "length".to_string(),
-                                    PropertyDescriptor::data(JsValue::Number((len + 1) as f64), true, false, false),
+                                    PropertyDescriptor::data(
+                                        JsValue::number((len + 1) as f64),
+                                        true,
+                                        false,
+                                        false,
+                                    ),
                                 );
                             } else {
                                 let new_arr = interp.create_array(vec![value]);
                                 // Create enumerable property
-                                obj.borrow_mut().insert_property(key_str, PropertyDescriptor::data(new_arr, true, true, true));
+                                obj.borrow_mut().insert_property(
+                                    key_str,
+                                    PropertyDescriptor::data(new_arr, true, true, true),
+                                );
                             }
                         }
                         k += 1;
@@ -5678,13 +5665,13 @@ impl Interpreter {
                 "is".to_string(),
                 2,
                 |_interp, _this, args| {
-                    let a = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let b = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    let result = match (&a, &b) {
-                        (JsValue::Number(x), JsValue::Number(y)) => number_ops::same_value(*x, *y),
+                    let a = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let b = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    let result = match (a.as_number(), b.as_number()) {
+                        (Some(x), Some(y)) => number_ops::same_value(x, y),
                         _ => strict_equality(&a, &b),
                     };
-                    Completion::Normal(JsValue::Boolean(result))
+                    Completion::Normal(JsValue::boolean(result))
                 },
             ));
             obj_func
@@ -5696,18 +5683,16 @@ impl Interpreter {
                 "getOwnPropertyNames".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let target = match interp.to_object(&target_arg) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
                         _ => return Completion::Normal(interp.create_array(Vec::new())),
                     };
-                    let o = if let JsValue::Object(ref o) = target {
-                        o.clone()
-                    } else {
+                    let Some(obj_id) = target.as_object_id() else {
                         return Completion::Normal(interp.create_array(Vec::new()));
                     };
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                    if let Some(obj) = interp.get_object_cell(obj_id) {
                         // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
                         {
                             let is_deferred_ns = obj
@@ -5716,24 +5701,22 @@ impl Interpreter {
                                 .as_ref()
                                 .is_some_and(|ns| ns.deferred);
                             if is_deferred_ns
-                                && let Err(e) = interp.ensure_deferred_namespace_evaluation(o.id)
+                                && let Err(e) = interp.ensure_deferred_namespace_evaluation(obj_id)
                             {
                                 return Completion::Throw(e);
                             }
                         }
-                        let obj = interp.get_object_cell(o.id).unwrap();
+                        let obj = interp.get_object_cell(obj_id).unwrap();
                         // Proxy ownKeys trap (getOwnPropertyNames returns all string keys)
                         let res = {
                             let _b = obj.borrow();
                             _b.is_proxy() || _b.is_proxy_revoked()
                         };
                         if res {
-                            match interp.proxy_own_keys(o.id) {
+                            match interp.proxy_own_keys(obj_id) {
                                 Ok(keys) => {
-                                    let str_keys: Vec<JsValue> = keys
-                                        .into_iter()
-                                        .filter(|k| matches!(k, JsValue::String(_)))
-                                        .collect();
+                                    let str_keys: Vec<JsValue> =
+                                        keys.into_iter().filter(|k| (k).is_string()).collect();
                                     let arr = interp.create_array(str_keys);
                                     return Completion::Normal(arr);
                                 }
@@ -5749,7 +5732,7 @@ impl Interpreter {
                                 drop(b);
                                 let mut names: Vec<JsValue> = Vec::new();
                                 for i in 0..len {
-                                    names.push(JsValue::String(JsString::from_str(&i.to_string())));
+                                    names.push(JsValue::string(JsString::from_str(&i.to_string())));
                                 }
                                 for k in &property_order {
                                     if k.is_symbol() {
@@ -5761,7 +5744,7 @@ impl Interpreter {
                                     {
                                         continue; // skip numeric indices
                                     }
-                                    names.push(JsValue::String(k.to_js_string()));
+                                    names.push(JsValue::string(k.to_js_string()));
                                 }
                                 let arr = interp.create_array(names);
                                 return Completion::Normal(arr);
@@ -5770,12 +5753,13 @@ impl Interpreter {
                         // String exotic: include "length" and character index keys
                         let b = obj.borrow();
                         let is_string_wrapper =
-                            matches!(b.primitive_value, Some(JsValue::String(_)));
+                            b.primitive_value.as_ref().is_some_and(JsValue::is_string);
                         let mut names: Vec<JsValue> = Vec::new();
-                        if is_string_wrapper && let Some(JsValue::String(ref s)) = b.primitive_value
+                        if is_string_wrapper
+                            && let Some(s) = b.primitive_value.as_ref().and_then(JsValue::as_string)
                         {
                             for i in 0..s.len() {
-                                names.push(JsValue::String(JsString::from_str(&i.to_string())));
+                                names.push(JsValue::string(JsString::from_str(&i.to_string())));
                             }
                         }
                         // Collect and sort non-symbol keys from property_order
@@ -5791,11 +5775,8 @@ impl Interpreter {
                         let mut str_keys2: Vec<JsPropertyKey> = Vec::new();
                         for k in prop_keys {
                             let already_added = names.iter().any(|v| {
-                                if let JsValue::String(s) = v {
-                                    JsPropertyKey::from_js_string(s) == k
-                                } else {
-                                    false
-                                }
+                                v.as_string()
+                                    .is_some_and(|s| JsPropertyKey::from_js_string(&s) == k)
                             });
                             if already_added {
                                 continue;
@@ -5816,14 +5797,14 @@ impl Interpreter {
                         }
                         int_keys.sort_by_key(|(n, _)| *n);
                         for (_, k) in int_keys {
-                            names.push(JsValue::String(k.to_js_string()));
+                            names.push(JsValue::string(k.to_js_string()));
                         }
                         for k in str_keys2 {
-                            names.push(JsValue::String(k.to_js_string()));
+                            names.push(JsValue::string(k.to_js_string()));
                         }
                         // String exotic: "length" is always an own property
                         if is_string_wrapper {
-                            names.push(JsValue::String(JsString::from_str("length")));
+                            names.push(JsValue::string(JsString::from_str("length")));
                         }
                         let arr = interp.create_array(names);
                         return Completion::Normal(arr);
@@ -5840,14 +5821,13 @@ impl Interpreter {
                 "getOwnPropertySymbols".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let target = match interp.to_object(&target_arg) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
                         _ => return Completion::Normal(interp.create_array(Vec::new())),
                     };
-                    if let JsValue::Object(ref o) = target {
-                        let obj_id = o.id;
+                    if let Some(obj_id) = target.as_object_id() {
                         // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
                         if let Some(obj) = interp.get_object_cell(obj_id) {
                             let is_deferred_ns = obj
@@ -5866,10 +5846,8 @@ impl Interpreter {
                             if obj.borrow().is_proxy() || obj.borrow().is_proxy_revoked() {
                                 match interp.proxy_own_keys(obj_id) {
                                     Ok(keys) => {
-                                        let sym_keys: Vec<JsValue> = keys
-                                            .into_iter()
-                                            .filter(|k| matches!(k, JsValue::Symbol(_)))
-                                            .collect();
+                                        let sym_keys: Vec<JsValue> =
+                                            keys.into_iter().filter(|k| (k).is_symbol()).collect();
                                         return Completion::Normal(interp.create_array(sym_keys));
                                     }
                                     Err(e) => return Completion::Throw(e),
@@ -5911,9 +5889,9 @@ impl Interpreter {
                 "preventExtensions".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(o) = &target
-                        && let Some(obj) = interp.get_object(o.id)
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(target_id) = target.as_object_id()
+                        && let Some(obj) = interp.get_object(target_id)
                     {
                         // Proxy preventExtensions trap
                         let res = {
@@ -5921,7 +5899,7 @@ impl Interpreter {
                             _b.is_proxy() || _b.is_proxy_revoked()
                         };
                         if res {
-                            match interp.proxy_prevent_extensions(o.id) {
+                            match interp.proxy_prevent_extensions(target_id) {
                                 Ok(true) => return Completion::Normal(target),
                                 Ok(false) => {
                                     return Completion::Throw(interp.create_type_error(
@@ -5963,9 +5941,9 @@ impl Interpreter {
                 "isExtensible".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(o) = &target
-                        && let Some(obj) = interp.get_object(o.id)
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(target_id) = target.as_object_id()
+                        && let Some(obj) = interp.get_object(target_id)
                     {
                         // Proxy isExtensible trap
                         let res = {
@@ -5973,14 +5951,14 @@ impl Interpreter {
                             _b.is_proxy() || _b.is_proxy_revoked()
                         };
                         if res {
-                            match interp.proxy_is_extensible(o.id) {
-                                Ok(result) => return Completion::Normal(JsValue::Boolean(result)),
+                            match interp.proxy_is_extensible(target_id) {
+                                Ok(result) => return Completion::Normal(JsValue::boolean(result)),
                                 Err(e) => return Completion::Throw(e),
                             }
                         }
-                        return Completion::Normal(JsValue::Boolean(obj.borrow().extensible));
+                        return Completion::Normal(JsValue::boolean(obj.borrow().extensible));
                     }
-                    Completion::Normal(JsValue::Boolean(false))
+                    Completion::Normal(JsValue::boolean(false))
                 },
             ));
             obj_func
@@ -5992,9 +5970,8 @@ impl Interpreter {
                 "isFrozen".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(o) = &target {
-                        let obj_id = o.id;
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(obj_id) = target.as_object_id() {
                         // TestIntegrityLevel: check extensible first, then each key
                         let is_proxy = interp
                             .get_object_cell(obj_id)
@@ -6006,14 +5983,14 @@ impl Interpreter {
                         if is_proxy {
                             // Check via proxy isExtensible trap
                             match interp.proxy_is_extensible(obj_id) {
-                                Ok(true) => return Completion::Normal(JsValue::Boolean(false)),
+                                Ok(true) => return Completion::Normal(JsValue::boolean(false)),
                                 Ok(false) => {}
                                 Err(e) => return Completion::Throw(e),
                             }
                         } else if let Some(obj) = interp.get_object(obj_id)
                             && obj.borrow().extensible
                         {
-                            return Completion::Normal(JsValue::Boolean(false));
+                            return Completion::Normal(JsValue::boolean(false));
                         }
                         // Get all own keys via proxy_own_keys
                         let all_keys = match interp.proxy_own_keys(obj_id) {
@@ -6029,16 +6006,16 @@ impl Interpreter {
                                 };
                             if let Ok(desc) = interp.to_property_descriptor(&desc_val) {
                                 if desc.configurable != Some(false) {
-                                    return Completion::Normal(JsValue::Boolean(false));
+                                    return Completion::Normal(JsValue::boolean(false));
                                 }
                                 if desc.is_data_descriptor() && desc.writable != Some(false) {
-                                    return Completion::Normal(JsValue::Boolean(false));
+                                    return Completion::Normal(JsValue::boolean(false));
                                 }
                             }
                         }
-                        return Completion::Normal(JsValue::Boolean(true));
+                        return Completion::Normal(JsValue::boolean(true));
                     }
-                    Completion::Normal(JsValue::Boolean(true))
+                    Completion::Normal(JsValue::boolean(true))
                 },
             ));
             obj_func
@@ -6050,9 +6027,8 @@ impl Interpreter {
                 "isSealed".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(o) = &target {
-                        let obj_id = o.id;
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(obj_id) = target.as_object_id() {
                         let is_proxy = interp
                             .get_object_cell(obj_id)
                             .map(|ob| {
@@ -6062,14 +6038,14 @@ impl Interpreter {
                             .unwrap_or(false);
                         if is_proxy {
                             match interp.proxy_is_extensible(obj_id) {
-                                Ok(true) => return Completion::Normal(JsValue::Boolean(false)),
+                                Ok(true) => return Completion::Normal(JsValue::boolean(false)),
                                 Ok(false) => {}
                                 Err(e) => return Completion::Throw(e),
                             }
                         } else if let Some(obj) = interp.get_object(obj_id)
                             && obj.borrow().extensible
                         {
-                            return Completion::Normal(JsValue::Boolean(false));
+                            return Completion::Normal(JsValue::boolean(false));
                         }
                         let all_keys = match interp.proxy_own_keys(obj_id) {
                             Ok(k) => k,
@@ -6085,12 +6061,12 @@ impl Interpreter {
                             if let Ok(desc) = interp.to_property_descriptor(&desc_val)
                                 && desc.configurable != Some(false)
                             {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                         }
-                        return Completion::Normal(JsValue::Boolean(true));
+                        return Completion::Normal(JsValue::boolean(true));
                     }
-                    Completion::Normal(JsValue::Boolean(true))
+                    Completion::Normal(JsValue::boolean(true))
                 },
             ));
             obj_func
@@ -6102,9 +6078,8 @@ impl Interpreter {
                 "seal".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = target {
-                        let obj_id = o.id;
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(obj_id) = target.as_object_id() {
                         let is_proxy = interp
                             .get_object_cell(obj_id)
                             .map(|obj| {
@@ -6133,7 +6108,7 @@ impl Interpreter {
                                         Ok(v) => v,
                                         Err(e) => return Completion::Throw(e),
                                     };
-                                if matches!(desc_val, JsValue::Undefined) {
+                                if (desc_val).is_undefined() {
                                     continue;
                                 }
                                 let new_desc = PropertyDescriptor {
@@ -6215,29 +6190,28 @@ impl Interpreter {
                 2,
                 |interp, _this, args| {
                     // Step 1: ToObject(O)
-                    let target_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_val = match interp.to_object(&target_arg) {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
                     // Step 2: ToPropertyKey(P)
-                    let key_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let key_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let key = match interp.to_property_key(&key_arg) {
                         Ok(k) => k,
                         Err(e) => return Completion::Throw(e),
                     };
-                    if let JsValue::Object(o) = &obj_val {
-                        match interp.proxy_get_own_property_descriptor(o.id, &key) {
+                    if let Some(obj_id) = obj_val.as_object_id() {
+                        match interp.proxy_get_own_property_descriptor(obj_id, &key) {
                             Ok(desc_val) => {
-                                return Completion::Normal(JsValue::Boolean(!matches!(
-                                    desc_val,
-                                    JsValue::Undefined
-                                )));
+                                return Completion::Normal(JsValue::boolean(
+                                    !(desc_val).is_undefined(),
+                                ));
                             }
                             Err(e) => return Completion::Throw(e),
                         }
                     }
-                    Completion::Normal(JsValue::Boolean(false))
+                    Completion::Normal(JsValue::boolean(false))
                 },
             ));
             obj_func
@@ -6249,22 +6223,22 @@ impl Interpreter {
                 "setPrototypeOf".to_string(),
                 2,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     // Step 1: RequireObjectCoercible(O)
-                    if matches!(target, JsValue::Null | JsValue::Undefined) {
+                    if (target).is_nullish() {
                         return Completion::Throw(interp.create_type_error(
                             "Object.setPrototypeOf called on null or undefined",
                         ));
                     }
-                    let proto = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let proto = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     // Step 3: If Type(proto) is neither Object nor Null, throw TypeError
-                    if !matches!(proto, JsValue::Object(_) | JsValue::Null) {
+                    if !proto.is_object() && !proto.is_null() {
                         return Completion::Throw(interp.create_type_error(
                             "Object prototype may only be an Object or null",
                         ));
                     }
-                    if let JsValue::Object(ref o) = target
-                        && let Some(obj) = interp.get_object_cell(o.id)
+                    if let Some(target_id) = target.as_object_id()
+                        && let Some(obj) = interp.get_object_cell(target_id)
                     {
                         // Proxy setPrototypeOf trap
                         let res = {
@@ -6272,7 +6246,7 @@ impl Interpreter {
                             _b.is_proxy() || _b.is_proxy_revoked()
                         };
                         if res {
-                            match interp.proxy_set_prototype_of(o.id, &proto) {
+                            match interp.proxy_set_prototype_of(target_id, &proto) {
                                 Ok(success) => {
                                     if !success {
                                         return Completion::Throw(interp.create_type_error(
@@ -6287,8 +6261,8 @@ impl Interpreter {
                         // Immutable prototype exotic object check (Object.prototype)
                         if obj.borrow().is_immutable_prototype {
                             let current_proto_id = obj.borrow().prototype_id;
-                            let new_proto_id = if let JsValue::Object(ref p) = proto { Some(p.id) } else { None };
-                            let same = (matches!(proto, JsValue::Null) && current_proto_id.is_none())
+                            let new_proto_id = proto.as_object_id();
+                            let same = ((proto).is_null() && current_proto_id.is_none())
                                 || matches!((new_proto_id, current_proto_id), (Some(a), Some(b)) if a == b);
                             if !same {
                                 return Completion::Throw(interp.create_type_error(
@@ -6298,11 +6272,10 @@ impl Interpreter {
                             return Completion::Normal(target);
                         }
                         // OrdinarySetPrototypeOf checks
-                        let target_id = o.id;
                         let current_proto_id = obj.borrow().prototype_id;
-                        let new_proto_id = if let JsValue::Object(ref p) = proto { Some(p.id) } else { None };
+                        let new_proto_id = proto.as_object_id();
                         // Same value check
-                        let same = (matches!(proto, JsValue::Null) && current_proto_id.is_none())
+                        let same = ((proto).is_null() && current_proto_id.is_none())
                             || matches!((new_proto_id, current_proto_id), (Some(a), Some(b)) if a == b);
                         if !same {
                             if !obj.borrow().extensible {
@@ -6330,14 +6303,10 @@ impl Interpreter {
                                 }
                             }
                         }
-                        match &proto {
-                            JsValue::Null => {
-                                obj.borrow_mut().prototype_id = None;
-                            }
-                            JsValue::Object(p) => {
-                                obj.borrow_mut().prototype_id = Some(p.id);
-                            }
-                            _ => {}
+                        if proto.is_null() {
+                            obj.borrow_mut().prototype_id = None;
+                        } else if let Some(proto_id) = proto.as_object_id() {
+                            obj.borrow_mut().prototype_id = Some(proto_id);
                         }
                     }
                     Completion::Normal(target)
@@ -6352,22 +6321,21 @@ impl Interpreter {
                 "defineProperties".to_string(),
                 2,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if !matches!(target, JsValue::Object(_)) {
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if !(target).is_object() {
                         return Completion::Throw(interp.create_type_error(
                             "Object.defineProperties called on non-object",
                         ));
                     }
-                    let descs_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let descs_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let descs = match interp.to_object(&descs_arg) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
                         _ => return Completion::Normal(target),
                     };
-                    if let JsValue::Object(ref t) = target
-                        && let JsValue::Object(ref d) = descs
+                    if let Some(target_id) = target.as_object_id()
+                        && let Some(d_id) = descs.as_object_id()
                     {
-                        let d_id = d.id;
                         // Use proxy_own_keys to call ownKeys trap if present
                         let all_keys = match interp.proxy_own_keys(d_id) {
                             Ok(k) => k,
@@ -6382,7 +6350,7 @@ impl Interpreter {
                                 Ok(v) => v,
                                 Err(e) => return Completion::Throw(e),
                             };
-                            if matches!(desc_val, JsValue::Undefined) { continue; }
+                            if (desc_val).is_undefined() { continue; }
                             // Only process enumerable properties (spec: ObjectDefineProperties)
                             if let Ok(desc) = interp.to_property_descriptor(&desc_val)
                                 && desc.enumerable == Some(false) { continue; }
@@ -6400,7 +6368,7 @@ impl Interpreter {
                         // Apply all descriptors via proxy-aware defineOwnProperty
                         for (key, desc) in descriptors {
                             let desc_val = interp.from_property_descriptor(&desc);
-                            match interp.proxy_define_own_property(t.id, key, &desc_val) {
+                            match interp.proxy_define_own_property(target_id, key, &desc_val) {
                                 Ok(true) => {}
                                 Ok(false) => {
                                     return Completion::Throw(interp.create_type_error(
@@ -6423,9 +6391,9 @@ impl Interpreter {
                 "getOwnPropertyDescriptors".to_string(),
                 1,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     // §22.1.2.8 step 1: RequireObjectCoercible then ToObject
-                    if matches!(target, JsValue::Undefined | JsValue::Null) {
+                    if (target).is_nullish() {
                         return Completion::Throw(
                             interp.create_type_error("Cannot convert undefined or null to object"),
                         );
@@ -6434,8 +6402,7 @@ impl Interpreter {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    if let JsValue::Object(ref t) = obj_val {
-                        let obj_id = t.id;
+                    if let Some(obj_id) = obj_val.as_object_id() {
                         // Use proxy_own_keys to invoke ownKeys trap (proxy-aware)
                         let all_keys = match interp.proxy_own_keys(obj_id) {
                             Ok(k) => k,
@@ -6450,7 +6417,7 @@ impl Interpreter {
                                     Ok(v) => v,
                                     Err(e) => return Completion::Throw(e),
                                 };
-                            if !matches!(desc_val, JsValue::Undefined) {
+                            if !(desc_val).is_undefined() {
                                 interp
                                     .get_object_cell_expect(result_id)
                                     .borrow_mut()
@@ -6458,12 +6425,12 @@ impl Interpreter {
                             }
                         }
                         let id = result_id;
-                        return Completion::Normal(JsValue::Object(crate::types::JsObject { id }));
+                        return Completion::Normal(JsValue::object(id));
                     }
                     // Primitive wrapped to object with no own properties
                     let result_id = interp.create_object_id();
                     let id = result_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 },
             ));
             obj_func
@@ -6475,9 +6442,9 @@ impl Interpreter {
                 "fromEntries".to_string(),
                 1,
                 |interp, _this, args| {
-                    let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_id = interp.create_object_id();
-                    let obj_val = JsValue::Object(crate::types::JsObject { id: obj_id });
+                    let obj_val = JsValue::object(obj_id);
                     let iterator = match interp.get_iterator(&iterable) {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
@@ -6501,9 +6468,7 @@ impl Interpreter {
                             }
                         };
                         // Step d: If Type(nextItem) is not Object, close and throw TypeError
-                        let item_id = if let JsValue::Object(ref vo) = next_item {
-                            vo.id
-                        } else {
+                        let Some(item_id) = next_item.as_object_id() else {
                             interp.gc_unroot_frame(gc_frame);
                             let err = interp.create_type_error("Iterator value is not an object");
                             interp.iterator_close(&iterator, err.clone());
@@ -6517,7 +6482,7 @@ impl Interpreter {
                                 interp.iterator_close(&iterator, e.clone());
                                 return Completion::Throw(e);
                             }
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         // Step g: Get value from entry[1]
                         let value = match interp.get_object_property(item_id, "1", &next_item) {
@@ -6527,7 +6492,7 @@ impl Interpreter {
                                 interp.iterator_close(&iterator, e.clone());
                                 return Completion::Throw(e);
                             }
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         // Step f: ToPropertyKey(key)
                         let key = match interp.to_property_key(&key_raw) {
@@ -6561,16 +6526,16 @@ impl Interpreter {
             "apply".to_string(),
             3,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !interp.is_callable(&target) {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.apply requires a function target"),
                     );
                 }
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                let args_list = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                let args_list = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 // CreateListFromArrayLike
-                if !matches!(args_list, JsValue::Object(_)) {
+                if !(args_list).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("CreateListFromArrayLike called on non-object"),
                     );
@@ -6591,13 +6556,13 @@ impl Interpreter {
             "construct".to_string(),
             2,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !interp.is_constructor(&target) {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.construct requires a constructor"),
                     );
                 }
-                let args_list = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let args_list = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let new_target = args.get(2).cloned().unwrap_or(target.clone());
                 if !interp.is_constructor(&new_target) {
                     return Completion::Throw(
@@ -6605,7 +6570,7 @@ impl Interpreter {
                     );
                 }
                 // CreateListFromArrayLike
-                if !matches!(args_list, JsValue::Object(_)) {
+                if !(args_list).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("CreateListFromArrayLike called on non-object"),
                     );
@@ -6626,20 +6591,20 @@ impl Interpreter {
             "defineProperty".to_string(),
             3,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.defineProperty requires an object"),
                     );
                 }
-                let key_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let key_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let key = match interp.to_property_key(&key_raw) {
                     Ok(k) => k,
                     Err(e) => return Completion::Throw(e),
                 };
-                let desc_val = args.get(2).cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object(o.id)
+                let desc_val = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object(target_id)
                 {
                     // Deferred namespace: trigger evaluation on [[DefineOwnProperty]]
                     {
@@ -6650,12 +6615,12 @@ impl Interpreter {
                             .is_some_and(|ns| ns.deferred);
                         if is_deferred_ns
                             && !Interpreter::is_symbol_like_namespace_key(&key, true)
-                            && let Err(e) = interp.ensure_deferred_namespace_evaluation(o.id)
+                            && let Err(e) = interp.ensure_deferred_namespace_evaluation(target_id)
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    let obj = interp.get_object(o.id).unwrap();
+                    let obj = interp.get_object(target_id).unwrap();
                     let res = {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.is_proxy_revoked()
@@ -6667,8 +6632,8 @@ impl Interpreter {
                             Err(Some(e)) => return Completion::Throw(e),
                             Err(None) => desc_val.clone(),
                         };
-                        match interp.proxy_define_own_property(o.id, key, &reparsed_desc) {
-                            Ok(result) => return Completion::Normal(JsValue::Boolean(result)),
+                        match interp.proxy_define_own_property(target_id, key, &reparsed_desc) {
+                            Ok(result) => return Completion::Normal(JsValue::boolean(result)),
                             Err(e) => return Completion::Throw(e),
                         }
                     }
@@ -6676,14 +6641,15 @@ impl Interpreter {
                     match interp.to_property_descriptor(&desc_val) {
                         Ok(desc) => {
                             if is_ta {
-                                match interp.typed_array_define_own_property(o.id, &key, &desc) {
+                                match interp.typed_array_define_own_property(target_id, &key, &desc)
+                                {
                                     Ok(Some(result)) => {
-                                        return Completion::Normal(JsValue::Boolean(result));
+                                        return Completion::Normal(JsValue::boolean(result));
                                     }
                                     Ok(None) => {
                                         let result =
                                             obj.borrow_mut().define_own_property(key, desc);
-                                        return Completion::Normal(JsValue::Boolean(result));
+                                        return Completion::Normal(JsValue::boolean(result));
                                     }
                                     Err(e) => return Completion::Throw(e),
                                 }
@@ -6692,25 +6658,25 @@ impl Interpreter {
                                 let is_array = obj.borrow().class_name == "Array";
                                 if is_array {
                                     match interp.array_define_own_property(
-                                        o.id as usize,
+                                        target_id as usize,
                                         &key,
                                         desc,
                                     ) {
                                         Ok(result) => {
-                                            return Completion::Normal(JsValue::Boolean(result));
+                                            return Completion::Normal(JsValue::boolean(result));
                                         }
                                         Err(e) => return Completion::Throw(e),
                                     }
                                 }
                                 let result = obj.borrow_mut().define_own_property(key, desc);
-                                return Completion::Normal(JsValue::Boolean(result));
+                                return Completion::Normal(JsValue::boolean(result));
                             }
                         }
                         Err(Some(e)) => return Completion::Throw(e),
                         Err(None) => {}
                     }
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)
@@ -6722,27 +6688,27 @@ impl Interpreter {
             "deleteProperty".to_string(),
             2,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.deleteProperty requires an object"),
                     );
                 }
-                let key_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let key_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let key = match interp.to_property_key(&key_raw) {
                     Ok(k) => k,
                     Err(e) => return Completion::Throw(e),
                 };
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                 {
                     let res = {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.is_proxy_revoked()
                     };
                     if res {
-                        match interp.proxy_delete_property(o.id, &key) {
-                            Ok(result) => return Completion::Normal(JsValue::Boolean(result)),
+                        match interp.proxy_delete_property(target_id, &key) {
+                            Ok(result) => return Completion::Normal(JsValue::boolean(result)),
                             Err(e) => return Completion::Throw(e),
                         }
                     }
@@ -6761,9 +6727,9 @@ impl Interpreter {
                                 .as_str()
                                 .is_some_and(|key| export_names.iter().any(|name| name == key))
                             {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                     }
                     // String exotic [[Delete]] (§10.4.3): "length" and own
@@ -6771,7 +6737,7 @@ impl Interpreter {
                     {
                         let b = obj.borrow();
                         if b.class_name == "String"
-                            && let Some(JsValue::String(ref s)) = b.primitive_value
+                            && let Some(s) = b.primitive_value.as_ref().and_then(JsValue::as_string)
                             && (key.as_str() == Some("length")
                                 || crate::interpreter::types::string_exotic_index(
                                     &key,
@@ -6779,14 +6745,14 @@ impl Interpreter {
                                 )
                                 .is_some())
                         {
-                            return Completion::Normal(JsValue::Boolean(false));
+                            return Completion::Normal(JsValue::boolean(false));
                         }
                     }
                     let mut obj_mut = obj.borrow_mut();
                     if let Some(desc) = obj_mut.properties.get(&key)
                         && desc.configurable == Some(false)
                     {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     obj_mut.remove_property(&key);
                     if let Some(key_str) = key.as_str()
@@ -6798,11 +6764,11 @@ impl Interpreter {
                         && let Some(elems) = obj_mut.array_elements_mut()
                         && idx < elems.len()
                     {
-                        elems[idx] = JsValue::Undefined;
+                        elems[idx] = JsValue::UNDEFINED;
                     }
-                    return Completion::Normal(JsValue::Boolean(true));
+                    return Completion::Normal(JsValue::boolean(true));
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)
@@ -6814,22 +6780,22 @@ impl Interpreter {
             "get".to_string(),
             2,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.get requires an object"),
                     );
                 }
-                let key_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let key_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let key = match interp.to_property_key(&key_raw) {
                     Ok(k) => k,
                     Err(e) => return Completion::Throw(e),
                 };
                 let receiver = args.get(2).cloned().unwrap_or(target.clone());
-                if let JsValue::Object(ref o) = target {
-                    interp.get_object_property(o.id, &key, &receiver)
+                if let Some(target_id) = target.as_object_id() {
+                    interp.get_object_property(target_id, &key, &receiver)
                 } else {
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 }
             },
         ));
@@ -6838,96 +6804,100 @@ impl Interpreter {
             .insert_builtin("get".to_string(), get_fn);
 
         // Reflect.getOwnPropertyDescriptor(target, key)
-        let gopd_fn =
-            self.create_function(JsFunction::native(
-                "getOwnPropertyDescriptor".to_string(),
-                2,
-                |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if !matches!(target, JsValue::Object(_)) {
-                        return Completion::Throw(interp.create_type_error(
+        let gopd_fn = self.create_function(JsFunction::native(
+            "getOwnPropertyDescriptor".to_string(),
+            2,
+            |interp, _this, args| {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
+                    return Completion::Throw(
+                        interp.create_type_error(
                             "Reflect.getOwnPropertyDescriptor requires an object",
-                        ));
+                        ),
+                    );
+                }
+                let key_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                let key = match interp.to_property_key(&key_raw) {
+                    Ok(k) => k,
+                    Err(e) => return Completion::Throw(e),
+                };
+                if let Some(target_id) = target.as_object_id() {
+                    // Deferred namespace: trigger evaluation
+                    {
+                        let deferred_ns = interp.get_object_cell(target_id).and_then(|obj| {
+                            let b = obj.borrow();
+                            b.module_namespace().map(|ns| ns.deferred)
+                        });
+                        if deferred_ns == Some(true)
+                            && !Interpreter::is_symbol_like_namespace_key(&key, true)
+                            && let Err(e) = interp.ensure_deferred_namespace_evaluation(target_id)
+                        {
+                            return Completion::Throw(e);
+                        }
                     }
-                    let key_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    let key = match interp.to_property_key(&key_raw) {
-                        Ok(k) => k,
-                        Err(e) => return Completion::Throw(e),
-                    };
-                    if let JsValue::Object(ref o) = target {
-                        // Deferred namespace: trigger evaluation
-                        {
-                            let deferred_ns = interp.get_object_cell(o.id).and_then(|obj| {
+                    if let Some(obj) = interp.get_object_cell(target_id)
+                        && {
+                            let _b = obj.borrow();
+                            _b.is_proxy() || _b.is_proxy_revoked()
+                        }
+                    {
+                        match interp.proxy_get_own_property_descriptor(target_id, &key) {
+                            Ok(v) => return Completion::Normal(v),
+                            Err(e) => return Completion::Throw(e),
+                        }
+                    }
+                    // Module namespace [[GetOwnProperty]] (§10.4.6.4): live binding
+                    let is_ns = interp
+                        .get_object_cell(target_id)
+                        .map(|obj| obj.borrow().module_namespace().is_some())
+                        .unwrap_or(false);
+                    if is_ns {
+                        let is_export = interp
+                            .get_object_cell(target_id)
+                            .and_then(|obj| {
                                 let b = obj.borrow();
-                                b.module_namespace().map(|ns| ns.deferred)
-                            });
-                            if deferred_ns == Some(true)
-                                && !Interpreter::is_symbol_like_namespace_key(&key, true)
-                                && let Err(e) = interp.ensure_deferred_namespace_evaluation(o.id)
-                            {
-                                return Completion::Throw(e);
-                            }
-                        }
-                        if let Some(obj) = interp.get_object_cell(o.id)
-                            && {
-                                let _b = obj.borrow();
-                                _b.is_proxy() || _b.is_proxy_revoked()
-                            }
-                        {
-                            match interp.proxy_get_own_property_descriptor(o.id, &key) {
-                                Ok(v) => return Completion::Normal(v),
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        }
-                        // Module namespace [[GetOwnProperty]] (§10.4.6.4): live binding
-                        let is_ns = interp
-                            .get_object_cell(o.id)
-                            .map(|obj| obj.borrow().module_namespace().is_some())
+                                let ns = b.module_namespace()?;
+                                Some(key.as_str().is_some_and(|key| {
+                                    ns.export_names.iter().any(|name| name == key)
+                                }))
+                            })
                             .unwrap_or(false);
-                        if is_ns {
-                            let is_export = interp
-                                .get_object_cell(o.id)
-                                .and_then(|obj| {
-                                    let b = obj.borrow();
-                                    let ns = b.module_namespace()?;
-                                    Some(key.as_str().is_some_and(|key| {
-                                        ns.export_names.iter().any(|name| name == key)
-                                    }))
-                                })
-                                .unwrap_or(false);
-                            if is_export {
-                                let live_val =
-                                    match interp.get_object_property(o.id, &key, &target.clone()) {
-                                        Completion::Normal(v) => v,
-                                        Completion::Throw(e) => return Completion::Throw(e),
-                                        other => return other,
-                                    };
-                                let desc = crate::interpreter::types::PropertyDescriptor {
-                                    value: Some(live_val),
-                                    writable: Some(true),
-                                    enumerable: Some(true),
-                                    configurable: Some(false),
-                                    get: None,
-                                    set: None,
-                                };
-                                return Completion::Normal(interp.from_property_descriptor(&desc));
-                            }
-                            if let Some(obj) = interp.get_object(o.id)
-                                && let Some(desc) = obj.borrow().get_own_property(&key)
-                            {
-                                return Completion::Normal(interp.from_property_descriptor(&desc));
-                            }
-                            return Completion::Normal(JsValue::Undefined);
+                        if is_export {
+                            let live_val = match interp.get_object_property(
+                                target_id,
+                                &key,
+                                &target.clone(),
+                            ) {
+                                Completion::Normal(v) => v,
+                                Completion::Throw(e) => return Completion::Throw(e),
+                                other => return other,
+                            };
+                            let desc = crate::interpreter::types::PropertyDescriptor {
+                                value: Some(live_val),
+                                writable: Some(true),
+                                enumerable: Some(true),
+                                configurable: Some(false),
+                                get: None,
+                                set: None,
+                            };
+                            return Completion::Normal(interp.from_property_descriptor(&desc));
                         }
-                        if let Some(obj) = interp.get_object(o.id)
+                        if let Some(obj) = interp.get_object(target_id)
                             && let Some(desc) = obj.borrow().get_own_property(&key)
                         {
                             return Completion::Normal(interp.from_property_descriptor(&desc));
                         }
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
-                    Completion::Normal(JsValue::Undefined)
-                },
-            ));
+                    if let Some(obj) = interp.get_object(target_id)
+                        && let Some(desc) = obj.borrow().get_own_property(&key)
+                    {
+                        return Completion::Normal(interp.from_property_descriptor(&desc));
+                    }
+                }
+                Completion::Normal(JsValue::UNDEFINED)
+            },
+        ));
         self.get_object_cell_expect(reflect_obj_id)
             .borrow_mut()
             .insert_builtin("getOwnPropertyDescriptor".to_string(), gopd_fn);
@@ -6937,30 +6907,30 @@ impl Interpreter {
             "getPrototypeOf".to_string(),
             1,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.getPrototypeOf requires an object"),
                     );
                 }
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                 {
                     let res = {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.is_proxy_revoked()
                     };
                     if res {
-                        match interp.proxy_get_prototype_of(o.id) {
+                        match interp.proxy_get_prototype_of(target_id) {
                             Ok(v) => return Completion::Normal(v),
                             Err(e) => return Completion::Throw(e),
                         }
                     }
                     if let Some(id) = obj.borrow().prototype_id {
-                        return Completion::Normal(JsValue::Object(crate::types::JsObject { id }));
+                        return Completion::Normal(JsValue::object(id));
                     }
                 }
-                Completion::Normal(JsValue::Null)
+                Completion::Normal(JsValue::NULL)
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)
@@ -6972,24 +6942,24 @@ impl Interpreter {
             "has".to_string(),
             2,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.has requires an object"),
                     );
                 }
-                let key_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let key_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let key = match interp.to_property_key(&key_raw) {
                     Ok(k) => k,
                     Err(e) => return Completion::Throw(e),
                 };
-                if let JsValue::Object(ref o) = target {
-                    match interp.proxy_has_property(o.id, &key) {
-                        Ok(result) => return Completion::Normal(JsValue::Boolean(result)),
+                if let Some(target_id) = target.as_object_id() {
+                    match interp.proxy_has_property(target_id, &key) {
+                        Ok(result) => return Completion::Normal(JsValue::boolean(result)),
                         Err(e) => return Completion::Throw(e),
                     }
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)
@@ -7001,28 +6971,28 @@ impl Interpreter {
             "isExtensible".to_string(),
             1,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.isExtensible requires an object"),
                     );
                 }
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                 {
                     let res = {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.is_proxy_revoked()
                     };
                     if res {
-                        match interp.proxy_is_extensible(o.id) {
-                            Ok(result) => return Completion::Normal(JsValue::Boolean(result)),
+                        match interp.proxy_is_extensible(target_id) {
+                            Ok(result) => return Completion::Normal(JsValue::boolean(result)),
                             Err(e) => return Completion::Throw(e),
                         }
                     }
-                    return Completion::Normal(JsValue::Boolean(obj.borrow().extensible));
+                    return Completion::Normal(JsValue::boolean(obj.borrow().extensible));
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)
@@ -7034,14 +7004,14 @@ impl Interpreter {
             "ownKeys".to_string(),
             1,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.ownKeys requires an object"),
                     );
                 }
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                 {
                     // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
                     {
@@ -7051,18 +7021,18 @@ impl Interpreter {
                             .as_ref()
                             .is_some_and(|ns| ns.deferred);
                         if is_deferred_ns
-                            && let Err(e) = interp.ensure_deferred_namespace_evaluation(o.id)
+                            && let Err(e) = interp.ensure_deferred_namespace_evaluation(target_id)
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    let obj = interp.get_object_cell(o.id).unwrap();
+                    let obj = interp.get_object_cell(target_id).unwrap();
                     let res = {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.is_proxy_revoked()
                     };
                     if res {
-                        match interp.proxy_own_keys(o.id) {
+                        match interp.proxy_own_keys(target_id) {
                             Ok(keys) => {
                                 let arr = interp.create_array(keys);
                                 return Completion::Normal(arr);
@@ -7079,7 +7049,7 @@ impl Interpreter {
                             drop(b);
                             let mut keys: Vec<JsValue> = Vec::new();
                             for i in 0..len {
-                                keys.push(JsValue::String(JsString::from_str(&i.to_string())));
+                                keys.push(JsValue::string(JsString::from_str(&i.to_string())));
                             }
                             let mut strings: Vec<(JsPropertyKey, usize)> = Vec::new();
                             let mut symbols: Vec<(JsPropertyKey, usize)> = Vec::new();
@@ -7096,7 +7066,7 @@ impl Interpreter {
                                 }
                             }
                             for (s, _) in &strings {
-                                keys.push(JsValue::String(s.to_js_string()));
+                                keys.push(JsValue::string(s.to_js_string()));
                             }
                             for (sym_key, _) in &symbols {
                                 keys.push(interp.symbol_key_to_jsvalue(sym_key));
@@ -7111,7 +7081,7 @@ impl Interpreter {
                     {
                         let b = obj.borrow();
                         if b.class_name == "String"
-                            && let Some(JsValue::String(ref s)) = b.primitive_value
+                            && let Some(s) = b.primitive_value.as_ref().and_then(JsValue::as_string)
                         {
                             let slen = s.code_units.len();
                             for i in 0..slen {
@@ -7151,14 +7121,14 @@ impl Interpreter {
                     let mut keys: Vec<JsValue> =
                         Vec::with_capacity(property_order.len() + virtual_indices.len() + 1);
                     for (n, _) in &indices {
-                        keys.push(JsValue::String(JsString::from_str(&n.to_string())));
+                        keys.push(JsValue::string(JsString::from_str(&n.to_string())));
                     }
                     // Add "length" for String exotic objects (before other strings)
                     if has_virtual_length && !existing_keys.contains("length".as_bytes()) {
-                        keys.push(JsValue::String(JsString::from_str("length")));
+                        keys.push(JsValue::string(JsString::from_str("length")));
                     }
                     for (s, _) in &strings {
-                        keys.push(JsValue::String(s.to_js_string()));
+                        keys.push(JsValue::string(s.to_js_string()));
                     }
                     for (sym_key, _) in &symbols {
                         keys.push(interp.symbol_key_to_jsvalue(sym_key));
@@ -7178,22 +7148,22 @@ impl Interpreter {
             "preventExtensions".to_string(),
             1,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.preventExtensions requires an object"),
                     );
                 }
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                 {
                     let res = {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.is_proxy_revoked()
                     };
                     if res {
-                        match interp.proxy_prevent_extensions(o.id) {
-                            Ok(result) => return Completion::Normal(JsValue::Boolean(result)),
+                        match interp.proxy_prevent_extensions(target_id) {
+                            Ok(result) => return Completion::Normal(JsValue::boolean(result)),
                             Err(e) => return Completion::Throw(e),
                         }
                     }
@@ -7210,13 +7180,13 @@ impl Interpreter {
                                 })
                                 .unwrap_or(true);
                             if !is_fixed {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                         }
                     }
                     obj.borrow_mut().extensible = false;
                 }
-                Completion::Normal(JsValue::Boolean(true))
+                Completion::Normal(JsValue::boolean(true))
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)
@@ -7228,52 +7198,48 @@ impl Interpreter {
             "set".to_string(),
             3,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.set requires an object"),
                     );
                 }
-                let key_raw = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let key_raw = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let key = match interp.to_property_key(&key_raw) {
                     Ok(k) => k,
                     Err(e) => return Completion::Throw(e),
                 };
-                let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let value = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 let receiver = args.get(3).cloned().unwrap_or(target.clone());
                 // Check if target is a proxy
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                     && {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.is_proxy_revoked()
                     }
                 {
-                    match interp.proxy_set(o.id, &key, value.clone(), &receiver) {
-                        Ok(result) => return Completion::Normal(JsValue::Boolean(result)),
+                    match interp.proxy_set(target_id, &key, value.clone(), &receiver) {
+                        Ok(result) => return Completion::Normal(JsValue::boolean(result)),
                         Err(e) => return Completion::Throw(e),
                     }
                 }
                 // Module namespace exotic: [[Set]] always returns false
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                     && obj.borrow().module_namespace().is_some()
                 {
-                    return Completion::Normal(JsValue::Boolean(false));
+                    return Completion::Normal(JsValue::boolean(false));
                 }
                 // TypedArray [[Set]] exotic — §10.4.5.5
-                if let JsValue::Object(ref o) = target {
+                if let Some(target_id) = target.as_object_id() {
                     let ta_info_opt = interp
-                        .get_object_cell(o.id)
+                        .get_object_cell(target_id)
                         .and_then(|obj| obj.borrow().typed_array_info().cloned());
                     if let Some(ta_info) = ta_info_opt
                         && let Some(index) = canonical_numeric_index_string(&key)
                     {
-                        let same = if let JsValue::Object(ref r) = receiver {
-                            r.id == o.id
-                        } else {
-                            false
-                        };
+                        let same = receiver.as_object_id() == Some(target_id);
                         if same {
                             let is_bigint = ta_info.kind.is_bigint();
                             let num_val = if is_bigint {
@@ -7282,7 +7248,7 @@ impl Interpreter {
                                     Err(e) => return Completion::Throw(e),
                                 }
                             } else {
-                                JsValue::Number(match interp.to_number_value(&value) {
+                                JsValue::number(match interp.to_number_value(&value) {
                                     Ok(n) => n,
                                     Err(e) => return Completion::Throw(e),
                                 })
@@ -7290,21 +7256,21 @@ impl Interpreter {
                             if is_valid_integer_index(&ta_info, index) {
                                 typed_array_set_index(&ta_info, index as usize, &num_val);
                             }
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                         // Not same: if index is out of bounds in target, silently succeed
                         if !is_valid_integer_index(&ta_info, index) {
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                         // Index is in bounds in target: OrdinarySet to receiver
-                        if let JsValue::Object(ref r) = receiver {
+                        if let Some(receiver_id) = receiver.as_object_id() {
                             let recv_ta_opt = interp
-                                .get_object_cell(r.id)
+                                .get_object_cell(receiver_id)
                                 .and_then(|obj| obj.borrow().typed_array_info().cloned());
                             if let Some(recv_ta) = recv_ta_opt {
                                 // Receiver is TypedArray: IntegerIndexedElementSet
                                 if !is_valid_integer_index(&recv_ta, index) {
-                                    return Completion::Normal(JsValue::Boolean(false));
+                                    return Completion::Normal(JsValue::boolean(false));
                                 }
                                 let is_bigint = recv_ta.kind.is_bigint();
                                 let num_val = if is_bigint {
@@ -7313,22 +7279,22 @@ impl Interpreter {
                                         Err(e) => return Completion::Throw(e),
                                     }
                                 } else {
-                                    JsValue::Number(match interp.to_number_value(&value) {
+                                    JsValue::number(match interp.to_number_value(&value) {
                                         Ok(n) => n,
                                         Err(e) => return Completion::Throw(e),
                                     })
                                 };
                                 typed_array_set_index(&recv_ta, index as usize, &num_val);
-                                return Completion::Normal(JsValue::Boolean(true));
-                            } else if let Some(recv_obj) = interp.get_object_cell(r.id) {
+                                return Completion::Normal(JsValue::boolean(true));
+                            } else if let Some(recv_obj) = interp.get_object_cell(receiver_id) {
                                 // Non-TypedArray receiver: create plain property, no coercion
                                 let existing = recv_obj.borrow().get_own_property(&key);
                                 if let Some(ref ed) = existing {
                                     if ed.get.is_some() || ed.set.is_some() {
-                                        return Completion::Normal(JsValue::Boolean(false));
+                                        return Completion::Normal(JsValue::boolean(false));
                                     }
                                     if ed.writable == Some(false) {
-                                        return Completion::Normal(JsValue::Boolean(false));
+                                        return Completion::Normal(JsValue::boolean(false));
                                     }
                                     let update_desc = PropertyDescriptor {
                                         value: Some(value),
@@ -7342,24 +7308,24 @@ impl Interpreter {
                                 } else {
                                     let success =
                                         recv_obj.borrow_mut().set_property_value(&key, value);
-                                    return Completion::Normal(JsValue::Boolean(success));
+                                    return Completion::Normal(JsValue::boolean(success));
                                 }
-                                return Completion::Normal(JsValue::Boolean(true));
+                                return Completion::Normal(JsValue::boolean(true));
                             }
                         }
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                 }
                 // OrdinarySet: find ownDesc on target, walking prototype chain
                 let mut own_desc: Option<PropertyDescriptor> = None;
-                if let JsValue::Object(ref o) = target {
-                    let mut cur_id = Some(o.id);
+                if let Some(target_id) = target.as_object_id() {
+                    let mut cur_id = Some(target_id);
                     'proto_walk: while let Some(cid) = cur_id {
                         // If cur_obj is a Proxy, delegate to proxy_set
                         if interp.get_proxy_info(cid).is_some() {
                             match interp.proxy_set(cid, &key, value.clone(), &receiver) {
                                 Ok(success) => {
-                                    return Completion::Normal(JsValue::Boolean(success));
+                                    return Completion::Normal(JsValue::boolean(success));
                                 }
                                 Err(e) => return Completion::Throw(e),
                             }
@@ -7371,11 +7337,7 @@ impl Interpreter {
                                 if let Some(ta) = borrow.typed_array_info()
                                     && let Some(index) = canonical_numeric_index_string(&key)
                                 {
-                                    let same = if let JsValue::Object(ref r) = receiver {
-                                        r.id == cid
-                                    } else {
-                                        false
-                                    };
+                                    let same = receiver.as_object_id() == Some(cid);
                                     if same {
                                         let is_bigint = ta.kind.is_bigint();
                                         let ta_clone = ta.clone();
@@ -7386,7 +7348,7 @@ impl Interpreter {
                                                 Err(e) => return Completion::Throw(e),
                                             }
                                         } else {
-                                            JsValue::Number(match interp.to_number_value(&value) {
+                                            JsValue::number(match interp.to_number_value(&value) {
                                                 Ok(n) => n,
                                                 Err(e) => return Completion::Throw(e),
                                             })
@@ -7398,9 +7360,9 @@ impl Interpreter {
                                                 &num_val,
                                             );
                                         }
-                                        return Completion::Normal(JsValue::Boolean(true));
+                                        return Completion::Normal(JsValue::boolean(true));
                                     } else if !is_valid_integer_index(ta, index) {
-                                        return Completion::Normal(JsValue::Boolean(true));
+                                        return Completion::Normal(JsValue::boolean(true));
                                     }
                                     // Valid index, not same: fall through to get_own_property
                                 }
@@ -7417,7 +7379,7 @@ impl Interpreter {
                 }
                 // If no own desc found, treat as default data descriptor
                 let own_desc = own_desc.unwrap_or(PropertyDescriptor {
-                    value: Some(JsValue::Undefined),
+                    value: Some(JsValue::UNDEFINED),
                     writable: Some(true),
                     enumerable: Some(true),
                     configurable: Some(true),
@@ -7427,34 +7389,34 @@ impl Interpreter {
                 // If accessor descriptor
                 if own_desc.get.is_some() || own_desc.set.is_some() {
                     if let Some(ref setter) = own_desc.set
-                        && !matches!(setter, JsValue::Undefined)
+                        && !(setter).is_undefined()
                     {
                         let setter = setter.clone();
                         return match interp.call_function(&setter, &receiver, &[value]) {
-                            Completion::Normal(_) => Completion::Normal(JsValue::Boolean(true)),
+                            Completion::Normal(_) => Completion::Normal(JsValue::boolean(true)),
                             Completion::Throw(e) => Completion::Throw(e),
-                            _ => Completion::Normal(JsValue::Boolean(true)),
+                            _ => Completion::Normal(JsValue::boolean(true)),
                         };
                     }
-                    return Completion::Normal(JsValue::Boolean(false));
+                    return Completion::Normal(JsValue::boolean(false));
                 }
                 // Data descriptor
                 if own_desc.writable == Some(false) {
-                    return Completion::Normal(JsValue::Boolean(false));
+                    return Completion::Normal(JsValue::boolean(false));
                 }
-                if !matches!(receiver, JsValue::Object(_)) {
-                    return Completion::Normal(JsValue::Boolean(false));
+                if !(receiver).is_object() {
+                    return Completion::Normal(JsValue::boolean(false));
                 }
-                if let JsValue::Object(ref r) = receiver {
-                    let is_proxy_recv = interp.get_proxy_info(r.id).is_some();
+                if let Some(receiver_id) = receiver.as_object_id() {
+                    let is_proxy_recv = interp.get_proxy_info(receiver_id).is_some();
                     if is_proxy_recv {
                         // §10.1.9.2: Receiver.[[GetOwnProperty]](P)
                         let existing_val =
-                            match interp.proxy_get_own_property_descriptor(r.id, &key) {
+                            match interp.proxy_get_own_property_descriptor(receiver_id, &key) {
                                 Ok(v) => v,
                                 Err(e) => return Completion::Throw(e),
                             };
-                        if matches!(existing_val, JsValue::Undefined) {
+                        if (existing_val).is_undefined() {
                             // CreateDataProperty(Receiver, P, V)
                             let create_desc = PropertyDescriptor {
                                 value: Some(value),
@@ -7465,9 +7427,9 @@ impl Interpreter {
                                 set: None,
                             };
                             let desc_val = interp.from_property_descriptor(&create_desc);
-                            match interp.proxy_define_own_property(r.id, key, &desc_val) {
+                            match interp.proxy_define_own_property(receiver_id, key, &desc_val) {
                                 Ok(success) => {
-                                    return Completion::Normal(JsValue::Boolean(success));
+                                    return Completion::Normal(JsValue::boolean(success));
                                 }
                                 Err(e) => return Completion::Throw(e),
                             }
@@ -7475,13 +7437,13 @@ impl Interpreter {
                             let existing_desc = match interp.to_property_descriptor(&existing_val) {
                                 Ok(d) => d,
                                 Err(Some(e)) => return Completion::Throw(e),
-                                Err(None) => return Completion::Normal(JsValue::Boolean(false)),
+                                Err(None) => return Completion::Normal(JsValue::boolean(false)),
                             };
                             if existing_desc.is_accessor_descriptor() {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                             if existing_desc.writable == Some(false) {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                             // Receiver.[[DefineOwnProperty]](P, {[[Value]]: V})
                             let val_desc = PropertyDescriptor {
@@ -7493,22 +7455,22 @@ impl Interpreter {
                                 set: None,
                             };
                             let desc_val = interp.from_property_descriptor(&val_desc);
-                            match interp.proxy_define_own_property(r.id, key, &desc_val) {
+                            match interp.proxy_define_own_property(receiver_id, key, &desc_val) {
                                 Ok(success) => {
-                                    return Completion::Normal(JsValue::Boolean(success));
+                                    return Completion::Normal(JsValue::boolean(success));
                                 }
                                 Err(e) => return Completion::Throw(e),
                             }
                         }
                     }
-                    if let Some(recv_obj) = interp.get_object_cell(r.id) {
+                    if let Some(recv_obj) = interp.get_object_cell(receiver_id) {
                         let existing = recv_obj.borrow().get_own_property(&key);
                         if let Some(ref ed) = existing {
                             if ed.get.is_some() || ed.set.is_some() {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                             if ed.writable == Some(false) {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                             let update_desc = PropertyDescriptor {
                                 value: Some(value),
@@ -7522,12 +7484,12 @@ impl Interpreter {
                             let is_array = recv_obj.borrow().class_name == "Array";
                             if is_array {
                                 match interp.array_define_own_property(
-                                    r.id as usize,
+                                    receiver_id as usize,
                                     &key,
                                     update_desc,
                                 ) {
                                     Ok(success) => {
-                                        return Completion::Normal(JsValue::Boolean(success));
+                                        return Completion::Normal(JsValue::boolean(success));
                                     }
                                     Err(e) => return Completion::Throw(e),
                                 }
@@ -7537,9 +7499,9 @@ impl Interpreter {
                             recv_obj.borrow_mut().set_property_value(&key, value);
                         }
                     }
-                    return Completion::Normal(JsValue::Boolean(true));
+                    return Completion::Normal(JsValue::boolean(true));
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)
@@ -7551,63 +7513,58 @@ impl Interpreter {
             "setPrototypeOf".to_string(),
             2,
             |interp, _this, args| {
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !(target).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Reflect.setPrototypeOf requires an object"),
                     );
                 }
-                let proto = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let proto = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // Step 2: If Type(proto) is not Object and proto is not null, throw TypeError
-                if !matches!(proto, JsValue::Object(_) | JsValue::Null) {
+                if !proto.is_object() && !proto.is_null() {
                     return Completion::Throw(interp.create_type_error(
                         "Reflect.setPrototypeOf: proto must be Object or null",
                     ));
                 }
-                if let JsValue::Object(ref o) = target
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                 {
                     let res = {
                         let _b = obj.borrow();
                         _b.is_proxy() || _b.is_proxy_revoked()
                     };
                     if res {
-                        match interp.proxy_set_prototype_of(o.id, &proto) {
-                            Ok(result) => return Completion::Normal(JsValue::Boolean(result)),
+                        match interp.proxy_set_prototype_of(target_id, &proto) {
+                            Ok(result) => return Completion::Normal(JsValue::boolean(result)),
                             Err(e) => return Completion::Throw(e),
                         }
                     }
                     // OrdinarySetPrototypeOf (§10.1.2)
-                    let target_id = o.id;
                     let current_proto_id = obj.borrow().prototype_id;
-                    let new_proto_id = if let JsValue::Object(ref p) = proto {
-                        Some(p.id)
-                    } else {
-                        None
-                    };
+                    let new_proto_id = proto.as_object_id();
                     // Step 4: If SameValue(V, current), return true
-                    if matches!(proto, JsValue::Null) && current_proto_id.is_none() {
-                        return Completion::Normal(JsValue::Boolean(true));
+                    if (proto).is_null() && current_proto_id.is_none() {
+                        return Completion::Normal(JsValue::boolean(true));
                     }
                     if let (Some(new_id), Some(cur_id)) = (new_proto_id, current_proto_id)
                         && new_id == cur_id
                     {
-                        return Completion::Normal(JsValue::Boolean(true));
+                        return Completion::Normal(JsValue::boolean(true));
                     }
                     // Immutable prototype check
                     if obj.borrow().is_immutable_prototype {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     // Step 5: If not extensible, return false
                     if !obj.borrow().extensible {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     // Steps 6-8: Check for circular prototype chain
                     if let Some(new_pid) = new_proto_id {
                         let mut p_id = Some(new_pid);
                         while let Some(pid) = p_id {
                             if pid == target_id {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                             if let Some(p_obj) = interp.get_object_cell(pid) {
                                 // If p is a Proxy, stop the loop (done = true per spec step 8.c.i)
@@ -7621,21 +7578,18 @@ impl Interpreter {
                         }
                     }
                     // Actually set the prototype
-                    match &proto {
-                        JsValue::Null => {
-                            obj.borrow_mut().prototype_id = None;
+                    if proto.is_null() {
+                        obj.borrow_mut().prototype_id = None;
+                    } else if let Some(proto_id) = proto.as_object_id() {
+                        if let Some(proto_obj) = interp.get_object_cell(proto_id) {
+                            obj.borrow_mut().prototype_id = Some(proto_obj.borrow().id.unwrap());
                         }
-                        JsValue::Object(p) => {
-                            if let Some(proto_obj) = interp.get_object_cell(p.id) {
-                                obj.borrow_mut().prototype_id =
-                                    Some(proto_obj.borrow().id.unwrap());
-                            }
-                        }
-                        _ => unreachable!(),
+                    } else {
+                        unreachable!()
                     }
-                    return Completion::Normal(JsValue::Boolean(true));
+                    return Completion::Normal(JsValue::boolean(true));
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)
@@ -7646,7 +7600,7 @@ impl Interpreter {
         self.define_to_string_tag(reflect_obj_id, "Reflect");
 
         // Register Reflect as global
-        let reflect_val = JsValue::Object(crate::types::JsObject { id: reflect_id });
+        let reflect_val = JsValue::object(reflect_id);
         self.realm()
             .global_env
             .borrow_mut()
@@ -7664,7 +7618,7 @@ impl Interpreter {
             "call".to_string(),
             1,
             |interp, _this, args| {
-                let this_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let call_args = if args.len() > 1 { &args[1..] } else { &[] };
                 interp.call_function(_this, &this_arg, call_args)
             },
@@ -7685,42 +7639,41 @@ impl Interpreter {
                         "Function.prototype.apply called on non-callable",
                     ));
                 }
-                let this_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let arr_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                let call_args = match &arr_arg {
-                    JsValue::Undefined | JsValue::Null => vec![],
-                    JsValue::Object(o) => {
-                        let len_val = match interp.get_object_property(o.id, "length", &arr_arg) {
+                let this_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let arr_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                let call_args = if arr_arg.is_nullish() {
+                    vec![]
+                } else if let Some(array_like_id) = arr_arg.as_object_id() {
+                    let len_val =
+                        match interp.get_object_property(array_like_id, "length", &arr_arg) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
-                        let len_num = match interp.to_number_value(&len_val) {
-                            Ok(n) => n,
-                            Err(e) => return Completion::Throw(e),
-                        };
-                        let len = if len_num.is_nan() || len_num <= 0.0 {
-                            0usize
-                        } else {
-                            (len_num.min(9007199254740991.0).floor()) as usize
-                        };
-                        let mut list = Vec::with_capacity(len);
-                        for i in 0..len {
-                            match interp.get_object_property(o.id, &i.to_string(), &arr_arg) {
-                                Completion::Normal(v) => list.push(v),
-                                Completion::Throw(e) => return Completion::Throw(e),
-                                _ => list.push(JsValue::Undefined),
-                            }
+                    let len_num = match interp.to_number_value(&len_val) {
+                        Ok(n) => n,
+                        Err(e) => return Completion::Throw(e),
+                    };
+                    let len = if len_num.is_nan() || len_num <= 0.0 {
+                        0usize
+                    } else {
+                        (len_num.min(9007199254740991.0).floor()) as usize
+                    };
+                    let mut list = Vec::with_capacity(len);
+                    for i in 0..len {
+                        match interp.get_object_property(array_like_id, &i.to_string(), &arr_arg) {
+                            Completion::Normal(v) => list.push(v),
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => list.push(JsValue::UNDEFINED),
                         }
-                        list
                     }
-                    _ => {
-                        return Completion::Throw(interp.create_error_in_realm(
-                            fn_proto_realm_id,
-                            "TypeError",
-                            "CreateListFromArrayLike called on non-object",
-                        ));
-                    }
+                    list
+                } else {
+                    return Completion::Throw(interp.create_error_in_realm(
+                        fn_proto_realm_id,
+                        "TypeError",
+                        "CreateListFromArrayLike called on non-object",
+                    ));
                 };
                 interp.call_function(_this, &this_arg, &call_args)
             },
@@ -7734,14 +7687,14 @@ impl Interpreter {
             "bind".to_string(),
             1,
             |interp, this_val, args: &[JsValue]| {
-                if !matches!(this_val, JsValue::Object(_)) {
+                if !(this_val).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Bind must be called on a function"),
                     );
                 }
                 // Check if target is callable
-                let is_callable = if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                let is_callable = if let Some(target_id) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                 {
                     obj.borrow().callable.is_some()
                 } else {
@@ -7753,29 +7706,30 @@ impl Interpreter {
                     );
                 }
 
-                let bind_this = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let bind_this = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let bound_args: Vec<JsValue> = args.iter().skip(1).cloned().collect();
 
                 // Spec §20.2.3.2: HasOwnProperty(Target, "length"), then Get, then type check
                 // For proxy targets, use invoke_proxy_trap to trigger getOwnPropertyDescriptor
-                let target_length_f64: f64 = if let JsValue::Object(o) = this_val {
+                let target_length_f64: f64 = if let Some(target_id) = this_val.as_object_id() {
                     let is_proxy = interp
-                        .get_object_cell(o.id)
+                        .get_object_cell(target_id)
                         .is_some_and(|obj| obj.borrow().is_proxy());
                     let has_own_length = if is_proxy {
                         match interp.invoke_proxy_trap(
-                            o.id,
+                            target_id,
                             "getOwnPropertyDescriptor",
                             vec![
-                                interp.get_proxy_target_val(o.id),
-                                JsValue::String(crate::types::JsString::from_str("length")),
+                                interp.get_proxy_target_val(target_id),
+                                JsValue::string(crate::types::JsString::from_str("length")),
                             ],
                         ) {
-                            Ok(Some(v)) => !matches!(v, JsValue::Undefined),
+                            Ok(Some(v)) => !(v).is_undefined(),
                             Ok(None) => {
-                                let target_val = interp.get_proxy_target_val(o.id);
-                                if let JsValue::Object(t) = &target_val
-                                    && let Some(target_obj) = interp.get_object_cell(t.id)
+                                let target_val = interp.get_proxy_target_val(target_id);
+                                if let Some(proxy_target_id) = target_val.as_object_id()
+                                    && let Some(target_obj) =
+                                        interp.get_object_cell(proxy_target_id)
                                 {
                                     target_obj.borrow().get_own_property("length").is_some()
                                 } else {
@@ -7784,18 +7738,17 @@ impl Interpreter {
                             }
                             Err(e) => return Completion::Throw(e),
                         }
-                    } else if let Some(obj) = interp.get_object_cell(o.id) {
+                    } else if let Some(obj) = interp.get_object_cell(target_id) {
                         obj.borrow().get_own_property("length").is_some()
                     } else {
                         false
                     };
                     if has_own_length {
-                        match interp.get_object_property(o.id, "length", this_val) {
-                            Completion::Normal(JsValue::Number(n)) => {
+                        match interp.get_object_property(target_id, "length", this_val) {
+                            Completion::Normal(value) => value.as_number().map_or(0.0, |n| {
                                 let int = to_integer_or_infinity(n);
                                 if int < 0.0 { 0.0 } else { int }
-                            }
-                            Completion::Normal(_) => 0.0,
+                            }),
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => 0.0,
                         }
@@ -7813,10 +7766,11 @@ impl Interpreter {
                 };
 
                 // Read target name using getter-aware access
-                let target_name = if let JsValue::Object(o) = this_val {
-                    match interp.get_object_property(o.id, "name", this_val) {
-                        Completion::Normal(JsValue::String(s)) => s.to_string(),
-                        Completion::Normal(_) => String::new(),
+                let target_name = if let Some(target_id) = this_val.as_object_id() {
+                    match interp.get_object_property(target_id, "name", this_val) {
+                        Completion::Normal(value) => value
+                            .as_string()
+                            .map_or_else(String::new, |s| s.to_string()),
                         Completion::Throw(e) => return Completion::Throw(e),
                         _ => String::new(),
                     }
@@ -7845,7 +7799,7 @@ impl Interpreter {
                                     Some(bd) => {
                                         (bd.target.clone(), bd.this.clone(), bd.args.clone())
                                     }
-                                    None => (JsValue::Undefined, JsValue::Undefined, Vec::new()),
+                                    None => (JsValue::UNDEFINED, JsValue::UNDEFINED, Vec::new()),
                                 }
                             };
                             let mut all_args = ba;
@@ -7860,13 +7814,13 @@ impl Interpreter {
                     is_ctor,
                 );
                 let result = interp.create_function(bound);
-                if let JsValue::Object(ref o) = result
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(result_id) = result.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(result_id)
                 {
-                    bound_id_cell.set(o.id);
+                    bound_id_cell.set(result_id);
                     // §20.2.3.2 step 4-5: Set bound function's [[Prototype]] to target's [[Prototype]]
-                    if let JsValue::Object(target_o) = this_val
-                        && let Some(target_obj) = interp.get_object_cell(target_o.id)
+                    if let Some(target_id) = this_val.as_object_id()
+                        && let Some(target_obj) = interp.get_object_cell(target_id)
                     {
                         obj.borrow_mut().prototype_id = target_obj.borrow().prototype_id;
                     }
@@ -7885,7 +7839,7 @@ impl Interpreter {
                     obj.borrow_mut().insert_property(
                         "length".to_string(),
                         PropertyDescriptor::data(
-                            JsValue::Number(bound_length_f64),
+                            JsValue::number(bound_length_f64),
                             false,
                             false,
                             true,
@@ -7904,8 +7858,8 @@ impl Interpreter {
             "toString".to_string(),
             0,
             |interp, this_val, _args: &[JsValue]| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(target_id) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(target_id)
                 {
                     let b = obj.borrow();
                     if b.is_proxy() || b.is_proxy_revoked() {
@@ -7918,7 +7872,7 @@ impl Interpreter {
                         drop(b);
                         // Only callable proxies return NativeFunction string
                         if interp.is_callable(this_val) {
-                            return Completion::Normal(JsValue::String(JsString::from_str(
+                            return Completion::Normal(JsValue::string(JsString::from_str(
                                 "function () { [native code] }",
                             )));
                         }
@@ -7959,7 +7913,7 @@ impl Interpreter {
                                 format!("function {}() {{ [native code] }}", sanitized)
                             }
                         };
-                        return Completion::Normal(JsValue::String(JsString::from_str(&s)));
+                        return Completion::Normal(JsValue::string(JsString::from_str(&s)));
                     }
                 }
                 // Step 2: If this is not callable, throw TypeError
@@ -7991,8 +7945,8 @@ impl Interpreter {
             "evaluate".to_string(),
             1,
             move |interp, this, args| {
-                let eval_realm_id = if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                let eval_realm_id = if let Some(shadow_realm_id) = this.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(shadow_realm_id)
                     && let Some(realm_id) = obj.borrow().shadow_realm_id()
                 {
                     realm_id
@@ -8004,16 +7958,15 @@ impl Interpreter {
                     ));
                 };
 
-                let source_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let source_text = match &source_val {
-                    JsValue::String(s) => s.to_string(),
-                    _ => {
-                        return Completion::Throw(interp.create_error_in_realm(
-                            my_realm_id,
-                            "TypeError",
-                            "ShadowRealm.prototype.evaluate: sourceText must be a string",
-                        ));
-                    }
+                let source_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let source_text = if let Some(source) = source_val.as_string() {
+                    source.to_string()
+                } else {
+                    return Completion::Throw(interp.create_error_in_realm(
+                        my_realm_id,
+                        "TypeError",
+                        "ShadowRealm.prototype.evaluate: sourceText must be a string",
+                    ));
                 };
 
                 interp.perform_realm_eval(&source_text, my_realm_id, eval_realm_id)
@@ -8028,8 +7981,8 @@ impl Interpreter {
             "importValue".to_string(),
             2,
             move |interp, this, args| {
-                let eval_realm_id = if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                let eval_realm_id = if let Some(shadow_realm_id) = this.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(shadow_realm_id)
                     && let Some(realm_id) = obj.borrow().shadow_realm_id()
                 {
                     realm_id
@@ -8041,23 +7994,22 @@ impl Interpreter {
                     ));
                 };
 
-                let specifier_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let export_name_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let specifier_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let export_name_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let specifier = match interp.to_string_value(&specifier_val) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let export_name = match &export_name_val {
-                    JsValue::String(s) => s.to_string(),
-                    _ => {
-                        return Completion::Throw(interp.create_error_in_realm(
-                            my_realm_id,
-                            "TypeError",
-                            "ShadowRealm.prototype.importValue: exportName must be a string",
-                        ));
-                    }
+                let export_name = if let Some(export_name) = export_name_val.as_string() {
+                    export_name.to_string()
+                } else {
+                    return Completion::Throw(interp.create_error_in_realm(
+                        my_realm_id,
+                        "TypeError",
+                        "ShadowRealm.prototype.importValue: exportName must be a string",
+                    ));
                 };
 
                 let caller_realm_id = my_realm_id;
@@ -8149,7 +8101,7 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("importValue".to_string(), import_value_fn);
 
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
 
         // ShadowRealm constructor
         let proto_val_for_ctor = proto_val.clone();
@@ -8170,17 +8122,17 @@ impl Interpreter {
                     let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                     o.class_name = "ShadowRealm".to_string();
                     o.kind = crate::interpreter::types::ObjectKind::ShadowRealm(new_realm_id);
-                    if let JsValue::Object(ref p) = proto_val_for_ctor {
-                        o.prototype_id = Some(p.id);
+                    if let Some(proto_id) = proto_val_for_ctor.as_object_id() {
+                        o.prototype_id = Some(proto_id);
                     }
                 }
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set ShadowRealm.prototype on constructor
-        if let JsValue::Object(ref ctor_o) = shadow_realm_ctor
-            && let Some(ctor_obj) = self.get_object_cell(ctor_o.id)
+        if let Some(constructor_id) = shadow_realm_ctor.as_object_id()
+            && let Some(ctor_obj) = self.get_object_cell(constructor_id)
         {
             ctor_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -8189,8 +8141,8 @@ impl Interpreter {
         }
 
         // Set ShadowRealm.prototype.constructor = ShadowRealm
-        if let JsValue::Object(ref p) = proto_val
-            && let Some(proto_obj) = self.get_object_cell(p.id)
+        if let Some(proto_id) = proto_val.as_object_id()
+            && let Some(proto_obj) = self.get_object_cell(proto_id)
         {
             proto_obj
                 .borrow_mut()

--- a/src/interpreter/builtins/number.rs
+++ b/src/interpreter/builtins/number.rs
@@ -259,19 +259,18 @@ impl Interpreter {
             interp: &Interpreter,
             this: &JsValue,
         ) -> Option<crate::types::JsSymbol> {
-            match this {
-                JsValue::Symbol(s) => Some(s.clone()),
-                JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|obj| {
-                    let b = obj.borrow();
-                    if b.class_name == "Symbol"
-                        && let Some(JsValue::Symbol(s)) = &b.primitive_value
-                    {
-                        return Some(s.clone());
-                    }
-                    None
-                }),
-                _ => None,
+            if let Some(symbol) = this.as_symbol() {
+                return Some(symbol);
             }
+            let object_id = this.as_object_id()?;
+            interp.get_object_cell(object_id).and_then(|obj| {
+                let object = obj.borrow();
+                if object.class_name == "Symbol" {
+                    object.primitive_value.as_ref().and_then(JsValue::as_symbol)
+                } else {
+                    None
+                }
+            })
         }
 
         #[allow(clippy::type_complexity)]
@@ -294,7 +293,7 @@ impl Interpreter {
                         .as_ref()
                         .map(|d| d.to_rust_string())
                         .unwrap_or_default();
-                    Completion::Normal(JsValue::String(JsString::from_str(&format!(
+                    Completion::Normal(JsValue::string(JsString::from_str(&format!(
                         "Symbol({desc})"
                     ))))
                 }),
@@ -308,7 +307,7 @@ impl Interpreter {
                             interp.create_type_error("Symbol.prototype.valueOf requires a Symbol");
                         return Completion::Throw(err);
                     };
-                    Completion::Normal(JsValue::Symbol(sym))
+                    Completion::Normal(JsValue::symbol(sym))
                 }),
             ),
         ];
@@ -329,8 +328,8 @@ impl Interpreter {
                 return Completion::Throw(err);
             };
             match sym.description {
-                Some(d) => Completion::Normal(JsValue::String(d)),
-                None => Completion::Normal(JsValue::Undefined),
+                Some(d) => Completion::Normal(JsValue::string(d)),
+                None => Completion::Normal(JsValue::UNDEFINED),
             }
         });
 
@@ -344,7 +343,7 @@ impl Interpreter {
                         interp.create_type_error("Symbol[Symbol.toPrimitive] requires a Symbol");
                     return Completion::Throw(err);
                 };
-                Completion::Normal(JsValue::Symbol(sym))
+                Completion::Normal(JsValue::symbol(sym))
             }),
             false,
         ));
@@ -363,21 +362,16 @@ impl Interpreter {
                 .borrow_mut()
                 .insert_property(
                     key,
-                    PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str("Symbol")),
-                        false,
-                        false,
-                        true,
-                    ),
+                    PropertyDescriptor::data(JsValue::from_str("Symbol"), false, false, true),
                 );
         }
 
         // Set Symbol.prototype on the Symbol constructor
         if let Some(sym_val) = self.get_global_var("Symbol")
-            && let JsValue::Object(o) = &sym_val
-            && let Some(sym_obj) = self.get_object_cell(o.id)
+            && let Some(symbol_id) = sym_val.as_object_id()
+            && let Some(sym_obj) = self.get_object_cell(symbol_id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             sym_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -399,22 +393,21 @@ impl Interpreter {
             .class_name = "Number".to_string();
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
-            .primitive_value = Some(JsValue::Number(0.0));
+            .primitive_value = Some(JsValue::number(0.0));
 
         fn this_number_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
-            match this {
-                JsValue::Number(n) => Some(*n),
-                JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|obj| {
-                    let b = obj.borrow();
-                    if b.class_name == "Number"
-                        && let Some(JsValue::Number(n)) = &b.primitive_value
-                    {
-                        return Some(*n);
-                    }
-                    None
-                }),
-                _ => None,
+            if let Some(number) = this.as_number() {
+                return Some(number);
             }
+            let object_id = this.as_object_id()?;
+            interp.get_object_cell(object_id).and_then(|obj| {
+                let object = obj.borrow();
+                if object.class_name == "Number" {
+                    object.primitive_value.as_ref().and_then(JsValue::as_number)
+                } else {
+                    None
+                }
+            })
         }
 
         #[allow(clippy::type_complexity)]
@@ -450,22 +443,22 @@ impl Interpreter {
                         return Completion::Throw(err);
                     }
                     if radix == 10 {
-                        Completion::Normal(JsValue::String(JsString::from_str(&to_js_string(
-                            &JsValue::Number(n),
+                        Completion::Normal(JsValue::string(JsString::from_str(&to_js_string(
+                            &JsValue::number(n),
                         ))))
                     } else if n.is_nan() {
-                        Completion::Normal(JsValue::String(JsString::from_str("NaN")))
+                        Completion::Normal(JsValue::from_str("NaN"))
                     } else if n.is_infinite() {
-                        Completion::Normal(JsValue::String(JsString::from_str(if n > 0.0 {
+                        Completion::Normal(JsValue::from_str(if n > 0.0 {
                             "Infinity"
                         } else {
                             "-Infinity"
-                        })))
+                        }))
                     } else if n == 0.0 {
-                        Completion::Normal(JsValue::String(JsString::from_str("0")))
+                        Completion::Normal(JsValue::from_str("0"))
                     } else {
                         let s = format_number_radix(n, radix);
-                        Completion::Normal(JsValue::String(JsString::from_str(&s)))
+                        Completion::Normal(JsValue::from_str(&s))
                     }
                 }),
             ),
@@ -478,7 +471,7 @@ impl Interpreter {
                             interp.create_type_error("Number.prototype.valueOf requires a Number");
                         return Completion::Throw(err);
                     };
-                    Completion::Normal(JsValue::Number(n))
+                    Completion::Normal(JsValue::number(n))
                 }),
             ),
             (
@@ -508,21 +501,23 @@ impl Interpreter {
                     }
                     let digits = f as usize;
                     if n.is_nan() {
-                        return Completion::Normal(JsValue::String(JsString::from_str("NaN")));
+                        return Completion::Normal(JsValue::from_str("NaN"));
                     }
                     if n.is_infinite() {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            if n > 0.0 { "Infinity" } else { "-Infinity" },
-                        )));
+                        return Completion::Normal(JsValue::from_str(if n > 0.0 {
+                            "Infinity"
+                        } else {
+                            "-Infinity"
+                        }));
                     }
                     // Step 2: If x is -0, set x to +0
                     let n = if n == 0.0 { 0.0 } else { n };
                     if n.abs() >= 1e21 {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            &to_js_string(&JsValue::Number(n)),
+                        return Completion::Normal(JsValue::from_str(&to_js_string(
+                            &JsValue::number(n),
                         )));
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&format!(
+                    Completion::Normal(JsValue::string(JsString::from_str(&format!(
                         "{n:.digits$}"
                     ))))
                 }),
@@ -547,12 +542,14 @@ impl Interpreter {
                         None
                     };
                     if n.is_nan() {
-                        return Completion::Normal(JsValue::String(JsString::from_str("NaN")));
+                        return Completion::Normal(JsValue::from_str("NaN"));
                     }
                     if n.is_infinite() {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            if n > 0.0 { "Infinity" } else { "-Infinity" },
-                        )));
+                        return Completion::Normal(JsValue::from_str(if n > 0.0 {
+                            "Infinity"
+                        } else {
+                            "-Infinity"
+                        }));
                     }
                     if let Some(f) = f {
                         if !(0.0..=100.0).contains(&f) {
@@ -563,10 +560,10 @@ impl Interpreter {
                             return Completion::Throw(err);
                         }
                         let result = format_exponential(n, Some(f as usize));
-                        Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                        Completion::Normal(JsValue::from_str(&result))
                     } else {
                         let result = format_exponential(n, None);
-                        Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                        Completion::Normal(JsValue::from_str(&result))
                     }
                 }),
             ),
@@ -581,8 +578,8 @@ impl Interpreter {
                     };
                     let has_arg = args.first().is_some_and(|v| !v.is_undefined());
                     if !has_arg {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            &to_js_string(&JsValue::Number(n)),
+                        return Completion::Normal(JsValue::from_str(&to_js_string(
+                            &JsValue::number(n),
                         )));
                     }
                     let p_raw = match interp.to_number_value(args.first().unwrap()) {
@@ -591,12 +588,14 @@ impl Interpreter {
                     };
                     let p = to_integer_or_infinity(p_raw);
                     if n.is_nan() {
-                        return Completion::Normal(JsValue::String(JsString::from_str("NaN")));
+                        return Completion::Normal(JsValue::from_str("NaN"));
                     }
                     if n.is_infinite() {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            if n > 0.0 { "Infinity" } else { "-Infinity" },
-                        )));
+                        return Completion::Normal(JsValue::from_str(if n > 0.0 {
+                            "Infinity"
+                        } else {
+                            "-Infinity"
+                        }));
                     }
                     if !(1.0..=100.0).contains(&p) {
                         let err = interp.create_error(
@@ -607,7 +606,7 @@ impl Interpreter {
                     }
                     let precision = p as usize;
                     let result = format_precision(n, precision);
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::from_str(&result))
                 }),
             ),
             (
@@ -619,13 +618,13 @@ impl Interpreter {
                             .create_type_error("Number.prototype.toLocaleString requires a Number");
                         return Completion::Throw(err);
                     };
-                    let locales = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let nf = match interp.intl_construct_number_format(&locales, &options) {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let num_val = JsValue::Number(n);
+                    let num_val = JsValue::number(n);
                     interp.intl_number_format_format(&nf, &num_val)
                 }),
             ),
@@ -641,10 +640,10 @@ impl Interpreter {
 
         // Set Number.prototype on the Number constructor
         if let Some(num_val) = self.get_global_var("Number")
-            && let JsValue::Object(o) = &num_val
-            && let Some(num_obj) = self.get_object_cell(o.id)
+            && let Some(number_id) = num_val.as_object_id()
+            && let Some(num_obj) = self.get_object_cell(number_id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             num_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -664,22 +663,24 @@ impl Interpreter {
             .class_name = "Boolean".to_string();
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
-            .primitive_value = Some(JsValue::Boolean(false));
+            .primitive_value = Some(JsValue::FALSE);
 
         fn this_boolean_value(interp: &Interpreter, this: &JsValue) -> Option<bool> {
-            match this {
-                JsValue::Boolean(b) => Some(*b),
-                JsValue::Object(o) => interp.get_object_cell(o.id).and_then(|obj| {
-                    let b = obj.borrow();
-                    if b.class_name == "Boolean"
-                        && let Some(JsValue::Boolean(v)) = &b.primitive_value
-                    {
-                        return Some(*v);
-                    }
-                    None
-                }),
-                _ => None,
+            if let Some(boolean) = this.as_boolean() {
+                return Some(boolean);
             }
+            let object_id = this.as_object_id()?;
+            interp.get_object_cell(object_id).and_then(|obj| {
+                let object = obj.borrow();
+                if object.class_name == "Boolean" {
+                    object
+                        .primitive_value
+                        .as_ref()
+                        .and_then(JsValue::as_boolean)
+                } else {
+                    None
+                }
+            })
         }
 
         #[allow(clippy::type_complexity)]
@@ -697,11 +698,7 @@ impl Interpreter {
                             .create_type_error("Boolean.prototype.toString requires a Boolean");
                         return Completion::Throw(err);
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(if b {
-                        "true"
-                    } else {
-                        "false"
-                    })))
+                    Completion::Normal(JsValue::from_str(if b { "true" } else { "false" }))
                 }),
             ),
             (
@@ -713,7 +710,7 @@ impl Interpreter {
                             .create_type_error("Boolean.prototype.valueOf requires a Boolean");
                         return Completion::Throw(err);
                     };
-                    Completion::Normal(JsValue::Boolean(b))
+                    Completion::Normal(JsValue::boolean(b))
                 }),
             ),
         ];
@@ -728,10 +725,10 @@ impl Interpreter {
 
         // Set Boolean.prototype on the Boolean constructor
         if let Some(bool_val) = self.get_global_var("Boolean")
-            && let JsValue::Object(o) = &bool_val
-            && let Some(bool_obj) = self.get_object_cell(o.id)
+            && let Some(boolean_id) = bool_val.as_object_id()
+            && let Some(bool_obj) = self.get_object_cell(boolean_id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             bool_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -11,7 +11,7 @@ pub(crate) struct PromiseCapability {
 impl Interpreter {
     /// IfAbruptRejectPromise: reject with error and return the promise.
     fn if_abrupt_reject_promise(&mut self, error: JsValue, cap: &PromiseCapability) -> Completion {
-        let _ = self.call_function(&cap.reject, &JsValue::Undefined, &[error]);
+        let _ = self.call_function(&cap.reject, &JsValue::UNDEFINED, &[error]);
         Completion::Normal(cap.promise.clone())
     }
 
@@ -32,11 +32,7 @@ impl Interpreter {
             && same_value(constructor, ctor_val)
         {
             let promise = self.create_promise_object();
-            let promise_id = if let JsValue::Object(ref o) = promise {
-                o.id
-            } else {
-                0
-            };
+            let promise_id = promise.as_object_id().unwrap_or_default();
             let (resolve, reject) = self.create_resolving_functions(promise_id);
             return Ok(PromiseCapability {
                 promise,
@@ -46,8 +42,8 @@ impl Interpreter {
         }
 
         // General case: call new C(executor) where executor captures resolve/reject
-        let resolve_slot: Rc<RefCell<JsValue>> = Rc::new(RefCell::new(JsValue::Undefined));
-        let reject_slot: Rc<RefCell<JsValue>> = Rc::new(RefCell::new(JsValue::Undefined));
+        let resolve_slot: Rc<RefCell<JsValue>> = Rc::new(RefCell::new(JsValue::UNDEFINED));
+        let reject_slot: Rc<RefCell<JsValue>> = Rc::new(RefCell::new(JsValue::UNDEFINED));
 
         let rs = resolve_slot.clone();
         let rj = reject_slot.clone();
@@ -55,17 +51,17 @@ impl Interpreter {
             "".to_string(),
             2,
             move |interp, _this, args| {
-                let resolve_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let reject_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let resolve_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let reject_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // Spec: If promiseCapability.[[Resolve]] is not undefined, throw TypeError
-                if !matches!(*rs.borrow(), JsValue::Undefined) {
+                if !(*rs.borrow()).is_undefined() {
                     return Completion::Throw(
                         interp.create_type_error("Promise executor has already been resolved"),
                     );
                 }
                 // Spec: If promiseCapability.[[Reject]] is not undefined, throw TypeError
-                if !matches!(*rj.borrow(), JsValue::Undefined) {
+                if !(*rj.borrow()).is_undefined() {
                     return Completion::Throw(
                         interp.create_type_error("Promise executor has already been resolved"),
                     );
@@ -76,7 +72,7 @@ impl Interpreter {
                 // Spec: Set promiseCapability.[[Reject]] to reject
                 *rj.borrow_mut() = reject_arg;
 
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
 
@@ -109,8 +105,8 @@ impl Interpreter {
         obj: &JsValue,
         default_ctor: &JsValue,
     ) -> Result<JsValue, JsValue> {
-        let obj_id = if let JsValue::Object(o) = obj {
-            o.id
+        let obj_id = if let Some(o) = obj.as_object_id() {
+            o
         } else {
             return Ok(default_ctor.clone());
         };
@@ -122,17 +118,17 @@ impl Interpreter {
             _ => return Ok(default_ctor.clone()),
         };
 
-        if matches!(ctor, JsValue::Undefined) {
+        if (ctor).is_undefined() {
             return Ok(default_ctor.clone());
         }
 
-        if !matches!(ctor, JsValue::Object(_)) {
+        if !(ctor).is_object() {
             return Err(self.create_type_error("Species constructor is not an object"));
         }
 
         // Get constructor[Symbol.species]
-        let ctor_id = if let JsValue::Object(o) = &ctor {
-            o.id
+        let ctor_id = if let Some(o) = ctor.as_object_id() {
+            o
         } else {
             return Ok(default_ctor.clone());
         };
@@ -146,7 +142,7 @@ impl Interpreter {
             _ => return Ok(default_ctor.clone()),
         };
 
-        if matches!(species, JsValue::Undefined | JsValue::Null) {
+        if (species).is_nullish() {
             return Ok(default_ctor.clone());
         }
 
@@ -165,14 +161,14 @@ impl Interpreter {
         value: &JsValue,
     ) -> Result<JsValue, JsValue> {
         // If value is a promise and its constructor matches C, return it
-        if let JsValue::Object(o) = value
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = value.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
             && obj.borrow().promise_data().is_some()
         {
-            let ctor_val = match self.get_object_property(o.id, "constructor", value) {
+            let ctor_val = match self.get_object_property(o, "constructor", value) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if same_value(&ctor_val, constructor) {
                 return Ok(value.clone());
@@ -182,7 +178,7 @@ impl Interpreter {
         let cap = self.new_promise_capability(constructor)?;
         if let Completion::Throw(e) = self.call_function(
             &cap.resolve,
-            &JsValue::Undefined,
+            &JsValue::UNDEFINED,
             std::slice::from_ref(value),
         ) {
             return Err(e);
@@ -199,8 +195,8 @@ impl Interpreter {
             "then".to_string(),
             2,
             |interp, this, args| {
-                let on_fulfilled = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let on_rejected = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let on_fulfilled = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let on_rejected = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.promise_then(this, &on_fulfilled, &on_rejected)
             },
         ));
@@ -213,25 +209,21 @@ impl Interpreter {
             "catch".to_string(),
             1,
             |interp, this, args| {
-                let on_rejected = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let on_rejected = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // Spec 27.2.5.1: Return ? Invoke(this, "then", « undefined, onRejected »).
                 // Invoke calls GetV(V, P) which calls ToObject(V).
                 let obj = match interp.to_object(this) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
-                let obj_id = if let JsValue::Object(ref o) = obj {
-                    o.id
-                } else {
-                    0
-                };
+                let obj_id = obj.as_object_id().unwrap_or_default();
                 let then_method = match interp.get_object_property(obj_id, "then", &obj) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 };
-                interp.call_function(&then_method, this, &[JsValue::Undefined, on_rejected])
+                interp.call_function(&then_method, this, &[JsValue::UNDEFINED, on_rejected])
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -244,26 +236,22 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 // Step 1-2: Let promise be the this value. If not Object, throw TypeError.
-                let promise_id =
-                    match this {
-                        JsValue::Object(o) => o.id,
-                        _ => {
-                            return Completion::Throw(interp.create_type_error(
-                                "Promise.prototype.finally called on non-object",
-                            ));
-                        }
-                    };
+                let Some(promise_id) = this.as_object_id() else {
+                    return Completion::Throw(
+                        interp.create_type_error("Promise.prototype.finally called on non-object"),
+                    );
+                };
 
                 // Step 3: Let C = ? SpeciesConstructor(promise, %Promise%).
                 let promise_ctor = interp
                     .get_global_var("Promise")
-                    .unwrap_or(JsValue::Undefined);
+                    .unwrap_or(JsValue::UNDEFINED);
                 let c = match interp.species_constructor(this, &promise_ctor) {
                     Ok(c) => c,
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let on_finally = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let on_finally = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // Steps 5-6: Create thenFinally and catchFinally
                 let (then_finally, catch_finally) = if !interp.is_callable(&on_finally) {
@@ -277,10 +265,10 @@ impl Interpreter {
                         "".to_string(),
                         1,
                         move |interp, _this, args| {
-                            let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                             // Step 6a.i: Let result = ? Call(onFinally, undefined).
                             let result =
-                                interp.call_function(&on_finally_clone, &JsValue::Undefined, &[]);
+                                interp.call_function(&on_finally_clone, &JsValue::UNDEFINED, &[]);
                             match result {
                                 Completion::Throw(e) => Completion::Throw(e),
                                 Completion::Normal(r) => {
@@ -301,20 +289,16 @@ impl Interpreter {
                                         },
                                     ));
                                     // Step 6a.v: Return ? Invoke(promise, "then", « valueThunk »).
-                                    let p_id = if let JsValue::Object(ref o) = p {
-                                        o.id
-                                    } else {
-                                        0
-                                    };
+                                    let p_id = p.as_object_id().unwrap_or_default();
                                     let then_method =
                                         match interp.get_object_property(p_id, "then", &p) {
                                             Completion::Normal(v) => v,
                                             Completion::Throw(e) => return Completion::Throw(e),
-                                            _ => JsValue::Undefined,
+                                            _ => JsValue::UNDEFINED,
                                         };
                                     interp.call_function(&then_method, &p, &[return_fn])
                                 }
-                                _ => Completion::Normal(JsValue::Undefined),
+                                _ => Completion::Normal(JsValue::UNDEFINED),
                             }
                         },
                     ));
@@ -326,10 +310,10 @@ impl Interpreter {
                         "".to_string(),
                         1,
                         move |interp, _this, args| {
-                            let reason = args.first().cloned().unwrap_or(JsValue::Undefined);
+                            let reason = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                             // Step 6c.i: Let result = ? Call(onFinally, undefined).
                             let result =
-                                interp.call_function(&on_finally_clone2, &JsValue::Undefined, &[]);
+                                interp.call_function(&on_finally_clone2, &JsValue::UNDEFINED, &[]);
                             match result {
                                 Completion::Throw(e) => Completion::Throw(e),
                                 Completion::Normal(r) => {
@@ -350,20 +334,16 @@ impl Interpreter {
                                         },
                                     ));
                                     // Step 6c.v: Return ? Invoke(promise, "then", « thrower »).
-                                    let p_id = if let JsValue::Object(ref o) = p {
-                                        o.id
-                                    } else {
-                                        0
-                                    };
+                                    let p_id = p.as_object_id().unwrap_or_default();
                                     let then_method =
                                         match interp.get_object_property(p_id, "then", &p) {
                                             Completion::Normal(v) => v,
                                             Completion::Throw(e) => return Completion::Throw(e),
-                                            _ => JsValue::Undefined,
+                                            _ => JsValue::UNDEFINED,
                                         };
                                     interp.call_function(&then_method, &p, &[throw_fn])
                                 }
-                                _ => Completion::Normal(JsValue::Undefined),
+                                _ => Completion::Normal(JsValue::UNDEFINED),
                             }
                         },
                     ));
@@ -375,7 +355,7 @@ impl Interpreter {
                 let then_method = match interp.get_object_property(promise_id, "then", this) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 };
                 interp.call_function(&then_method, this, &[then_finally, catch_finally])
             },
@@ -400,7 +380,7 @@ impl Interpreter {
                     );
                 }
                 // Step 2: If IsCallable(executor) is false, throw a TypeError
-                let executor = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let executor = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if !interp.is_callable(&executor) {
                     let err = interp.create_type_error("Promise resolver is not a function");
                     return Completion::Throw(err);
@@ -414,25 +394,21 @@ impl Interpreter {
                 };
                 let promise = interp.create_promise_object();
                 if let Some(p) = proto
-                    && let JsValue::Object(po) = &promise
-                    && let Some(pobj) = interp.get_object_cell(po.id)
+                    && let Some(po) = promise.as_object_id()
+                    && let Some(pobj) = interp.get_object_cell(po)
                 {
                     pobj.borrow_mut().prototype_id = Some(p);
                 }
-                let promise_id = if let JsValue::Object(ref o) = promise {
-                    o.id
-                } else {
-                    0
-                };
+                let promise_id = promise.as_object_id().unwrap_or_default();
                 let (resolve_fn, reject_fn) = interp.create_resolving_functions(promise_id);
                 let result = interp.call_function(
                     &executor,
-                    &JsValue::Undefined,
+                    &JsValue::UNDEFINED,
                     &[resolve_fn.clone(), reject_fn.clone()],
                 );
                 if let Completion::Throw(e) = result
                     && let Completion::Throw(e2) =
-                        interp.call_function(&reject_fn, &JsValue::Undefined, &[e])
+                        interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e])
                 {
                     return Completion::Throw(e2);
                 }
@@ -442,27 +418,22 @@ impl Interpreter {
 
         // Mark Promise constructor as deferred_construct so construct_with_new_target
         // skips early prototype access (Promise checks callable before OrdinaryCreateFromConstructor).
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj.borrow_mut().deferred_construct = true;
         }
 
         // Set Promise.prototype on constructor
-        if let JsValue::Object(ref o) = ctor
-            && self.get_object_cell(o.id).is_some()
+        if let Some(o) = ctor.as_object_id()
+            && self.get_object_cell(o).is_some()
         {
-            let ctor_id = o.id;
+            let ctor_id = o;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
                     "prototype".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::Object(crate::types::JsObject { id: proto_id }),
-                        false,
-                        false,
-                        false,
-                    ),
+                    PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                 );
 
             // Promise[Symbol.species] getter
@@ -499,20 +470,20 @@ impl Interpreter {
             "resolve".to_string(),
             1,
             |interp, this, args| {
-                if !matches!(this, JsValue::Object(_)) {
+                if !(this).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Promise.resolve requires an object"),
                     );
                 }
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 match interp.promise_resolve_with_constructor(this, &value) {
                     Ok(p) => Completion::Normal(p),
                     Err(e) => Completion::Throw(e),
                 }
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -524,16 +495,16 @@ impl Interpreter {
             "reject".to_string(),
             1,
             |interp, this, args| {
-                if !matches!(this, JsValue::Object(_)) {
+                if !(this).is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Promise.reject requires an object"),
                     );
                 }
-                let reason = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let reason = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 match interp.new_promise_capability(this) {
                     Ok(cap) => {
                         if let Completion::Throw(e) =
-                            interp.call_function(&cap.reject, &JsValue::Undefined, &[reason])
+                            interp.call_function(&cap.reject, &JsValue::UNDEFINED, &[reason])
                         {
                             return Completion::Throw(e);
                         }
@@ -543,8 +514,8 @@ impl Interpreter {
                 }
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -556,12 +527,12 @@ impl Interpreter {
             "all".to_string(),
             1,
             |interp, this, args| {
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.promise_all(this, &iterable)
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -573,12 +544,12 @@ impl Interpreter {
             "allSettled".to_string(),
             1,
             |interp, this, args| {
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.promise_all_settled(this, &iterable)
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -590,12 +561,12 @@ impl Interpreter {
             "race".to_string(),
             1,
             |interp, this, args| {
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.promise_race(this, &iterable)
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -607,12 +578,12 @@ impl Interpreter {
             "any".to_string(),
             1,
             |interp, this, args| {
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.promise_any(this, &iterable)
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -639,13 +610,13 @@ impl Interpreter {
                         .borrow_mut()
                         .insert_value("reject".to_string(), cap.reject);
                     let id = result_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 }
                 Err(e) => Completion::Throw(e),
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -661,7 +632,7 @@ impl Interpreter {
                     Ok(cap) => cap,
                     Err(e) => return Completion::Throw(e),
                 };
-                let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let call_args: Vec<JsValue> = if args.len() > 1 {
                     args[1..].to_vec()
                 } else {
@@ -670,24 +641,24 @@ impl Interpreter {
                 if !interp.is_callable(&callback) {
                     let err = interp.create_type_error("Promise.try requires a callable");
                     if let Completion::Throw(e) =
-                        interp.call_function(&cap.reject, &JsValue::Undefined, &[err])
+                        interp.call_function(&cap.reject, &JsValue::UNDEFINED, &[err])
                     {
                         return Completion::Throw(e);
                     }
                     return Completion::Normal(cap.promise);
                 }
-                let result = interp.call_function(&callback, &JsValue::Undefined, &call_args);
+                let result = interp.call_function(&callback, &JsValue::UNDEFINED, &call_args);
                 match result {
                     Completion::Normal(v) => {
                         if let Completion::Throw(e) =
-                            interp.call_function(&cap.resolve, &JsValue::Undefined, &[v])
+                            interp.call_function(&cap.resolve, &JsValue::UNDEFINED, &[v])
                         {
                             return Completion::Throw(e);
                         }
                     }
                     Completion::Throw(e) => {
                         if let Completion::Throw(e2) =
-                            interp.call_function(&cap.reject, &JsValue::Undefined, &[e])
+                            interp.call_function(&cap.reject, &JsValue::UNDEFINED, &[e])
                         {
                             return Completion::Throw(e2);
                         }
@@ -697,8 +668,8 @@ impl Interpreter {
                 Completion::Normal(cap.promise)
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -710,12 +681,12 @@ impl Interpreter {
             "allKeyed".to_string(),
             1,
             |interp, this, args| {
-                let promises = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let promises = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.promise_all_keyed(this, &promises)
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -727,12 +698,12 @@ impl Interpreter {
             "allSettledKeyed".to_string(),
             1,
             |interp, this, args| {
-                let promises = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let promises = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.promise_all_settled_keyed(this, &promises)
             },
         ));
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj
                 .borrow_mut()
@@ -754,32 +725,28 @@ impl Interpreter {
         data.class_name = "Promise".to_string();
         data.kind = crate::interpreter::types::ObjectKind::Promise(PromiseData::new());
         let id = self.alloc_object(data);
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     pub(crate) fn create_resolved_promise(&mut self, value: JsValue) -> Completion {
         let promise = self.create_promise_object();
-        if let JsValue::Object(ref o) = promise {
-            self.fulfill_promise(o.id, value);
+        if let Some(o) = promise.as_object_id() {
+            self.fulfill_promise(o, value);
         }
         Completion::Normal(promise)
     }
 
     pub(crate) fn create_rejected_promise(&mut self, reason: JsValue) -> Completion {
         let promise = self.create_promise_object();
-        if let JsValue::Object(ref o) = promise {
-            self.reject_promise(o.id, reason);
+        if let Some(o) = promise.as_object_id() {
+            self.reject_promise(o, reason);
         }
         Completion::Normal(promise)
     }
 
     pub(crate) fn create_promise_parts(&mut self) -> (JsValue, JsValue, JsValue) {
         let promise = self.create_promise_object();
-        let promise_id = if let JsValue::Object(ref o) = promise {
-            o.id
-        } else {
-            0
-        };
+        let promise_id = promise.as_object_id().unwrap_or_default();
         let (resolve, reject) = self.create_resolving_functions(promise_id);
         (resolve, reject, promise)
     }
@@ -793,38 +760,38 @@ impl Interpreter {
             1,
             move |interp, _this, args| {
                 if ar1.get() {
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 ar1.set(true);
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // If resolving with self, reject with TypeError
-                if let JsValue::Object(ref o) = value
-                    && o.id == promise_id
+                if let Some(o) = value.as_object_id()
+                    && o == promise_id
                 {
                     let err = interp.create_type_error("A promise cannot be resolved with itself.");
                     interp.reject_promise(promise_id, err);
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 // Check if value is a thenable
-                if let JsValue::Object(ref o) = value {
+                if let Some(o) = value.as_object_id() {
                     // Spec step 8: Let then be Completion(Get(resolution, "then")).
                     // Step 9: If then is an abrupt completion, then
                     //   a. Return RejectPromise(promise, then.[[Value]]).
-                    let then_val = match interp.get_object_property(o.id, "then", &value) {
+                    let then_val = match interp.get_object_property(o, "then", &value) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
                             interp.reject_promise(promise_id, e);
-                            return Completion::Normal(JsValue::Undefined);
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
                     if interp.is_callable(&then_val) {
                         interp.promise_resolve_thenable(promise_id, value.clone(), then_val);
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                 }
                 interp.fulfill_promise(promise_id, value);
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
 
@@ -834,12 +801,12 @@ impl Interpreter {
             1,
             move |interp, _this, args| {
                 if ar2.get() {
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 ar2.set(true);
-                let reason = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let reason = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.reject_promise(promise_id, reason);
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
 
@@ -848,10 +815,10 @@ impl Interpreter {
         // resolving functions so the Promise survives as long as either
         // resolve or reject is reachable.
         if promise_id != 0 {
-            let pin = JsValue::Object(crate::types::JsObject { id: promise_id });
+            let pin = JsValue::object(promise_id);
             for fn_val in [&resolve_fn, &reject_fn] {
-                if let JsValue::Object(o) = fn_val
-                    && let Some(fn_obj) = self.get_object_cell(o.id)
+                if let Some(o) = fn_val.as_object_id()
+                    && let Some(fn_obj) = self.get_object_cell(o)
                 {
                     let mut borrowed = fn_obj.borrow_mut();
                     borrowed
@@ -924,7 +891,7 @@ impl Interpreter {
             // The resolve/reject closures only capture promise_id as a u64, which is
             // invisible to the GC tracer.
             if let Some(pid) = reaction.promise_id {
-                roots.push(JsValue::Object(crate::types::JsObject { id: pid }));
+                roots.push(JsValue::object(pid));
             }
             self.scheduler.enqueue_microtask((
                 roots,
@@ -933,7 +900,7 @@ impl Interpreter {
                         if interp.is_callable(handler) {
                             match interp.call_function(
                                 handler,
-                                &JsValue::Undefined,
+                                &JsValue::UNDEFINED,
                                 std::slice::from_ref(&arg),
                             ) {
                                 Completion::Throw(e) => Err(e),
@@ -943,7 +910,7 @@ impl Interpreter {
                                 // `Completion::Exit` — the Promise reaction must
                                 // not consume it into a fulfillment/rejection.
                                 Completion::Exit(code) => return Completion::Exit(code),
-                                _ => Ok(JsValue::Undefined),
+                                _ => Ok(JsValue::UNDEFINED),
                             }
                         } else {
                             match reaction.reaction_type {
@@ -963,7 +930,7 @@ impl Interpreter {
                             Ok(value) => {
                                 if let Completion::Throw(e) = interp.call_function(
                                     &reaction.resolve,
-                                    &JsValue::Undefined,
+                                    &JsValue::UNDEFINED,
                                     &[value],
                                 ) {
                                     return Completion::Throw(e);
@@ -972,7 +939,7 @@ impl Interpreter {
                             Err(reason) => {
                                 if let Completion::Throw(e) = interp.call_function(
                                     &reaction.reject,
-                                    &JsValue::Undefined,
+                                    &JsValue::UNDEFINED,
                                     &[reason],
                                 ) {
                                     return Completion::Throw(e);
@@ -980,7 +947,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 }),
             ));
         }
@@ -998,7 +965,7 @@ impl Interpreter {
             then_fn.clone(),
             resolve_fn.clone(),
             reject_fn.clone(),
-            JsValue::Object(crate::types::JsObject { id: promise_id }),
+            JsValue::object(promise_id),
         ];
         self.scheduler.enqueue_microtask((
             roots,
@@ -1013,11 +980,11 @@ impl Interpreter {
                 }
                 if let Completion::Throw(e) = result
                     && let Completion::Throw(e2) =
-                        interp.call_function(&reject_fn, &JsValue::Undefined, &[e])
+                        interp.call_function(&reject_fn, &JsValue::UNDEFINED, &[e])
                 {
                     return Completion::Throw(e2);
                 }
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             }),
         ));
     }
@@ -1033,18 +1000,14 @@ impl Interpreter {
         result_resolve: JsValue,
         result_reject: JsValue,
     ) -> Completion {
-        let promise_id = if let JsValue::Object(o) = promise_val {
-            o.id
+        let promise_id = if let Some(o) = promise_val.as_object_id() {
+            o
         } else {
             return Completion::Throw(
                 self.create_type_error("PerformPromiseThen called on non-promise"),
             );
         };
-        let derived_id = if let JsValue::Object(ref o) = result_promise {
-            o.id
-        } else {
-            0
-        };
+        let derived_id = result_promise.as_object_id().unwrap_or_default();
 
         let fulfill_handler = if self.is_callable(on_fulfilled) {
             Some(on_fulfilled.clone())
@@ -1111,10 +1074,10 @@ impl Interpreter {
         on_fulfilled: &JsValue,
         on_rejected: &JsValue,
     ) -> Completion {
-        let promise_id = if let JsValue::Object(o) = promise_val {
-            if let Some(obj) = self.get_object_cell(o.id) {
+        let promise_id = if let Some(o) = promise_val.as_object_id() {
+            if let Some(obj) = self.get_object_cell(o) {
                 if obj.borrow().promise_data().is_some() {
-                    o.id
+                    o
                 } else {
                     let err =
                         self.create_type_error("Promise.prototype.then called on non-promise");
@@ -1130,7 +1093,7 @@ impl Interpreter {
         };
 
         // SpeciesConstructor(promise, %Promise%)
-        let promise_ctor = self.get_global_var("Promise").unwrap_or(JsValue::Undefined);
+        let promise_ctor = self.get_global_var("Promise").unwrap_or(JsValue::UNDEFINED);
         let c = match self.species_constructor(promise_val, &promise_ctor) {
             Ok(c) => c,
             Err(e) => return Completion::Throw(e),
@@ -1141,11 +1104,7 @@ impl Interpreter {
             Err(e) => return Completion::Throw(e),
         };
         let derived = cap.promise;
-        let derived_id = if let JsValue::Object(ref o) = derived {
-            o.id
-        } else {
-            0
-        };
+        let derived_id = derived.as_object_id().unwrap_or_default();
         let resolve_fn = cap.resolve;
         let reject_fn = cap.reject;
 
@@ -1210,11 +1169,11 @@ impl Interpreter {
 
     pub(crate) fn promise_resolve_value(&mut self, value: &JsValue) -> JsValue {
         // §27.2.4.7.1 PromiseResolve(C, x): if IsPromise(x), check x.constructor === C
-        if let JsValue::Object(o) = value
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = value.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
             && obj.borrow().promise_data().is_some()
         {
-            match self.get_object_property(o.id, "constructor", value) {
+            match self.get_object_property(o, "constructor", value) {
                 Completion::Normal(ctor) => {
                     let promise_ctor = self.get_global_var("Promise");
                     if let Some(ref pc) = promise_ctor
@@ -1226,11 +1185,7 @@ impl Interpreter {
                 Completion::Throw(e) => {
                     // Get(x, "constructor") threw — create rejected promise
                     let promise = self.create_promise_object();
-                    let promise_id = if let JsValue::Object(ref o) = promise {
-                        o.id
-                    } else {
-                        0
-                    };
+                    let promise_id = promise.as_object_id().unwrap_or_default();
                     self.reject_promise(promise_id, e);
                     return promise;
                 }
@@ -1238,20 +1193,16 @@ impl Interpreter {
             }
         }
         let promise = self.create_promise_object();
-        let promise_id = if let JsValue::Object(ref o) = promise {
-            o.id
-        } else {
-            0
-        };
+        let promise_id = promise.as_object_id().unwrap_or_default();
         // Check if value is a thenable using [[Get]] to trigger Proxy traps/getters
-        if let JsValue::Object(o) = value {
-            let then_val = match self.get_object_property(o.id, "then", value) {
+        if let Some(o) = value.as_object_id() {
+            let then_val = match self.get_object_property(o, "then", value) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => {
                     self.reject_promise(promise_id, e);
                     return promise;
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if self.is_callable(&then_val) {
                 self.promise_resolve_thenable(promise_id, value.clone(), then_val);
@@ -1269,17 +1220,13 @@ impl Interpreter {
         };
 
         // GetPromiseResolve(C) + IfAbruptRejectPromise
-        let ctor_id = if let JsValue::Object(o) = constructor {
-            o.id
-        } else {
-            0
-        };
+        let ctor_id = constructor.as_object_id().unwrap_or_default();
         let promise_resolve = match self.get_object_property(ctor_id, "resolve", constructor) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => {
                 return self.if_abrupt_reject_promise(e, &cap);
             }
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
         if !self.is_callable(&promise_resolve) {
             let err = self.create_type_error("Promise resolve is not a function");
@@ -1308,7 +1255,7 @@ impl Interpreter {
                         let values = results.borrow().clone();
                         let arr = self.create_array(values);
                         if let Completion::Throw(e) =
-                            self.call_function(&cap.resolve, &JsValue::Undefined, &[arr])
+                            self.call_function(&cap.resolve, &JsValue::UNDEFINED, &[arr])
                         {
                             return self.if_abrupt_reject_promise(e, &cap);
                         }
@@ -1329,7 +1276,7 @@ impl Interpreter {
                 }
             };
 
-            results.borrow_mut().push(JsValue::Undefined);
+            results.borrow_mut().push(JsValue::UNDEFINED);
             remaining.set(remaining.get() + 1);
 
             let p = match self.call_function(&promise_resolve, constructor, &[next_value]) {
@@ -1338,7 +1285,7 @@ impl Interpreter {
                     self.iterator_close(&iterator, e.clone());
                     return self.if_abrupt_reject_promise(e, &cap);
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
             let i = index;
@@ -1353,10 +1300,10 @@ impl Interpreter {
                 1,
                 move |interp, _this, args| {
                     if ac.get() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     ac.set(true);
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     results.borrow_mut()[i] = val;
                     let r = remaining.get() - 1;
                     remaining.set(r);
@@ -1364,28 +1311,24 @@ impl Interpreter {
                         let values = results.borrow().clone();
                         let arr = interp.create_array(values);
                         if let Completion::Throw(e) =
-                            interp.call_function(&resolve_fn, &JsValue::Undefined, &[arr])
+                            interp.call_function(&resolve_fn, &JsValue::UNDEFINED, &[arr])
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
 
             let reject_fn_clone = cap.reject.clone();
-            let p_id = if let JsValue::Object(ref o) = p {
-                o.id
-            } else {
-                0
-            };
+            let p_id = p.as_object_id().unwrap_or_default();
             let then_fn = match self.get_object_property(p_id, "then", &p) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => {
                     self.iterator_close(&iterator, e.clone());
                     return self.if_abrupt_reject_promise(e, &cap);
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if let Completion::Throw(e) =
                 self.call_function(&then_fn, &p, &[on_fulfilled, reject_fn_clone])
@@ -1404,15 +1347,11 @@ impl Interpreter {
             Err(e) => return Completion::Throw(e),
         };
 
-        let ctor_id = if let JsValue::Object(o) = constructor {
-            o.id
-        } else {
-            0
-        };
+        let ctor_id = constructor.as_object_id().unwrap_or_default();
         let promise_resolve = match self.get_object_property(ctor_id, "resolve", constructor) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
         if !self.is_callable(&promise_resolve) {
             let err = self.create_type_error("Promise resolve is not a function");
@@ -1439,7 +1378,7 @@ impl Interpreter {
                         let values = results.borrow().clone();
                         let arr = self.create_array(values);
                         if let Completion::Throw(e) =
-                            self.call_function(&cap.resolve, &JsValue::Undefined, &[arr])
+                            self.call_function(&cap.resolve, &JsValue::UNDEFINED, &[arr])
                         {
                             return self.if_abrupt_reject_promise(e, &cap);
                         }
@@ -1459,7 +1398,7 @@ impl Interpreter {
                 }
             };
 
-            results.borrow_mut().push(JsValue::Undefined);
+            results.borrow_mut().push(JsValue::UNDEFINED);
             remaining.set(remaining.get() + 1);
 
             let p = match self.call_function(&promise_resolve, constructor, &[next_value]) {
@@ -1468,7 +1407,7 @@ impl Interpreter {
                     self.iterator_close(&iterator, e.clone());
                     return self.if_abrupt_reject_promise(e, &cap);
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
             let i = index;
@@ -1486,33 +1425,33 @@ impl Interpreter {
                 1,
                 move |interp, _this, args| {
                     if ac_f.get() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     ac_f.set(true);
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_id = interp.create_object_id();
                     {
                         let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         o.insert_value(
                             "status".to_string(),
-                            JsValue::String(JsString::from_str("fulfilled")),
+                            JsValue::string(JsString::from_str("fulfilled")),
                         );
                         o.insert_value("value".to_string(), val);
                     }
                     let oid = obj_id;
-                    results_f.borrow_mut()[i] = JsValue::Object(crate::types::JsObject { id: oid });
+                    results_f.borrow_mut()[i] = JsValue::object(oid);
                     let r = remaining_f.get() - 1;
                     remaining_f.set(r);
                     if r == 0 {
                         let values = results_f.borrow().clone();
                         let arr = interp.create_array(values);
                         if let Completion::Throw(e) =
-                            interp.call_function(&resolve_fn_f, &JsValue::Undefined, &[arr])
+                            interp.call_function(&resolve_fn_f, &JsValue::UNDEFINED, &[arr])
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             let ac_r = already_called.clone();
@@ -1521,48 +1460,44 @@ impl Interpreter {
                 1,
                 move |interp, _this, args| {
                     if ac_r.get() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     ac_r.set(true);
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_id = interp.create_object_id();
                     {
                         let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         o.insert_value(
                             "status".to_string(),
-                            JsValue::String(JsString::from_str("rejected")),
+                            JsValue::string(JsString::from_str("rejected")),
                         );
                         o.insert_value("reason".to_string(), val);
                     }
                     let oid = obj_id;
-                    results_r.borrow_mut()[i] = JsValue::Object(crate::types::JsObject { id: oid });
+                    results_r.borrow_mut()[i] = JsValue::object(oid);
                     let r = remaining_r.get() - 1;
                     remaining_r.set(r);
                     if r == 0 {
                         let values = results_r.borrow().clone();
                         let arr = interp.create_array(values);
                         if let Completion::Throw(e) =
-                            interp.call_function(&resolve_fn_r, &JsValue::Undefined, &[arr])
+                            interp.call_function(&resolve_fn_r, &JsValue::UNDEFINED, &[arr])
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
 
-            let p_id = if let JsValue::Object(ref o) = p {
-                o.id
-            } else {
-                0
-            };
+            let p_id = p.as_object_id().unwrap_or_default();
             let then_fn = match self.get_object_property(p_id, "then", &p) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => {
                     self.iterator_close(&iterator, e.clone());
                     return self.if_abrupt_reject_promise(e, &cap);
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if let Completion::Throw(e) =
                 self.call_function(&then_fn, &p, &[on_fulfilled, on_rejected])
@@ -1583,15 +1518,11 @@ impl Interpreter {
         };
 
         // GetPromiseResolve(C) + IfAbruptRejectPromise
-        let ctor_id = if let JsValue::Object(o) = constructor {
-            o.id
-        } else {
-            0
-        };
+        let ctor_id = constructor.as_object_id().unwrap_or_default();
         let promise_resolve = match self.get_object_property(ctor_id, "resolve", constructor) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
         if !self.is_callable(&promise_resolve) {
             let err = self.create_type_error("Promise resolve is not a function");
@@ -1599,12 +1530,9 @@ impl Interpreter {
         }
 
         // If `promises` is not an Object, reject the returned promise.
-        let promises_obj_id = match promises {
-            JsValue::Object(o) => o.id,
-            _ => {
-                let err = self.create_type_error("Promise.allKeyed argument is not an object");
-                return self.if_abrupt_reject_promise(err, &cap);
-            }
+        let Some(promises_obj_id) = promises.as_object_id() else {
+            let err = self.create_type_error("Promise.allKeyed argument is not an object");
+            return self.if_abrupt_reject_promise(err, &cap);
         };
 
         // allKeys = ? promises.[[OwnPropertyKeys]]()
@@ -1625,7 +1553,7 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(e) => return self.if_abrupt_reject_promise(e, &cap),
             };
-            if matches!(desc_val, JsValue::Undefined) {
+            if (desc_val).is_undefined() {
                 continue;
             }
             // Spec: process only when desc.[[Enumerable]] is true. After
@@ -1644,18 +1572,18 @@ impl Interpreter {
             let next_value = match self.get_object_property(promises_obj_id, &key_str, promises) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
             let i = values.borrow().len();
             keys.borrow_mut().push(key_str.clone());
-            values.borrow_mut().push(JsValue::Undefined);
+            values.borrow_mut().push(JsValue::UNDEFINED);
             remaining.set(remaining.get() + 1);
 
             let p = match self.call_function(&promise_resolve, constructor, &[next_value]) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
             let remaining_c = remaining.clone();
@@ -1670,10 +1598,10 @@ impl Interpreter {
                 1,
                 move |interp, _this, args| {
                     if ac.get() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     ac.set(true);
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     values_c.borrow_mut()[i] = val;
                     let r = remaining_c.get() - 1;
                     remaining_c.set(r);
@@ -1682,24 +1610,20 @@ impl Interpreter {
                         let values_snapshot = values_c.borrow().clone();
                         let result = interp.build_keyed_result(&keys_snapshot, &values_snapshot);
                         if let Completion::Throw(e) =
-                            interp.call_function(&resolve_fn, &JsValue::Undefined, &[result])
+                            interp.call_function(&resolve_fn, &JsValue::UNDEFINED, &[result])
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
 
-            let p_id = if let JsValue::Object(ref o) = p {
-                o.id
-            } else {
-                0
-            };
+            let p_id = p.as_object_id().unwrap_or_default();
             let then_fn = match self.get_object_property(p_id, "then", &p) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if let Completion::Throw(e) =
                 self.call_function(&then_fn, &p, &[on_fulfilled, cap.reject.clone()])
@@ -1716,7 +1640,7 @@ impl Interpreter {
             let values_snapshot = values.borrow().clone();
             let result = self.build_keyed_result(&keys_snapshot, &values_snapshot);
             if let Completion::Throw(e) =
-                self.call_function(&cap.resolve, &JsValue::Undefined, &[result])
+                self.call_function(&cap.resolve, &JsValue::UNDEFINED, &[result])
             {
                 return self.if_abrupt_reject_promise(e, &cap);
             }
@@ -1736,28 +1660,20 @@ impl Interpreter {
             Err(e) => return Completion::Throw(e),
         };
 
-        let ctor_id = if let JsValue::Object(o) = constructor {
-            o.id
-        } else {
-            0
-        };
+        let ctor_id = constructor.as_object_id().unwrap_or_default();
         let promise_resolve = match self.get_object_property(ctor_id, "resolve", constructor) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
         if !self.is_callable(&promise_resolve) {
             let err = self.create_type_error("Promise resolve is not a function");
             return self.if_abrupt_reject_promise(err, &cap);
         }
 
-        let promises_obj_id = match promises {
-            JsValue::Object(o) => o.id,
-            _ => {
-                let err =
-                    self.create_type_error("Promise.allSettledKeyed argument is not an object");
-                return self.if_abrupt_reject_promise(err, &cap);
-            }
+        let Some(promises_obj_id) = promises.as_object_id() else {
+            let err = self.create_type_error("Promise.allSettledKeyed argument is not an object");
+            return self.if_abrupt_reject_promise(err, &cap);
         };
 
         let all_keys = match self.proxy_own_keys(promises_obj_id) {
@@ -1776,7 +1692,7 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(e) => return self.if_abrupt_reject_promise(e, &cap),
             };
-            if matches!(desc_val, JsValue::Undefined) {
+            if (desc_val).is_undefined() {
                 continue;
             }
             // Spec: process only when desc.[[Enumerable]] is true (absent
@@ -1793,18 +1709,18 @@ impl Interpreter {
             let next_value = match self.get_object_property(promises_obj_id, &key_str, promises) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
             let i = values.borrow().len();
             keys.borrow_mut().push(key_str.clone());
-            values.borrow_mut().push(JsValue::Undefined);
+            values.borrow_mut().push(JsValue::UNDEFINED);
             remaining.set(remaining.get() + 1);
 
             let p = match self.call_function(&promise_resolve, constructor, &[next_value]) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
             let already_called = Rc::new(Cell::new(false));
@@ -1819,21 +1735,20 @@ impl Interpreter {
                 1,
                 move |interp, _this, args| {
                     if ac_f.get() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     ac_f.set(true);
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_id = interp.create_object_id();
                     {
                         let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         o.insert_value(
                             "status".to_string(),
-                            JsValue::String(JsString::from_str("fulfilled")),
+                            JsValue::string(JsString::from_str("fulfilled")),
                         );
                         o.insert_value("value".to_string(), val);
                     }
-                    values_f.borrow_mut()[i] =
-                        JsValue::Object(crate::types::JsObject { id: obj_id });
+                    values_f.borrow_mut()[i] = JsValue::object(obj_id);
                     let r = remaining_f.get() - 1;
                     remaining_f.set(r);
                     if r == 0 {
@@ -1841,12 +1756,12 @@ impl Interpreter {
                         let values_snapshot = values_f.borrow().clone();
                         let result = interp.build_keyed_result(&keys_snapshot, &values_snapshot);
                         if let Completion::Throw(e) =
-                            interp.call_function(&resolve_fn_f, &JsValue::Undefined, &[result])
+                            interp.call_function(&resolve_fn_f, &JsValue::UNDEFINED, &[result])
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
 
@@ -1860,21 +1775,20 @@ impl Interpreter {
                 1,
                 move |interp, _this, args| {
                     if ac_r.get() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     ac_r.set(true);
-                    let reason = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let reason = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let obj_id = interp.create_object_id();
                     {
                         let mut o = interp.get_object_cell_expect(obj_id).borrow_mut();
                         o.insert_value(
                             "status".to_string(),
-                            JsValue::String(JsString::from_str("rejected")),
+                            JsValue::string(JsString::from_str("rejected")),
                         );
                         o.insert_value("reason".to_string(), reason);
                     }
-                    values_r.borrow_mut()[i] =
-                        JsValue::Object(crate::types::JsObject { id: obj_id });
+                    values_r.borrow_mut()[i] = JsValue::object(obj_id);
                     let r = remaining_r.get() - 1;
                     remaining_r.set(r);
                     if r == 0 {
@@ -1882,24 +1796,20 @@ impl Interpreter {
                         let values_snapshot = values_r.borrow().clone();
                         let result = interp.build_keyed_result(&keys_snapshot, &values_snapshot);
                         if let Completion::Throw(e) =
-                            interp.call_function(&resolve_fn_r, &JsValue::Undefined, &[result])
+                            interp.call_function(&resolve_fn_r, &JsValue::UNDEFINED, &[result])
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
 
-            let p_id = if let JsValue::Object(ref o) = p {
-                o.id
-            } else {
-                0
-            };
+            let p_id = p.as_object_id().unwrap_or_default();
             let then_fn = match self.get_object_property(p_id, "then", &p) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if let Completion::Throw(e) =
                 self.call_function(&then_fn, &p, &[on_fulfilled, on_rejected])
@@ -1915,7 +1825,7 @@ impl Interpreter {
             let values_snapshot = values.borrow().clone();
             let result = self.build_keyed_result(&keys_snapshot, &values_snapshot);
             if let Completion::Throw(e) =
-                self.call_function(&cap.resolve, &JsValue::Undefined, &[result])
+                self.call_function(&cap.resolve, &JsValue::UNDEFINED, &[result])
             {
                 return self.if_abrupt_reject_promise(e, &cap);
             }
@@ -1937,7 +1847,7 @@ impl Interpreter {
                 o.insert_value(k.clone(), v.clone());
             }
         }
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     fn promise_race(&mut self, constructor: &JsValue, iterable: &JsValue) -> Completion {
@@ -1946,15 +1856,11 @@ impl Interpreter {
             Err(e) => return Completion::Throw(e),
         };
 
-        let ctor_id = if let JsValue::Object(o) = constructor {
-            o.id
-        } else {
-            0
-        };
+        let ctor_id = constructor.as_object_id().unwrap_or_default();
         let promise_resolve = match self.get_object_property(ctor_id, "resolve", constructor) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
         if !self.is_callable(&promise_resolve) {
             let err = self.create_type_error("Promise resolve is not a function");
@@ -1990,21 +1896,17 @@ impl Interpreter {
                     self.iterator_close(&iterator, e.clone());
                     return self.if_abrupt_reject_promise(e, &cap);
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
-            let p_id = if let JsValue::Object(ref o) = p {
-                o.id
-            } else {
-                0
-            };
+            let p_id = p.as_object_id().unwrap_or_default();
             let then_fn = match self.get_object_property(p_id, "then", &p) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => {
                     self.iterator_close(&iterator, e.clone());
                     return self.if_abrupt_reject_promise(e, &cap);
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if let Completion::Throw(e) =
                 self.call_function(&then_fn, &p, &[cap.resolve.clone(), cap.reject.clone()])
@@ -2021,15 +1923,11 @@ impl Interpreter {
             Err(e) => return Completion::Throw(e),
         };
 
-        let ctor_id = if let JsValue::Object(o) = constructor {
-            o.id
-        } else {
-            0
-        };
+        let ctor_id = constructor.as_object_id().unwrap_or_default();
         let promise_resolve = match self.get_object_property(ctor_id, "resolve", constructor) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return self.if_abrupt_reject_promise(e, &cap),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
         if !self.is_callable(&promise_resolve) {
             let err = self.create_type_error("Promise resolve is not a function");
@@ -2072,7 +1970,7 @@ impl Interpreter {
                 }
             };
 
-            errors.borrow_mut().push(JsValue::Undefined);
+            errors.borrow_mut().push(JsValue::UNDEFINED);
             remaining.set(remaining.get() + 1);
 
             let p = match self.call_function(&promise_resolve, constructor, &[next_value]) {
@@ -2081,7 +1979,7 @@ impl Interpreter {
                     self.iterator_close(&iterator, e.clone());
                     return self.if_abrupt_reject_promise(e, &cap);
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
             let i = index;
@@ -2096,10 +1994,10 @@ impl Interpreter {
                 1,
                 move |interp, _this, args| {
                     if ac.get() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     ac.set(true);
-                    let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     errors.borrow_mut()[i] = val;
                     let r = remaining.get() - 1;
                     remaining.set(r);
@@ -2107,27 +2005,23 @@ impl Interpreter {
                         let errs = errors.borrow().clone();
                         let err = interp.create_aggregate_error(errs, "All promises were rejected");
                         if let Completion::Throw(e) =
-                            interp.call_function(&reject_fn_clone, &JsValue::Undefined, &[err])
+                            interp.call_function(&reject_fn_clone, &JsValue::UNDEFINED, &[err])
                         {
                             return Completion::Throw(e);
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
 
-            let p_id = if let JsValue::Object(ref o) = p {
-                o.id
-            } else {
-                0
-            };
+            let p_id = p.as_object_id().unwrap_or_default();
             let then_fn = match self.get_object_property(p_id, "then", &p) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => {
                     self.iterator_close(&iterator, e.clone());
                     return self.if_abrupt_reject_promise(e, &cap);
                 }
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             if let Completion::Throw(e) =
                 self.call_function(&then_fn, &p, &[cap.resolve.clone(), on_rejected])
@@ -2150,7 +2044,7 @@ impl Interpreter {
             }
             o.insert_builtin(
                 "message".to_string(),
-                JsValue::String(JsString::from_str(message)),
+                JsValue::string(JsString::from_str(message)),
             );
         }
         let errors_arr = self.create_array(errors);
@@ -2158,19 +2052,19 @@ impl Interpreter {
             .borrow_mut()
             .insert_builtin("errors".to_string(), errors_arr);
         let id = obj_id;
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     pub(crate) fn is_callable(&self, val: &JsValue) -> bool {
-        if let JsValue::Object(o) = val
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = val.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             if obj.borrow().callable.is_some() {
                 return true;
             }
             // Proxy wrapping a callable is callable
             if obj.borrow().is_proxy() {
-                let target_val = self.get_proxy_target_val(o.id);
+                let target_val = self.get_proxy_target_val(o);
                 return self.is_callable(&target_val);
             }
         }
@@ -2178,8 +2072,8 @@ impl Interpreter {
     }
 
     pub(crate) fn is_constructor(&self, val: &JsValue) -> bool {
-        if let JsValue::Object(o) = val
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = val.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             if let Some(ref func) = obj.borrow().callable {
                 return match func {
@@ -2195,7 +2089,7 @@ impl Interpreter {
             }
             // Proxy wrapping a constructor is a constructor
             if obj.borrow().is_proxy() {
-                let target_val = self.get_proxy_target_val(o.id);
+                let target_val = self.get_proxy_target_val(o);
                 return self.is_constructor(&target_val);
             }
         }
@@ -2203,8 +2097,8 @@ impl Interpreter {
     }
 
     pub(crate) fn is_promise(&self, val: &JsValue) -> bool {
-        if let JsValue::Object(o) = val
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = val.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             return obj.borrow().promise_data().is_some();
         }

--- a/src/interpreter/builtins/proxy.rs
+++ b/src/interpreter/builtins/proxy.rs
@@ -13,14 +13,14 @@ impl Interpreter {
                         interp.create_type_error("Constructor Proxy requires 'new'"),
                     );
                 }
-                let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let handler = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(target, JsValue::Object(_)) {
+                let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let handler = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                if !target.is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Cannot create proxy with a non-object as target"),
                     );
                 }
-                if !matches!(handler, JsValue::Object(_)) {
+                if !handler.is_object() {
                     return Completion::Throw(
                         interp
                             .create_type_error("Cannot create proxy with a non-object as handler"),
@@ -31,9 +31,9 @@ impl Interpreter {
                     .get_object_cell_expect(proxy_obj_id)
                     .borrow_mut()
                     .class_name = "Proxy".to_string();
-                if let JsValue::Object(ref t) = target
-                    && let JsValue::Object(ref h) = handler
-                    && let Some(target_rc) = interp.get_object_cell(t.id)
+                if let Some(target_id) = target.as_object_id()
+                    && let Some(handler_id) = handler.as_object_id()
+                    && let Some(target_rc) = interp.get_object_cell(target_id)
                 {
                     let callable = target_rc.borrow().callable.clone();
                     let mut proxy = interp.get_object_cell_expect(proxy_obj_id).borrow_mut();
@@ -41,11 +41,11 @@ impl Interpreter {
                         proxy.callable = callable;
                     }
                     proxy.kind = crate::interpreter::types::ObjectKind::Proxy(
-                        crate::interpreter::types::ProxyData::active(t.id, h.id),
+                        crate::interpreter::types::ProxyData::active(target_id, handler_id),
                     );
                 }
                 let proxy_id = proxy_obj_id;
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: proxy_id }))
+                Completion::Normal(JsValue::object(proxy_id))
             },
         ));
 
@@ -53,30 +53,30 @@ impl Interpreter {
         // The proxy constructor already returns an Object, so eval_new will use it.
 
         // Per spec §26.2.2: Proxy constructor has no prototype property
-        if let JsValue::Object(ref pf) = proxy_fn
-            && let Some(proxy_func_obj) = self.get_object_cell(pf.id)
+        if let Some(proxy_fn_id) = proxy_fn.as_object_id()
+            && let Some(proxy_func_obj) = self.get_object_cell(proxy_fn_id)
         {
             proxy_func_obj.borrow_mut().remove_property("prototype");
         }
 
         // Proxy.revocable(target, handler)
-        if let JsValue::Object(ref pf) = proxy_fn
-            && let Some(proxy_func_obj) = self.get_object(pf.id)
+        if let Some(proxy_fn_id) = proxy_fn.as_object_id()
+            && let Some(proxy_func_obj) = self.get_object(proxy_fn_id)
         {
             let revocable_fn = self.create_function(JsFunction::native(
                 "revocable".to_string(),
                 2,
                 |interp, _this, args| {
-                    let target = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let handler = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    if !matches!(target, JsValue::Object(_)) {
+                    let target = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let handler = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    if !target.is_object() {
                         return Completion::Throw(
                             interp.create_type_error(
                                 "Cannot create proxy with a non-object as target",
                             ),
                         );
                     }
-                    if !matches!(handler, JsValue::Object(_)) {
+                    if !handler.is_object() {
                         return Completion::Throw(interp.create_type_error(
                             "Cannot create proxy with a non-object as handler",
                         ));
@@ -86,9 +86,9 @@ impl Interpreter {
                         .get_object_cell_expect(proxy_obj_id)
                         .borrow_mut()
                         .class_name = "Proxy".to_string();
-                    if let JsValue::Object(ref t) = target
-                        && let JsValue::Object(ref h) = handler
-                        && let Some(target_rc) = interp.get_object_cell(t.id)
+                    if let Some(target_id) = target.as_object_id()
+                        && let Some(handler_id) = handler.as_object_id()
+                        && let Some(target_rc) = interp.get_object_cell(target_id)
                     {
                         let callable = target_rc.borrow().callable.clone();
                         let mut obj = interp.get_object_cell_expect(proxy_obj_id).borrow_mut();
@@ -96,11 +96,11 @@ impl Interpreter {
                             obj.callable = callable;
                         }
                         obj.kind = crate::interpreter::types::ObjectKind::Proxy(
-                            crate::interpreter::types::ProxyData::active(t.id, h.id),
+                            crate::interpreter::types::ProxyData::active(target_id, handler_id),
                         );
                     }
                     let proxy_id = proxy_obj_id;
-                    let proxy_val = JsValue::Object(crate::types::JsObject { id: proxy_id });
+                    let proxy_val = JsValue::object(proxy_id);
 
                     // Create revoke function that captures proxy_id
                     let revoke_fn = interp.create_function(JsFunction::native(
@@ -113,7 +113,7 @@ impl Interpreter {
                             {
                                 pd.revoke();
                             }
-                            Completion::Normal(JsValue::Undefined)
+                            Completion::Normal(JsValue::UNDEFINED)
                         },
                     ));
 
@@ -126,7 +126,7 @@ impl Interpreter {
                         .get_object_cell_expect(result_id)
                         .borrow_mut()
                         .insert_builtin("revoke".to_string(), revoke_fn);
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
+                    Completion::Normal(JsValue::object(result_id))
                 },
             ));
             proxy_func_obj

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -4,54 +4,51 @@ use icu_normalizer::{ComposingNormalizerBorrowed, DecomposingNormalizerBorrowed}
 
 // §22.1.3 thisStringValue — RequireObjectCoercible + extract primitive from String wrapper
 fn this_string_value(interp: &mut Interpreter, this: &JsValue) -> Result<String, Completion> {
-    match this {
-        JsValue::Null | JsValue::Undefined => Err(Completion::Throw(
-            interp.create_type_error("String.prototype method called on null or undefined"),
-        )),
-        JsValue::String(s) => Ok(s.to_rust_string()),
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id)
-                && obj.borrow().class_name == "String"
-                && let Some(JsValue::String(s)) = &obj.borrow().primitive_value
-            {
-                return Ok(s.to_rust_string());
-            }
-            match interp.to_string_value(this) {
-                Ok(s) => Ok(s),
-                Err(e) => Err(Completion::Throw(e)),
-            }
-        }
-        _ => match interp.to_string_value(this) {
-            Ok(s) => Ok(s),
-            Err(e) => Err(Completion::Throw(e)),
-        },
+    if this.is_nullish() {
+        return Err(Completion::Throw(interp.create_type_error(
+            "String.prototype method called on null or undefined",
+        )));
     }
+    if let Some(string) = this.as_string() {
+        return Ok(string.to_rust_string());
+    }
+    if let Some(object_id) = this.as_object_id()
+        && let Some(obj) = interp.get_object_cell(object_id)
+    {
+        let object = obj.borrow();
+        if object.class_name == "String"
+            && let Some(string) = object.primitive_value.as_ref().and_then(JsValue::as_string)
+        {
+            return Ok(string.to_rust_string());
+        }
+    }
+    interp.to_string_value(this).map_err(Completion::Throw)
 }
 
 // Extract the raw JsString (preserving lone surrogates) from this value
 fn this_js_string(interp: &mut Interpreter, this: &JsValue) -> Result<JsString, Completion> {
-    match this {
-        JsValue::Null | JsValue::Undefined => Err(Completion::Throw(
-            interp.create_type_error("String.prototype method called on null or undefined"),
-        )),
-        JsValue::String(s) => Ok(s.clone()),
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id)
-                && obj.borrow().class_name == "String"
-                && let Some(JsValue::String(s)) = &obj.borrow().primitive_value
-            {
-                return Ok(s.clone());
-            }
-            match interp.to_string_value(this) {
-                Ok(s) => Ok(JsString::from_str(&s)),
-                Err(e) => Err(Completion::Throw(e)),
-            }
-        }
-        _ => match interp.to_string_value(this) {
-            Ok(s) => Ok(JsString::from_str(&s)),
-            Err(e) => Err(Completion::Throw(e)),
-        },
+    if this.is_nullish() {
+        return Err(Completion::Throw(interp.create_type_error(
+            "String.prototype method called on null or undefined",
+        )));
     }
+    if let Some(string) = this.as_string() {
+        return Ok(string);
+    }
+    if let Some(object_id) = this.as_object_id()
+        && let Some(obj) = interp.get_object_cell(object_id)
+    {
+        let object = obj.borrow();
+        if object.class_name == "String"
+            && let Some(string) = object.primitive_value.as_ref().and_then(JsValue::as_string)
+        {
+            return Ok(string);
+        }
+    }
+    interp
+        .to_string_value(this)
+        .map(|string| JsString::from_str(&string))
+        .map_err(Completion::Throw)
 }
 
 fn to_str(interp: &mut Interpreter, val: &JsValue) -> Result<String, Completion> {
@@ -85,7 +82,7 @@ fn utf16_units(s: &str) -> Vec<u16> {
 fn is_regexp(interp: &mut Interpreter, obj_id: u64, obj_val: &JsValue) -> Result<bool, JsValue> {
     if let Some(match_key) = interp.get_symbol_key("match") {
         match interp.get_object_property(obj_id, &match_key, obj_val) {
-            Completion::Normal(v) if !matches!(v, JsValue::Undefined) => {
+            Completion::Normal(v) if !(v).is_undefined() => {
                 return Ok(interp.to_boolean_val(&v));
             }
             Completion::Normal(_) => {}
@@ -116,7 +113,7 @@ impl Interpreter {
             .class_name = "String".to_string();
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
-            .primitive_value = Some(JsValue::String(JsString::from_str("")));
+            .primitive_value = Some(JsValue::string(JsString::from_str("")));
 
         #[allow(clippy::type_complexity)]
         let methods: Vec<(
@@ -142,9 +139,9 @@ impl Interpreter {
                     let units = &js_str.code_units;
                     let idx = pos as isize;
                     if idx < 0 || idx as usize >= units.len() {
-                        return Completion::Normal(JsValue::String(JsString::from_str("")));
+                        return Completion::Normal(JsValue::string(JsString::from_str("")));
                     }
-                    Completion::Normal(JsValue::String(JsString::from_vec(vec![
+                    Completion::Normal(JsValue::string(JsString::from_vec(vec![
                         units[idx as usize],
                     ])))
                 }),
@@ -167,9 +164,9 @@ impl Interpreter {
                     let units = &js_str.code_units;
                     let idx = pos as isize;
                     if idx < 0 || idx as usize >= units.len() {
-                        return Completion::Normal(JsValue::Number(f64::NAN));
+                        return Completion::Normal(JsValue::number(f64::NAN));
                     }
-                    Completion::Normal(JsValue::Number(units[idx as usize] as f64))
+                    Completion::Normal(JsValue::number(units[idx as usize] as f64))
                 }),
             ),
             (
@@ -190,7 +187,7 @@ impl Interpreter {
                     let units = &js_str.code_units;
                     let idx = pos as isize;
                     if idx < 0 || idx as usize >= units.len() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     let idx = idx as usize;
                     let code = units[idx];
@@ -199,10 +196,10 @@ impl Interpreter {
                         if (0xDC00..=0xDFFF).contains(&trail) {
                             let cp =
                                 ((code as u32 - 0xD800) << 10) + (trail as u32 - 0xDC00) + 0x10000;
-                            return Completion::Normal(JsValue::Number(cp as f64));
+                            return Completion::Normal(JsValue::number(cp as f64));
                         }
                     }
-                    Completion::Normal(JsValue::Number(code as f64))
+                    Completion::Normal(JsValue::number(code as f64))
                 }),
             ),
             (
@@ -233,16 +230,16 @@ impl Interpreter {
                     let search_len = search_units.len();
                     let start = pos.max(0.0).min(s_len as f64) as usize;
                     if search_len == 0 {
-                        return Completion::Normal(JsValue::Number(start.min(s_len) as f64));
+                        return Completion::Normal(JsValue::number(start.min(s_len) as f64));
                     }
                     if search_len <= s_len {
                         for i in start..=s_len - search_len {
                             if s_units[i..i + search_len] == search_units[..] {
-                                return Completion::Normal(JsValue::Number(i as f64));
+                                return Completion::Normal(JsValue::number(i as f64));
                             }
                         }
                     }
-                    Completion::Normal(JsValue::Number(-1.0))
+                    Completion::Normal(JsValue::number(-1.0))
                 }),
             ),
             (
@@ -261,7 +258,7 @@ impl Interpreter {
                         None => "undefined".to_string(),
                     };
                     let num_pos = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => match to_num(interp, v) {
+                        Some(v) if !(v).is_undefined() => match to_num(interp, v) {
                             Ok(n) => n,
                             Err(c) => return c,
                         },
@@ -277,16 +274,16 @@ impl Interpreter {
                         to_integer_or_infinity(num_pos).max(0.0).min(s_len as f64) as usize
                     };
                     if search_len == 0 {
-                        return Completion::Normal(JsValue::Number(pos.min(s_len) as f64));
+                        return Completion::Normal(JsValue::number(pos.min(s_len) as f64));
                     }
                     let max_start = pos.min(s_len.saturating_sub(search_len));
                     for i in (0..=max_start).rev() {
                         if i + search_len <= s_len && s_units[i..i + search_len] == search_units[..]
                         {
-                            return Completion::Normal(JsValue::Number(i as f64));
+                            return Completion::Normal(JsValue::number(i as f64));
                         }
                     }
-                    Completion::Normal(JsValue::Number(-1.0))
+                    Completion::Normal(JsValue::number(-1.0))
                 }),
             ),
             (
@@ -297,9 +294,9 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let search_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = search_arg {
-                        match is_regexp(interp, o.id, &search_arg) {
+                    let search_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(object_id) = search_arg.as_object_id() {
+                        match is_regexp(interp, object_id, &search_arg) {
                             Ok(true) => {
                                 return Completion::Throw(interp.create_type_error(
                                     "First argument to String.prototype.includes must not be a regular expression",
@@ -325,16 +322,16 @@ impl Interpreter {
                     let s_len = s_units.len();
                     let search_len = search_units.len();
                     if search_len == 0 {
-                        return Completion::Normal(JsValue::Boolean(true));
+                        return Completion::Normal(JsValue::boolean(true));
                     }
                     if search_len <= s_len {
                         for i in pos..=s_len - search_len {
                             if s_units[i..i + search_len] == search_units[..] {
-                                return Completion::Normal(JsValue::Boolean(true));
+                                return Completion::Normal(JsValue::boolean(true));
                             }
                         }
                     }
-                    Completion::Normal(JsValue::Boolean(false))
+                    Completion::Normal(JsValue::boolean(false))
                 }),
             ),
             (
@@ -345,9 +342,9 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let search_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = search_arg {
-                        match is_regexp(interp, o.id, &search_arg) {
+                    let search_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(object_id) = search_arg.as_object_id() {
+                        match is_regexp(interp, object_id, &search_arg) {
                             Ok(true) => {
                                 return Completion::Throw(interp.create_type_error(
                                     "First argument to String.prototype.startsWith must not be a regular expression",
@@ -362,12 +359,10 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let pos = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => {
-                            match to_int_or_inf(interp, v) {
-                                Ok(n) => n.max(0.0) as usize,
-                                Err(c) => return c,
-                            }
-                        }
+                        Some(v) if !(v).is_undefined() => match to_int_or_inf(interp, v) {
+                            Ok(n) => n.max(0.0) as usize,
+                            Err(c) => return c,
+                        },
                         _ => 0,
                     };
                     let s_units = utf16_units(&s);
@@ -375,10 +370,10 @@ impl Interpreter {
                     let s_len = s_units.len();
                     let start = pos.min(s_len);
                     if start + search_units.len() > s_len {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     let result = s_units[start..start + search_units.len()] == search_units[..];
-                    Completion::Normal(JsValue::Boolean(result))
+                    Completion::Normal(JsValue::boolean(result))
                 }),
             ),
             (
@@ -389,9 +384,9 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let search_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = search_arg {
-                        match is_regexp(interp, o.id, &search_arg) {
+                    let search_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(object_id) = search_arg.as_object_id() {
+                        match is_regexp(interp, object_id, &search_arg) {
                             Ok(true) => {
                                 return Completion::Throw(interp.create_type_error(
                                     "First argument to String.prototype.endsWith must not be a regular expression",
@@ -409,21 +404,19 @@ impl Interpreter {
                     let search_units = utf16_units(&search);
                     let s_len = s_units.len();
                     let end_pos = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => {
-                            match to_int_or_inf(interp, v) {
-                                Ok(n) => n.max(0.0).min(s_len as f64) as usize,
-                                Err(c) => return c,
-                            }
-                        }
+                        Some(v) if !(v).is_undefined() => match to_int_or_inf(interp, v) {
+                            Ok(n) => n.max(0.0).min(s_len as f64) as usize,
+                            Err(c) => return c,
+                        },
                         _ => s_len,
                     };
                     let search_len = search_units.len();
                     if search_len > end_pos {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
                     let start = end_pos - search_len;
                     let result = s_units[start..end_pos] == search_units[..];
-                    Completion::Normal(JsValue::Boolean(result))
+                    Completion::Normal(JsValue::boolean(result))
                 }),
             ),
             (
@@ -444,12 +437,10 @@ impl Interpreter {
                         None => 0.0,
                     };
                     let int_end = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => {
-                            match to_int_or_inf(interp, v) {
-                                Ok(n) => n,
-                                Err(c) => return c,
-                            }
-                        }
+                        Some(v) if !(v).is_undefined() => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
+                            Err(c) => return c,
+                        },
                         _ => len,
                     };
                     let from = resolve_relative_index(int_start, len as usize);
@@ -457,9 +448,9 @@ impl Interpreter {
                     let from = from.min(units.len());
                     let to = to.min(units.len());
                     if from >= to {
-                        return Completion::Normal(JsValue::String(JsString::from_str("")));
+                        return Completion::Normal(JsValue::string(JsString::from_str("")));
                     }
-                    Completion::Normal(JsValue::String(JsString::from_vec(
+                    Completion::Normal(JsValue::string(JsString::from_vec(
                         units[from..to].to_vec(),
                     )))
                 }),
@@ -485,7 +476,7 @@ impl Interpreter {
                         None => 0.0,
                     };
                     let int_end = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => match to_num(interp, v) {
+                        Some(v) if !(v).is_undefined() => match to_num(interp, v) {
                             Ok(n) => {
                                 let i = to_integer_or_infinity(n);
                                 if n.is_nan() { 0.0 } else { i }
@@ -502,7 +493,7 @@ impl Interpreter {
                         (final_end, final_start)
                     };
                     let result = utf16_substring(&units, from, to);
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::string(JsString::from_str(&result)))
                 }),
             ),
             (
@@ -513,7 +504,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&s.to_lowercase())))
+                    Completion::Normal(JsValue::string(JsString::from_str(&s.to_lowercase())))
                 }),
             ),
             (
@@ -524,7 +515,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&s.to_uppercase())))
+                    Completion::Normal(JsValue::string(JsString::from_str(&s.to_uppercase())))
                 }),
             ),
             (
@@ -535,7 +526,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let locale_list = match interp.intl_canonicalize_locale_list(&locales_arg) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),
@@ -545,7 +536,7 @@ impl Interpreter {
                         resolved.parse().unwrap_or_else(|_| "und".parse().unwrap());
                     let cm = icu::casemap::CaseMapper::new();
                     let result = cm.lowercase_to_string(&s, &langid);
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::string(JsString::from_str(&result)))
                 }),
             ),
             (
@@ -556,7 +547,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let locale_list = match interp.intl_canonicalize_locale_list(&locales_arg) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),
@@ -566,7 +557,7 @@ impl Interpreter {
                         resolved.parse().unwrap_or_else(|_| "und".parse().unwrap());
                     let cm = icu::casemap::CaseMapper::new();
                     let result = cm.uppercase_to_string(&s, &langid);
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::string(JsString::from_str(&result)))
                 }),
             ),
             (
@@ -577,7 +568,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(
+                    Completion::Normal(JsValue::string(JsString::from_str(
                         s.trim_matches(is_ecma_whitespace),
                     )))
                 }),
@@ -590,7 +581,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(
+                    Completion::Normal(JsValue::string(JsString::from_str(
                         s.trim_start_matches(is_ecma_whitespace),
                     )))
                 }),
@@ -603,7 +594,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(
+                    Completion::Normal(JsValue::string(JsString::from_str(
                         s.trim_end_matches(is_ecma_whitespace),
                     )))
                 }),
@@ -627,7 +618,7 @@ impl Interpreter {
                         return Completion::Throw(interp.create_range_error("Invalid count value"));
                     }
                     let count = n as usize;
-                    Completion::Normal(JsValue::String(JsString::from_str(&s.repeat(count))))
+                    Completion::Normal(JsValue::string(JsString::from_str(&s.repeat(count))))
                 }),
             ),
             (
@@ -646,7 +637,7 @@ impl Interpreter {
                         None => 0.0,
                     };
                     let fill = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => match to_str(interp, v) {
+                        Some(v) if !(v).is_undefined() => match to_str(interp, v) {
                             Ok(s) => s,
                             Err(c) => return c,
                         },
@@ -656,14 +647,14 @@ impl Interpreter {
                     let s_len = s_units.len();
                     let int_max = max_length as usize;
                     if int_max <= s_len || fill.is_empty() {
-                        return Completion::Normal(JsValue::String(JsString::from_str(&s)));
+                        return Completion::Normal(JsValue::string(JsString::from_str(&s)));
                     }
                     let fill_units = utf16_units(&fill);
                     let fill_len = int_max - s_len;
                     let pad: Vec<u16> = fill_units.iter().copied().cycle().take(fill_len).collect();
                     let mut result = pad;
                     result.extend_from_slice(&s_units);
-                    Completion::Normal(JsValue::String(JsString::from_vec(result)))
+                    Completion::Normal(JsValue::string(JsString::from_vec(result)))
                 }),
             ),
             (
@@ -682,7 +673,7 @@ impl Interpreter {
                         None => 0.0,
                     };
                     let fill = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => match to_str(interp, v) {
+                        Some(v) if !(v).is_undefined() => match to_str(interp, v) {
                             Ok(s) => s,
                             Err(c) => return c,
                         },
@@ -692,14 +683,14 @@ impl Interpreter {
                     let s_len = s_units.len();
                     let int_max = max_length as usize;
                     if int_max <= s_len || fill.is_empty() {
-                        return Completion::Normal(JsValue::String(JsString::from_str(&s)));
+                        return Completion::Normal(JsValue::string(JsString::from_str(&s)));
                     }
                     let fill_units = utf16_units(&fill);
                     let fill_len = int_max - s_len;
                     let pad: Vec<u16> = fill_units.iter().copied().cycle().take(fill_len).collect();
                     let mut result = s_units;
                     result.extend_from_slice(&pad);
-                    Completion::Normal(JsValue::String(JsString::from_vec(result)))
+                    Completion::Normal(JsValue::string(JsString::from_vec(result)))
                 }),
             ),
             (
@@ -716,7 +707,7 @@ impl Interpreter {
                             Err(c) => return c,
                         }
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&s)))
+                    Completion::Normal(JsValue::string(JsString::from_str(&s)))
                 }),
             ),
             (
@@ -724,24 +715,24 @@ impl Interpreter {
                 2,
                 Rc::new(|interp, this_val, args| {
                     // RequireObjectCoercible
-                    if matches!(this_val, JsValue::Null | JsValue::Undefined) {
+                    if (this_val).is_nullish() {
                         return Completion::Throw(interp.create_type_error(
                             "String.prototype.split called on null or undefined",
                         ));
                     }
-                    let separator = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let separator = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     // Check for Symbol.split on the separator
-                    if let JsValue::Object(ref o) = separator
+                    if let Some(object_id) = separator.as_object_id()
                         && let Some(key) = interp.get_symbol_key("split")
                     {
-                        let method = match interp.get_object_property(o.id, &key, &separator) {
+                        let method = match interp.get_object_property(object_id, &key, &separator) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
                             other => return other,
                         };
-                        if !matches!(method, JsValue::Undefined | JsValue::Null) {
+                        if !(method).is_nullish() {
                             let this_str = this_val.clone();
-                            let limit = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                            let limit = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                             return interp.call_function(&method, &separator, &[this_str, limit]);
                         }
                     }
@@ -749,9 +740,9 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let limit_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let limit_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     // Per spec: ToUint32(limit) — NaN/Infinity/2^32/etc map to 0
-                    let limit: u32 = if matches!(limit_arg, JsValue::Undefined) {
+                    let limit: u32 = if (limit_arg).is_undefined() {
                         0xFFFF_FFFF // 2^32 - 1
                     } else {
                         match to_num(interp, &limit_arg) {
@@ -760,7 +751,7 @@ impl Interpreter {
                         }
                     };
                     // Per spec step 7: ToString(separator) BEFORE limit check
-                    let sep_is_undef = matches!(separator, JsValue::Undefined);
+                    let sep_is_undef = (separator).is_undefined();
                     let sep_str = if !sep_is_undef {
                         match to_str(interp, &separator) {
                             Ok(s) => Some(s),
@@ -774,7 +765,7 @@ impl Interpreter {
                     }
                     if sep_is_undef {
                         return Completion::Normal(
-                            interp.create_array(vec![JsValue::String(JsString::from_str(&s))]),
+                            interp.create_array(vec![JsValue::string(JsString::from_str(&s))]),
                         );
                     }
                     let sep_str = sep_str.unwrap();
@@ -791,7 +782,7 @@ impl Interpreter {
                                 break;
                             }
                             let ch = String::from_utf16_lossy(&s_units[i..i + 1]);
-                            parts.push(JsValue::String(JsString::from_str(&ch)));
+                            parts.push(JsValue::string(JsString::from_str(&ch)));
                         }
                         return Completion::Normal(interp.create_array(parts));
                     }
@@ -803,7 +794,7 @@ impl Interpreter {
                     while q + sep_len <= s_len {
                         if s_units[q..q + sep_len] == sep_units[..] {
                             let seg = utf16_substring(&s_units, p, q);
-                            parts.push(JsValue::String(JsString::from_str(&seg)));
+                            parts.push(JsValue::string(JsString::from_str(&seg)));
                             if parts.len() >= limit as usize {
                                 return Completion::Normal(interp.create_array(parts));
                             }
@@ -815,7 +806,7 @@ impl Interpreter {
                     }
                     // Add remaining
                     let seg = utf16_substring(&s_units, p, s_len);
-                    parts.push(JsValue::String(JsString::from_str(&seg)));
+                    parts.push(JsValue::string(JsString::from_str(&seg)));
                     parts.truncate(limit as usize);
                     Completion::Normal(interp.create_array(parts))
                 }),
@@ -824,22 +815,23 @@ impl Interpreter {
                 "replace",
                 2,
                 Rc::new(|interp, this_val, args| {
-                    if matches!(this_val, JsValue::Null | JsValue::Undefined) {
+                    if (this_val).is_nullish() {
                         return Completion::Throw(interp.create_type_error(
                             "String.prototype.replace called on null or undefined",
                         ));
                     }
-                    let search_value = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = search_value
+                    let search_value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(object_id) = search_value.as_object_id()
                         && let Some(key) = interp.get_symbol_key("replace")
                     {
-                        let method = match interp.get_object_property(o.id, &key, &search_value) {
-                            Completion::Normal(v) => v,
-                            Completion::Throw(e) => return Completion::Throw(e),
-                            other => return other,
-                        };
-                        if !matches!(method, JsValue::Undefined | JsValue::Null) {
-                            let replace_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                        let method =
+                            match interp.get_object_property(object_id, &key, &search_value) {
+                                Completion::Normal(v) => v,
+                                Completion::Throw(e) => return Completion::Throw(e),
+                                other => return other,
+                            };
+                        if !(method).is_nullish() {
+                            let replace_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                             return interp.call_function(
                                 &method,
                                 &search_value,
@@ -855,10 +847,10 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let replace_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    let is_fn = if let JsValue::Object(ref o) = replace_arg {
+                    let replace_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    let is_fn = if let Some(object_id) = replace_arg.as_object_id() {
                         interp
-                            .get_object_cell(o.id)
+                            .get_object_cell(object_id)
                             .map(|obj| obj.borrow().callable.is_some())
                             .unwrap_or(false)
                     } else {
@@ -885,11 +877,11 @@ impl Interpreter {
                             let matched = utf16_substring(&s_units, p, p + search_len);
                             let r = interp.call_function(
                                 &replace_arg,
-                                &JsValue::Undefined,
+                                &JsValue::UNDEFINED,
                                 &[
-                                    JsValue::String(JsString::from_str(&matched)),
-                                    JsValue::Number(p as f64),
-                                    JsValue::String(JsString::from_str(&s)),
+                                    JsValue::string(JsString::from_str(&matched)),
+                                    JsValue::number(p as f64),
+                                    JsValue::string(JsString::from_str(&s)),
                                 ],
                             );
                             let replacement = match r {
@@ -902,9 +894,9 @@ impl Interpreter {
                             let before = utf16_substring(&s_units, 0, p);
                             let after = utf16_substring(&s_units, p + search_len, s_len);
                             let result = format!("{before}{replacement}{after}");
-                            Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                            Completion::Normal(JsValue::string(JsString::from_str(&result)))
                         } else {
-                            Completion::Normal(JsValue::String(JsString::from_str(&s)))
+                            Completion::Normal(JsValue::string(JsString::from_str(&s)))
                         }
                     } else {
                         let replacement = match to_str(interp, &replace_arg) {
@@ -933,9 +925,9 @@ impl Interpreter {
                             let matched = utf16_substring(&s_units, pos, pos + search_len);
                             let rep = apply_replacement_pattern(&replacement, &matched, &s, pos);
                             let result = format!("{before}{rep}{after}");
-                            Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                            Completion::Normal(JsValue::string(JsString::from_str(&result)))
                         } else {
-                            Completion::Normal(JsValue::String(JsString::from_str(&s)))
+                            Completion::Normal(JsValue::string(JsString::from_str(&s)))
                         }
                     }
                 }),
@@ -944,21 +936,21 @@ impl Interpreter {
                 "replaceAll",
                 2,
                 Rc::new(|interp, this_val, args| {
-                    if matches!(this_val, JsValue::Null | JsValue::Undefined) {
+                    if (this_val).is_nullish() {
                         return Completion::Throw(interp.create_type_error(
                             "String.prototype.replaceAll called on null or undefined",
                         ));
                     }
-                    let search_value = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = search_value {
+                    let search_value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(object_id) = search_value.as_object_id() {
                         // Step 2a: IsRegExp check
                         let is_regexp = if let Some(match_key) = interp.get_symbol_key("match") {
-                            match interp.get_object_property(o.id, &match_key, &search_value) {
-                                Completion::Normal(v) if !matches!(v, JsValue::Undefined) => {
+                            match interp.get_object_property(object_id, &match_key, &search_value) {
+                                Completion::Normal(v) if !(v).is_undefined() => {
                                     interp.to_boolean_val(&v)
                                 }
                                 Completion::Normal(_) => interp
-                                    .get_object_cell(o.id)
+                                    .get_object_cell(object_id)
                                     .map(|obj| obj.borrow().class_name == "RegExp")
                                     .unwrap_or(false),
                                 Completion::Throw(e) => return Completion::Throw(e),
@@ -966,14 +958,15 @@ impl Interpreter {
                             }
                         } else {
                             interp
-                                .get_object_cell(o.id)
+                                .get_object_cell(object_id)
                                 .map(|obj| obj.borrow().class_name == "RegExp")
                                 .unwrap_or(false)
                         };
                         if is_regexp {
                             // Step 2b: Get flags via getter
                             let flags_val =
-                                match interp.get_object_property(o.id, "flags", &search_value) {
+                                match interp.get_object_property(object_id, "flags", &search_value)
+                                {
                                     Completion::Normal(v) => v,
                                     Completion::Throw(e) => return Completion::Throw(e),
                                     other => return other,
@@ -990,15 +983,15 @@ impl Interpreter {
                         }
                         // Step 2c-d: GetMethod(searchValue, @@replace)
                         if let Some(key) = interp.get_symbol_key("replace") {
-                            let method = match interp.get_object_property(o.id, &key, &search_value)
-                            {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => return Completion::Throw(e),
-                                other => return other,
-                            };
-                            if !matches!(method, JsValue::Undefined | JsValue::Null) {
+                            let method =
+                                match interp.get_object_property(object_id, &key, &search_value) {
+                                    Completion::Normal(v) => v,
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    other => return other,
+                                };
+                            if !(method).is_nullish() {
                                 let replace_val =
-                                    args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                                    args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                                 return interp.call_function(
                                     &method,
                                     &search_value,
@@ -1015,10 +1008,10 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let replace_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    let is_fn = if let JsValue::Object(ref o) = replace_arg {
+                    let replace_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    let is_fn = if let Some(object_id) = replace_arg.as_object_id() {
                         interp
-                            .get_object_cell(o.id)
+                            .get_object_cell(object_id)
                             .map(|obj| obj.borrow().callable.is_some())
                             .unwrap_or(false)
                     } else {
@@ -1057,7 +1050,7 @@ impl Interpreter {
                     }
 
                     if positions.is_empty() {
-                        return Completion::Normal(JsValue::String(JsString::from_str(&s)));
+                        return Completion::Normal(JsValue::string(JsString::from_str(&s)));
                     }
 
                     let mut result = Vec::new();
@@ -1068,11 +1061,11 @@ impl Interpreter {
                         if is_fn {
                             let r = interp.call_function(
                                 &replace_arg,
-                                &JsValue::Undefined,
+                                &JsValue::UNDEFINED,
                                 &[
-                                    JsValue::String(JsString::from_str(&matched)),
-                                    JsValue::Number(pos as f64),
-                                    JsValue::String(JsString::from_str(&s)),
+                                    JsValue::string(JsString::from_str(&matched)),
+                                    JsValue::number(pos as f64),
+                                    JsValue::string(JsString::from_str(&s)),
                                 ],
                             );
                             let rep = match r {
@@ -1091,7 +1084,7 @@ impl Interpreter {
                         last_end = pos + search_len;
                     }
                     result.extend_from_slice(&s_units[last_end..]);
-                    Completion::Normal(JsValue::String(JsString::from_str(
+                    Completion::Normal(JsValue::string(JsString::from_str(
                         &String::from_utf16_lossy(&result),
                     )))
                 }),
@@ -1115,9 +1108,9 @@ impl Interpreter {
                     };
                     let actual = if idx < 0 { len + idx } else { idx };
                     if actual < 0 || actual >= len {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
-                    Completion::Normal(JsValue::String(JsString::from_vec(vec![
+                    Completion::Normal(JsValue::string(JsString::from_vec(vec![
                         units[actual as usize],
                     ])))
                 }),
@@ -1126,21 +1119,21 @@ impl Interpreter {
                 "search",
                 1,
                 Rc::new(|interp, this_val, args| {
-                    if matches!(this_val, JsValue::Null | JsValue::Undefined) {
+                    if (this_val).is_nullish() {
                         return Completion::Throw(interp.create_type_error(
                             "String.prototype.search called on null or undefined",
                         ));
                     }
-                    let regexp = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = regexp
+                    let regexp = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(object_id) = regexp.as_object_id()
                         && let Some(key) = interp.get_symbol_key("search")
                     {
-                        let method = match interp.get_object_property(o.id, &key, &regexp) {
+                        let method = match interp.get_object_property(object_id, &key, &regexp) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
                             other => return other,
                         };
-                        if !matches!(method, JsValue::Undefined | JsValue::Null) {
+                        if !(method).is_nullish() {
                             let this_str = this_val.clone();
                             return interp.call_function(&method, &regexp, &[this_str]);
                         }
@@ -1149,7 +1142,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let source = if matches!(regexp, JsValue::Undefined) {
+                    let source = if (regexp).is_undefined() {
                         String::new()
                     } else {
                         match to_str(interp, &regexp) {
@@ -1159,12 +1152,12 @@ impl Interpreter {
                     };
                     // Create a RegExp and call @@search
                     let rx = interp.create_regexp(&source, "");
-                    if let JsValue::Object(ref ro) = rx
+                    if let Some(regexp_id) = rx.as_object_id()
                         && let Some(key) = interp.get_symbol_key("search")
                     {
-                        let method = interp.get_property_on_id(ro.id, &key);
-                        if !matches!(method, JsValue::Undefined | JsValue::Null) {
-                            let this_str = JsValue::String(JsString::from_str(&s));
+                        let method = interp.get_property_on_id(regexp_id, &key);
+                        if !(method).is_nullish() {
+                            let this_str = JsValue::string(JsString::from_str(&s));
                             return interp.call_function(&method, &rx, &[this_str]);
                         }
                     }
@@ -1172,30 +1165,30 @@ impl Interpreter {
                     if let Ok(re) = regex::Regex::new(&source)
                         && let Some(m) = re.find(&s)
                     {
-                        return Completion::Normal(JsValue::Number(m.start() as f64));
+                        return Completion::Normal(JsValue::number(m.start() as f64));
                     }
-                    Completion::Normal(JsValue::Number(-1.0))
+                    Completion::Normal(JsValue::number(-1.0))
                 }),
             ),
             (
                 "match",
                 1,
                 Rc::new(|interp, this_val, args| {
-                    if matches!(this_val, JsValue::Null | JsValue::Undefined) {
+                    if (this_val).is_nullish() {
                         return Completion::Throw(interp.create_type_error(
                             "String.prototype.match called on null or undefined",
                         ));
                     }
-                    let regexp = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = regexp
+                    let regexp = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(object_id) = regexp.as_object_id()
                         && let Some(key) = interp.get_symbol_key("match")
                     {
-                        let method = match interp.get_object_property(o.id, &key, &regexp) {
+                        let method = match interp.get_object_property(object_id, &key, &regexp) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
                             other => return other,
                         };
-                        if !matches!(method, JsValue::Undefined | JsValue::Null) {
+                        if !(method).is_nullish() {
                             let this_str = this_val.clone();
                             return interp.call_function(&method, &regexp, &[this_str]);
                         }
@@ -1204,7 +1197,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let source = if args.is_empty() || matches!(regexp, JsValue::Undefined) {
+                    let source = if args.is_empty() || (regexp).is_undefined() {
                         String::new()
                     } else {
                         match to_str(interp, &regexp) {
@@ -1214,38 +1207,38 @@ impl Interpreter {
                     };
                     // Create a RegExp and call @@match
                     let rx = interp.create_regexp(&source, "");
-                    if let JsValue::Object(ref ro) = rx
+                    if let Some(regexp_id) = rx.as_object_id()
                         && let Some(key) = interp.get_symbol_key("match")
                     {
-                        let method = interp.get_property_on_id(ro.id, &key);
-                        if !matches!(method, JsValue::Undefined | JsValue::Null) {
-                            let this_str = JsValue::String(JsString::from_str(&s));
+                        let method = interp.get_property_on_id(regexp_id, &key);
+                        if !(method).is_nullish() {
+                            let this_str = JsValue::string(JsString::from_str(&s));
                             return interp.call_function(&method, &rx, &[this_str]);
                         }
                     }
                     // Fallback
                     if let Ok(re) = regex::Regex::new(&source) {
                         if let Some(m) = re.find(&s) {
-                            let matched = JsValue::String(JsString::from_str(m.as_str()));
+                            let matched = JsValue::string(JsString::from_str(m.as_str()));
                             let result = interp.create_array(vec![matched]);
-                            if let JsValue::Object(ro) = &result
-                                && let Some(robj) = interp.get_object_cell(ro.id)
+                            if let Some(result_id) = result.as_object_id()
+                                && let Some(robj) = interp.get_object_cell(result_id)
                             {
                                 robj.borrow_mut().insert_value(
                                     "index".to_string(),
-                                    JsValue::Number(m.start() as f64),
+                                    JsValue::number(m.start() as f64),
                                 );
                                 robj.borrow_mut().insert_value(
                                     "input".to_string(),
-                                    JsValue::String(JsString::from_str(&s)),
+                                    JsValue::string(JsString::from_str(&s)),
                                 );
                             }
                             Completion::Normal(result)
                         } else {
-                            Completion::Normal(JsValue::Null)
+                            Completion::Normal(JsValue::NULL)
                         }
                     } else {
-                        Completion::Normal(JsValue::Null)
+                        Completion::Normal(JsValue::NULL)
                     }
                 }),
             ),
@@ -1253,21 +1246,21 @@ impl Interpreter {
                 "matchAll",
                 1,
                 Rc::new(|interp, this_val, args| {
-                    if matches!(this_val, JsValue::Null | JsValue::Undefined) {
+                    if (this_val).is_nullish() {
                         return Completion::Throw(interp.create_type_error(
                             "String.prototype.matchAll called on null or undefined",
                         ));
                     }
-                    let regexp = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref o) = regexp {
+                    let regexp = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(object_id) = regexp.as_object_id() {
                         // IsRegExp check
                         let is_regexp = if let Some(match_key) = interp.get_symbol_key("match") {
-                            match interp.get_object_property(o.id, &match_key, &regexp) {
-                                Completion::Normal(v) if !matches!(v, JsValue::Undefined) => {
+                            match interp.get_object_property(object_id, &match_key, &regexp) {
+                                Completion::Normal(v) if !(v).is_undefined() => {
                                     interp.to_boolean_val(&v)
                                 }
                                 Completion::Normal(_) => interp
-                                    .get_object_cell(o.id)
+                                    .get_object_cell(object_id)
                                     .map(|obj| obj.borrow().class_name == "RegExp")
                                     .unwrap_or(false),
                                 Completion::Throw(e) => return Completion::Throw(e),
@@ -1275,17 +1268,17 @@ impl Interpreter {
                             }
                         } else {
                             interp
-                                .get_object_cell(o.id)
+                                .get_object_cell(object_id)
                                 .map(|obj| obj.borrow().class_name == "RegExp")
                                 .unwrap_or(false)
                         };
                         if is_regexp {
-                            let flags_val = match interp.get_object_property(o.id, "flags", &regexp)
-                            {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => return Completion::Throw(e),
-                                other => return other,
-                            };
+                            let flags_val =
+                                match interp.get_object_property(object_id, "flags", &regexp) {
+                                    Completion::Normal(v) => v,
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    other => return other,
+                                };
                             let flags = match interp.to_string_value(&flags_val) {
                                 Ok(s) => s,
                                 Err(e) => return Completion::Throw(e),
@@ -1297,12 +1290,13 @@ impl Interpreter {
                             }
                         }
                         if let Some(key) = interp.get_symbol_key("matchAll") {
-                            let method = match interp.get_object_property(o.id, &key, &regexp) {
+                            let method = match interp.get_object_property(object_id, &key, &regexp)
+                            {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 other => return other,
                             };
-                            if !matches!(method, JsValue::Undefined | JsValue::Null) {
+                            if !(method).is_nullish() {
                                 let this_str = this_val.clone();
                                 return interp.call_function(&method, &regexp, &[this_str]);
                             }
@@ -1315,7 +1309,7 @@ impl Interpreter {
                     };
                     // Step 4: Let R be ? ToString(regexp)
                     // Per spec: RegExpCreate(regexp, "g") — undefined -> empty pattern
-                    let source = if matches!(regexp, JsValue::Undefined) {
+                    let source = if (regexp).is_undefined() {
                         String::new()
                     } else {
                         match to_str(interp, &regexp) {
@@ -1324,16 +1318,16 @@ impl Interpreter {
                         }
                     };
                     let rx = interp.create_regexp(&source, "g");
-                    if let JsValue::Object(ref ro) = rx
+                    if let Some(regexp_id) = rx.as_object_id()
                         && let Some(key) = interp.get_symbol_key("matchAll")
                     {
-                        let method = match interp.get_object_property(ro.id, &key, &rx) {
+                        let method = match interp.get_object_property(regexp_id, &key, &rx) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
                             other => return other,
                         };
-                        if !matches!(method, JsValue::Undefined | JsValue::Null) {
-                            let this_str = JsValue::String(JsString::from_str(&s));
+                        if !(method).is_nullish() {
+                            let this_str = JsValue::string(JsString::from_str(&s));
                             return interp.call_function(&method, &rx, &[this_str]);
                         }
                     }
@@ -1349,7 +1343,7 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let form = match args.first() {
-                        Some(v) if !matches!(v, JsValue::Undefined) => match to_str(interp, v) {
+                        Some(v) if !(v).is_undefined() => match to_str(interp, v) {
                             Ok(s) => s,
                             Err(c) => return c,
                         },
@@ -1366,7 +1360,7 @@ impl Interpreter {
                             ));
                         }
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&normalized)))
+                    Completion::Normal(JsValue::string(JsString::from_str(&normalized)))
                 }),
             ),
             (
@@ -1384,10 +1378,10 @@ impl Interpreter {
                         },
                         None => "undefined".to_string(),
                     };
-                    let locales = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    let options = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    let options = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                     match interp.intl_locale_compare(&s, &that, &locales, &options) {
-                        Ok(result) => Completion::Normal(JsValue::Number(result)),
+                        Ok(result) => Completion::Normal(JsValue::number(result)),
                         Err(e) => Completion::Throw(e),
                     }
                 }),
@@ -1406,16 +1400,16 @@ impl Interpreter {
                         let cu = units[i];
                         if (0xD800..=0xDBFF).contains(&cu) {
                             if i + 1 >= units.len() || !(0xDC00..=0xDFFF).contains(&units[i + 1]) {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                             i += 2;
                         } else if (0xDC00..=0xDFFF).contains(&cu) {
-                            return Completion::Normal(JsValue::Boolean(false));
+                            return Completion::Normal(JsValue::boolean(false));
                         } else {
                             i += 1;
                         }
                     }
-                    Completion::Normal(JsValue::Boolean(true))
+                    Completion::Normal(JsValue::boolean(true))
                 }),
             ),
             (
@@ -1448,7 +1442,7 @@ impl Interpreter {
                             i += 1;
                         }
                     }
-                    Completion::Normal(JsValue::String(JsString::from_vec(result)))
+                    Completion::Normal(JsValue::string(JsString::from_vec(result)))
                 }),
             ),
         ];
@@ -1467,26 +1461,22 @@ impl Interpreter {
             let tostring_fn = self.create_function(JsFunction::native(
                 "toString".to_string(),
                 0,
-                move |interp, this_val, _args| match this_val {
-                    JsValue::String(s) => Completion::Normal(JsValue::String(s.clone())),
-                    JsValue::Object(o) => {
-                        if let Some(obj) = interp.get_object_cell(o.id)
-                            && obj.borrow().class_name == "String"
-                            && let Some(ref pv) = obj.borrow().primitive_value
-                        {
-                            return Completion::Normal(pv.clone());
-                        }
-                        Completion::Throw(interp.create_error_in_realm(
-                            realm_id,
-                            "TypeError",
-                            "String.prototype.toString requires that 'this' be a String",
-                        ))
+                move |interp, this_val, _args| {
+                    if this_val.is_string() {
+                        return Completion::Normal(this_val.clone());
                     }
-                    _ => Completion::Throw(interp.create_error_in_realm(
+                    if let Some(object_id) = this_val.as_object_id()
+                        && let Some(obj) = interp.get_object_cell(object_id)
+                        && obj.borrow().class_name == "String"
+                        && let Some(ref primitive) = obj.borrow().primitive_value
+                    {
+                        return Completion::Normal(primitive.clone());
+                    }
+                    Completion::Throw(interp.create_error_in_realm(
                         realm_id,
                         "TypeError",
                         "String.prototype.toString requires that 'this' be a String",
-                    )),
+                    ))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -1496,26 +1486,22 @@ impl Interpreter {
             let valueof_fn = self.create_function(JsFunction::native(
                 "valueOf".to_string(),
                 0,
-                move |interp, this_val, _args| match this_val {
-                    JsValue::String(s) => Completion::Normal(JsValue::String(s.clone())),
-                    JsValue::Object(o) => {
-                        if let Some(obj) = interp.get_object_cell(o.id)
-                            && obj.borrow().class_name == "String"
-                            && let Some(ref pv) = obj.borrow().primitive_value
-                        {
-                            return Completion::Normal(pv.clone());
-                        }
-                        Completion::Throw(interp.create_error_in_realm(
-                            realm_id,
-                            "TypeError",
-                            "String.prototype.valueOf requires that 'this' be a String",
-                        ))
+                move |interp, this_val, _args| {
+                    if this_val.is_string() {
+                        return Completion::Normal(this_val.clone());
                     }
-                    _ => Completion::Throw(interp.create_error_in_realm(
+                    if let Some(object_id) = this_val.as_object_id()
+                        && let Some(obj) = interp.get_object_cell(object_id)
+                        && obj.borrow().class_name == "String"
+                        && let Some(ref primitive) = obj.borrow().primitive_value
+                    {
+                        return Completion::Normal(primitive.clone());
+                    }
+                    Completion::Throw(interp.create_error_in_realm(
                         realm_id,
                         "TypeError",
                         "String.prototype.valueOf requires that 'this' be a String",
-                    )),
+                    ))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -1546,7 +1532,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&format!(
+                    Completion::Normal(JsValue::string(JsString::from_str(&format!(
                         "<{tag_o}>{s}</{tag_c}>"
                     ))))
                 }),
@@ -1575,13 +1561,13 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let attr_val = match interp.to_string_value(&arg) {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
                     let escaped = attr_val.replace('"', "&quot;");
-                    Completion::Normal(JsValue::String(JsString::from_str(&format!(
+                    Completion::Normal(JsValue::string(JsString::from_str(&format!(
                         "<{tag_o} {attr_name}=\"{escaped}\">{s}</{tag_c}>"
                     ))))
                 }),
@@ -1618,7 +1604,7 @@ impl Interpreter {
                         (int_start as usize).min(units.len())
                     };
                     let result_len = match args.get(1) {
-                        Some(v) if !matches!(v, JsValue::Undefined) => {
+                        Some(v) if !(v).is_undefined() => {
                             let l = match to_num(interp, v) {
                                 Ok(n) => n,
                                 Err(c) => return c,
@@ -1629,7 +1615,7 @@ impl Interpreter {
                         _ => units.len(),
                     };
                     let end = (start + result_len).min(units.len());
-                    Completion::Normal(JsValue::String(JsString::from_vec(
+                    Completion::Normal(JsValue::string(JsString::from_vec(
                         units[start..end].to_vec(),
                     )))
                 }),
@@ -1655,14 +1641,14 @@ impl Interpreter {
             "[Symbol.iterator]".to_string(),
             0,
             |interp, this_val, _args| {
-                if matches!(this_val, JsValue::Null | JsValue::Undefined) {
+                if (this_val).is_nullish() {
                     return Completion::Throw(interp.create_type_error(
                         "String.prototype[Symbol.iterator] called on null or undefined",
                     ));
                 }
-                let s = match this_val {
-                    JsValue::String(s) => s.clone(),
-                    _ => match interp.to_string_value(this_val) {
+                let s = match this_val.as_string() {
+                    Some(string) => string,
+                    None => match interp.to_string_value(this_val) {
                         Ok(converted) => JsString::from_str(&converted),
                         Err(e) => return Completion::Throw(e),
                     },
@@ -1681,10 +1667,10 @@ impl Interpreter {
 
         // Set String.prototype on the String constructor and wire constructor back
         if let Some(str_val) = self.get_global_var("String")
-            && let JsValue::Object(o) = &str_val
-            && let Some(str_obj) = self.get_object_cell(o.id)
+            && let Some(string_id) = str_val.as_object_id()
+            && let Some(str_obj) = self.get_object_cell(string_id)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             str_obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val.clone(), false, false, false),


### PR DESCRIPTION
## Summary

- migrate direct JsValue enum construction and matching in the ten scoped core builtin modules to constructors, predicates, and accessors
- preserve object identity, error ordering, collection semantics, and the setTimeout Send boundary
- leave representation and JavaScript behavior unchanged

## Validation

- cargo fmt --check
- cargo clippy --locked -j 2 -- -D warnings
- cargo build --release --locked -j 2
- cargo test --release --locked -j 2
- uv run python scripts/run-custom-tests.py (11/11)
- ./scripts/lint.sh
- built-ins test262: 47,031/47,031
- full test262: 99,568/99,568, zero regressions

Closes #409