### PR TITLE
refactor(array): deepen relative-index argument resolution into helpers

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -1556,28 +1556,14 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(c) => return c,
             } as i64;
-            let relative_start = if let Some(v) = args.first() {
-                match interp.to_integer_or_infinity_value(v) {
-                    Ok(n) => n,
-                    Err(e) => return Completion::Throw(e),
-                }
-            } else {
-                0.0
+            let k = match resolve_start_index(interp, args.first(), len as usize) {
+                Ok(k) => k,
+                Err(c) => return c,
             };
-            let k = resolve_relative_index(relative_start, len as usize);
-            let relative_end = if let Some(v) = args.get(1) {
-                if (v).is_undefined() {
-                    len as f64
-                } else {
-                    match interp.to_integer_or_infinity_value(v) {
-                        Ok(n) => n,
-                        Err(e) => return Completion::Throw(e),
-                    }
-                }
-            } else {
-                len as f64
+            let fin = match resolve_end_index(interp, args.get(1), len as usize) {
+                Ok(f) => f,
+                Err(c) => return c,
             };
-            let fin = resolve_relative_index(relative_end, len as usize);
             let count = fin.saturating_sub(k);
             let a = match array_species_create(interp, &o, count) {
                 Ok(v) => v,
@@ -2273,15 +2259,10 @@ impl Interpreter {
                 Ok(v) => v as i64,
                 Err(c) => return c,
             };
-            let relative_start = if let Some(v) = args.first() {
-                match interp.to_integer_or_infinity_value(v) {
-                    Ok(n) => n,
-                    Err(e) => return Completion::Throw(e),
-                }
-            } else {
-                0.0
+            let actual_start = match resolve_start_index(interp, args.first(), len as usize) {
+                Ok(k) => k,
+                Err(c) => return c,
             };
-            let actual_start = resolve_relative_index(relative_start, len as usize);
             let insert_count = if args.len() > 2 { args.len() - 2 } else { 0 };
             let actual_delete_count = if args.is_empty() {
                 0usize
@@ -2433,15 +2414,10 @@ impl Interpreter {
                 Ok(v) => v as i64,
                 Err(c) => return c,
             };
-            let relative_start = if let Some(v) = args.first() {
-                match interp.to_integer_or_infinity_value(v) {
-                    Ok(n) => n,
-                    Err(e) => return Completion::Throw(e),
-                }
-            } else {
-                0.0
+            let actual_start = match resolve_start_index(interp, args.first(), len as usize) {
+                Ok(k) => k,
+                Err(c) => return c,
             };
-            let actual_start = resolve_relative_index(relative_start, len as usize);
             let actual_delete_count = if args.is_empty() {
                 0usize
             } else if args.len() == 1 {
@@ -2494,28 +2470,14 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-            let relative_start = if let Some(v) = args.get(1) {
-                match interp.to_integer_or_infinity_value(v) {
-                    Ok(n) => n,
-                    Err(e) => return Completion::Throw(e),
-                }
-            } else {
-                0.0
+            let k = match resolve_start_index(interp, args.get(1), len as usize) {
+                Ok(k) => k,
+                Err(c) => return c,
             };
-            let k = resolve_relative_index(relative_start, len as usize);
-            let relative_end = if let Some(v) = args.get(2) {
-                if (v).is_undefined() {
-                    len as f64
-                } else {
-                    match interp.to_integer_or_infinity_value(v) {
-                        Ok(n) => n,
-                        Err(e) => return Completion::Throw(e),
-                    }
-                }
-            } else {
-                len as f64
+            let fin = match resolve_end_index(interp, args.get(2), len as usize) {
+                Ok(f) => f,
+                Err(c) => return c,
             };
-            let fin = resolve_relative_index(relative_end, len as usize);
             for i in k..fin {
                 if let Err(e) = obj_set_throw(interp, &o, &i.to_string(), value.clone()) {
                     return Completion::Throw(e);
@@ -2950,37 +2912,18 @@ impl Interpreter {
                 Ok(v) => v as i64,
                 Err(c) => return c,
             };
-            let relative_target = if let Some(v) = args.first() {
-                match interp.to_integer_or_infinity_value(v) {
-                    Ok(n) => n,
-                    Err(e) => return Completion::Throw(e),
-                }
-            } else {
-                0.0
+            let to_val = match resolve_start_index(interp, args.first(), len as usize) {
+                Ok(k) => k as i64,
+                Err(c) => return c,
             };
-            let to_val = resolve_relative_index(relative_target, len as usize) as i64;
-            let relative_start = if let Some(v) = args.get(1) {
-                match interp.to_integer_or_infinity_value(v) {
-                    Ok(n) => n,
-                    Err(e) => return Completion::Throw(e),
-                }
-            } else {
-                0.0
+            let from = match resolve_start_index(interp, args.get(1), len as usize) {
+                Ok(k) => k as i64,
+                Err(c) => return c,
             };
-            let from = resolve_relative_index(relative_start, len as usize) as i64;
-            let relative_end = if let Some(v) = args.get(2) {
-                if (v).is_undefined() {
-                    len as f64
-                } else {
-                    match interp.to_integer_or_infinity_value(v) {
-                        Ok(n) => n,
-                        Err(e) => return Completion::Throw(e),
-                    }
-                }
-            } else {
-                len as f64
+            let fin = match resolve_end_index(interp, args.get(2), len as usize) {
+                Ok(f) => f as i64,
+                Err(c) => return c,
             };
-            let fin = resolve_relative_index(relative_end, len as usize) as i64;
             let count = (fin - from).min(len - to_val);
             if count <= 0 {
                 return Completion::Normal(o);

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -13,6 +13,47 @@ pub(crate) fn resolve_relative_index(n: f64, len: usize) -> usize {
     }
 }
 
+// Resolves a spec "start"-style relative-index argument for the range-based
+// Array methods (slice, fill, copyWithin, splice, toSpliced). An absent
+// argument defaults to index 0; otherwise the argument is passed through
+// ToIntegerOrInfinity and clamped against `len` by `resolve_relative_index`.
+// Unlike the "end" argument, an explicit `undefined` is NOT special-cased —
+// it coerces to 0 like any other non-numeric value.
+// `len` must be the array length captured *before* this coercion runs, since a
+// user-supplied `valueOf` observes it (the spec computes both `start` and `end`
+// against the single length captured at the top of the method).
+pub(crate) fn resolve_start_index(
+    interp: &mut Interpreter,
+    arg: Option<&JsValue>,
+    len: usize,
+) -> Result<usize, Completion> {
+    let relative = match arg {
+        Some(v) => interp
+            .to_integer_or_infinity_value(v)
+            .map_err(Completion::Throw)?,
+        None => 0.0,
+    };
+    Ok(resolve_relative_index(relative, len))
+}
+
+// Resolves a spec "end"-style relative-index argument for the range-based Array
+// methods. An absent argument *or* an explicit `undefined` defaults to `len`;
+// otherwise the argument is passed through ToIntegerOrInfinity and clamped
+// against `len`. See `resolve_start_index` for the `len` capture invariant.
+pub(crate) fn resolve_end_index(
+    interp: &mut Interpreter,
+    arg: Option<&JsValue>,
+    len: usize,
+) -> Result<usize, Completion> {
+    let relative = match arg {
+        Some(v) if !v.is_undefined() => interp
+            .to_integer_or_infinity_value(v)
+            .map_err(Completion::Throw)?,
+        _ => len as f64,
+    };
+    Ok(resolve_relative_index(relative, len))
+}
+
 pub(crate) fn to_integer_or_infinity(n: f64) -> f64 {
     if n.is_nan() || n == 0.0 {
         0.0
@@ -2529,6 +2570,152 @@ fn hex_val(b: u8) -> Result<u8, String> {
         b'a'..=b'f' => Ok(b - b'a' + 10),
         b'A'..=b'F' => Ok(b - b'A' + 10),
         _ => Err("URI malformed".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod resolve_index_arg_tests {
+    use super::{resolve_end_index, resolve_start_index};
+    use crate::interpreter::{Completion, Interpreter};
+    use crate::types::{JsBigInt, JsValue};
+
+    fn num(n: f64) -> JsValue {
+        JsValue::Number(n)
+    }
+
+    // A value whose ToNumber (and thus ToIntegerOrInfinity) throws a TypeError:
+    // BigInt cannot be converted to a Number (ECMAScript, sec-tonumber).
+    fn throwing_arg() -> JsValue {
+        JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(1)))
+    }
+
+    // --- resolve_start_index: absent defaults to 0, no undefined special-case ---
+
+    #[test]
+    fn start_absent_defaults_to_zero() {
+        let mut interp = Interpreter::new();
+        assert_eq!(resolve_start_index(&mut interp, None, 10).unwrap(), 0);
+    }
+
+    #[test]
+    fn start_undefined_coerces_to_zero_not_length() {
+        // ToIntegerOrInfinity(undefined) is NaN -> 0; start does NOT treat
+        // undefined as "use length" (that is the end-index behavior).
+        let mut interp = Interpreter::new();
+        let u = JsValue::UNDEFINED;
+        assert_eq!(resolve_start_index(&mut interp, Some(&u), 10).unwrap(), 0);
+    }
+
+    #[test]
+    fn start_positive_in_range_is_unchanged() {
+        let mut interp = Interpreter::new();
+        assert_eq!(
+            resolve_start_index(&mut interp, Some(&num(3.0)), 10).unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn start_negative_counts_back_from_length() {
+        let mut interp = Interpreter::new();
+        assert_eq!(
+            resolve_start_index(&mut interp, Some(&num(-3.0)), 10).unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn start_negative_beyond_length_clamps_to_zero() {
+        let mut interp = Interpreter::new();
+        assert_eq!(
+            resolve_start_index(&mut interp, Some(&num(-100.0)), 10).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn start_positive_beyond_length_clamps_to_length() {
+        let mut interp = Interpreter::new();
+        assert_eq!(
+            resolve_start_index(&mut interp, Some(&num(100.0)), 10).unwrap(),
+            10
+        );
+    }
+
+    // --- resolve_end_index: absent OR undefined defaults to length ---
+
+    #[test]
+    fn end_absent_defaults_to_length() {
+        let mut interp = Interpreter::new();
+        assert_eq!(resolve_end_index(&mut interp, None, 10).unwrap(), 10);
+    }
+
+    #[test]
+    fn end_undefined_defaults_to_length() {
+        let mut interp = Interpreter::new();
+        let u = JsValue::UNDEFINED;
+        assert_eq!(resolve_end_index(&mut interp, Some(&u), 10).unwrap(), 10);
+    }
+
+    #[test]
+    fn end_positive_in_range_is_unchanged() {
+        let mut interp = Interpreter::new();
+        assert_eq!(
+            resolve_end_index(&mut interp, Some(&num(3.0)), 10).unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn end_negative_counts_back_from_length() {
+        let mut interp = Interpreter::new();
+        assert_eq!(
+            resolve_end_index(&mut interp, Some(&num(-3.0)), 10).unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn end_negative_beyond_length_clamps_to_zero() {
+        let mut interp = Interpreter::new();
+        assert_eq!(
+            resolve_end_index(&mut interp, Some(&num(-100.0)), 10).unwrap(),
+            0
+        );
+    }
+
+    // --- error propagation: the coercion's own TypeError must survive ---
+
+    #[test]
+    fn start_propagates_coercion_throw_verbatim() {
+        let mut interp = Interpreter::new();
+        let bad = throwing_arg();
+        match resolve_start_index(&mut interp, Some(&bad), 10) {
+            Err(Completion::Throw(e)) => {
+                assert!(
+                    interp.format_value(&e).contains("TypeError"),
+                    "expected the ToNumber TypeError to propagate, got {}",
+                    interp.format_value(&e)
+                );
+            }
+            other => panic!("expected a propagated Throw, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn end_propagates_coercion_throw_verbatim() {
+        let mut interp = Interpreter::new();
+        let bad = throwing_arg();
+        match resolve_end_index(&mut interp, Some(&bad), 10) {
+            Err(Completion::Throw(e)) => {
+                assert!(
+                    interp.format_value(&e).contains("TypeError"),
+                    "expected the ToNumber TypeError to propagate, got {}",
+                    interp.format_value(&e)
+                );
+            }
+            other => panic!("expected a propagated Throw, got {other:?}"),
+        }
     }
 }
 

--- a/test262-extra/Array-range-index-argument-coercion.js
+++ b/test262-extra/Array-range-index-argument-coercion.js
@@ -1,0 +1,70 @@
+/*---
+description: >
+  The range-based Array.prototype methods (slice, fill, copyWithin, splice,
+  toSpliced) resolve their start/end index arguments consistently: an absent
+  start defaults to 0, an absent OR explicitly `undefined` end defaults to the
+  length, every present argument is coerced through ToIntegerOrInfinity and the
+  relative index is clamped against the length, and a throwing coercion is
+  propagated unchanged.
+esid: sec-array.prototype.slice
+info: |
+  Array.prototype.slice ( start, end )
+    3. Let relativeStart be ? ToIntegerOrInfinity(start).
+    4. If relativeStart is -infinity, let k be 0.
+       Else if relativeStart < 0, let k be max(len + relativeStart, 0).
+       Else, let k be min(relativeStart, len).
+    5. If end is undefined, let relativeEnd be len;
+       else let relativeEnd be ? ToIntegerOrInfinity(end).
+    6. If relativeEnd is -infinity, let final be 0.
+       Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
+       Else, let final be min(relativeEnd, len).
+
+  The `start`-style argument (slice/fill/copyWithin/splice/toSpliced start,
+  copyWithin target) does NOT special-case `undefined`: ToIntegerOrInfinity(
+  undefined) is NaN, which becomes 0. Only the `end`-style argument treats
+  `undefined` as "use length". This test pins that distinction and the shared
+  clamping/coercion, which the engine factors through the resolve_start_index /
+  resolve_end_index helpers.
+includes: [compareArray.js]
+---*/
+
+// --- start argument: absent and `undefined` both resolve to 0 ---
+assert.compareArray([10, 20, 30, 40, 50].slice(), [10, 20, 30, 40, 50], "slice(): absent start is 0");
+assert.compareArray([10, 20, 30, 40, 50].slice(undefined), [10, 20, 30, 40, 50], "slice(undefined): undefined start is 0, not length");
+assert.compareArray([0, 0, 0, 0, 0].fill(7, undefined), [7, 7, 7, 7, 7], "fill(v, undefined): undefined start is 0");
+
+// --- end argument: absent and `undefined` both resolve to length ---
+assert.compareArray([10, 20, 30, 40, 50].slice(1), [20, 30, 40, 50], "slice(1): absent end is length");
+assert.compareArray([10, 20, 30, 40, 50].slice(1, undefined), [20, 30, 40, 50], "slice(1, undefined): undefined end is length");
+assert.compareArray([0, 0, 0, 0, 0].fill(7, 1, undefined), [0, 7, 7, 7, 7], "fill(v, 1, undefined): undefined end is length");
+
+// --- negative indices count back from the length; overshoot clamps ---
+assert.compareArray([10, 20, 30, 40, 50].slice(-2), [40, 50], "slice(-2)");
+assert.compareArray([10, 20, 30, 40, 50].slice(1, -1), [20, 30, 40], "slice(1, -1)");
+assert.compareArray([10, 20, 30, 40, 50].slice(-100, 100), [10, 20, 30, 40, 50], "slice clamps out-of-range to [0, len]");
+assert.compareArray([0, 0, 0, 0, 0].fill(9, -2), [0, 0, 0, 9, 9], "fill(v, -2)");
+
+// --- copyWithin: target and start are `start`-style, end is `end`-style ---
+assert.compareArray([1, 2, 3, 4, 5].copyWithin(0, 3, undefined), [4, 5, 3, 4, 5], "copyWithin end undefined is length");
+assert.compareArray([1, 2, 3, 4, 5].copyWithin(0, undefined), [1, 2, 3, 4, 5], "copyWithin start undefined is 0");
+
+// --- splice: a single `undefined` start removes from index 0 to the end ---
+var spliced = [10, 20, 30, 40, 50];
+var removed = spliced.splice(undefined);
+assert.compareArray(removed, [10, 20, 30, 40, 50], "splice(undefined) removes from index 0");
+assert.compareArray(spliced, [], "splice(undefined) empties the array");
+
+// --- toSpliced: `undefined` start with an explicit delete count of 0 ---
+assert.compareArray([10, 20, 30].toSpliced(undefined, 0, 99), [99, 10, 20, 30], "toSpliced(undefined, 0, 99) inserts at index 0");
+
+// --- a throwing coercion is propagated unchanged from every coerced position ---
+var boom = { valueOf: function () { throw new Test262Error("coercion ran"); } };
+
+assert.throws(Test262Error, function () { [1, 2, 3].slice(boom); }, "slice start coercion throw propagates");
+assert.throws(Test262Error, function () { [1, 2, 3].slice(0, boom); }, "slice end coercion throw propagates");
+assert.throws(Test262Error, function () { [1, 2, 3].fill(0, boom); }, "fill start coercion throw propagates");
+assert.throws(Test262Error, function () { [1, 2, 3].fill(0, 0, boom); }, "fill end coercion throw propagates");
+assert.throws(Test262Error, function () { [1, 2, 3].copyWithin(boom, 0); }, "copyWithin target coercion throw propagates");
+assert.throws(Test262Error, function () { [1, 2, 3].copyWithin(0, boom); }, "copyWithin start coercion throw propagates");
+assert.throws(Test262Error, function () { [1, 2, 3].copyWithin(0, 0, boom); }, "copyWithin end coercion throw propagates");
+assert.throws(Test262Error, function () { [1, 2, 3].splice(boom); }, "splice start coercion throw propagates");


### PR DESCRIPTION
## Architecture audit → refactoring

Run of the **improve-codebase-architecture** skill (two parallel `Explore` passes over the hot files `eval.rs` / `array.rs` / `helpers.rs`, from the recent commit history). The full candidate report was written to the OS temp dir as an HTML architecture review; the candidates it surfaced were:

| Candidate | Files | Strength |
|---|---|---|
| **`resolve_start_index` / `resolve_end_index`** (this PR) | `helpers.rs` → `array.rs` (×9) | **Strong** |
| `PropertyDescriptor::with_accessor` | `eval/literals.rs` (×4) | Strong |
| `array_like_this_and_length` | `array.rs` (×31) | Worth exploring |
| `Interpreter::require_callable` | 8 files (×24) | Worth exploring |
| `cannot_read_property_error` | `eval.rs`/`eval/access.rs` (×11) | Worth exploring |
| `invoke_setter` | `eval.rs` (×6) | Worth exploring |
| `PropertyDescriptor::value_only` | `builtins/mod.rs` (×5+) | Speculative |

## The deepening

The spec *relative index* argument dance — presence check → `undefined` special-case → `ToIntegerOrInfinity` → clamp via `resolve_relative_index` — was re-inlined **9 times** across `Array.prototype.{slice, fill, copyWithin, splice, toSpliced}`. The non-obvious rule that an absent **start** is `0`, but an absent *or* `undefined` **end** is `len`, lived in every copy and was easy to get subtly wrong.

This factors the concept into two deep helpers placed next to the existing `resolve_relative_index`, so one module now owns relative-index resolution end to end:

```rust
resolve_start_index(interp, arg, len) -> Result<usize, Completion>
resolve_end_index(interp, arg, len)   -> Result<usize, Completion>
```

`array.rs` sheds ~57 net lines of duplication; each call site drops from ~9 lines to ~4, matching the local `to_object_val` / `length_of_array_like` prologue idiom (`Err(c) => return c`).

**Behaviour-preserving.** `len` is held as a caller-supplied parameter, preserving the "length captured before coercion" invariant. All 9 sites keep their coercion order and `copyWithin`'s `as i64` casts. Confirmed each `relative_*` binding was read exactly once before extracting.

## Tests (TDD — written before the helpers)

- **13 focused unit tests** in `helpers.rs`, beside the existing `resolve_relative_index` tests: default/`undefined`/negative/positive-clamp branches for both helpers (pinning the **undefined-vs-absent** distinction), plus verbatim propagation of the coercion's own `TypeError`.
- **`test262-extra/Array-range-index-argument-coercion.js`** — an end-to-end characterization test (test262 conventions) covering the same distinction and throw-propagation across all five methods. Run with `uv run python scripts/run-test262.py test262-extra/`.

## Verification

- `cargo test --release` — **453 pass** / 0 fail (440 → 453, +13 new).
- test262 `Array/prototype/{slice, fill, copyWithin, splice, toSpliced}` — **100%** (486 scenarios), identical to the pre-edit baseline.
- `test262-extra/` — new test passes; the only 2 failures are pre-existing and unrelated (`Eval-scoping.js:strict`, `with-gc-root.js:strict`).
- Custom tests **11/11**; `./scripts/lint.sh` (rustfmt + clippy) clean.

The full test262 sweep was not run in this environment (too slow to complete synchronously); the change is behaviour-preserving so no suite-wide delta is expected, and the affected blast radius (exactly these 5 methods — the helpers are called only from `array.rs`) is fully covered above.

## Follow-ups (deliberately out of scope)

The TypedArray and String relative-index sites reuse `resolve_relative_index` too, but migrating them reintroduces the ArrayBuffer detach/resize capture hazard that scoping to plain arrays avoids. Left for a separate PR.

🤖 Generated with Claude Code