### PR TITLE
refactor(nan-box): migrate core interpreter files to JsValue accessors

### DIFF
--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -10,7 +10,7 @@
 
 use super::types::*;
 use super::*;
-use crate::types::{JsString, JsValue};
+use crate::types::JsValue;
 
 impl Interpreter {
     /// Read a name from the current realm's global env, falling through to
@@ -54,9 +54,7 @@ impl Interpreter {
             let action = {
                 let mut e = current.borrow_mut();
                 if e.is_indirect_binding(name) {
-                    return Err(JsValue::String(JsString::from_str(
-                        "Assignment to constant variable.",
-                    )));
+                    return Err(JsValue::from_str("Assignment to constant variable."));
                 }
                 let strict = e.strict;
                 let global_object_id = e.global_object_id;
@@ -64,23 +62,19 @@ impl Interpreter {
                     if !binding.initialized
                         && matches!(binding.kind, BindingKind::Let | BindingKind::Const)
                     {
-                        return Err(JsValue::String(JsString::from_str(&format!(
+                        return Err(JsValue::from_str(&format!(
                             "Cannot access '{name}' before initialization"
-                        ))));
+                        )));
                     }
                     if binding.kind == BindingKind::Const && binding.initialized {
-                        return Err(JsValue::String(JsString::from_str(
-                            "Assignment to constant variable.",
-                        )));
+                        return Err(JsValue::from_str("Assignment to constant variable."));
                     }
                     if (binding.kind == BindingKind::FunctionName
                         || binding.kind == BindingKind::ImmutableValue)
                         && binding.initialized
                     {
                         if strict {
-                            return Err(JsValue::String(JsString::from_str(
-                                "Assignment to constant variable.",
-                            )));
+                            return Err(JsValue::from_str("Assignment to constant variable."));
                         }
                         return Ok(());
                     }
@@ -116,9 +110,9 @@ impl Interpreter {
                                 .set_property_value(name, value.clone());
                             if !ok {
                                 if strict {
-                                    return Err(JsValue::String(JsString::from_str(&format!(
+                                    return Err(JsValue::from_str(&format!(
                                         "Cannot assign to read only property '{name}' of object '#<Object>'"
-                                    ))));
+                                    )));
                                 }
                                 return Ok(());
                             }
@@ -230,7 +224,7 @@ impl Interpreter {
                     g.property_order.push(key.clone());
                     g.properties.insert(
                         key,
-                        PropertyDescriptor::data(JsValue::Undefined, true, true, false),
+                        PropertyDescriptor::data(JsValue::UNDEFINED, true, true, false),
                     );
                 }
             }
@@ -258,7 +252,7 @@ impl Interpreter {
                     g.property_order.push(key.clone());
                     g.properties.insert(
                         key,
-                        PropertyDescriptor::data(JsValue::Undefined, true, true, true),
+                        PropertyDescriptor::data(JsValue::UNDEFINED, true, true, true),
                     );
                 }
             }

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -200,10 +200,10 @@ impl Interpreter {
         owner: &crate::interpreter::object_arena::ObjectHandle,
         value: &JsValue,
     ) {
-        if let JsValue::Object(object) = value
+        if let Some(object_id) = value.as_object_id()
             && self
                 .objects
-                .get_cell(object.id)
+                .get_cell(object_id)
                 .is_some_and(crate::interpreter::object_arena::ObjectHandle::is_young)
         {
             owner.remember_if_old();
@@ -256,8 +256,8 @@ impl Interpreter {
         for realm in &self.realms {
             realm.collect_roots(&mut roots, &mut seen_envs);
         }
-        if let Some(JsValue::Object(o)) = &self.new_target {
-            roots.push(o.id);
+        if let Some(id) = self.new_target.as_ref().and_then(JsValue::as_object_id) {
+            roots.push(id);
         }
         // Module environments are not necessarily reachable from global_env.
         for module in self.module_registry.values() {
@@ -393,11 +393,11 @@ impl Interpreter {
             obj.map_data().is_some_and(|entries| {
                 entries.iter().flatten().any(|(key, value)| {
                     [key, value].iter().any(|candidate| {
-                        let JsValue::Object(object) = candidate else {
+                        let Some(object_id) = candidate.as_object_id() else {
                             return false;
                         };
                         self.objects
-                            .get_cell(object.id)
+                            .get_cell(object_id)
                             .is_some_and(|handle| handle.is_young())
                     })
                 })
@@ -405,11 +405,11 @@ impl Interpreter {
         } else if obj.class_name == "WeakSet" {
             obj.set_data().is_some_and(|entries| {
                 entries.iter().flatten().any(|value| {
-                    let JsValue::Object(object) = value else {
+                    let Some(object_id) = value.as_object_id() else {
                         return false;
                     };
                     self.objects
-                        .get_cell(object.id)
+                        .get_cell(object_id)
                         .is_some_and(|handle| handle.is_young())
                 })
             })
@@ -501,15 +501,15 @@ impl Interpreter {
                 }
                 if let Some(entries) = obj.map_data() {
                     for entry in entries.iter().flatten() {
-                        if let JsValue::Object(key_obj) = &entry.0
-                            && self.minor_value_is_live(key_obj.id)
-                            && let JsValue::Object(value_obj) = &entry.1
+                        if let Some(key_id) = entry.0.as_object_id()
+                            && self.minor_value_is_live(key_id)
+                            && let Some(value_id) = entry.1.as_object_id()
                             && self
                                 .objects
-                                .get_cell(value_obj.id)
+                                .get_cell(value_id)
                                 .is_some_and(|value_handle| value_handle.mark_young())
                         {
-                            worklist.push(value_obj.id);
+                            worklist.push(value_id);
                             new_marks = true;
                         }
                     }
@@ -536,10 +536,10 @@ impl Interpreter {
             if obj.class_name == "WeakMap" {
                 if let Some(entries) = obj.map_data_mut() {
                     for entry in entries.iter_mut() {
-                        let dead = matches!(
-                            entry,
-                            Some((JsValue::Object(key), _)) if !self.minor_value_is_live(key.id)
-                        );
+                        let dead = entry.as_ref().is_some_and(|(key, _)| {
+                            key.as_object_id()
+                                .is_some_and(|id| !self.minor_value_is_live(id))
+                        });
                         if dead {
                             *entry = None;
                         }
@@ -549,10 +549,11 @@ impl Interpreter {
                 && let Some(entries) = obj.set_data_mut()
             {
                 for entry in entries.iter_mut() {
-                    let dead = matches!(
-                        entry,
-                        Some(JsValue::Object(value)) if !self.minor_value_is_live(value.id)
-                    );
+                    let dead = entry.as_ref().is_some_and(|value| {
+                        value
+                            .as_object_id()
+                            .is_some_and(|id| !self.minor_value_is_live(id))
+                    });
                     if dead {
                         *entry = None;
                     }
@@ -635,18 +636,17 @@ impl Interpreter {
                 }
                 if let Some(entries) = obj.map_data() {
                     for entry in entries.iter().flatten() {
-                        if let JsValue::Object(key_obj) = &entry.0 {
-                            let kid = key_obj.id as usize;
-                            if kid < obj_count && marks[kid] {
-                                // Key is reachable — mark the value
-                                if let JsValue::Object(val_obj) = &entry.1 {
-                                    let vid = val_obj.id as usize;
-                                    if vid < obj_count && !marks[vid] {
-                                        marks[vid] = true;
-                                        new_marks = true;
-                                        worklist.push(val_obj.id);
-                                    }
-                                }
+                        // Key is reachable — mark the value
+                        if let Some(key_id) = entry.0.as_object_id()
+                            && (key_id as usize) < obj_count
+                            && marks[key_id as usize]
+                            && let Some(value_id) = entry.1.as_object_id()
+                        {
+                            let vid = value_id as usize;
+                            if vid < obj_count && !marks[vid] {
+                                marks[vid] = true;
+                                new_marks = true;
+                                worklist.push(value_id);
                             }
                         }
                     }
@@ -688,11 +688,9 @@ impl Interpreter {
             if obj.class_name == "WeakMap" {
                 if let Some(entries) = obj.map_data_mut() {
                     for entry in entries.iter_mut() {
-                        let dead = if let Some((JsValue::Object(key_obj), _)) = entry {
-                            let kid = key_obj.id as usize;
-                            kid >= obj_count || !marks[kid]
-                        } else {
-                            false
+                        let dead = match entry.as_ref().and_then(|(key, _)| key.as_object_id()) {
+                            Some(kid) => (kid as usize) >= obj_count || !marks[kid as usize],
+                            None => false,
                         };
                         if dead {
                             *entry = None;
@@ -703,11 +701,9 @@ impl Interpreter {
                 && let Some(entries) = obj.set_data_mut()
             {
                 for entry in entries.iter_mut() {
-                    let dead = if let Some(JsValue::Object(val_obj)) = entry {
-                        let vid = val_obj.id as usize;
-                        vid >= obj_count || !marks[vid]
-                    } else {
-                        false
+                    let dead = match entry.as_ref().and_then(JsValue::as_object_id) {
+                        Some(vid) => (vid as usize) >= obj_count || !marks[vid as usize],
+                        None => false,
                     };
                     if dead {
                         *entry = None;
@@ -727,8 +723,8 @@ impl Interpreter {
     }
 
     fn collect_value_roots(val: &JsValue, worklist: &mut Vec<u64>) {
-        if let JsValue::Object(o) = val {
-            worklist.push(o.id);
+        if let Some(id) = val.as_object_id() {
+            worklist.push(id);
         }
     }
 

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::types::ValueKind;
 
 // Resolves a spec "relative index" argument (already passed through ToIntegerOrInfinity)
 // against a length, per the clamp used by e.g. Array.prototype.slice, String.prototype.slice,
@@ -89,24 +90,29 @@ pub(crate) fn format_radix(mut n: i64, radix: u32) -> String {
 
 // §7.1.3 ToBoolean
 pub(crate) fn to_boolean(val: &JsValue) -> bool {
-    match val {
-        JsValue::Undefined | JsValue::Null => false,
-        JsValue::Boolean(b) => *b,
-        JsValue::Number(n) => *n != 0.0 && !n.is_nan(),
-        JsValue::String(s) => !s.is_empty(),
-        JsValue::BigInt(b) => *b.value != num_bigint::BigInt::from(0),
-        JsValue::Symbol(_) | JsValue::Object(_) => true,
+    match val.kind() {
+        ValueKind::Undefined | ValueKind::Null => false,
+        ValueKind::Boolean => val.as_boolean().unwrap(),
+        ValueKind::Number => {
+            let n = val.as_number().unwrap();
+            n != 0.0 && !n.is_nan()
+        }
+        ValueKind::String => !val.as_string().unwrap().is_empty(),
+        ValueKind::BigInt => val
+            .with_bigint(|b| *b != num_bigint::BigInt::from(0))
+            .unwrap(),
+        ValueKind::Symbol | ValueKind::Object => true,
     }
 }
 
 // §7.1.4 ToNumber
 pub(crate) fn to_number(val: &JsValue) -> f64 {
-    match val {
-        JsValue::Undefined => f64::NAN,
-        JsValue::Null => 0.0,
-        JsValue::Boolean(b) => *b as u8 as f64,
-        JsValue::Number(n) => *n,
-        JsValue::String(s) => string_to_number(s),
+    match val.kind() {
+        ValueKind::Undefined => f64::NAN,
+        ValueKind::Null => 0.0,
+        ValueKind::Boolean => val.as_boolean().unwrap() as u8 as f64,
+        ValueKind::Number => val.as_number().unwrap(),
+        ValueKind::String => string_to_number(&val.as_string().unwrap()),
         _ => f64::NAN,
     }
 }
@@ -192,87 +198,96 @@ fn string_to_number(s: &JsString) -> f64 {
 }
 
 pub(crate) fn to_js_string(val: &JsValue) -> String {
-    match val {
-        JsValue::BigInt(b) => b.value.to_string(),
-        _ => format!("{val}"),
-    }
+    val.with_bigint(|b| b.to_string())
+        .unwrap_or_else(|| format!("{val}"))
 }
 
 /// Convert a JsValue to UTF-16 code units, preserving lone surrogates for strings.
 pub(crate) fn js_value_to_code_units(val: &JsValue) -> Vec<u16> {
-    match val {
-        JsValue::String(s) => s.code_units.to_vec(),
-        _ => to_js_string(val).encode_utf16().collect(),
-    }
+    val.with_string(|units| units.to_vec())
+        .unwrap_or_else(|| to_js_string(val).encode_utf16().collect())
 }
 
 /// Convert a JsValue to a property key string. For symbols, uses the id-based
 /// format to ensure uniqueness. For other types, same as to_js_string.
 pub(crate) fn to_property_key_string(val: &JsValue) -> JsPropertyKey {
-    match val {
-        JsValue::String(s) => JsPropertyKey::from_js_string(s),
-        JsValue::Symbol(s) => s.to_property_key(),
-        _ => JsPropertyKey::from(format!("{val}")),
+    if let Some(s) = val.as_string() {
+        return JsPropertyKey::from_js_string(&s);
     }
+    if let Some(key) = val.with_symbol(|s| s.to_property_key()) {
+        return key;
+    }
+    JsPropertyKey::from(format!("{val}"))
 }
 
 pub(crate) fn is_string(val: &JsValue) -> bool {
-    matches!(val, JsValue::String(_))
+    val.is_string()
 }
 
 pub(crate) fn same_value(left: &JsValue, right: &JsValue) -> bool {
-    match (left, right) {
-        (JsValue::Number(a), JsValue::Number(b)) => {
-            if a.is_nan() && b.is_nan() {
-                return true;
-            }
-            if *a == 0.0 && *b == 0.0 {
-                return a.is_sign_positive() == b.is_sign_positive();
-            }
-            a == b
+    if let (Some(a), Some(b)) = (left.as_number(), right.as_number()) {
+        if a.is_nan() && b.is_nan() {
+            return true;
         }
-        _ => strict_equality(left, right),
+        if a == 0.0 && b == 0.0 {
+            return a.is_sign_positive() == b.is_sign_positive();
+        }
+        return a == b;
     }
+    strict_equality(left, right)
 }
 
 pub(crate) fn same_value_zero(left: &JsValue, right: &JsValue) -> bool {
-    match (left, right) {
-        (JsValue::Number(a), JsValue::Number(b)) => {
-            if a.is_nan() && b.is_nan() {
-                return true;
-            }
-            // -0 === +0
-            a == b
+    if let (Some(a), Some(b)) = (left.as_number(), right.as_number()) {
+        if a.is_nan() && b.is_nan() {
+            return true;
         }
-        _ => strict_equality(left, right),
+        // -0 === +0
+        return a == b;
     }
+    strict_equality(left, right)
 }
 
 pub(crate) fn strict_equality(left: &JsValue, right: &JsValue) -> bool {
-    match (left, right) {
-        (JsValue::Undefined, JsValue::Undefined) => true,
-        (JsValue::Null, JsValue::Null) => true,
-        (JsValue::Boolean(a), JsValue::Boolean(b)) => a == b,
-        (JsValue::Number(a), JsValue::Number(b)) => number_ops::equal(*a, *b),
-        (JsValue::String(a), JsValue::String(b)) => a == b,
-        (JsValue::Symbol(a), JsValue::Symbol(b)) => a.id() == b.id(),
-        (JsValue::BigInt(a), JsValue::BigInt(b)) => bigint_ops::equal(&a.value, &b.value),
-        (JsValue::Object(a), JsValue::Object(b)) => a.id == b.id,
-        _ => false,
+    if left.kind() != right.kind() {
+        return false;
+    }
+    match left.kind() {
+        ValueKind::Undefined | ValueKind::Null => true,
+        ValueKind::Boolean => left.as_boolean() == right.as_boolean(),
+        ValueKind::Number => {
+            number_ops::equal(left.as_number().unwrap(), right.as_number().unwrap())
+        }
+        ValueKind::String => left
+            .with_string(|a| right.with_string(|b| a == b).unwrap_or(false))
+            .unwrap_or(false),
+        ValueKind::Symbol => left
+            .with_symbol(|a| right.with_symbol(|b| a.id() == b.id()).unwrap_or(false))
+            .unwrap_or(false),
+        ValueKind::BigInt => left
+            .with_bigint(|a| {
+                right
+                    .with_bigint(|b| bigint_ops::equal(a, b))
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false),
+        ValueKind::Object => left.as_object_id() == right.as_object_id(),
     }
 }
 
 pub(crate) fn typeof_val<'a>(val: &JsValue, objects: &super::object_arena::ObjectArena) -> &'a str {
-    match val {
-        JsValue::Undefined => "undefined",
-        JsValue::Null => "object",
-        JsValue::Boolean(_) => "boolean",
-        JsValue::Number(_) => "number",
-        JsValue::String(_) => "string",
-        JsValue::Symbol(_) => "symbol",
-        JsValue::BigInt(_) => "bigint",
-        JsValue::Object(o) => {
-            if let Some(obj) = objects.get(o.id) {
+    match val.kind() {
+        ValueKind::Undefined => "undefined",
+        ValueKind::Null => "object",
+        ValueKind::Boolean => "boolean",
+        ValueKind::Number => "number",
+        ValueKind::String => "string",
+        ValueKind::Symbol => "symbol",
+        ValueKind::BigInt => "bigint",
+        ValueKind::Object => {
+            if let Some(id) = val.as_object_id()
+                && let Some(obj) = objects.get(id)
+            {
                 let b = obj.borrow();
                 if b.is_htmldda {
                     return "undefined";
@@ -405,10 +420,10 @@ pub(crate) fn enumerable_own_keys(
                 Ok(Some(v)) => {
                     interp.validate_ownkeys_invariant(&v, &target_val)?;
                     let mut keys = Vec::new();
-                    if let JsValue::Object(arr) = &v {
+                    if let Some(arr_id) = v.as_object_id() {
                         const MAX_PROXY_OWNKEYS_RESULT_LEN: usize = 1_000_000;
-                        let len = match interp.get_property_on_id(arr.id, "length") {
-                            JsValue::Number(n) if n.is_finite() && n > 0.0 => {
+                        let len = match interp.get_property_on_id(arr_id, "length").as_number() {
+                            Some(n) if n.is_finite() && n > 0.0 => {
                                 let len = n.floor() as usize;
                                 if len > MAX_PROXY_OWNKEYS_RESULT_LEN {
                                     return Err(interp.create_type_error(
@@ -420,27 +435,27 @@ pub(crate) fn enumerable_own_keys(
                             _ => 0,
                         };
                         for i in 0..len {
-                            let k = interp.get_property_on_id(arr.id, &i.to_string());
-                            if let JsValue::String(s) = k {
+                            let k = interp.get_property_on_id(arr_id, &i.to_string());
+                            if let Some(s) = k.into_string() {
                                 let key = JsPropertyKey::from_js_string(&s);
-                                let key_val = JsValue::String(s);
+                                let key_val = JsValue::string(s);
                                 match interp.invoke_proxy_trap(
                                     obj_id,
                                     "getOwnPropertyDescriptor",
                                     vec![target_val.clone(), key_val],
                                 ) {
                                     Ok(Some(desc_val)) => {
-                                        if let JsValue::Object(dobj) = &desc_val {
+                                        if let Some(desc_id) = desc_val.as_object_id() {
                                             let enum_val =
-                                                interp.get_property_on_id(dobj.id, "enumerable");
+                                                interp.get_property_on_id(desc_id, "enumerable");
                                             if interp.to_boolean_val(&enum_val) {
                                                 keys.push(key.clone());
                                             }
                                         }
                                     }
                                     Ok(None) => {
-                                        if let JsValue::Object(ref t) = target_val
-                                            && let Some(tobj) = interp.get_object_cell(t.id)
+                                        if let Some(target_id) = target_val.as_object_id()
+                                            && let Some(tobj) = interp.get_object_cell(target_id)
                                             && let Some(d) = tobj.borrow().properties.get(&key)
                                             && d.enumerable != Some(false)
                                         {
@@ -456,8 +471,8 @@ pub(crate) fn enumerable_own_keys(
                 }
                 Ok(None) => {
                     // No ownKeys trap — delegate to the target
-                    if let JsValue::Object(ref t) = target_val {
-                        return enumerable_own_keys(interp, t.id);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return enumerable_own_keys(interp, target_id);
                     }
                     return Ok(Vec::new());
                 }
@@ -467,8 +482,11 @@ pub(crate) fn enumerable_own_keys(
         let b = obj.borrow();
         // String exotic object: character indices come first
         let mut result: Vec<JsPropertyKey> = Vec::new();
-        if let Some(JsValue::String(ref s)) = b.primitive_value {
-            let len = s.len();
+        if let Some(len) = b
+            .primitive_value
+            .as_ref()
+            .and_then(|pv| pv.with_string(|units| units.len()))
+        {
             for i in 0..len {
                 result.push(JsPropertyKey::from(i.to_string()));
             }
@@ -479,7 +497,7 @@ pub(crate) fn enumerable_own_keys(
                 result.push(JsPropertyKey::from(i.to_string()));
             }
         }
-        let is_string_wrapper = matches!(b.primitive_value, Some(JsValue::String(_)));
+        let is_string_wrapper = b.primitive_value.as_ref().is_some_and(|pv| pv.is_string());
         let keys: Vec<JsPropertyKey> = b
             .property_order
             .iter()
@@ -517,48 +535,47 @@ pub(crate) fn json_stringify_full(
     let mut replacer_fn: Option<JsValue> = None;
 
     if let Some(rep) = replacer
-        && let JsValue::Object(o) = rep
-        && let Some(obj) = interp.get_object_cell(o.id)
+        && let Some(rep_id) = rep.as_object_id()
+        && let Some(obj) = interp.get_object_cell(rep_id)
     {
         if obj.borrow().callable.is_some() {
             replacer_fn = Some(rep.clone());
-        } else if is_array_value(interp, o.id)? {
+        } else if is_array_value(interp, rep_id)? {
             let mut keys = Vec::new();
-            let obj_val = JsValue::Object(crate::types::JsObject { id: o.id });
-            let len_val = match interp.get_object_property(o.id, "length", &obj_val) {
+            let obj_val = JsValue::object(rep_id);
+            let len_val = match interp.get_object_property(rep_id, "length", &obj_val) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             let len = {
                 let n = interp.to_number_value(&len_val)?;
                 n as usize
             };
             for i in 0..len {
-                let item = match interp.get_object_property(o.id, &i.to_string(), &obj_val) {
+                let item = match interp.get_object_property(rep_id, &i.to_string(), &obj_val) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 };
-                let key_str = match &item {
-                    JsValue::String(s) => Some(JsPropertyKey::from_js_string(s)),
-                    JsValue::Number(n) => Some(JsPropertyKey::from(number_ops::to_string(*n))),
-                    JsValue::Object(oo) => {
-                        if let Some(inner) = interp.get_object_cell(oo.id) {
-                            let cn = inner.borrow().class_name.clone();
-                            if cn == "String" || cn == "Number" {
-                                {
-                                    let s = interp.to_string_value(&item)?;
-                                    Some(JsPropertyKey::from(s))
-                                }
-                            } else {
-                                None
-                            }
+                let key_str = if let Some(s) = item.as_string() {
+                    Some(JsPropertyKey::from_js_string(&s))
+                } else if let Some(n) = item.as_number() {
+                    Some(JsPropertyKey::from(number_ops::to_string(n)))
+                } else if let Some(item_id) = item.as_object_id() {
+                    if let Some(inner) = interp.get_object_cell(item_id) {
+                        let cn = inner.borrow().class_name.clone();
+                        if cn == "String" || cn == "Number" {
+                            let s = interp.to_string_value(&item)?;
+                            Some(JsPropertyKey::from(s))
                         } else {
                             None
                         }
+                    } else {
+                        None
                     }
-                    _ => None,
+                } else {
+                    None
                 };
                 if let Some(k) = key_str
                     && !keys.contains(&k)
@@ -606,37 +623,37 @@ fn json_stringify_internal(
     let mut value = val.clone();
 
     // Step 2: If Type(value) is Object or BigInt, check for toJSON
-    let check_tojson = matches!(&value, JsValue::Object(_) | JsValue::BigInt(_));
+    let check_tojson = value.is_object() || value.is_bigint();
     if check_tojson {
-        let to_json = if let JsValue::Object(o) = &value {
-            match interp.get_object_property(o.id, "toJSON", &value) {
+        let to_json = if let Some(value_id) = value.as_object_id() {
+            match interp.get_object_property(value_id, "toJSON", &value) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             }
-        } else if let JsValue::BigInt(_) = &value {
+        } else if value.is_bigint() {
             let obj_val = match interp.to_object(&value) {
                 Completion::Normal(v) => v,
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
-            if let JsValue::Object(o) = &obj_val {
+            if let Some(wrapper_id) = obj_val.as_object_id() {
                 // Use original BigInt value as receiver for proper getter behavior
-                match interp.get_object_property(o.id, "toJSON", &value) {
+                match interp.get_object_property(wrapper_id, "toJSON", &value) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 }
             } else {
-                JsValue::Undefined
+                JsValue::UNDEFINED
             }
         } else {
-            JsValue::Undefined
+            JsValue::UNDEFINED
         };
-        if let JsValue::Object(fobj) = &to_json
-            && let Some(fdata) = interp.get_object_cell(fobj.id)
+        if let Some(to_json_id) = to_json.as_object_id()
+            && let Some(fdata) = interp.get_object_cell(to_json_id)
             && fdata.borrow().callable.is_some()
         {
-            let key_val = JsValue::String(key.to_js_string());
+            let key_val = JsValue::string(key.to_js_string());
             match interp.call_function(&to_json, &value, &[key_val]) {
                 Completion::Normal(v) => value = v,
                 Completion::Throw(e) => return Err(e),
@@ -647,8 +664,8 @@ fn json_stringify_internal(
 
     // Step 3: Apply replacer function
     if let Some(rep) = replacer_fn {
-        let holder_val = JsValue::Object(crate::types::JsObject { id: holder_id });
-        let key_val = JsValue::String(key.to_js_string());
+        let holder_val = JsValue::object(holder_id);
+        let key_val = JsValue::string(key.to_js_string());
         match interp.call_function(rep, &holder_val, &[key_val, value.clone()]) {
             Completion::Normal(v) => value = v,
             Completion::Throw(e) => return Err(e),
@@ -657,8 +674,8 @@ fn json_stringify_internal(
     }
 
     // Step 4: Unwrap wrapper objects per spec (ToNumber/ToString trigger valueOf/toString)
-    if let JsValue::Object(o) = &value {
-        let class = if let Some(cell) = interp.get_object_cell(o.id) {
+    if let Some(value_id) = value.as_object_id() {
+        let class = if let Some(cell) = interp.get_object_cell(value_id) {
             cell.borrow().class_name.clone()
         } else {
             String::new()
@@ -666,21 +683,21 @@ fn json_stringify_internal(
         match class.as_str() {
             "Number" => {
                 let n = interp.to_number_value(&value)?;
-                value = JsValue::Number(n)
+                value = JsValue::number(n)
             }
             "String" => {
                 let s = interp.to_string_value(&value)?;
-                value = JsValue::String(JsString::from_str(&s))
+                value = JsValue::from_str(&s)
             }
             "Boolean" => {
-                if let Some(cell) = interp.get_object_cell(o.id)
+                if let Some(cell) = interp.get_object_cell(value_id)
                     && let Some(pv) = cell.borrow().primitive_value.clone()
                 {
                     value = pv;
                 }
             }
             "BigInt" => {
-                if let Some(cell) = interp.get_object_cell(o.id)
+                if let Some(cell) = interp.get_object_cell(value_id)
                     && let Some(pv) = cell.borrow().primitive_value.clone()
                 {
                     value = pv;
@@ -690,22 +707,23 @@ fn json_stringify_internal(
         }
     }
 
-    match &value {
-        JsValue::Null => Ok(Some("null".to_string())),
-        JsValue::Boolean(b) => Ok(Some(b.to_string())),
-        JsValue::Number(n) => {
+    match value.kind() {
+        ValueKind::Null => Ok(Some("null".to_string())),
+        ValueKind::Boolean => Ok(Some(value.as_boolean().unwrap().to_string())),
+        ValueKind::Number => {
+            let n = value.as_number().unwrap();
             if n.is_nan() || n.is_infinite() {
                 Ok(Some("null".to_string()))
             } else {
-                Ok(Some(number_ops::to_string(*n)))
+                Ok(Some(number_ops::to_string(n)))
             }
         }
-        JsValue::String(s) => Ok(Some(json_quote_js_string(s))),
-        JsValue::BigInt(_) => {
+        ValueKind::String => Ok(Some(value.with_string(json_quote_units).unwrap())),
+        ValueKind::BigInt => {
             Err(interp.create_error("TypeError", "Do not know how to serialize a BigInt"))
         }
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id) {
+        ValueKind::Object => {
+            if let Some(obj) = interp.get_object_cell(value.as_object_id().unwrap()) {
                 if obj.borrow().is_raw_json
                     && let Some(raw) = obj.borrow().get_property_value("rawJSON")
                 {
@@ -723,7 +741,7 @@ fn json_stringify_internal(
                 stack.push(obj_id);
 
                 let is_array = is_array_value(interp, obj_id)?;
-                let obj_val = JsValue::Object(crate::types::JsObject { id: obj_id });
+                let obj_val = JsValue::object(obj_id);
                 let new_indent = format!("{}{}", indent, gap);
 
                 let result = if is_array {
@@ -733,7 +751,7 @@ fn json_stringify_internal(
                             stack.pop();
                             return Err(e);
                         }
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
                     let len = match interp.to_number_value(&len_val) {
                         Ok(n) => n as usize,
@@ -751,7 +769,7 @@ fn json_stringify_internal(
                                 stack.pop();
                                 return Err(e);
                             }
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         match json_stringify_internal(
                             interp,
@@ -801,7 +819,7 @@ fn json_stringify_internal(
                                 stack.pop();
                                 return Err(e);
                             }
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         if let Some(sv) = json_stringify_internal(
                             interp,
@@ -842,7 +860,7 @@ fn json_stringify_internal(
                 Ok(Some("null".to_string()))
             }
         }
-        JsValue::Undefined | JsValue::Symbol(_) => Ok(None),
+        ValueKind::Undefined | ValueKind::Symbol => Ok(None),
     }
 }
 
@@ -888,13 +906,13 @@ fn json_parse_value_inner(
 ) -> Completion {
     let s = json_trim(s);
     if s == "null" {
-        return Completion::Normal(JsValue::Null);
+        return Completion::Normal(JsValue::NULL);
     }
     if s == "true" {
-        return Completion::Normal(JsValue::Boolean(true));
+        return Completion::Normal(JsValue::TRUE);
     }
     if s == "false" {
-        return Completion::Normal(JsValue::Boolean(false));
+        return Completion::Normal(JsValue::FALSE);
     }
     if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
         let inner = &s[1..s.len() - 1];
@@ -902,12 +920,12 @@ fn json_parse_value_inner(
             let err = interp.create_error("SyntaxError", &msg);
             return Completion::Throw(err);
         }
-        return Completion::Normal(JsValue::String(json_unescape_js_string(inner)));
+        return Completion::Normal(JsValue::string(json_unescape_js_string(inner)));
     }
     if json_is_valid_number(s)
         && let Ok(n) = s.parse::<f64>()
     {
-        return Completion::Normal(JsValue::Number(n));
+        return Completion::Normal(JsValue::number(n));
     }
     if s.starts_with('[') && s.ends_with(']') {
         let inner = &s[1..s.len() - 1];
@@ -925,10 +943,9 @@ fn json_parse_value_inner(
         }
         let vals: Vec<JsValue> = parsed_items.iter().map(|(v, _)| v.clone()).collect();
         let arr_val = interp.create_array(vals);
-        if let JsValue::Object(ref arr_obj) = arr_val
+        if let Some(arr_id) = arr_val.as_object_id()
             && let Some(ref mut smap) = source_map
         {
-            let arr_id = arr_obj.id;
             for (i, (v, src)) in parsed_items.iter().enumerate() {
                 if is_json_primitive(v) {
                     smap.insert((arr_id, JsPropertyKey::from(i.to_string())), src.clone());
@@ -985,7 +1002,7 @@ fn json_parse_value_inner(
                 other => return other,
             }
         }
-        return Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }));
+        return Completion::Normal(JsValue::object(obj_id));
     }
     if let Some(token) = s.chars().next() {
         return json_unexpected_token_error(interp, token, root_source);
@@ -1016,8 +1033,8 @@ fn json_unexpected_token_error(interp: &mut Interpreter, token: char, source: &s
 
 pub(crate) fn is_json_primitive(val: &JsValue) -> bool {
     matches!(
-        val,
-        JsValue::Null | JsValue::Boolean(_) | JsValue::Number(_) | JsValue::String(_)
+        val.kind(),
+        ValueKind::Null | ValueKind::Boolean | ValueKind::Number | ValueKind::String
     )
 }
 
@@ -1091,9 +1108,9 @@ fn json_internalize_apply<K: PropertyKeyLike + ?Sized>(
 
     if is_proxy {
         let target_val = interp.get_proxy_target_val(obj_id);
-        if let JsValue::Undefined = &new_val {
+        if new_val.is_undefined() {
             // Delete via proxy deleteProperty trap
-            let key_val = JsValue::String(key.to_js_property_key().to_js_string());
+            let key_val = JsValue::string(key.to_js_property_key().to_js_string());
             match interp.invoke_proxy_trap(obj_id, "deleteProperty", vec![target_val, key_val]) {
                 Ok(Some(v)) => {
                     if !interp.to_boolean_val(&v) {
@@ -1104,8 +1121,8 @@ fn json_internalize_apply<K: PropertyKeyLike + ?Sized>(
                 }
                 Ok(None) => {
                     // No trap, delete on target directly
-                    if let JsValue::Object(t) = &interp.get_proxy_target_val(obj_id)
-                        && let Some(tobj) = interp.get_object_cell(t.id)
+                    if let Some(target_id) = interp.get_proxy_target_val(obj_id).as_object_id()
+                        && let Some(tobj) = interp.get_object_cell(target_id)
                     {
                         tobj.borrow_mut().remove_property(key);
                     }
@@ -1114,7 +1131,7 @@ fn json_internalize_apply<K: PropertyKeyLike + ?Sized>(
             }
         } else {
             // CreateDataProperty via proxy defineProperty trap
-            let key_val = JsValue::String(key.to_js_property_key().to_js_string());
+            let key_val = JsValue::string(key.to_js_property_key().to_js_string());
             let desc_obj_id = interp.create_object_id();
             interp
                 .get_object_cell_expect(desc_obj_id)
@@ -1123,16 +1140,16 @@ fn json_internalize_apply<K: PropertyKeyLike + ?Sized>(
             interp
                 .get_object_cell_expect(desc_obj_id)
                 .borrow_mut()
-                .insert_value("writable".to_string(), JsValue::Boolean(true));
+                .insert_value("writable".to_string(), JsValue::TRUE);
             interp
                 .get_object_cell_expect(desc_obj_id)
                 .borrow_mut()
-                .insert_value("enumerable".to_string(), JsValue::Boolean(true));
+                .insert_value("enumerable".to_string(), JsValue::TRUE);
             interp
                 .get_object_cell_expect(desc_obj_id)
                 .borrow_mut()
-                .insert_value("configurable".to_string(), JsValue::Boolean(true));
-            let desc_val = JsValue::Object(crate::types::JsObject { id: desc_obj_id });
+                .insert_value("configurable".to_string(), JsValue::TRUE);
+            let desc_val = JsValue::object(desc_obj_id);
             match interp.invoke_proxy_trap(
                 obj_id,
                 "defineProperty",
@@ -1147,8 +1164,8 @@ fn json_internalize_apply<K: PropertyKeyLike + ?Sized>(
                 }
                 Ok(None) => {
                     // No trap, define on target directly
-                    if let JsValue::Object(t) = &interp.get_proxy_target_val(obj_id)
-                        && let Some(tobj) = interp.get_object_cell(t.id)
+                    if let Some(target_id) = interp.get_proxy_target_val(obj_id).as_object_id()
+                        && let Some(tobj) = interp.get_object_cell(target_id)
                     {
                         tobj.borrow_mut()
                             .insert_value(key.to_js_property_key(), new_val);
@@ -1171,7 +1188,7 @@ fn json_internalize_apply<K: PropertyKeyLike + ?Sized>(
         if !configurable {
             return Ok(());
         }
-        if let JsValue::Undefined = &new_val {
+        if new_val.is_undefined() {
             cell.borrow_mut().remove_property(key);
             // Also clear dense array storage so get_property doesn't find stale values
             if let Some(key_str) = key.as_property_key_str()
@@ -1181,7 +1198,7 @@ fn json_internalize_apply<K: PropertyKeyLike + ?Sized>(
                 if let Some(elems) = b.array_elements_mut()
                     && idx < elems.len()
                 {
-                    elems[idx] = JsValue::Undefined;
+                    elems[idx] = JsValue::UNDEFINED;
                 }
             }
         } else {
@@ -1199,18 +1216,17 @@ pub(crate) fn json_internalize<K: PropertyKeyLike + ?Sized>(
     reviver: &JsValue,
     source_map: &Option<SourceTextMap>,
 ) -> Completion {
-    let val = if let JsValue::Object(o) = holder {
-        match interp.get_object_property(o.id, name, holder) {
+    let val = if let Some(holder_id) = holder.as_object_id() {
+        match interp.get_object_property(holder_id, name, holder) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Completion::Throw(e),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         }
     } else {
-        JsValue::Undefined
+        JsValue::UNDEFINED
     };
 
-    let walked = if let JsValue::Object(o) = &val {
-        let obj_id = o.id;
+    let walked = if let Some(obj_id) = val.as_object_id() {
         let is_array = match is_array_value(interp, obj_id) {
             Ok(v) => v,
             Err(e) => return Completion::Throw(e),
@@ -1219,7 +1235,7 @@ pub(crate) fn json_internalize<K: PropertyKeyLike + ?Sized>(
             let len_val = match interp.get_object_property(obj_id, "length", &val) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Completion::Throw(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             let len = match interp.to_number_value(&len_val) {
                 Ok(n) => n as usize,
@@ -1264,40 +1280,40 @@ pub(crate) fn json_internalize<K: PropertyKeyLike + ?Sized>(
         let ctx_id = interp.create_object_id();
         if is_json_primitive(&walked)
             && let Some(smap) = source_map
-            && let JsValue::Object(o) = holder
-            && let Some(src) = smap.get(&(o.id, name.to_js_property_key()))
+            && let Some(holder_id) = holder.as_object_id()
+            && let Some(src) = smap.get(&(holder_id, name.to_js_property_key()))
         {
             // Verify the source text matches the actual value
             // (forward modifications make source invalid)
-            let source_matches = match &walked {
-                JsValue::Null => src == "null",
-                JsValue::Boolean(true) => src == "true",
-                JsValue::Boolean(false) => src == "false",
-                JsValue::Number(n) => src
-                    .parse::<f64>()
-                    .is_ok_and(|parsed| (parsed.is_nan() && n.is_nan()) || parsed == *n),
-                JsValue::String(s)
-                    // Source includes quotes, parse it to compare
-                    if src.starts_with('"') && src.ends_with('"') => {
+            let source_matches = if walked.is_null() {
+                src == "null"
+            } else if let Some(b) = walked.as_boolean() {
+                src == if b { "true" } else { "false" }
+            } else if let Some(n) = walked.as_number() {
+                src.parse::<f64>()
+                    .is_ok_and(|parsed| (parsed.is_nan() && n.is_nan()) || parsed == n)
+            } else {
+                walked
+                    .with_string(|units| {
+                        if !(src.starts_with('"') && src.ends_with('"')) {
+                            return false;
+                        }
+                        // Source includes quotes, parse it to compare
                         let inner = &src[1..src.len() - 1];
-                        json_unescape_js_string(inner) == *s
-                    }
-                _ => false,
+                        json_unescape_js_string(inner).code_units.as_slice() == units
+                    })
+                    .unwrap_or(false)
             };
             if source_matches {
                 interp
                     .get_object_cell_expect(ctx_id)
                     .borrow_mut()
-                    .insert_value(
-                        "source".to_string(),
-                        JsValue::String(JsString::from_str(src)),
-                    );
+                    .insert_value("source".to_string(), JsValue::from_str(src));
             }
         }
-        let id = ctx_id;
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(ctx_id)
     };
-    let key_val = JsValue::String(name.to_js_property_key().to_js_string());
+    let key_val = JsValue::string(name.to_js_property_key().to_js_string());
     interp.call_function(reviver, holder, &[key_val, walked, context])
 }
 

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -80,24 +80,22 @@ impl Interpreter {
                     if is_valid_integer_index(ta, index) {
                         return Completion::Normal(typed_array_get_index(ta, index as usize));
                     }
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
 
                 // Check own property
                 let own_desc = b.get_own_property_full(key);
                 match own_desc {
-                    Some(ref d)
-                        if d.get.is_some() && !matches!(d.get, Some(JsValue::Undefined)) =>
-                    {
+                    Some(ref d) if d.get.as_ref().is_some_and(|g| !g.is_undefined()) => {
                         let getter = d.get.clone().unwrap();
                         drop(b);
                         return self.call_function(&getter, this_val, &[]);
                     }
                     Some(ref d) if d.get.is_some() => {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     Some(ref d) => {
-                        return Completion::Normal(d.value.clone().unwrap_or(JsValue::Undefined));
+                        return Completion::Normal(d.value.clone().unwrap_or(JsValue::UNDEFINED));
                     }
                     None => {}
                 }
@@ -109,7 +107,7 @@ impl Interpreter {
                     let proto_id = proto_rc;
                     return self.get_object_property(proto_id, key, this_val);
                 }
-                return Completion::Normal(JsValue::Undefined);
+                return Completion::Normal(JsValue::UNDEFINED);
             }
             drop(b);
         }
@@ -133,8 +131,8 @@ impl Interpreter {
             {
                 Ok(Some(v)) => {
                     // Invariant checks
-                    if let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object_cell(t.id)
+                    if let Some(target_id) = target_val.as_object_id()
+                        && let Some(tobj) = self.get_object_cell(target_id)
                     {
                         let target_desc = tobj.borrow().get_own_property(key);
                         if let Some(ref desc) = target_desc
@@ -144,7 +142,7 @@ impl Interpreter {
                                 && desc.writable == Some(false)
                                 && !same_value(
                                     &v,
-                                    desc.value.as_ref().unwrap_or(&JsValue::Undefined),
+                                    desc.value.as_ref().unwrap_or(&JsValue::UNDEFINED),
                                 )
                             {
                                 return Completion::Throw(self.create_type_error(
@@ -152,11 +150,8 @@ impl Interpreter {
                                     ));
                             }
                             if desc.is_accessor_descriptor()
-                                && matches!(
-                                    desc.get.as_ref().unwrap_or(&JsValue::Undefined),
-                                    JsValue::Undefined
-                                )
-                                && !matches!(v, JsValue::Undefined)
+                                && desc.get.as_ref().is_none_or(|g| g.is_undefined())
+                                && !v.is_undefined()
                             {
                                 return Completion::Throw(self.create_type_error(
                                         "'get' on proxy: property is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap did not return 'undefined'",
@@ -168,10 +163,10 @@ impl Interpreter {
                 }
                 Ok(None) => {
                     // No trap, fall through to target
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.get_object_property(t.id, key, this_val);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.get_object_property(target_id, key, this_val);
                     }
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 Err(e) => return Completion::Throw(e),
             }
@@ -222,12 +217,12 @@ impl Interpreter {
             None
         };
         match own_desc {
-            Some(ref d) if d.get.is_some() && !matches!(d.get, Some(JsValue::Undefined)) => {
+            Some(ref d) if d.get.as_ref().is_some_and(|g| !g.is_undefined()) => {
                 let getter = d.get.clone().unwrap();
                 self.call_function(&getter, this_val, &[])
             }
-            Some(ref d) if d.get.is_some() => Completion::Normal(JsValue::Undefined),
-            Some(ref d) => Completion::Normal(d.value.clone().unwrap_or(JsValue::Undefined)),
+            Some(ref d) if d.get.is_some() => Completion::Normal(JsValue::UNDEFINED),
+            Some(ref d) => Completion::Normal(d.value.clone().unwrap_or(JsValue::UNDEFINED)),
             None => {
                 let proto = if let Some(obj) = self.get_object_cell(obj_id) {
                     obj.borrow().prototype_id
@@ -238,7 +233,7 @@ impl Interpreter {
                     let proto_id = proto_rc;
                     self.get_object_property(proto_id, key, this_val)
                 } else {
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 }
             }
         }
@@ -257,8 +252,8 @@ impl Interpreter {
                 Ok(Some(v)) => {
                     let trap_result = self.to_boolean_val(&v);
                     if !trap_result
-                        && let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object_cell(t.id)
+                        && let Some(target_id) = target_val.as_object_id()
+                        && let Some(tobj) = self.get_object_cell(target_id)
                     {
                         let target_desc = tobj.borrow().get_own_property(key);
                         if let Some(ref desc) = target_desc {
@@ -277,8 +272,8 @@ impl Interpreter {
                     Ok(trap_result)
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_has_property(t.id, key);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_has_property(target_id, key);
                     }
                     Ok(false)
                 }
@@ -341,7 +336,7 @@ impl Interpreter {
             drop(b);
             current = next;
         }
-        JsValue::Undefined
+        JsValue::UNDEFINED
     }
 
     /// Iterative prototype-chain walk of `get_property_descriptor`.
@@ -447,7 +442,7 @@ impl Interpreter {
         }
 
         // 5. Set newLenDesc.[[Value]] to newLen (as a Number).
-        new_len_desc.value = Some(JsValue::Number(new_len as f64));
+        new_len_desc.value = Some(JsValue::number(new_len as f64));
 
         // 6. Let oldLenDesc be OrdinaryGetOwnProperty(A, "length").
         let (old_len, old_len_writable) = {
@@ -459,13 +454,8 @@ impl Interpreter {
                     let ol = d
                         .value
                         .as_ref()
-                        .and_then(|v| {
-                            if let JsValue::Number(n) = v {
-                                Some(*n as u32)
-                            } else {
-                                None
-                            }
-                        })
+                        .and_then(JsValue::as_number)
+                        .map(|n| n as u32)
                         .unwrap_or(0);
                     let w = d.writable.unwrap_or(true);
                     (ol, w)
@@ -556,7 +546,7 @@ impl Interpreter {
             let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
             let mut obj = obj_rc.borrow_mut();
             if let Some(len_desc) = obj.properties.get_mut("length") {
-                len_desc.value = Some(JsValue::Number(actual_new_len as f64));
+                len_desc.value = Some(JsValue::number(actual_new_len as f64));
             }
             // 13.d.iii.2. If newWritable is false, set length writable to false.
             if !new_writable && let Some(len_desc) = obj.properties.get_mut("length") {
@@ -604,13 +594,8 @@ impl Interpreter {
                 let len_desc = obj.properties.get("length");
                 let ol = len_desc
                     .and_then(|d| d.value.as_ref())
-                    .and_then(|v| {
-                        if let JsValue::Number(n) = v {
-                            Some(*n as u32)
-                        } else {
-                            None
-                        }
-                    })
+                    .and_then(JsValue::as_number)
+                    .map(|n| n as u32)
                     .unwrap_or(0);
                 let w = len_desc.and_then(|d| d.writable).unwrap_or(true);
                 (ol, w)
@@ -640,16 +625,16 @@ impl Interpreter {
                 let obj_rc = self.get_object_cell(obj_id as u64).unwrap();
                 let mut obj = obj_rc.borrow_mut();
                 if let Some(len_desc) = obj.properties.get_mut("length") {
-                    len_desc.value = Some(JsValue::Number(new_len as f64));
+                    len_desc.value = Some(JsValue::number(new_len as f64));
                 }
                 if let Some(elems) = obj.array_elements_mut() {
-                    let val = desc.value.unwrap_or(JsValue::Undefined);
+                    let val = desc.value.unwrap_or(JsValue::UNDEFINED);
                     let idx = index_u32 as usize;
                     if idx < elems.len() {
                         elems[idx] = val;
                     } else if idx <= elems.len() + 1024 {
                         while elems.len() < idx {
-                            elems.push(JsValue::Undefined);
+                            elems.push(JsValue::UNDEFINED);
                         }
                         elems.push(val);
                     }
@@ -695,8 +680,8 @@ impl Interpreter {
             ) {
                 Ok(Some(v)) => {
                     if self.to_boolean_val(&v) {
-                        if let JsValue::Object(ref t) = target_val
-                            && let Some(tobj) = self.get_object(t.id)
+                        if let Some(target_id) = target_val.as_object_id()
+                            && let Some(tobj) = self.get_object(target_id)
                         {
                             let target_desc = tobj.borrow().get_own_property(key);
                             if let Some(ref desc) = target_desc
@@ -706,7 +691,7 @@ impl Interpreter {
                                     && desc.writable == Some(false)
                                     && !same_value(
                                         &value,
-                                        desc.value.as_ref().unwrap_or(&JsValue::Undefined),
+                                        desc.value.as_ref().unwrap_or(&JsValue::UNDEFINED),
                                     )
                                 {
                                     return Err(self.create_type_error(
@@ -714,10 +699,7 @@ impl Interpreter {
                                         ));
                                 }
                                 if desc.is_accessor_descriptor()
-                                    && matches!(
-                                        desc.set.as_ref().unwrap_or(&JsValue::Undefined),
-                                        JsValue::Undefined
-                                    )
+                                    && desc.set.as_ref().is_none_or(|s| s.is_undefined())
                                 {
                                     return Err(self.create_type_error(
                                             "'set' on proxy: trap returned truish for property which exists in the proxy target as a non-configurable and non-writable accessor property without a setter",
@@ -731,8 +713,8 @@ impl Interpreter {
                     }
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_set(t.id, key, value, receiver);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_set(target_id, key, value, receiver);
                     }
                     Ok(false)
                 }
@@ -742,11 +724,7 @@ impl Interpreter {
             // TypedArray [[Set]] §10.4.5.5
             let is_ta = obj.borrow().typed_array_info().is_some();
             if is_ta && let Some(index) = canonical_numeric_index_string(key) {
-                let same_val = if let JsValue::Object(ref r) = *receiver {
-                    r.id == obj_id
-                } else {
-                    false
-                };
+                let same_val = receiver.as_object_id() == Some(obj_id);
                 if same_val {
                     // SameValue(O, Receiver): IntegerIndexedElementSet
                     let is_bigint = obj
@@ -757,7 +735,7 @@ impl Interpreter {
                     let num_val = if is_bigint {
                         self.to_bigint_value(&value)?
                     } else {
-                        JsValue::Number(self.to_number_value(&value)?)
+                        JsValue::number(self.to_number_value(&value)?)
                     };
                     let obj_ref = obj.borrow();
                     let ta = obj_ref.typed_array_info().unwrap();
@@ -788,7 +766,7 @@ impl Interpreter {
                 if desc.is_accessor_descriptor() {
                     // Call setter with receiver as this
                     if let Some(ref setter) = desc.set
-                        && !matches!(setter, JsValue::Undefined)
+                        && !setter.is_undefined()
                     {
                         let setter = setter.clone();
                         match self.call_function(&setter, receiver, &[value]) {
@@ -804,11 +782,7 @@ impl Interpreter {
                     return Ok(false);
                 }
                 // OrdinarySetWithOwnDescriptor step 3.c: use Receiver.[[GetOwnProperty]] / [[DefineOwnProperty]]
-                let recv_id = if let JsValue::Object(r) = receiver {
-                    Some(r.id)
-                } else {
-                    None
-                };
+                let recv_id = receiver.as_object_id();
                 if recv_id == Some(obj_id) {
                     // Common case: receiver is the same object, direct set
                     self.gc_write_barrier_value(&obj, &value);
@@ -817,7 +791,7 @@ impl Interpreter {
                 // Receiver differs: call Receiver.[[GetOwnProperty]](P) and [[DefineOwnProperty]]
                 if let Some(rid) = recv_id {
                     let existing = self.proxy_get_own_property_descriptor(rid, key)?;
-                    if matches!(existing, JsValue::Undefined) {
+                    if existing.is_undefined() {
                         // CreateDataProperty(Receiver, P, V)
                         let desc = crate::interpreter::types::PropertyDescriptor {
                             value: Some(value),
@@ -874,14 +848,13 @@ impl Interpreter {
             }
             // No prototype: OrdinarySetWithOwnDescriptor with synthetic {writable:true,...} ownDesc.
             // Per spec step 1.c.i + 2.c: call Receiver.[[GetOwnProperty]](P) then act on result.
-            if let JsValue::Object(recv_o) = receiver {
-                let recv_id = recv_o.id;
+            if let Some(recv_id) = receiver.as_object_id() {
                 let is_proxy_recv = self
                     .get_object_cell(recv_id)
                     .is_some_and(|o| o.borrow().is_proxy() || o.borrow().is_proxy_revoked());
                 if is_proxy_recv {
                     let existing = self.proxy_get_own_property_descriptor(recv_id, key)?;
-                    if matches!(existing, JsValue::Undefined) {
+                    if existing.is_undefined() {
                         // CreateDataProperty(Receiver, P, V)
                         let create_desc = crate::interpreter::types::PropertyDescriptor {
                             value: Some(value),
@@ -971,8 +944,8 @@ impl Interpreter {
                 Ok(Some(v)) => {
                     let trap_result = self.to_boolean_val(&v);
                     if trap_result
-                        && let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object_cell(t.id)
+                        && let Some(target_id) = target_val.as_object_id()
+                        && let Some(tobj) = self.get_object_cell(target_id)
                     {
                         let target_desc = tobj.borrow().get_own_property(key);
                         if let Some(ref desc) = target_desc {
@@ -991,8 +964,8 @@ impl Interpreter {
                     Ok(trap_result)
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_delete_property(t.id, key);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_delete_property(target_id, key);
                     }
                     Ok(true)
                 }
@@ -1003,14 +976,15 @@ impl Interpreter {
             {
                 let borrow = obj.borrow();
                 if borrow.class_name == "String"
-                    && let Some(JsValue::String(ref s)) = borrow.primitive_value
+                    && let Some(len) = borrow
+                        .primitive_value
+                        .as_ref()
+                        .and_then(|v| v.with_string(|s| s.len()))
                 {
                     if key.as_property_key_str() == Some("length") {
                         return Ok(false);
                     }
-                    if crate::interpreter::types::string_exotic_index(key, s.code_units.len())
-                        .is_some()
-                    {
+                    if crate::interpreter::types::string_exotic_index(key, len).is_some() {
                         return Ok(false);
                     }
                 }
@@ -1027,7 +1001,7 @@ impl Interpreter {
                 && let Ok(idx) = key_str.parse::<usize>()
                 && idx < elems.len()
             {
-                elems[idx] = JsValue::Undefined;
+                elems[idx] = JsValue::UNDEFINED;
             }
             Ok(true)
         } else {
@@ -1108,7 +1082,7 @@ impl Interpreter {
             let num_val = if is_bigint {
                 self.to_bigint_value(value)?
             } else {
-                JsValue::Number(self.to_number_value(value)?)
+                JsValue::number(self.to_number_value(value)?)
             };
             // After conversion, re-read ta info (buffer may have been detached during conversion)
             if let Some(obj) = self.get_object_cell(obj_id) {
@@ -1151,8 +1125,8 @@ impl Interpreter {
                     if !trap_result {
                         return Ok(false);
                     }
-                    if let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object_cell(t.id)
+                    if let Some(target_id) = target_val.as_object_id()
+                        && let Some(tobj) = self.get_object_cell(target_id)
                     {
                         let target_desc = tobj.borrow().get_own_property(&key);
                         let target_extensible = tobj.borrow().extensible;
@@ -1204,8 +1178,8 @@ impl Interpreter {
                     Ok(true)
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_define_own_property(t.id, key, desc_val);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_define_own_property(target_id, key, desc_val);
                     }
                     Ok(false)
                 }
@@ -1257,17 +1231,17 @@ impl Interpreter {
             ) {
                 Ok(Some(v)) => {
                     // Step 11: If Type(trapResultObj) is neither Object nor Undefined, throw TypeError
-                    if !matches!(v, JsValue::Object(_) | JsValue::Undefined) {
+                    if !v.is_object() && !v.is_undefined() {
                         return Err(self.create_type_error(
                             "'getOwnPropertyDescriptor' on proxy: trap returned neither Object nor undefined",
                         ));
                     }
-                    if let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object_cell(t.id)
+                    if let Some(target_id) = target_val.as_object_id()
+                        && let Some(tobj) = self.get_object_cell(target_id)
                     {
                         let target_desc = tobj.borrow().get_own_property(key);
                         let target_extensible = tobj.borrow().extensible;
-                        if matches!(v, JsValue::Undefined) {
+                        if v.is_undefined() {
                             if let Some(ref td) = target_desc {
                                 if td.configurable == Some(false) {
                                     return Err(self.create_type_error(
@@ -1280,11 +1254,11 @@ impl Interpreter {
                                     ));
                                 }
                             }
-                        } else if matches!(v, JsValue::Object(_)) {
+                        } else if v.is_object() {
                             let result_desc = match self.to_property_descriptor(&v) {
                                 Ok(d) => d,
                                 Err(Some(e)) => return Err(e),
-                                Err(None) => return Ok(JsValue::Undefined),
+                                Err(None) => return Ok(JsValue::UNDEFINED),
                             };
                             // Step 22: If resultDesc.[[Configurable]] is false
                             if result_desc.configurable == Some(false) {
@@ -1391,10 +1365,10 @@ impl Interpreter {
                     Ok(v)
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_get_own_property_descriptor(t.id, key);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_get_own_property_descriptor(target_id, key);
                     }
-                    Ok(JsValue::Undefined)
+                    Ok(JsValue::UNDEFINED)
                 }
                 Err(e) => Err(e),
             }
@@ -1404,10 +1378,10 @@ impl Interpreter {
             let desc = obj.borrow().get_own_property(key);
             match desc {
                 Some(d) => Ok(self.from_property_descriptor(&d)),
-                None => Ok(JsValue::Undefined),
+                None => Ok(JsValue::UNDEFINED),
             }
         } else {
-            Ok(JsValue::Undefined)
+            Ok(JsValue::UNDEFINED)
         }
     }
 
@@ -1420,21 +1394,20 @@ impl Interpreter {
             let target_val = self.get_proxy_target_val(obj_id);
             match self.invoke_proxy_trap(obj_id, "ownKeys", vec![target_val.clone()]) {
                 Ok(Some(v)) => {
-                    if !matches!(v, JsValue::Object(_)) {
+                    if !v.is_object() {
                         return Err(
                             self.create_type_error("CreateListFromArrayLike called on non-object")
                         );
                     }
-                    if let JsValue::Object(arr) = &v {
-                        let arr_id = arr.id;
+                    if let Some(arr_id) = v.as_object_id() {
                         // Use [[Get]] for length (spec: CreateListFromArrayLike)
                         let len_val = match self.get_object_property(arr_id, "length", &v) {
                             Completion::Normal(lv) => lv,
                             Completion::Throw(e) => return Err(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
-                        let len = match len_val {
-                            JsValue::Number(n) if n.is_finite() && n > 0.0 => {
+                        let len = match len_val.as_number() {
+                            Some(n) if n.is_finite() && n > 0.0 => {
                                 let len = n.floor() as usize;
                                 if len > MAX_PROXY_OWNKEYS_RESULT_LEN {
                                     return Err(self.create_type_error(
@@ -1443,8 +1416,8 @@ impl Interpreter {
                                 }
                                 len
                             }
-                            JsValue::Number(_) => 0,
-                            _ => {
+                            Some(_) => 0,
+                            None => {
                                 return Err(self.create_type_error(
                                     "ownKeys trap result length is not a number",
                                 ));
@@ -1456,12 +1429,12 @@ impl Interpreter {
                             let elem = match self.get_object_property(arr_id, &i.to_string(), &v) {
                                 Completion::Normal(ev) => ev,
                                 Completion::Throw(e) => return Err(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
                             keys.push(elem);
                         }
                         for key in &keys {
-                            if !matches!(key, JsValue::String(_) | JsValue::Symbol(_)) {
+                            if !key.is_string() && !key.is_symbol() {
                                 return Err(self.create_type_error(
                                     "'ownKeys' on proxy: trap returned non-string/symbol key",
                                 ));
@@ -1483,8 +1456,8 @@ impl Interpreter {
                     }
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_own_keys(t.id);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_own_keys(target_id);
                     }
                     Ok(vec![])
                 }
@@ -1507,14 +1480,13 @@ impl Interpreter {
             let b = obj.borrow();
 
             // String exotic objects (§10.4.3.3): virtual char indices included
-            let is_string_wrapper =
-                b.class_name == "String" && matches!(b.primitive_value, Some(JsValue::String(_)));
+            let is_string_wrapper = b.class_name == "String"
+                && b.primitive_value.as_ref().is_some_and(JsValue::is_string);
             let string_len = if is_string_wrapper {
-                if let Some(JsValue::String(ref s)) = b.primitive_value {
-                    s.code_units.len()
-                } else {
-                    0
-                }
+                b.primitive_value
+                    .as_ref()
+                    .and_then(|v| v.with_string(|s| s.len()))
+                    .unwrap_or(0)
             } else {
                 0
             };
@@ -1544,7 +1516,7 @@ impl Interpreter {
 
             if let Some(elems) = b.array_elements() {
                 for (i, value) in elems.iter().enumerate() {
-                    if matches!(value, JsValue::Undefined) || i > 0xFFFF_FFFE {
+                    if value.is_undefined() || i > 0xFFFF_FFFE {
                         continue;
                     }
                     int_keys_set.insert(i as u64, i.to_string());
@@ -1572,14 +1544,14 @@ impl Interpreter {
 
             let mut result: Vec<JsValue> = Vec::new();
             for (_, k) in int_keys_set {
-                result.push(JsValue::String(JsString::from_str(&k)));
+                result.push(JsValue::from_str(&k));
             }
             for k in str_keys {
-                result.push(JsValue::String(k.to_js_string()));
+                result.push(JsValue::string(k.to_js_string()));
             }
             // String exotic: "length" is a virtual non-enumerable string key (after other str keys, before symbols)
             if is_string_wrapper {
-                result.push(JsValue::String(JsString::from_str("length")));
+                result.push(JsValue::from_str("length"));
             }
             for k in sym_keys {
                 result.push(self.symbol_key_to_jsvalue(&k));
@@ -1603,15 +1575,15 @@ impl Interpreter {
             // Get own keys for current object (proxy-aware)
             let own_keys = self.proxy_own_keys(cid)?;
             for key in &own_keys {
-                if let JsValue::String(s) = key {
-                    let key_str = JsPropertyKey::from_js_string(s);
+                if let Some(s) = key.as_string() {
+                    let key_str = JsPropertyKey::from_js_string(&s);
                     if seen.contains(&key_str) {
                         continue;
                     }
                     // Check enumerability via proxy-aware [[GetOwnProperty]]
                     let desc_val = self.proxy_get_own_property_descriptor(cid, &key_str)?;
                     seen.insert(key_str.clone());
-                    if !matches!(desc_val, JsValue::Undefined)
+                    if !desc_val.is_undefined()
                         && let Ok(desc) = self.to_property_descriptor(&desc_val)
                         && desc.enumerable != Some(false)
                     {
@@ -1621,13 +1593,7 @@ impl Interpreter {
             }
 
             // Walk prototype chain (proxy-aware)
-            match self.proxy_get_prototype_of(cid) {
-                Ok(JsValue::Object(proto_ref)) => {
-                    current_id = Some(proto_ref.id);
-                }
-                Ok(_) => current_id = None,
-                Err(e) => return Err(e),
-            }
+            current_id = self.proxy_get_prototype_of(cid)?.as_object_id();
         }
         Ok(keys)
     }
@@ -1638,20 +1604,20 @@ impl Interpreter {
             let target_val = self.get_proxy_target_val(obj_id);
             match self.invoke_proxy_trap(obj_id, "getPrototypeOf", vec![target_val.clone()]) {
                 Ok(Some(v)) => {
-                    if !matches!(v, JsValue::Object(_) | JsValue::Null) {
+                    if !v.is_object() && !v.is_null() {
                         return Err(self.create_type_error(
                             "'getPrototypeOf' on proxy: trap returned neither object nor null",
                         ));
                     }
                     // Step 8: extensibleTarget = ? IsExtensible(target)
-                    if let JsValue::Object(ref t) = target_val {
-                        let extensible_target = self.proxy_is_extensible(t.id)?;
+                    if let Some(target_id) = target_val.as_object_id() {
+                        let extensible_target = self.proxy_is_extensible(target_id)?;
                         if !extensible_target {
                             // Step 10: targetProto = ? target.[[GetPrototypeOf]]()
-                            let actual_proto = self.proxy_get_prototype_of(t.id)?;
-                            let same = match (&v, &actual_proto) {
-                                (JsValue::Object(a), JsValue::Object(b)) => a.id == b.id,
-                                (JsValue::Null, JsValue::Null) => true,
+                            let actual_proto = self.proxy_get_prototype_of(target_id)?;
+                            let same = match (v.as_object_id(), actual_proto.as_object_id()) {
+                                (Some(a), Some(b)) => a == b,
+                                (None, None) => v.is_null() && actual_proto.is_null(),
                                 _ => false,
                             };
                             if !same {
@@ -1664,21 +1630,21 @@ impl Interpreter {
                     Ok(v)
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_get_prototype_of(t.id);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_get_prototype_of(target_id);
                     }
-                    Ok(JsValue::Null)
+                    Ok(JsValue::NULL)
                 }
                 Err(e) => Err(e),
             }
         } else if let Some(obj) = self.get_object_cell(obj_id) {
             if let Some(id) = obj.borrow().prototype_id {
-                Ok(JsValue::Object(crate::types::JsObject { id }))
+                Ok(JsValue::object(id))
             } else {
-                Ok(JsValue::Null)
+                Ok(JsValue::NULL)
             }
         } else {
-            Ok(JsValue::Null)
+            Ok(JsValue::NULL)
         }
     }
 
@@ -1700,9 +1666,7 @@ impl Interpreter {
                         return Ok(false);
                     }
                     // Step 8: IsExtensible(target) — may throw, must use proxy-aware check
-                    let target_id = if let JsValue::Object(ref t) = target_val {
-                        t.id
-                    } else {
+                    let Some(target_id) = target_val.as_object_id() else {
                         return Ok(true);
                     };
                     let extensible_target = self.proxy_is_extensible(target_id)?;
@@ -1712,9 +1676,9 @@ impl Interpreter {
                     }
                     // Step 10: GetPrototypeOf(target) — may throw
                     let actual_proto = self.proxy_get_prototype_of(target_id)?;
-                    let same = match (proto, &actual_proto) {
-                        (JsValue::Object(a), JsValue::Object(b)) => a.id == b.id,
-                        (JsValue::Null, JsValue::Null) => true,
+                    let same = match (proto.as_object_id(), actual_proto.as_object_id()) {
+                        (Some(a), Some(b)) => a == b,
+                        (None, None) => proto.is_null() && actual_proto.is_null(),
                         _ => false,
                     };
                     if !same {
@@ -1725,8 +1689,8 @@ impl Interpreter {
                     Ok(true)
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_set_prototype_of(t.id, proto);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_set_prototype_of(target_id, proto);
                     }
                     Ok(true)
                 }
@@ -1735,12 +1699,8 @@ impl Interpreter {
         } else if let Some(obj) = self.get_object_cell(obj_id) {
             // OrdinarySetPrototypeOf
             let current_proto_id = obj.borrow().prototype_id;
-            let new_proto_id = if let JsValue::Object(p) = proto {
-                Some(p.id)
-            } else {
-                None
-            };
-            let same = (matches!(proto, JsValue::Null) && current_proto_id.is_none())
+            let new_proto_id = proto.as_object_id();
+            let same = (proto.is_null() && current_proto_id.is_none())
                 || matches!((new_proto_id, current_proto_id), (Some(a), Some(b)) if a == b);
             if same {
                 return Ok(true);
@@ -1749,8 +1709,8 @@ impl Interpreter {
                 return Ok(false);
             }
             // Cycle check
-            if let JsValue::Object(p) = proto {
-                let mut check_id = Some(p.id);
+            if let Some(proto_id) = proto.as_object_id() {
+                let mut check_id = Some(proto_id);
                 while let Some(cid) = check_id {
                     if cid == obj_id {
                         return Ok(false);
@@ -1760,16 +1720,12 @@ impl Interpreter {
                         .and_then(|o| o.borrow().prototype_id.as_ref().copied());
                 }
             }
-            match proto {
-                JsValue::Null => {
-                    obj.borrow_mut().prototype_id = None;
-                }
-                JsValue::Object(p) => {
-                    if let Some(po) = self.get_object_cell(p.id) {
-                        obj.borrow_mut().prototype_id = Some(po.borrow().id.unwrap());
-                    }
-                }
-                _ => {}
+            if proto.is_null() {
+                obj.borrow_mut().prototype_id = None;
+            } else if let Some(new_id) = proto.as_object_id()
+                && let Some(po) = self.get_object_cell(new_id)
+            {
+                obj.borrow_mut().prototype_id = Some(po.borrow().id.unwrap());
             }
             Ok(true)
         } else {
@@ -1784,8 +1740,8 @@ impl Interpreter {
             match self.invoke_proxy_trap(obj_id, "isExtensible", vec![target_val.clone()]) {
                 Ok(Some(v)) => {
                     let trap_result = self.to_boolean_val(&v);
-                    if let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object_cell(t.id)
+                    if let Some(target_id) = target_val.as_object_id()
+                        && let Some(tobj) = self.get_object_cell(target_id)
                     {
                         let target_extensible = tobj.borrow().extensible;
                         if trap_result != target_extensible {
@@ -1797,8 +1753,8 @@ impl Interpreter {
                     Ok(trap_result)
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_is_extensible(t.id);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_is_extensible(target_id);
                     }
                     Ok(false)
                 }
@@ -1819,8 +1775,8 @@ impl Interpreter {
                 Ok(Some(v)) => {
                     let trap_result = self.to_boolean_val(&v);
                     if trap_result
-                        && let JsValue::Object(ref t) = target_val
-                        && let Some(tobj) = self.get_object_cell(t.id)
+                        && let Some(target_id) = target_val.as_object_id()
+                        && let Some(tobj) = self.get_object_cell(target_id)
                         && tobj.borrow().extensible
                     {
                         return Err(self.create_type_error(
@@ -1830,8 +1786,8 @@ impl Interpreter {
                     Ok(trap_result)
                 }
                 Ok(None) => {
-                    if let JsValue::Object(ref t) = target_val {
-                        return self.proxy_prevent_extensions(t.id);
+                    if let Some(target_id) = target_val.as_object_id() {
+                        return self.proxy_prevent_extensions(target_id);
                     }
                     Ok(false)
                 }
@@ -1887,11 +1843,13 @@ fn is_compatible_property_desc(
                 return false;
             }
             // 6a.ii: If Desc has [[Value]] and SameValue(Desc.[[Value]], current.[[Value]]) is false
-            if let Some(ref desc_val) = desc.value {
-                let current_val = current.value.as_ref().unwrap_or(&JsValue::Undefined);
-                if !same_value(desc_val, current_val) {
-                    return false;
-                }
+            if let Some(ref desc_val) = desc.value
+                && !same_value(
+                    desc_val,
+                    current.value.as_ref().unwrap_or(&JsValue::UNDEFINED),
+                )
+            {
+                return false;
             }
         }
         return true;
@@ -1899,18 +1857,22 @@ fn is_compatible_property_desc(
     // Step 7: Both are accessor descriptors
     if current.configurable == Some(false) {
         // 7a.i: If Desc has [[Set]] and SameValue(Desc.[[Set]], current.[[Set]]) is false
-        if let Some(ref desc_set) = desc.set {
-            let current_set = current.set.as_ref().unwrap_or(&JsValue::Undefined);
-            if !same_value(desc_set, current_set) {
-                return false;
-            }
+        if let Some(ref desc_set) = desc.set
+            && !same_value(
+                desc_set,
+                current.set.as_ref().unwrap_or(&JsValue::UNDEFINED),
+            )
+        {
+            return false;
         }
         // 7a.ii: If Desc has [[Get]] and SameValue(Desc.[[Get]], current.[[Get]]) is false
-        if let Some(ref desc_get) = desc.get {
-            let current_get = current.get.as_ref().unwrap_or(&JsValue::Undefined);
-            if !same_value(desc_get, current_get) {
-                return false;
-            }
+        if let Some(ref desc_get) = desc.get
+            && !same_value(
+                desc_get,
+                current.get.as_ref().unwrap_or(&JsValue::UNDEFINED),
+            )
+        {
+            return false;
         }
     }
     true

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -3,7 +3,7 @@ use crate::interpreter::PropertyMap;
 use crate::interpreter::generator_transform::{GeneratorStateMachine, SentValueBinding};
 use crate::interpreter::helpers::same_value;
 use crate::interpreter::key_intern::intern_js_key;
-use crate::types::{JsPropertyKey, JsString, JsValue, PropertyKeyLike, number_ops};
+use crate::types::{JsPropertyKey, JsString, JsValue, PropertyKeyLike, ValueKind, number_ops};
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
@@ -638,21 +638,37 @@ impl Realm {
             &self.typed_array_constructor,
             &self.abstract_module_source_ctor,
         ] {
-            if let Some(JsValue::Object(o)) = ctor {
-                worklist.push(o.id);
+            if let Some(id) = ctor.as_ref().and_then(JsValue::as_object_id) {
+                worklist.push(id);
             }
         }
-        if let Some(JsValue::Object(o)) = &self.throw_type_error {
-            worklist.push(o.id);
+        if let Some(id) = self
+            .throw_type_error
+            .as_ref()
+            .and_then(JsValue::as_object_id)
+        {
+            worklist.push(id);
         }
-        if let Some(JsValue::Object(o)) = &self.object_prototype_tostring {
-            worklist.push(o.id);
+        if let Some(id) = self
+            .object_prototype_tostring
+            .as_ref()
+            .and_then(JsValue::as_object_id)
+        {
+            worklist.push(id);
         }
-        if let Some(JsValue::Object(o)) = &self.sloppy_caller_getter {
-            worklist.push(o.id);
+        if let Some(id) = self
+            .sloppy_caller_getter
+            .as_ref()
+            .and_then(JsValue::as_object_id)
+        {
+            worklist.push(id);
         }
-        if let Some(JsValue::Object(o)) = &self.sloppy_arguments_getter {
-            worklist.push(o.id);
+        if let Some(id) = self
+            .sloppy_arguments_getter
+            .as_ref()
+            .and_then(JsValue::as_object_id)
+        {
+            worklist.push(id);
         }
         for &obj_id in self.template_cache.values() {
             worklist.push(obj_id);
@@ -860,7 +876,7 @@ impl Environment {
         self.bindings.insert(
             name.to_string(),
             Binding {
-                value: JsValue::Undefined,
+                value: JsValue::UNDEFINED,
                 kind,
                 initialized: kind == BindingKind::Var,
                 deletable: false,
@@ -928,7 +944,7 @@ impl Environment {
         self.bindings.insert(
             name.to_string(),
             Binding {
-                value: JsValue::Undefined,
+                value: JsValue::UNDEFINED,
                 kind,
                 initialized: kind == BindingKind::Var,
                 deletable: true,
@@ -974,31 +990,25 @@ impl Environment {
     pub(crate) fn set(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         // Indirect bindings (module imports) are immutable
         if self.is_indirect_binding(name) {
-            return Err(JsValue::String(JsString::from_str(
-                "Assignment to constant variable.",
-            )));
+            return Err(JsValue::from_str("Assignment to constant variable."));
         }
         if let Some(binding) = self.bindings.get_mut(name) {
             // TDZ: let/const bindings that haven't been initialized yet
             if !binding.initialized && matches!(binding.kind, BindingKind::Let | BindingKind::Const)
             {
-                return Err(JsValue::String(JsString::from_str(&format!(
+                return Err(JsValue::from_str(&format!(
                     "Cannot access '{name}' before initialization"
-                ))));
+                )));
             }
             if binding.kind == BindingKind::Const && binding.initialized {
-                return Err(JsValue::String(JsString::from_str(
-                    "Assignment to constant variable.",
-                )));
+                return Err(JsValue::from_str("Assignment to constant variable."));
             }
             if (binding.kind == BindingKind::FunctionName
                 || binding.kind == BindingKind::ImmutableValue)
                 && binding.initialized
             {
                 if self.strict {
-                    return Err(JsValue::String(JsString::from_str(
-                        "Assignment to constant variable.",
-                    )));
+                    return Err(JsValue::from_str("Assignment to constant variable."));
                 }
                 return Ok(());
             }
@@ -2073,15 +2083,15 @@ impl JsObjectData {
 
     fn string_exotic_value<K: PropertyKeyLike + ?Sized>(&self, key: &K) -> Option<JsValue> {
         let key = key.as_property_key_str()?;
-        if let Some(JsValue::String(ref s)) = self.primitive_value
-            && self.class_name == "String"
+        if self.class_name == "String"
+            && let Some(s) = self.primitive_value.as_ref().and_then(JsValue::as_string)
         {
             let units = &s.code_units;
             if key == "length" {
-                return Some(JsValue::Number(units.len() as f64));
+                return Some(JsValue::number(units.len() as f64));
             }
             if let Some(idx) = string_exotic_index(key, units.len()) {
-                return Some(JsValue::String(crate::types::JsString::from_vec(vec![
+                return Some(JsValue::string(crate::types::JsString::from_vec(vec![
                     units[idx],
                 ])));
             }
@@ -2115,7 +2125,7 @@ impl JsObjectData {
             && let Some(elems) = self.array_elements()
             && let Ok(idx) = key_str.parse::<usize>()
             && idx < elems.len()
-            && !matches!(elems[idx], JsValue::Undefined)
+            && !elems[idx].is_undefined()
         {
             return Some(PropertyDescriptor {
                 value: Some(elems[idx].clone()),
@@ -2141,13 +2151,13 @@ impl JsObjectData {
             }
             return None;
         }
-        if let Some(JsValue::String(ref s)) = self.primitive_value
-            && self.class_name == "String"
+        if self.class_name == "String"
+            && let Some(s) = self.primitive_value.as_ref().and_then(JsValue::as_string)
         {
             let units = &s.code_units;
             if key.as_property_key_str() == Some("length") {
                 return Some(PropertyDescriptor {
-                    value: Some(JsValue::Number(units.len() as f64)),
+                    value: Some(JsValue::number(units.len() as f64)),
                     writable: Some(false),
                     enumerable: Some(false),
                     configurable: Some(false),
@@ -2157,7 +2167,7 @@ impl JsObjectData {
             }
             if let Some(idx) = string_exotic_index(key, units.len()) {
                 return Some(PropertyDescriptor {
-                    value: Some(JsValue::String(crate::types::JsString::from_vec(vec![
+                    value: Some(JsValue::string(crate::types::JsString::from_vec(vec![
                         units[idx],
                     ]))),
                     writable: Some(false),
@@ -2185,9 +2195,9 @@ impl JsObjectData {
                         .env
                         .borrow()
                         .get(binding_name)
-                        .unwrap_or(JsValue::Undefined)
+                        .unwrap_or(JsValue::UNDEFINED)
                 } else {
-                    JsValue::Undefined
+                    JsValue::UNDEFINED
                 };
                 return Some(PropertyDescriptor {
                     value: Some(val),
@@ -2215,10 +2225,10 @@ impl JsObjectData {
             // OrdinaryGetOwnProperty: complete accessor descriptors
             if d.is_accessor_descriptor() {
                 if d.get.is_none() {
-                    d.get = Some(JsValue::Undefined);
+                    d.get = Some(JsValue::UNDEFINED);
                 }
                 if d.set.is_none() {
-                    d.set = Some(JsValue::Undefined);
+                    d.set = Some(JsValue::UNDEFINED);
                 }
             }
             return Some(d);
@@ -2226,7 +2236,7 @@ impl JsObjectData {
         if let Some(elems) = self.array_elements()
             && let Some(idx) = parse_array_index(key)
             && (idx as usize) < elems.len()
-            && !matches!(elems[idx as usize], JsValue::Undefined)
+            && !elems[idx as usize].is_undefined()
         {
             return Some(PropertyDescriptor {
                 value: Some(elems[idx as usize].clone()),
@@ -2254,12 +2264,12 @@ impl JsObjectData {
             return None;
         }
         // String exotic: §10.4.3.1
-        if let Some(JsValue::String(ref s)) = self.primitive_value
-            && self.class_name == "String"
+        if self.class_name == "String"
+            && let Some(s) = self.primitive_value.as_ref().and_then(JsValue::as_string)
         {
             if key.as_property_key_str() == Some("length") {
                 return Some(PropertyDescriptor::data(
-                    JsValue::Number(s.code_units.len() as f64),
+                    JsValue::number(s.code_units.len() as f64),
                     false,
                     false,
                     false,
@@ -2267,7 +2277,7 @@ impl JsObjectData {
             }
             if let Some(idx) = string_exotic_index(key, s.code_units.len()) {
                 return Some(PropertyDescriptor::data(
-                    JsValue::String(JsString::from_vec(vec![s.code_units[idx]])),
+                    JsValue::string(JsString::from_vec(vec![s.code_units[idx]])),
                     false,
                     true,
                     false,
@@ -2290,7 +2300,7 @@ impl JsObjectData {
         if let Some(elems) = self.array_elements()
             && let Some(idx) = parse_array_index(key)
             && (idx as usize) < elems.len()
-            && !matches!(elems[idx as usize], JsValue::Undefined)
+            && !elems[idx as usize].is_undefined()
         {
             return true;
         }
@@ -2300,8 +2310,8 @@ impl JsObjectData {
         {
             return is_valid_integer_index(ta, index);
         }
-        if let Some(JsValue::String(ref s)) = self.primitive_value
-            && self.class_name == "String"
+        if self.class_name == "String"
+            && let Some(s) = self.primitive_value.as_ref().and_then(JsValue::as_string)
         {
             if key.as_property_key_str() == Some("length") {
                 return true;
@@ -2324,7 +2334,7 @@ impl JsObjectData {
         let key = intern_js_key(key.into());
         // String exotic §10.4.3.3 [[DefineOwnProperty]]: reject changes to character index properties
         if self.class_name == "String"
-            && let Some(JsValue::String(ref s)) = self.primitive_value
+            && let Some(s) = self.primitive_value.as_ref().and_then(JsValue::as_string)
             && let Some(idx) = string_exotic_index(&key, s.code_units.len())
         {
             // String index property: {value: char, writable: false, enumerable: true, configurable: false}
@@ -2343,7 +2353,7 @@ impl JsObjectData {
             }
             if let Some(ref v) = desc.value {
                 let char_val =
-                    JsValue::String(crate::types::JsString::from_vec(vec![s.code_units[idx]]));
+                    JsValue::string(crate::types::JsString::from_vec(vec![s.code_units[idx]]));
                 if !same_value(v, &char_val) {
                     return false;
                 }
@@ -2492,13 +2502,13 @@ impl JsObjectData {
                 } else if current_is_accessor {
                     // Non-configurable accessor property
                     if let Some(ref new_get) = desc.get {
-                        let cur_get = current.get.as_ref().unwrap_or(&JsValue::Undefined);
+                        let cur_get = current.get.as_ref().unwrap_or(&JsValue::UNDEFINED);
                         if !same_value(new_get, cur_get) {
                             return false;
                         }
                     }
                     if let Some(ref new_set) = desc.set {
-                        let cur_set = current.set.as_ref().unwrap_or(&JsValue::Undefined);
+                        let cur_set = current.set.as_ref().unwrap_or(&JsValue::UNDEFINED);
                         if !same_value(new_set, cur_set) {
                             return false;
                         }
@@ -2546,7 +2556,7 @@ impl JsObjectData {
             {
                 // Changing from accessor to data
                 PropertyDescriptor {
-                    value: desc.value.or(Some(JsValue::Undefined)),
+                    value: desc.value.or(Some(JsValue::UNDEFINED)),
                     writable: desc.writable.or(Some(false)),
                     get: None,
                     set: None,
@@ -2558,8 +2568,8 @@ impl JsObjectData {
                 PropertyDescriptor {
                     value: None,
                     writable: None,
-                    get: desc.get.or(Some(JsValue::Undefined)),
-                    set: desc.set.or(Some(JsValue::Undefined)),
+                    get: desc.get.or(Some(JsValue::UNDEFINED)),
+                    set: desc.set.or(Some(JsValue::UNDEFINED)),
                     enumerable: desc.enumerable.or(current.enumerable),
                     configurable: desc.configurable.or(current.configurable),
                 }
@@ -2657,7 +2667,7 @@ impl JsObjectData {
             let is_accessor = desc.is_accessor_descriptor();
             let new_desc = PropertyDescriptor {
                 value: desc.value.or(if !is_accessor {
-                    Some(JsValue::Undefined)
+                    Some(JsValue::UNDEFINED)
                 } else {
                     None
                 }),
@@ -2706,9 +2716,9 @@ impl JsObjectData {
             if !len_writable {
                 return false;
             }
-            if let JsValue::Number(new_len_f) = &value {
-                let new_len_u32 = *new_len_f as u32;
-                if (new_len_u32 as f64) != *new_len_f {
+            if let Some(new_len_f) = value.as_number() {
+                let new_len_u32 = new_len_f as u32;
+                if (new_len_u32 as f64) != new_len_f {
                     // ArraySetLength §10.4.2.4 step 5: invalid length
                     return false;
                 }
@@ -2717,13 +2727,8 @@ impl JsObjectData {
                     .properties
                     .get("length")
                     .and_then(|d| d.value.as_ref())
-                    .and_then(|v| {
-                        if let JsValue::Number(n) = v {
-                            Some(*n as u32)
-                        } else {
-                            None
-                        }
-                    });
+                    .and_then(JsValue::as_number)
+                    .map(|n| n as u32);
                 if let Some(old_len) = old_len
                     && new_len_u32 < old_len
                 {
@@ -2769,7 +2774,7 @@ impl JsObjectData {
                     }
                 }
                 if let Some(desc) = self.properties.get_mut("length") {
-                    desc.value = Some(JsValue::Number(actual_new_len as f64));
+                    desc.value = Some(JsValue::number(actual_new_len as f64));
                     return true;
                 }
             }
@@ -2781,7 +2786,7 @@ impl JsObjectData {
             let _ = env_ref.borrow_mut().set(param_name, value.clone());
         }
         if self.class_name == "Array"
-            && !matches!(value, JsValue::Undefined)
+            && !value.is_undefined()
             && !self.properties.contains_key(key)
             && let Some(idx_u32) = parse_array_index(key)
             && self.array_elements().is_some()
@@ -2791,13 +2796,8 @@ impl JsObjectData {
                 .properties
                 .get("length")
                 .and_then(|d| d.value.as_ref())
-                .and_then(|v| {
-                    if let JsValue::Number(n) = v {
-                        Some(*n as u32)
-                    } else {
-                        None
-                    }
-                })
+                .and_then(JsValue::as_number)
+                .map(|n| n as u32)
                 .unwrap_or(0);
             let length_writable = self
                 .properties
@@ -2807,7 +2807,7 @@ impl JsObjectData {
             let extensible = self.extensible;
             let elements = self.array_elements_mut().unwrap();
             if idx <= elements.len() + 1024 {
-                let existed = idx < elements.len() && !matches!(elements[idx], JsValue::Undefined);
+                let existed = idx < elements.len() && !elements[idx].is_undefined();
                 if !existed && !extensible {
                     return false;
                 }
@@ -2818,14 +2818,14 @@ impl JsObjectData {
                     elements[idx] = value;
                 } else {
                     while elements.len() < idx {
-                        elements.push(JsValue::Undefined);
+                        elements.push(JsValue::UNDEFINED);
                     }
                     elements.push(value);
                 }
                 if idx_u32 >= old_len
                     && let Some(len_desc) = self.properties.get_mut("length")
                 {
-                    len_desc.value = Some(JsValue::Number((idx_u32 + 1) as f64));
+                    len_desc.value = Some(JsValue::number((idx_u32 + 1) as f64));
                 }
                 if !existed {
                     self.shape_id = fresh_shape_id();
@@ -2844,7 +2844,7 @@ impl JsObjectData {
             } else if idx < 0xFFFF_FFFF && idx <= elements.len() + 1024 {
                 // Extend for small gaps and valid array indices only
                 while elements.len() < idx {
-                    elements.push(JsValue::Undefined);
+                    elements.push(JsValue::UNDEFINED);
                 }
                 elements.push(value.clone());
                 // Issue #71 (Step 5): array_elements grew — structural mutation.
@@ -2852,19 +2852,19 @@ impl JsObjectData {
                 // Only update length if idx+1 exceeds the current property length
                 let new_idx_len = (idx + 1) as f64;
                 if let Some(len_desc) = self.properties.get_mut("length")
-                    && let Some(JsValue::Number(cur_len)) = &len_desc.value
-                    && new_idx_len > *cur_len
+                    && let Some(cur_len) = len_desc.value.as_ref().and_then(JsValue::as_number)
+                    && new_idx_len > cur_len
                 {
-                    len_desc.value = Some(JsValue::Number(new_idx_len));
+                    len_desc.value = Some(JsValue::number(new_idx_len));
                 }
             } else if idx < 0xFFFF_FFFF {
                 // Valid array index but too sparse for array_elements — update length
                 let new_len = (idx + 1) as f64;
                 if let Some(len_desc) = self.properties.get_mut("length")
-                    && let Some(JsValue::Number(cur_len)) = &len_desc.value
-                    && new_len > *cur_len
+                    && let Some(cur_len) = len_desc.value.as_ref().and_then(JsValue::as_number)
+                    && new_len > cur_len
                 {
-                    len_desc.value = Some(JsValue::Number(new_len));
+                    len_desc.value = Some(JsValue::number(new_len));
                 }
             }
             // idx >= 0xFFFFFFFF: not a valid array index, stored as named property
@@ -2877,8 +2877,8 @@ impl JsObjectData {
             true
         } else {
             // String exotic: length and index properties are non-writable (§10.4.3.2)
-            if let Some(JsValue::String(ref s)) = self.primitive_value
-                && self.class_name == "String"
+            if self.class_name == "String"
+                && let Some(s) = self.primitive_value.as_ref().and_then(JsValue::as_string)
                 && (key.as_property_key_str() == Some("length")
                     || string_exotic_index(key, s.code_units.len()).is_some())
             {
@@ -2971,7 +2971,7 @@ impl JsObjectData {
                     .env
                     .borrow()
                     .get(binding_name)
-                    .unwrap_or(JsValue::Undefined),
+                    .unwrap_or(JsValue::UNDEFINED),
             );
         }
         if let Some(key_str) = key.as_property_key_str()
@@ -2985,13 +2985,13 @@ impl JsObjectData {
             if let Some(ref val) = desc.value {
                 return Some(val.clone());
             }
-            return Some(JsValue::Undefined);
+            return Some(JsValue::UNDEFINED);
         }
         if let Some(key_str) = key.as_property_key_str()
             && let Some(elems) = self.array_elements()
             && let Ok(idx) = key_str.parse::<usize>()
             && idx < elems.len()
-            && !matches!(elems[idx], JsValue::Undefined)
+            && !elems[idx].is_undefined()
         {
             return Some(elems[idx].clone());
         }
@@ -3001,7 +3001,7 @@ impl JsObjectData {
             if is_valid_integer_index(ta, index) {
                 return Some(typed_array_get_index(ta, index as usize));
             }
-            return Some(JsValue::Undefined);
+            return Some(JsValue::UNDEFINED);
         }
         if let Some(val) = self.string_exotic_value(key) {
             return Some(val);
@@ -3028,10 +3028,10 @@ impl JsObjectData {
             }
             if d.is_accessor_descriptor() {
                 if d.get.is_none() {
-                    d.get = Some(JsValue::Undefined);
+                    d.get = Some(JsValue::UNDEFINED);
                 }
                 if d.set.is_none() {
-                    d.set = Some(JsValue::Undefined);
+                    d.set = Some(JsValue::UNDEFINED);
                 }
             }
             return Some(d);
@@ -3040,7 +3040,7 @@ impl JsObjectData {
             && let Some(elems) = self.array_elements()
             && let Ok(idx) = key_str.parse::<usize>()
             && idx < elems.len()
-            && !matches!(elems[idx], JsValue::Undefined)
+            && !elems[idx].is_undefined()
         {
             return Some(PropertyDescriptor {
                 value: Some(elems[idx].clone()),
@@ -3066,13 +3066,13 @@ impl JsObjectData {
             }
             return None;
         }
-        if let Some(JsValue::String(ref s)) = self.primitive_value
-            && self.class_name == "String"
+        if self.class_name == "String"
+            && let Some(s) = self.primitive_value.as_ref().and_then(JsValue::as_string)
         {
             let units = &s.code_units;
             if key.as_property_key_str() == Some("length") {
                 return Some(PropertyDescriptor {
-                    value: Some(JsValue::Number(units.len() as f64)),
+                    value: Some(JsValue::number(units.len() as f64)),
                     writable: Some(false),
                     enumerable: Some(false),
                     configurable: Some(false),
@@ -3082,7 +3082,7 @@ impl JsObjectData {
             }
             if let Some(idx) = string_exotic_index(key, units.len()) {
                 return Some(PropertyDescriptor {
-                    value: Some(JsValue::String(crate::types::JsString::from_vec(vec![
+                    value: Some(JsValue::string(crate::types::JsString::from_vec(vec![
                         units[idx],
                     ]))),
                     writable: Some(false),
@@ -3125,8 +3125,8 @@ impl JsObjectData {
         let mut index_keys: Vec<(u32, JsPropertyKey)> = Vec::new();
         let mut string_keys: Vec<JsPropertyKey> = Vec::new();
 
-        if let Some(JsValue::String(ref s)) = self.primitive_value
-            && self.class_name == "String"
+        if self.class_name == "String"
+            && let Some(s) = self.primitive_value.as_ref().and_then(JsValue::as_string)
         {
             let utf16_len = s.code_units.len();
             for i in 0..utf16_len {
@@ -3149,7 +3149,7 @@ impl JsObjectData {
 
         if let Some(elems) = self.array_elements() {
             for (i, value) in elems.iter().enumerate() {
-                if matches!(value, JsValue::Undefined) || i > 0xFFFF_FFFE {
+                if value.is_undefined() || i > 0xFFFF_FFFE {
                     continue;
                 }
                 let k = JsPropertyKey::from(i.to_string());
@@ -3336,33 +3336,33 @@ fn typed_array_get_index_shared(
     match kind {
         TypedArrayKind::Int8 => sab.with_read(|buf| {
             if offset + 1 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
-            JsValue::Number(buf[offset] as i8 as f64)
+            JsValue::number(buf[offset] as i8 as f64)
         }),
         TypedArrayKind::Uint8 | TypedArrayKind::Uint8Clamped => sab.with_read(|buf| {
             if offset + 1 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
-            JsValue::Number(buf[offset] as f64)
+            JsValue::number(buf[offset] as f64)
         }),
         TypedArrayKind::Int16 => sab.with_read(|buf| {
             if offset + 2 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let v = i16::from_ne_bytes([buf[offset], buf[offset + 1]]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }),
         TypedArrayKind::Uint16 => sab.with_read(|buf| {
             if offset + 2 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let v = u16::from_ne_bytes([buf[offset], buf[offset + 1]]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }),
         TypedArrayKind::Int32 => sab.with_read(|buf| {
             if offset + 4 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let v = i32::from_ne_bytes([
                 buf[offset],
@@ -3370,11 +3370,11 @@ fn typed_array_get_index_shared(
                 buf[offset + 2],
                 buf[offset + 3],
             ]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }),
         TypedArrayKind::Uint32 => sab.with_read(|buf| {
             if offset + 4 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let v = u32::from_ne_bytes([
                 buf[offset],
@@ -3382,31 +3382,31 @@ fn typed_array_get_index_shared(
                 buf[offset + 2],
                 buf[offset + 3],
             ]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }),
         TypedArrayKind::BigInt64 => sab.with_read(|buf| {
             if offset + 8 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let mut bytes = [0u8; 8];
             bytes.copy_from_slice(&buf[offset..offset + 8]);
-            JsValue::BigInt(crate::types::JsBigInt::new(num_bigint::BigInt::from(
+            JsValue::bigint(crate::types::JsBigInt::new(num_bigint::BigInt::from(
                 i64::from_ne_bytes(bytes),
             )))
         }),
         TypedArrayKind::BigUint64 => sab.with_read(|buf| {
             if offset + 8 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let mut bytes = [0u8; 8];
             bytes.copy_from_slice(&buf[offset..offset + 8]);
-            JsValue::BigInt(crate::types::JsBigInt::new(num_bigint::BigInt::from(
+            JsValue::bigint(crate::types::JsBigInt::new(num_bigint::BigInt::from(
                 u64::from_ne_bytes(bytes),
             )))
         }),
         TypedArrayKind::Float16 => sab.with_read(|buf| {
             if offset + 2 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let bits = u16::from_ne_bytes([buf[offset], buf[offset + 1]]);
             JsValue::number(crate::interpreter::builtins::typedarray::dv_f16_to_f64(
@@ -3415,7 +3415,7 @@ fn typed_array_get_index_shared(
         }),
         TypedArrayKind::Float32 => sab.with_read(|buf| {
             if offset + 4 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let v = f32::from_ne_bytes([
                 buf[offset],
@@ -3427,7 +3427,7 @@ fn typed_array_get_index_shared(
         }),
         TypedArrayKind::Float64 => sab.with_read(|buf| {
             if offset + 8 > buf.len() {
-                return JsValue::Undefined;
+                return JsValue::UNDEFINED;
             }
             let mut bytes = [0u8; 8];
             bytes.copy_from_slice(&buf[offset..offset + 8]);
@@ -3438,7 +3438,7 @@ fn typed_array_get_index_shared(
 
 pub(crate) fn typed_array_get_index(ta: &TypedArrayInfo, idx: usize) -> JsValue {
     if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-        return JsValue::Undefined;
+        return JsValue::UNDEFINED;
     }
     let offset = ta.byte_offset + idx * ta.kind.bytes_per_element();
     let buf_borrow = ta.buffer.borrow();
@@ -3447,20 +3447,20 @@ pub(crate) fn typed_array_get_index(ta: &TypedArrayInfo, idx: usize) -> JsValue 
     }
     buf_borrow.with_read(|buf| {
         if offset + ta.kind.bytes_per_element() > buf.len() {
-            return JsValue::Undefined;
+            return JsValue::UNDEFINED;
         }
         match ta.kind {
-            TypedArrayKind::Int8 => JsValue::Number(buf[offset] as i8 as f64),
+            TypedArrayKind::Int8 => JsValue::number(buf[offset] as i8 as f64),
             TypedArrayKind::Uint8 | TypedArrayKind::Uint8Clamped => {
-                JsValue::Number(buf[offset] as f64)
+                JsValue::number(buf[offset] as f64)
             }
             TypedArrayKind::Int16 => {
                 let v = i16::from_ne_bytes([buf[offset], buf[offset + 1]]);
-                JsValue::Number(v as f64)
+                JsValue::number(v as f64)
             }
             TypedArrayKind::Uint16 => {
                 let v = u16::from_ne_bytes([buf[offset], buf[offset + 1]]);
-                JsValue::Number(v as f64)
+                JsValue::number(v as f64)
             }
             TypedArrayKind::Int32 => {
                 let v = i32::from_ne_bytes([
@@ -3469,7 +3469,7 @@ pub(crate) fn typed_array_get_index(ta: &TypedArrayInfo, idx: usize) -> JsValue 
                     buf[offset + 2],
                     buf[offset + 3],
                 ]);
-                JsValue::Number(v as f64)
+                JsValue::number(v as f64)
             }
             TypedArrayKind::Uint32 => {
                 let v = u32::from_ne_bytes([
@@ -3478,7 +3478,7 @@ pub(crate) fn typed_array_get_index(ta: &TypedArrayInfo, idx: usize) -> JsValue 
                     buf[offset + 2],
                     buf[offset + 3],
                 ]);
-                JsValue::Number(v as f64)
+                JsValue::number(v as f64)
             }
             TypedArrayKind::Float32 => {
                 let v = f32::from_ne_bytes([
@@ -3497,14 +3497,14 @@ pub(crate) fn typed_array_get_index(ta: &TypedArrayInfo, idx: usize) -> JsValue 
             TypedArrayKind::BigInt64 => {
                 let mut bytes = [0u8; 8];
                 bytes.copy_from_slice(&buf[offset..offset + 8]);
-                JsValue::BigInt(crate::types::JsBigInt::new(num_bigint::BigInt::from(
+                JsValue::bigint(crate::types::JsBigInt::new(num_bigint::BigInt::from(
                     i64::from_ne_bytes(bytes),
                 )))
             }
             TypedArrayKind::BigUint64 => {
                 let mut bytes = [0u8; 8];
                 bytes.copy_from_slice(&buf[offset..offset + 8]);
-                JsValue::BigInt(crate::types::JsBigInt::new(num_bigint::BigInt::from(
+                JsValue::bigint(crate::types::JsBigInt::new(num_bigint::BigInt::from(
                     u64::from_ne_bytes(bytes),
                 )))
             }
@@ -3692,13 +3692,25 @@ pub(crate) fn typed_array_set_index(ta: &TypedArrayInfo, idx: usize, value: &JsV
 }
 
 fn to_number(v: &JsValue) -> f64 {
-    match v {
-        JsValue::Number(n) => *n,
-        JsValue::Boolean(true) => 1.0,
-        JsValue::Boolean(false) | JsValue::Null => 0.0,
-        JsValue::Undefined => f64::NAN,
-        JsValue::String(s) => s.to_string().parse::<f64>().unwrap_or(f64::NAN),
-        _ => f64::NAN,
+    match v.kind() {
+        ValueKind::Number => v.as_number().expect("kind checked"),
+        ValueKind::Boolean => {
+            if v.as_boolean().expect("kind checked") {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        ValueKind::Null => 0.0,
+        ValueKind::Undefined => f64::NAN,
+        ValueKind::String => v
+            .with_string(|units| {
+                String::from_utf16_lossy(units)
+                    .parse::<f64>()
+                    .unwrap_or(f64::NAN)
+            })
+            .expect("kind checked"),
+        ValueKind::Symbol | ValueKind::BigInt | ValueKind::Object => f64::NAN,
     }
 }
 
@@ -3741,29 +3753,27 @@ fn to_uint32(v: &JsValue) -> u32 {
     number_ops::to_uint32(to_number(v))
 }
 fn to_bigint64(v: &JsValue) -> i64 {
-    match v {
-        JsValue::BigInt(b) => {
-            i64::try_from(b.value.as_ref()).unwrap_or_else(|_| {
-                // Truncate to 64 bits
-                let bytes = b.value.to_signed_bytes_le();
-                let mut result = [0u8; 8];
-                let len = bytes.len().min(8);
-                result[..len].copy_from_slice(&bytes[..len]);
-                if bytes.len() < 8 && !bytes.is_empty() && (bytes[bytes.len() - 1] & 0x80) != 0 {
-                    for byte in result.iter_mut().skip(len) {
-                        *byte = 0xFF;
-                    }
+    v.with_bigint(|b| {
+        i64::try_from(b).unwrap_or_else(|_| {
+            // Truncate to 64 bits
+            let bytes = b.to_signed_bytes_le();
+            let mut result = [0u8; 8];
+            let len = bytes.len().min(8);
+            result[..len].copy_from_slice(&bytes[..len]);
+            if bytes.len() < 8 && !bytes.is_empty() && (bytes[bytes.len() - 1] & 0x80) != 0 {
+                for byte in result.iter_mut().skip(len) {
+                    *byte = 0xFF;
                 }
-                i64::from_le_bytes(result)
-            })
-        }
-        _ => 0,
-    }
+            }
+            i64::from_le_bytes(result)
+        })
+    })
+    .unwrap_or(0)
 }
 fn to_biguint64(v: &JsValue) -> u64 {
-    match v {
-        JsValue::BigInt(b) => u64::try_from(b.value.as_ref()).unwrap_or_else(|_| {
-            let bytes = b.value.to_signed_bytes_le();
+    v.with_bigint(|b| {
+        u64::try_from(b).unwrap_or_else(|_| {
+            let bytes = b.to_signed_bytes_le();
             let mut result = [0u8; 8];
             let len = bytes.len().min(8);
             result[..len].copy_from_slice(&bytes[..len]);
@@ -3774,9 +3784,9 @@ fn to_biguint64(v: &JsValue) -> u64 {
                 }
             }
             u64::from_le_bytes(result)
-        }),
-        _ => 0,
-    }
+        })
+    })
+    .unwrap_or(0)
 }
 
 #[derive(Debug, Clone)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -817,21 +817,24 @@ pub(crate) mod bigint_ops {
 
 impl fmt::Display for JsValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            JsValue::Undefined => write!(f, "undefined"),
-            JsValue::Null => write!(f, "null"),
-            JsValue::Boolean(b) => write!(f, "{b}"),
-            JsValue::Number(n) => write!(f, "{}", number_ops::to_string(*n)),
-            JsValue::String(s) => write!(f, "{s}"),
-            JsValue::Symbol(s) => {
-                if let Some(desc) = s.description() {
-                    write!(f, "Symbol({desc})")
-                } else {
-                    write!(f, "Symbol()")
-                }
+        match self.kind() {
+            ValueKind::Undefined => write!(f, "undefined"),
+            ValueKind::Null => write!(f, "null"),
+            ValueKind::Boolean => write!(f, "{}", self.as_boolean().unwrap()),
+            ValueKind::Number => {
+                write!(f, "{}", number_ops::to_string(self.as_number().unwrap()))
             }
-            JsValue::BigInt(b) => write!(f, "{}n", b.value),
-            JsValue::Object(_) => write!(f, "[object Object]"),
+            ValueKind::String => self
+                .with_string(|units| write!(f, "{}", String::from_utf16_lossy(units)))
+                .unwrap(),
+            ValueKind::Symbol => self
+                .with_symbol(|s| match s.description() {
+                    Some(desc) => write!(f, "Symbol({desc})"),
+                    None => write!(f, "Symbol()"),
+                })
+                .unwrap(),
+            ValueKind::BigInt => self.with_bigint(|b| write!(f, "{b}n")).unwrap(),
+            ValueKind::Object => write!(f, "[object Object]"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Converts direct `JsValue::Variant` construction/pattern-matching to PR #154's accessor API (`as_*`/`with_*`/`into_*`/`kind()`/`discriminant()`, plus the `is_*` predicates) in `src/types.rs` (Display impl only — the accessor/constructor surface itself must keep matching the raw enum), `src/interpreter/gc.rs`, `src/interpreter/env_helpers.rs`, `src/interpreter/helpers.rs`, `src/interpreter/property.rs`, and `src/interpreter/types.rs` (non-test body).
- `src/interpreter/property_map.rs` needed no production changes — its only `JsValue::` sites are inside `#[cfg(test)]`.
- Mechanical, zero-behavior-change: exhaustive multi-arm dispatch (Display, ToBoolean, ToNumber, strict equality, JSON.stringify, typeof) now matches on `.kind()` to preserve compile-time exhaustiveness ahead of the Phase 3 representation swap.
- Does not touch the raw-byte float-read sites in `interpreter/types.rs` already converted by #425, or any `#[cfg(test)]` module (test-scope conversion is a separate, later issue).

This is Phase 2.1 of the NaN-boxing epic (#69, design in #402) — one of 7 independent conversion PRs splitting ~5,700 call sites across 54 files.

Fixes #407

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo clippy --release -- -D warnings` — clean
- [x] `cargo test --release` — 453 unit tests + integration tests pass
- [x] Full test262 (`scripts/run-test262.py -j 32`) — 100.00% (99,568/99,568), 0 regressions vs `origin/main:test262-pass.txt`
- [x] test262-extra (`scripts/run-test262.py test262-extra/`) — 100.00% (118/118), including the bit-exact NaN round-trip tests from #425/#426
- [x] Custom tests (`scripts/run-custom-tests.py`) — 11/11 pass