### PR TITLE
refactor(nan-box): make JsSymbol Arc-backed

### DIFF
--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -842,12 +842,12 @@ impl Interpreter {
         }
         let id = self.next_symbol_id;
         self.next_symbol_id += 1;
-        let sym = JsValue::Symbol(crate::types::JsSymbol {
+        let sym = JsValue::Symbol(crate::types::JsSymbol::new(
             id,
-            description: Some(crate::types::JsString::from_str(
+            Some(crate::types::JsString::from_str(
                 "IntlLegacyConstructedSymbol",
             )),
-        });
+        ));
         self.realm_mut().intl_fallback_symbol = Some(sym.clone());
         sym
     }

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -1350,10 +1350,7 @@ impl Interpreter {
                     };
                     let id = interp.next_symbol_id;
                     interp.next_symbol_id += 1;
-                    Completion::Normal(JsValue::Symbol(crate::types::JsSymbol {
-                        id,
-                        description: desc,
-                    }))
+                    Completion::Normal(JsValue::Symbol(crate::types::JsSymbol::new(id, desc)))
                 },
             ));
             if let JsValue::Object(ref o) = symbol_fn
@@ -1382,10 +1379,10 @@ impl Interpreter {
                     } else {
                         let id = self.next_symbol_id;
                         self.next_symbol_id += 1;
-                        let sym = crate::types::JsSymbol {
+                        let sym = crate::types::JsSymbol::new(
                             id,
-                            description: Some(JsString::from_str(desc)),
-                        };
+                            Some(JsString::from_str(desc)),
+                        );
                         self.well_known_symbols
                             .insert(name.to_string(), sym.clone());
                         JsValue::Symbol(sym)
@@ -1414,10 +1411,10 @@ impl Interpreter {
                         }
                         let id = interp.next_symbol_id;
                         interp.next_symbol_id += 1;
-                        let sym = crate::types::JsSymbol {
+                        let sym = crate::types::JsSymbol::new(
                             id,
-                            description: Some(JsString::from_str(&key)),
-                        };
+                            Some(JsString::from_str(&key)),
+                        );
                         interp.global_symbol_registry.insert(key, sym.clone());
                         Completion::Normal(JsValue::Symbol(sym))
                     }),
