### PR TITLE
ci: run test262-extra in both default and bytecode modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,13 @@ jobs:
 
       - name: Run test262 (10% sample, fixed seed ${{ env.TEST262_SAMPLE_SEED }})
         run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 --sample 0.1 --seed "$TEST262_SAMPLE_SEED"
+
+      # test262-extra is first-party (every file added deliberately by us,
+      # not an upstream corpus that evolves out from under us like
+      # test262/), so unlike the steps above it is gated on zero failures
+      # rather than on regressions against a baseline.
+      - name: Run test262-extra
+        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 test262-extra/ --fail-on-failures
+
+      - name: Run test262-extra (bytecode VM)
+        run: uv run python scripts/run-test262.py --jsse ./target/release/jsse --test262 ./test262 test262-extra/ --bytecode --fail-on-failures

--- a/test262-extra/Eval-scoping-sloppy-leakage.js
+++ b/test262-extra/Eval-scoping-sloppy-leakage.js
@@ -1,0 +1,39 @@
+/*---
+description: >
+  A direct eval called from sloppy-mode code shares the caller's
+  VariableEnvironment, so `var` and function declarations inside it leak
+  to the enclosing function scope. Split out of Eval-scoping.js because a
+  direct eval called from strict-mode code always gets its own fresh
+  VariableEnvironment instead (EvalDeclarationInstantiation), so none of
+  this leakage happens under the "strict" test variant. Cross-checked
+  against Node, which agrees: `"use strict"; eval("var x = 1")` throws
+  ReferenceError on the outer read.
+esid: sec-eval-x
+flags: [noStrict]
+---*/
+
+// eval var scoping — var in eval leaks to enclosing function scope
+(function() {
+  eval("var evalVar = 42;");
+  if (evalVar !== 42) {
+    throw new Test262Error('eval var should leak to function scope, got: ' + typeof evalVar);
+  }
+})();
+
+// eval var in block scope still leaks to function scope
+(function() {
+  {
+    eval("var blockEvalVar = 10;");
+  }
+  if (blockEvalVar !== 10) {
+    throw new Test262Error('eval var in block should leak to function scope');
+  }
+})();
+
+// eval function declarations in sloppy mode
+(function() {
+  eval("function evalFunc() { return 'hello'; }");
+  if (evalFunc() !== "hello") {
+    throw new Test262Error('eval function declaration should be accessible');
+  }
+})();

--- a/test262-extra/Eval-scoping.js
+++ b/test262-extra/Eval-scoping.js
@@ -1,13 +1,14 @@
-// Tests eval() scoping behavior.
+// Tests eval() scoping behavior that holds identically in sloppy and
+// strict mode: `let` declared inside an eval never leaks regardless of
+// mode, reading an outer binding through a direct eval works in both,
+// indirect eval always targets the global scope in both, and eval's
+// return value / `this` binding are mode-independent. The var/function-
+// declaration leakage assertions that are sloppy-mode-only live in
+// Eval-scoping-sloppy-leakage.js instead — a direct eval called from
+// strict-mode code gets its own fresh VariableEnvironment
+// (EvalDeclarationInstantiation) and never leaks a `var` or function
+// declaration outward, so those assertions cannot hold here.
 // Spec: ECMAScript 2024, sec-eval-x
-
-// eval var scoping — var in eval leaks to enclosing function scope
-(function() {
-  eval("var evalVar = 42;");
-  if (evalVar !== 42) {
-    throw new Test262Error('eval var should leak to function scope, got: ' + typeof evalVar);
-  }
-})();
 
 // eval let scoping — let in eval stays in eval scope
 (function() {
@@ -19,16 +20,6 @@
     if (!(e instanceof ReferenceError)) {
       throw new Test262Error('accessing eval let should throw ReferenceError, got: ' + e);
     }
-  }
-})();
-
-// eval var in block scope still leaks to function scope
-(function() {
-  {
-    eval("var blockEvalVar = 10;");
-  }
-  if (blockEvalVar !== 10) {
-    throw new Test262Error('eval var in block should leak to function scope');
   }
 })();
 
@@ -58,14 +49,6 @@ var globalForEval = 500;
   var result2 = indirectEval("globalForEval");
   if (result2 !== 500) {
     throw new Test262Error('indirect eval should access global scope, got: ' + result2);
-  }
-})();
-
-// eval function declarations in sloppy mode
-(function() {
-  eval("function evalFunc() { return 'hello'; }");
-  if (evalFunc() !== "hello") {
-    throw new Test262Error('eval function declaration should be accessible');
   }
 })();
 

--- a/test262-extra/with-gc-root.js
+++ b/test262-extra/with-gc-root.js
@@ -1,9 +1,15 @@
-// Tests that the with-statement target object stays live across a GC
-// triggered inside the with-block.
-// Spec: ECMAScript 2024 §14.11 (The with Statement) — the binding object
-// must remain reachable for the duration of the with-block. Regression test
-// for PR 1b.4 (issue #66 / #107) where WithObject._object was dropped and
-// the obj_id is now rooted only via Interpreter::collect_env_roots.
+/*---
+description: >
+  Tests that the with-statement target object stays live across a GC
+  triggered inside the with-block.
+esid: sec-with-statement-runtime-semantics-evaluation
+info: |
+  ECMAScript 2024 §14.11 (The with Statement) — the binding object must
+  remain reachable for the duration of the with-block. Regression test for
+  PR 1b.4 (issue #66 / #107) where WithObject._object was dropped and the
+  obj_id is now rooted only via Interpreter::collect_env_roots.
+flags: [noStrict]
+---*/
 
 var probe = { sentinel: 0xdeadbeef, marker: "with-target" };
 


### PR DESCRIPTION
## Summary

- `test262-extra/` (61 files, 116 scenarios) was never run in CI — neither `ci.yml` (smoke set + 10% test262 sample) nor the nightly full-suite run touches it, only the main test262 corpus. Adds two steps to `ci.yml` running it in default and `--bytecode` mode, gated on `--fail-on-failures` (unlike the test262 steps above, which gate on regressions against a baseline — test262-extra is first-party, so it's held to zero failures rather than "no worse than before").
- The bytecode VM (`src/interpreter/bytecode/`) has never been exercised against test262-shaped input in any CI job before this — only its own unit tests. Confirmed locally both modes are 100% green (116/116).
- Enforcing `--fail-on-failures` surfaced two pre-existing frontmatter bugs, fixed here as a prerequisite (metadata-only, no behavior change, both cross-checked against Node):
  - `with-gc-root.js` — a `with` statement is a SyntaxError in strict mode, so the file is sloppy-only; added `flags: [noStrict]`.
  - `Eval-scoping.js` — 3 of its 8 assertions test that `var`/function declarations inside a direct eval leak to the enclosing scope, which only holds in sloppy mode (strict-mode eval gets its own fresh VariableEnvironment). Split those 3 into a new `Eval-scoping-sloppy-leakage.js` with `flags: [noStrict]`; the remaining 5 mode-agnostic assertions stay in `Eval-scoping.js` and keep their strict-mode coverage — no coverage lost.

Fixes #427

## Test plan

- [x] `uv run python scripts/run-test262.py test262-extra/ --fail-on-failures` — 116/116 (100%)
- [x] `uv run python scripts/run-test262.py test262-extra/ --bytecode --fail-on-failures` — 116/116 (100%)
- [x] `actionlint` and `zizmor` clean on the modified `ci.yml`