### PR TITLE
refactor(nan-box): route raw-byte float reads through JsValue::number

### DIFF
--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -5336,7 +5336,7 @@ impl Interpreter {
             } else {
                 f32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]])
             };
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         });
         dv_get_method!("getFloat64", 8, |buf: &[u8], le: bool| -> JsValue {
             let mut bytes = [0u8; 8];
@@ -5346,7 +5346,7 @@ impl Interpreter {
             } else {
                 f64::from_be_bytes(bytes)
             };
-            JsValue::Number(v)
+            JsValue::number(v)
         });
         dv_get_method!("getBigInt64", 8, |buf: &[u8], le: bool| -> JsValue {
             let mut bytes = [0u8; 8];
@@ -5374,7 +5374,7 @@ impl Interpreter {
             } else {
                 u16::from_be_bytes([buf[0], buf[1]])
             };
-            JsValue::Number(dv_f16_to_f64(bits))
+            JsValue::number(dv_f16_to_f64(bits))
         });
 
         // DataView set methods

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -3409,7 +3409,7 @@ fn typed_array_get_index_shared(
                 return JsValue::Undefined;
             }
             let bits = u16::from_ne_bytes([buf[offset], buf[offset + 1]]);
-            JsValue::Number(crate::interpreter::builtins::typedarray::dv_f16_to_f64(
+            JsValue::number(crate::interpreter::builtins::typedarray::dv_f16_to_f64(
                 bits,
             ))
         }),
@@ -3423,7 +3423,7 @@ fn typed_array_get_index_shared(
                 buf[offset + 2],
                 buf[offset + 3],
             ]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }),
         TypedArrayKind::Float64 => sab.with_read(|buf| {
             if offset + 8 > buf.len() {
@@ -3431,7 +3431,7 @@ fn typed_array_get_index_shared(
             }
             let mut bytes = [0u8; 8];
             bytes.copy_from_slice(&buf[offset..offset + 8]);
-            JsValue::Number(f64::from_ne_bytes(bytes))
+            JsValue::number(f64::from_ne_bytes(bytes))
         }),
     }
 }
@@ -3487,12 +3487,12 @@ pub(crate) fn typed_array_get_index(ta: &TypedArrayInfo, idx: usize) -> JsValue 
                     buf[offset + 2],
                     buf[offset + 3],
                 ]);
-                JsValue::Number(v as f64)
+                JsValue::number(v as f64)
             }
             TypedArrayKind::Float64 => {
                 let mut bytes = [0u8; 8];
                 bytes.copy_from_slice(&buf[offset..offset + 8]);
-                JsValue::Number(f64::from_ne_bytes(bytes))
+                JsValue::number(f64::from_ne_bytes(bytes))
             }
             TypedArrayKind::BigInt64 => {
                 let mut bytes = [0u8; 8];
@@ -3510,7 +3510,7 @@ pub(crate) fn typed_array_get_index(ta: &TypedArrayInfo, idx: usize) -> JsValue 
             }
             TypedArrayKind::Float16 => {
                 let bits = u16::from_ne_bytes([buf[offset], buf[offset + 1]]);
-                JsValue::Number(crate::interpreter::builtins::typedarray::dv_f16_to_f64(
+                JsValue::number(crate::interpreter::builtins::typedarray::dv_f16_to_f64(
                     bits,
                 ))
             }


### PR DESCRIPTION
## Summary

- Phase 1.3 of the NaN-boxing epic (#69), per the design ratified in #402 (`docs/specs/2026-07-26-nan-boxed-js-value-design.md`).
- Routes all 9 raw-byte-to-`f64` construction sites for Float16/32/64 reads through the existing `JsValue::number()` constructor instead of the enum's tuple constructor directly:
  - `typed_array_get_index` (`src/interpreter/types.rs`) — Float16, Float32, Float64 arms
  - `typed_array_get_index_shared` (`src/interpreter/types.rs`) — Float16, Float32, Float64 arms
  - `dv_get_method!` expansions for `getFloat32`, `getFloat64`, `getFloat16` (`src/interpreter/builtins/typedarray.rs`)
- These are called out explicitly in the design doc as the highest-value targets: the bytes backing them are 100% JS-controlled (test262's own `DataView/prototype/getFloat64/return-nan.js` builds a NaN byte-by-byte via `setUint8`), unlike ordinary arithmetic NaNs. Once Phase 3 (#414) makes `JsValue::number()` unconditionally canonicalize, a crafted byte sequence read through any of these sites can no longer bypass it.
- The neighboring integer arms (`Int8`/`Uint8`/`Int16`/`Uint16`/`Int32`/`Uint32`) in the same `match` statements are deliberately left constructing `JsValue::Number(...)` directly — an integer-to-`f64` cast can never produce a NaN bit pattern, so they're outside this issue's safety-relevant scope. Closing every remaining direct `JsValue::Number(...)` site across the codebase is Phase 2's job (#407-#413), which is a separate, broader mechanical conversion.
- No behavior change: `JsValue::number()` is still a thin passthrough (`JsValue::Number(n)`) until Phase 3 fills in real canonicalization, so this is purely a call-site audit/centralization.

Fixes #405

## Test plan

- [x] `./scripts/lint.sh` — clean
- [x] `cargo test --release` — 453 passed
- [x] `uv run python scripts/run-custom-tests.py` — 11 passed
- [x] Targeted test262 (`DataView/`, `TypedArray/`, `TypedArrayConstructors/`) — 5444/5444 (100%), 0 regressions
- [x] Full `uv run python scripts/run-test262.py -j 32` — 99,568/99,568 (100%), 0 regressions