@@ -1436,7 +1433,7 @@ impl Interpreter {
                             return Completion::Throw(err);
                         };
                         for (key, reg_sym) in &interp.global_symbol_registry {
-                            if reg_sym.id == sym.id {
+                            if reg_sym.id() == sym.id() {
                                 return Completion::Normal(JsValue::String(JsString::from_str(
                                     key,
                                 )));
@@ -1474,7 +1471,7 @@ impl Interpreter {
                     if interp.new_target.is_none()
                         && let JsValue::Symbol(sym) = val
                     {
-                        let desc = if let Some(desc) = &sym.description {
+                        let desc = if let Some(desc) = sym.description() {
                             format!("Symbol({desc})")
                         } else {
                             "Symbol()".to_string()

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -1379,10 +1379,7 @@ impl Interpreter {
                     } else {
                         let id = self.next_symbol_id;
                         self.next_symbol_id += 1;
-                        let sym = crate::types::JsSymbol::new(
-                            id,
-                            Some(JsString::from_str(desc)),
-                        );
+                        let sym = crate::types::JsSymbol::new(id, Some(JsString::from_str(desc)));
                         self.well_known_symbols
                             .insert(name.to_string(), sym.clone());
                         JsValue::Symbol(sym)
@@ -1411,10 +1408,7 @@ impl Interpreter {
                         }
                         let id = interp.next_symbol_id;
                         interp.next_symbol_id += 1;
-                        let sym = crate::types::JsSymbol::new(
-                            id,
-                            Some(JsString::from_str(&key)),
-                        );
+                        let sym = crate::types::JsSymbol::new(id, Some(JsString::from_str(&key)));
                         interp.global_symbol_registry.insert(key, sym.clone());
                         Completion::Normal(JsValue::Symbol(sym))
                     }),

--- a/src/interpreter/builtins/number.rs
+++ b/src/interpreter/builtins/number.rs
@@ -290,8 +290,7 @@ impl Interpreter {
                         return Completion::Throw(err);
                     };
                     let desc = sym
-                        .description
-                        .as_ref()
+                        .description()
                         .map(|d| d.to_rust_string())
                         .unwrap_or_default();
                     Completion::Normal(JsValue::String(JsString::from_str(&format!(
@@ -328,8 +327,8 @@ impl Interpreter {
                     interp.create_type_error("Symbol.prototype.description requires a Symbol");
                 return Completion::Throw(err);
             };
-            match sym.description {
-                Some(d) => Completion::Normal(JsValue::String(d)),
+            match sym.description() {
+                Some(d) => Completion::Normal(JsValue::String(d.clone())),
                 None => Completion::Normal(JsValue::Undefined),
             }
         });

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -562,7 +562,7 @@ impl Interpreter {
                             Completion::Normal(v) => {
                                 let is_symbol = matches!(&v, JsValue::Symbol(_));
                                 let fn_name = if let JsValue::Symbol(ref sym) = v {
-                                    match &sym.description {
+                                    match sym.description() {
                                         Some(desc) => format!("[{}]", desc),
                                         None => String::new(),
                                     }
@@ -1290,7 +1290,7 @@ impl Interpreter {
                             self.gc_root_value(&v);
                             let is_symbol = matches!(&v, JsValue::Symbol(_));
                             let fn_name = if let JsValue::Symbol(ref sym) = v {
-                                match &sym.description {
+                                match sym.description() {
                                     Some(desc) => format!("[{}]", desc),
                                     None => String::new(),
                                 }

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -214,7 +214,7 @@ pub(crate) fn strict_equality(left: &JsValue, right: &JsValue) -> bool {
         (JsValue::Boolean(a), JsValue::Boolean(b)) => a == b,
         (JsValue::Number(a), JsValue::Number(b)) => number_ops::equal(*a, *b),
         (JsValue::String(a), JsValue::String(b)) => a == b,
-        (JsValue::Symbol(a), JsValue::Symbol(b)) => a.id == b.id,
+        (JsValue::Symbol(a), JsValue::Symbol(b)) => a.id() == b.id(),
         (JsValue::BigInt(a), JsValue::BigInt(b)) => bigint_ops::equal(&a.value, &b.value),
         (JsValue::Object(a), JsValue::Object(b)) => a.id == b.id,
         _ => false,

--- a/src/interpreter/key_intern.rs
+++ b/src/interpreter/key_intern.rs
@@ -163,10 +163,8 @@ mod tests {
 
     #[test]
     fn symbol_keys_are_interned_and_preserved() {
-        let symbol = crate::types::JsSymbol::new(
-            42,
-            Some(crate::types::JsString::from_str("desc")),
-        );
+        let symbol =
+            crate::types::JsSymbol::new(42, Some(crate::types::JsString::from_str("desc")));
         let a = intern_js_key(symbol.to_property_key());
         let b = intern_js_key(symbol.to_property_key());
         assert!(a.shares_storage_with(&b), "Symbol keys must intern");

--- a/src/interpreter/key_intern.rs
+++ b/src/interpreter/key_intern.rs
@@ -163,10 +163,10 @@ mod tests {
 
     #[test]
     fn symbol_keys_are_interned_and_preserved() {
-        let symbol = crate::types::JsSymbol {
-            id: 42,
-            description: Some(crate::types::JsString::from_str("desc")),
-        };
+        let symbol = crate::types::JsSymbol::new(
+            42,
+            Some(crate::types::JsString::from_str("desc")),
+        );
         let a = intern_js_key(symbol.to_property_key());
         let b = intern_js_key(symbol.to_property_key());
         assert!(a.shares_storage_with(&b), "Symbol keys must intern");
@@ -256,12 +256,12 @@ mod tests {
     #[test]
     fn oversized_symbol_keys_preserve_their_exact_encoding() {
         let mut cache = KeyCache::new();
-        let symbol = crate::types::JsSymbol {
-            id: 99,
-            description: Some(crate::types::JsString::from_str(
+        let symbol = crate::types::JsSymbol::new(
+            99,
+            Some(crate::types::JsString::from_str(
                 &"s".repeat(MAX_CACHEABLE_KEY_BYTES),
             )),
-        };
+        );
         let original = symbol.to_property_key();
         let a = cache.intern(symbol.to_property_key());
         let b = cache.intern(symbol.to_property_key());

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1028,7 +1028,7 @@ impl Interpreter {
             JsValue::Symbol(sym) => !self
                 .global_symbol_registry
                 .values()
-                .any(|reg| reg.id == sym.id),
+                .any(|reg| reg.id() == sym.id()),
             _ => false,
         }
     }
@@ -1849,14 +1849,11 @@ impl Interpreter {
             };
             // Check global_symbol_registry for Symbol.for() symbols
             for sym in self.global_symbol_registry.values() {
-                if sym.id == id {
+                if sym.id() == id {
                     return JsValue::Symbol(sym.clone());
                 }
             }
-            return JsValue::Symbol(crate::types::JsSymbol {
-                id,
-                description: desc,
-            });
+            return JsValue::Symbol(crate::types::JsSymbol::new(id, desc));
         }
         // Fallback: return as string
         JsValue::String(exact_key.to_js_string())

--- a/src/types.rs
+++ b/src/types.rs
@@ -332,24 +332,48 @@ impl<T: PropertyKeyLike + ?Sized> PropertyKeyLike for &T {
     }
 }
 
+#[derive(Debug)]
+struct JsSymbolData {
+    id: u64,
+    description: Option<JsString>,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct JsSymbol {
-    pub id: u64,
-    pub description: Option<JsString>,
+    data: Arc<JsSymbolData>,
 }
 
 impl JsSymbol {
+    pub(crate) fn new(id: u64, description: Option<JsString>) -> Self {
+        Self {
+            data: Arc::new(JsSymbolData { id, description }),
+        }
+    }
+
+    pub(crate) fn id(&self) -> u64 {
+        self.data.id
+    }
+
+    pub(crate) fn description(&self) -> Option<&JsString> {
+        self.data.description.as_ref()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shares_storage_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.data, &other.data)
+    }
+
     /// Convert to the internal Symbol-valued property key.
     /// Well-known symbols (description starts with "Symbol.") use a stable format
     /// without id, so bootstrap lookups can construct the same key directly.
     /// User-created symbols include the unique id to avoid collisions.
     pub(crate) fn to_property_key(&self) -> JsPropertyKey {
-        let encoding = match &self.description {
+        let encoding = match self.description() {
             Some(desc) if desc.to_string().starts_with("Symbol.") => {
                 format!("Symbol({})", desc)
             }
-            Some(desc) => format!("Symbol({})#{}", desc, self.id),
-            None => format!("Symbol()#{}", self.id),
+            Some(desc) => format!("Symbol({})#{}", desc, self.id()),
+            None => format!("Symbol()#{}", self.id()),
         };
         JsPropertyKey::from_symbol_encoding(encoding)
     }
@@ -800,7 +824,7 @@ impl fmt::Display for JsValue {
             JsValue::Number(n) => write!(f, "{}", number_ops::to_string(*n)),
             JsValue::String(s) => write!(f, "{s}"),
             JsValue::Symbol(s) => {
-                if let Some(desc) = &s.description {
+                if let Some(desc) = s.description() {
                     write!(f, "Symbol({desc})")
                 } else {
                     write!(f, "Symbol()")
@@ -1020,11 +1044,8 @@ mod tests {
 
     #[test]
     fn symbol_property_keys_do_not_collide_with_display_text() {
-        let symbol = JsSymbol {
-            id: 7,
-            description: Some(JsString::from_str("x")),
-        }
-        .to_property_key();
+        let symbol =
+            JsSymbol::new(7, Some(JsString::from_str("x"))).to_property_key();
         let text = JsPropertyKey::from_str("Symbol(x)#7");
 
         assert!(symbol.is_symbol());
@@ -1037,17 +1058,31 @@ mod tests {
     #[test]
     fn well_known_symbol_property_keys_are_tagged() {
         let constructed = JsPropertyKey::well_known_symbol("iterator");
-        let symbol = JsSymbol {
-            id: 1,
-            description: Some(JsString::from_str("Symbol.iterator")),
-        }
-        .to_property_key();
+        let symbol = JsSymbol::new(1, Some(JsString::from_str("Symbol.iterator")))
+            .to_property_key();
 
         assert_eq!(constructed, symbol);
         assert!(constructed.is_symbol());
         assert_ne!(
             constructed,
             JsPropertyKey::from_str("Symbol(Symbol.iterator)")
+        );
+    }
+
+    #[test]
+    fn symbol_clones_share_one_word_data_pointer() {
+        let symbol = JsSymbol::new(7, Some(JsString::from_str("description")));
+        let cloned = symbol.clone();
+
+        assert_eq!(
+            std::mem::size_of::<JsSymbol>(),
+            std::mem::size_of::<Arc<JsSymbolData>>()
+        );
+        assert!(symbol.shares_storage_with(&cloned));
+        assert_eq!(cloned.id(), 7);
+        assert_eq!(
+            cloned.description().map(JsString::to_rust_string),
+            Some("description".to_string())
         );
     }
 
@@ -1076,11 +1111,8 @@ mod tests {
                 .to_rust_string(),
             "yo"
         );
-        let sym = JsSymbol {
-            id: 1,
-            description: Some(JsString::from_str("s")),
-        };
-        assert_eq!(JsValue::symbol(sym).as_symbol().unwrap().id, 1);
+        let sym = JsSymbol::new(1, Some(JsString::from_str("s")));
+        assert_eq!(JsValue::symbol(sym).as_symbol().unwrap().id(), 1);
         let big = JsBigInt::new(num_bigint::BigInt::from(42));
         assert_eq!(
             *JsValue::bigint(big).as_bigint().unwrap().value,
@@ -1105,12 +1137,9 @@ mod tests {
         assert_eq!(s.with_string(|cu| cu.len()), Some(3));
         assert_eq!(JsValue::Null.with_string(|cu| cu.len()), None);
 
-        let sym = JsValue::Symbol(JsSymbol {
-            id: 9,
-            description: None,
-        });
-        assert_eq!(sym.with_symbol(|s| s.id), Some(9));
-        assert_eq!(JsValue::Null.with_symbol(|s| s.id), None);
+        let sym = JsValue::Symbol(JsSymbol::new(9, None));
+        assert_eq!(sym.with_symbol(JsSymbol::id), Some(9));
+        assert_eq!(JsValue::Null.with_symbol(JsSymbol::id), None);
 
         let big = JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(5)));
         assert_eq!(
@@ -1143,10 +1172,7 @@ mod tests {
             (JsValue::Number(1.0), ValueKind::Number),
             (JsValue::from_str("s"), ValueKind::String),
             (
-                JsValue::Symbol(JsSymbol {
-                    id: 0,
-                    description: None,
-                }),
+                JsValue::Symbol(JsSymbol::new(0, None)),
                 ValueKind::Symbol,
             ),
             (

--- a/src/types.rs
+++ b/src/types.rs
@@ -1044,8 +1044,7 @@ mod tests {
 
     #[test]
     fn symbol_property_keys_do_not_collide_with_display_text() {
-        let symbol =
-            JsSymbol::new(7, Some(JsString::from_str("x"))).to_property_key();
+        let symbol = JsSymbol::new(7, Some(JsString::from_str("x"))).to_property_key();
         let text = JsPropertyKey::from_str("Symbol(x)#7");
 
         assert!(symbol.is_symbol());
@@ -1058,8 +1057,8 @@ mod tests {
     #[test]
     fn well_known_symbol_property_keys_are_tagged() {
         let constructed = JsPropertyKey::well_known_symbol("iterator");
-        let symbol = JsSymbol::new(1, Some(JsString::from_str("Symbol.iterator")))
-            .to_property_key();
+        let symbol =
+            JsSymbol::new(1, Some(JsString::from_str("Symbol.iterator"))).to_property_key();
 
         assert_eq!(constructed, symbol);
         assert!(constructed.is_symbol());
@@ -1171,10 +1170,7 @@ mod tests {
             (JsValue::Boolean(true), ValueKind::Boolean),
             (JsValue::Number(1.0), ValueKind::Number),
             (JsValue::from_str("s"), ValueKind::String),
-            (
-                JsValue::Symbol(JsSymbol::new(0, None)),
-                ValueKind::Symbol,
-            ),
+            (JsValue::Symbol(JsSymbol::new(0, None)), ValueKind::Symbol),
             (
                 JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(0))),
                 ValueKind::BigInt,


### PR DESCRIPTION
## Summary

- wrap immutable Symbol id and description data in Arc-backed `JsSymbolData`
- centralize Symbol construction and expose read-only identity/description accessors
- preserve id-based equality, registry behavior, property-key encoding, and display semantics
- add a focused unit test proving `JsSymbol` is one `Arc` wide and clones share storage
- apply rustfmt to the Symbol construction and test call sites

## Validation

- `cargo fmt --all -- --check`: passed
- `cargo clippy`: passed
- `./scripts/lint.sh`: passed
- `cargo build --release`: passed
- `cargo test --release`: passed (415 unit tests, 3 integration tests, 1 test262 smoke-oracle test)
- `uv run python scripts/run-custom-tests.py`: 11/11 passed
- `uv run python scripts/run-test262.py test262/test/built-ins/Symbol/`: 192/192 passed, 0 regressions
- full test262 suite: 99,568/99,568 passed (100.00%), 0 regressions in the isolated full-suite workflow on `7bac82e`: https://github.com/pmatos/jsse/actions/runs/30252660425
- regular PR CI: all checks passed

`README.md` already reports the measured full-suite result of 99,568/99,568 (100.00%), so no numeric documentation change was necessary.

Closes #404