### PR TITLE
refactor(nan-box): migrate TypedArray/Atomics/RegExp/iterators to JsValue accessors

### DIFF
--- a/src/interpreter/builtins/atomics.rs
+++ b/src/interpreter/builtins/atomics.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use crate::interpreter::types::{BufferData, SharedBufferInner};
-use crate::types::{JsBigInt, JsObject, JsString, JsValue};
+use crate::types::{JsBigInt, JsValue};
 use rustc_hash::FxHashMap;
 use std::sync::atomic::{
     AtomicI8, AtomicI16, AtomicI32, AtomicI64, AtomicU8, AtomicU16, AtomicU32, Ordering,
@@ -15,8 +15,8 @@ static WAITER_MAP: LazyLock<Mutex<FxHashMap<(u64, usize), Vec<WaiterEntry>>>> =
     LazyLock::new(|| Mutex::new(FxHashMap::default()));
 
 fn check_ta_detached(interp: &mut Interpreter, ta_val: &JsValue) -> Result<(), JsValue> {
-    let detached = if let JsValue::Object(o) = ta_val {
-        interp.get_object_cell(o.id).is_some_and(|cell| {
+    let detached = if let Some(ta_id) = ta_val.as_object_id() {
+        interp.get_object_cell(ta_id).is_some_and(|cell| {
             cell.borrow()
                 .typed_array_info()
                 .is_some_and(|info| info.is_detached.get())
@@ -31,8 +31,8 @@ fn check_ta_detached(interp: &mut Interpreter, ta_val: &JsValue) -> Result<(), J
 }
 
 fn get_sab_info(interp: &Interpreter, ta_val: &JsValue) -> Option<(Arc<SharedBufferInner>, usize)> {
-    if let JsValue::Object(o) = ta_val
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(ta_id) = ta_val.as_object_id()
+        && let Some(obj) = interp.get_object_cell(ta_id)
     {
         let obj_ref = obj.borrow();
         let byte_offset = obj_ref
@@ -100,8 +100,8 @@ impl Interpreter {
 
         // Atomics.load
         self.define_method(atomics_obj_id, "load", 2, |interp, _this, args| {
-            let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-            let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let ta_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let index_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             let (kind, buffer, byte_offset, element_size, is_bigint) =
                 match validate_integer_typed_array(interp, &ta_val, false, false) {
                     Ok(info) => info,
@@ -130,9 +130,9 @@ impl Interpreter {
 
         // Atomics.store
         self.define_method(atomics_obj_id, "store", 3, |interp, _this, args| {
-            let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-            let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-            let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+            let ta_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let index_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            let value = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
             let (kind, buffer, byte_offset, element_size, is_bigint) =
                 match validate_integer_typed_array(interp, &ta_val, false, true) {
                     Ok(info) => info,
@@ -161,7 +161,7 @@ impl Interpreter {
                 } else {
                     n.trunc()
                 };
-                (JsValue::Number(n), JsValue::Number(int_val))
+                (JsValue::number(n), JsValue::number(int_val))
             };
             if let Err(e) = check_ta_detached(interp, &ta_val) {
                 return Completion::Throw(e);
@@ -187,10 +187,10 @@ impl Interpreter {
             "compareExchange",
             4,
             |interp, _this, args| {
-                let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                let expected_val = args.get(2).cloned().unwrap_or(JsValue::Undefined);
-                let replacement_val = args.get(3).cloned().unwrap_or(JsValue::Undefined);
+                let ta_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let index_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                let expected_val = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
+                let replacement_val = args.get(3).cloned().unwrap_or(JsValue::UNDEFINED);
                 let (kind, buffer, byte_offset, element_size, is_bigint) =
                     match validate_integer_typed_array(interp, &ta_val, false, true) {
                         Ok(info) => info,
@@ -213,11 +213,11 @@ impl Interpreter {
                     (exp, rep)
                 } else {
                     let exp = match interp.to_number_value(&expected_val) {
-                        Ok(n) => JsValue::Number(n),
+                        Ok(n) => JsValue::number(n),
                         Err(e) => return Completion::Throw(e),
                     };
                     let rep = match interp.to_number_value(&replacement_val) {
-                        Ok(n) => JsValue::Number(n),
+                        Ok(n) => JsValue::number(n),
                         Err(e) => return Completion::Throw(e),
                     };
                     (exp, rep)
@@ -258,20 +258,20 @@ impl Interpreter {
 
         // Atomics.isLockFree
         self.define_method(atomics_obj_id, "isLockFree", 1, |interp, _this, args| {
-            let size_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+            let size_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
             let size = match interp.to_number_value(&size_val) {
                 Ok(n) => n,
                 Err(e) => return Completion::Throw(e),
             };
             let result = matches!(size as u64, 1 | 2 | 4 | 8) && size == (size as u64) as f64;
-            Completion::Normal(JsValue::Boolean(result))
+            Completion::Normal(JsValue::boolean(result))
         });
 
         // Atomics.wait
         self.define_method(atomics_obj_id, "wait", 4, |interp, _this, args| {
-            let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-            let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-            let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+            let ta_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let index_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            let value = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
             let (_kind, _buffer, byte_offset, element_size, is_bigint) =
                 match validate_integer_typed_array(interp, &ta_val, true, false) {
                     Ok(info) => info,
@@ -297,12 +297,12 @@ impl Interpreter {
                 }
             } else {
                 match interp.to_number_value(&value) {
-                    Ok(n) => JsValue::Number(n),
+                    Ok(n) => JsValue::number(n),
                     Err(e) => return Completion::Throw(e),
                 }
             };
-            let timeout_val = args.get(3).cloned().unwrap_or(JsValue::Undefined);
-            let timeout = if matches!(timeout_val, JsValue::Undefined) {
+            let timeout_val = args.get(3).cloned().unwrap_or(JsValue::UNDEFINED);
+            let timeout = if timeout_val.is_undefined() {
                 f64::INFINITY
             } else {
                 match interp.to_number_value(&timeout_val) {
@@ -325,10 +325,9 @@ impl Interpreter {
                         AtomicI64::from_ptr(ptr).load(Ordering::SeqCst)
                     })
                     .unwrap_or(0);
-                let expected = match &converted {
-                    JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
-                    _ => 0,
-                };
+                let expected = converted
+                    .with_bigint(|b| i64::try_from(b).unwrap_or(0))
+                    .unwrap_or(0);
                 current == expected
             } else {
                 let current = sab
@@ -336,15 +335,12 @@ impl Interpreter {
                         AtomicI32::from_ptr(ptr).load(Ordering::SeqCst)
                     })
                     .unwrap_or(0);
-                let expected = match &converted {
-                    JsValue::Number(n) => *n as i32,
-                    _ => 0,
-                };
+                let expected = converted.as_number().map_or(0, |n| n as i32);
                 current == expected
             };
 
             if !current_matches {
-                return Completion::Normal(JsValue::String(JsString::from_str("not-equal")));
+                return Completion::Normal(JsValue::from_str("not-equal"));
             }
 
             // §25.4.12 step 14-15: AgentCanSuspend() check
@@ -355,7 +351,7 @@ impl Interpreter {
             }
 
             if timeout == 0.0 {
-                return Completion::Normal(JsValue::String(JsString::from_str("timed-out")));
+                return Completion::Normal(JsValue::from_str("timed-out"));
             }
 
             let pair = Arc::new((Mutex::new(false), Condvar::new()));
@@ -401,13 +397,13 @@ impl Interpreter {
                 }
             }
 
-            Completion::Normal(JsValue::String(JsString::from_str(result)))
+            Completion::Normal(JsValue::from_str(result))
         });
 
         // Atomics.notify
         self.define_method(atomics_obj_id, "notify", 3, |interp, _this, args| {
-            let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-            let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+            let ta_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let index_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
             let (kind, _buffer, byte_offset, element_size, _is_bigint) =
                 match validate_integer_typed_array(interp, &ta_val, true, false) {
                     Ok(info) => info,
@@ -419,8 +415,8 @@ impl Interpreter {
                 Ok(i) => i,
                 Err(e) => return Completion::Throw(e),
             };
-            let count_val = args.get(2).cloned().unwrap_or(JsValue::Undefined);
-            let count: usize = if matches!(count_val, JsValue::Undefined) {
+            let count_val = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
+            let count: usize = if count_val.is_undefined() {
                 usize::MAX
             } else {
                 let c = match interp.to_number_value(&count_val) {
@@ -438,7 +434,7 @@ impl Interpreter {
 
             let sab_info = get_sab_info(interp, &ta_val);
             if sab_info.is_none() {
-                return Completion::Normal(JsValue::Number(0.0));
+                return Completion::Normal(JsValue::number(0.0));
             }
             let (sab, _ta_byte_offset) = sab_info.unwrap();
             let offset = byte_offset + byte_index;
@@ -460,22 +456,22 @@ impl Interpreter {
                 }
             }
 
-            Completion::Normal(JsValue::Number(woken as f64))
+            Completion::Normal(JsValue::number(woken as f64))
         });
 
         // Atomics.waitAsync
         self.define_method(atomics_obj_id, "waitAsync", 4, |interp, _this, args| {
-            let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-            let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-            let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+            let ta_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let index_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            let value = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
             let (kind, buffer, byte_offset, element_size, is_bigint) =
                 match validate_integer_typed_array(interp, &ta_val, true, false) {
                     Ok(info) => info,
                     Err(e) => return Completion::Throw(e),
                 };
             // Step 3: IsSharedArrayBuffer check — before index/value/timeout
-            let buffer_is_shared = if let JsValue::Object(o) = &ta_val
-                && let Some(obj) = interp.get_object_cell(o.id)
+            let buffer_is_shared = if let Some(ta_id) = ta_val.as_object_id()
+                && let Some(obj) = interp.get_object_cell(ta_id)
             {
                 let obj_ref = obj.borrow();
                 if obj_ref.typed_array_info().is_some() {
@@ -510,12 +506,12 @@ impl Interpreter {
                 }
             } else {
                 match interp.to_number_value(&value) {
-                    Ok(n) => JsValue::Number(n),
+                    Ok(n) => JsValue::number(n),
                     Err(e) => return Completion::Throw(e),
                 }
             };
-            let timeout_val = args.get(3).cloned().unwrap_or(JsValue::Undefined);
-            let timeout = if matches!(timeout_val, JsValue::Undefined) {
+            let timeout_val = args.get(3).cloned().unwrap_or(JsValue::UNDEFINED);
+            let timeout = if timeout_val.is_undefined() {
                 f64::INFINITY
             } else {
                 match interp.to_number_value(&timeout_val) {
@@ -550,19 +546,14 @@ impl Interpreter {
                     .borrow_mut()
                     .insert_property(
                         "async".to_string(),
-                        PropertyDescriptor::data(JsValue::Boolean(false), true, true, true),
+                        PropertyDescriptor::data(JsValue::FALSE, true, true, true),
                     );
                 interp
                     .get_object_cell_expect(result_id)
                     .borrow_mut()
                     .insert_property(
                         "value".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str("not-equal")),
-                            true,
-                            true,
-                            true,
-                        ),
+                        PropertyDescriptor::data(JsValue::from_str("not-equal"), true, true, true),
                     );
             } else if timeout <= 0.0 {
                 interp
@@ -570,19 +561,14 @@ impl Interpreter {
                     .borrow_mut()
                     .insert_property(
                         "async".to_string(),
-                        PropertyDescriptor::data(JsValue::Boolean(false), true, true, true),
+                        PropertyDescriptor::data(JsValue::FALSE, true, true, true),
                     );
                 interp
                     .get_object_cell_expect(result_id)
                     .borrow_mut()
                     .insert_property(
                         "value".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str("timed-out")),
-                            true,
-                            true,
-                            true,
-                        ),
+                        PropertyDescriptor::data(JsValue::from_str("timed-out"), true, true, true),
                     );
             } else {
                 let sab_info = get_sab_info(interp, &ta_val);
@@ -606,11 +592,7 @@ impl Interpreter {
                     let pending = interp.agent_async_completions.clone();
                     let pending_jobs = interp.scheduler.pending_async_jobs_handle();
                     let pending_promise_ids = interp.scheduler.pending_async_promise_ids_handle();
-                    let promise_id = if let JsValue::Object(ref o) = promise_val {
-                        o.id
-                    } else {
-                        0
-                    };
+                    let promise_id = promise_val.as_object_id().unwrap_or(0);
                     if promise_id != 0 {
                         pending_promise_ids.lock().unwrap().insert(promise_id);
                     }
@@ -646,7 +628,7 @@ impl Interpreter {
                                 }
                             }
                         }
-                        let result_val = JsValue::String(JsString::from_str(result_str));
+                        let result_val = JsValue::from_str(result_str);
                         let resolve = resolve_clone;
                         let (ref mtx, ref completion_cvar) = *pending;
                         mtx.lock()
@@ -654,7 +636,7 @@ impl Interpreter {
                             .push(Box::new(move |interp: &mut Interpreter| {
                                 let _ = interp.call_function(
                                     &resolve,
-                                    &JsValue::Undefined,
+                                    &JsValue::UNDEFINED,
                                     &[result_val],
                                 );
                                 interp.gc_unroot_value(&resolve);
@@ -672,7 +654,7 @@ impl Interpreter {
                     .borrow_mut()
                     .insert_property(
                         "async".to_string(),
-                        PropertyDescriptor::data(JsValue::Boolean(true), true, true, true),
+                        PropertyDescriptor::data(JsValue::TRUE, true, true, true),
                     );
                 interp
                     .get_object_cell_expect(result_id)
@@ -685,16 +667,16 @@ impl Interpreter {
                 interp.gc_unroot_frame(gc_frame_promise);
             }
             let id = result_id;
-            Completion::Normal(JsValue::Object(JsObject { id }))
+            Completion::Normal(JsValue::object(id))
         });
 
         // Atomics.pause
         self.define_method(atomics_obj_id, "pause", 0, |interp, _this, args| {
             if let Some(arg) = args.first()
-                && !matches!(arg, JsValue::Undefined)
+                && !arg.is_undefined()
             {
-                let n = if let JsValue::Number(n) = arg {
-                    *n
+                let n = if let Some(n) = arg.as_number() {
+                    n
                 } else {
                     return Completion::Throw(
                         interp.create_type_error("Atomics.pause requires a non-negative integer"),
@@ -706,13 +688,13 @@ impl Interpreter {
                     );
                 }
             }
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         // @@toStringTag
         self.define_to_string_tag(atomics_obj_id, "Atomics");
 
-        let atomics_val = JsValue::Object(crate::types::JsObject { id: atomics_id });
+        let atomics_val = JsValue::object(atomics_id);
         self.realm()
             .global_env
             .borrow_mut()
@@ -740,12 +722,12 @@ fn atomic_load_shared(
             .unwrap_or(0);
         let bv = match kind {
             TypedArrayKind::BigInt64 => {
-                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(val)))
+                JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(val)))
             }
             TypedArrayKind::BigUint64 => {
-                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(val as u64)))
+                JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(val as u64)))
             }
-            _ => JsValue::Number(0.0),
+            _ => JsValue::number(0.0),
         };
         Completion::Normal(bv)
     } else {
@@ -788,7 +770,7 @@ fn atomic_load_shared(
                 .unwrap_or(0),
             _ => 0,
         };
-        Completion::Normal(JsValue::Number(val as f64))
+        Completion::Normal(JsValue::number(val as f64))
     }
 }
 
@@ -800,18 +782,14 @@ fn atomic_store_shared(
     val: &JsValue,
 ) {
     if is_bigint {
-        let i = match val {
-            JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
-            _ => 0,
-        };
+        let i = val
+            .with_bigint(|b| i64::try_from(b).unwrap_or(0))
+            .unwrap_or(0);
         let _ = sab.with_atomic_ptr::<i64, _>(offset, 8, |ptr| unsafe {
             AtomicI64::from_ptr(ptr).store(i, Ordering::SeqCst)
         });
     } else {
-        let n = match val {
-            JsValue::Number(n) => *n,
-            _ => 0.0,
-        };
+        let n = val.as_number().unwrap_or(0.0);
         let i = converted_number_to_i64_val(kind, n);
         match kind {
             TypedArrayKind::Int8 => {
@@ -858,14 +836,12 @@ fn atomic_compare_exchange_shared(
     replacement: &JsValue,
 ) -> Completion {
     if is_bigint {
-        let exp = match expected {
-            JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
-            _ => 0,
-        };
-        let rep = match replacement {
-            JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
-            _ => 0,
-        };
+        let exp = expected
+            .with_bigint(|b| i64::try_from(b).unwrap_or(0))
+            .unwrap_or(0);
+        let rep = replacement
+            .with_bigint(|b| i64::try_from(b).unwrap_or(0))
+            .unwrap_or(0);
         let old = sab
             .with_atomic_ptr::<i64, _>(offset, 8, |ptr| unsafe {
                 AtomicI64::from_ptr(ptr)
@@ -875,31 +851,21 @@ fn atomic_compare_exchange_shared(
             .unwrap_or(0);
         let bv = match kind {
             TypedArrayKind::BigInt64 => {
-                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(old)))
+                JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(old)))
             }
             TypedArrayKind::BigUint64 => {
-                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(old as u64)))
+                JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(old as u64)))
             }
-            _ => JsValue::Number(0.0),
+            _ => JsValue::number(0.0),
         };
         Completion::Normal(bv)
     } else {
         match kind {
             TypedArrayKind::Int8 => {
-                let exp = converted_number_to_i64_val(
-                    kind,
-                    match expected {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as i8;
-                let rep = converted_number_to_i64_val(
-                    kind,
-                    match replacement {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as i8;
+                let exp =
+                    converted_number_to_i64_val(kind, expected.as_number().unwrap_or(0.0)) as i8;
+                let rep =
+                    converted_number_to_i64_val(kind, replacement.as_number().unwrap_or(0.0)) as i8;
                 let old = sab
                     .with_atomic_ptr::<i8, _>(offset, 1, |ptr| unsafe {
                         AtomicI8::from_ptr(ptr)
@@ -907,23 +873,13 @@ fn atomic_compare_exchange_shared(
                             .unwrap_or_else(|v| v)
                     })
                     .unwrap_or(0);
-                Completion::Normal(JsValue::Number(old as f64))
+                Completion::Normal(JsValue::number(old as f64))
             }
             TypedArrayKind::Uint8 => {
-                let exp = converted_number_to_i64_val(
-                    kind,
-                    match expected {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as u8;
-                let rep = converted_number_to_i64_val(
-                    kind,
-                    match replacement {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as u8;
+                let exp =
+                    converted_number_to_i64_val(kind, expected.as_number().unwrap_or(0.0)) as u8;
+                let rep =
+                    converted_number_to_i64_val(kind, replacement.as_number().unwrap_or(0.0)) as u8;
                 let old = sab
                     .with_atomic_ptr::<u8, _>(offset, 1, |ptr| unsafe {
                         AtomicU8::from_ptr(ptr)
@@ -931,23 +887,13 @@ fn atomic_compare_exchange_shared(
                             .unwrap_or_else(|v| v)
                     })
                     .unwrap_or(0);
-                Completion::Normal(JsValue::Number(old as f64))
+                Completion::Normal(JsValue::number(old as f64))
             }
             TypedArrayKind::Int16 => {
-                let exp = converted_number_to_i64_val(
-                    kind,
-                    match expected {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as i16;
-                let rep = converted_number_to_i64_val(
-                    kind,
-                    match replacement {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as i16;
+                let exp =
+                    converted_number_to_i64_val(kind, expected.as_number().unwrap_or(0.0)) as i16;
+                let rep = converted_number_to_i64_val(kind, replacement.as_number().unwrap_or(0.0))
+                    as i16;
                 let old = sab
                     .with_atomic_ptr::<i16, _>(offset, 2, |ptr| unsafe {
                         AtomicI16::from_ptr(ptr)
@@ -955,23 +901,13 @@ fn atomic_compare_exchange_shared(
                             .unwrap_or_else(|v| v)
                     })
                     .unwrap_or(0);
-                Completion::Normal(JsValue::Number(old as f64))
+                Completion::Normal(JsValue::number(old as f64))
             }
             TypedArrayKind::Uint16 => {
-                let exp = converted_number_to_i64_val(
-                    kind,
-                    match expected {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as u16;
-                let rep = converted_number_to_i64_val(
-                    kind,
-                    match replacement {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as u16;
+                let exp =
+                    converted_number_to_i64_val(kind, expected.as_number().unwrap_or(0.0)) as u16;
+                let rep = converted_number_to_i64_val(kind, replacement.as_number().unwrap_or(0.0))
+                    as u16;
                 let old = sab
                     .with_atomic_ptr::<u16, _>(offset, 2, |ptr| unsafe {
                         AtomicU16::from_ptr(ptr)
@@ -979,23 +915,13 @@ fn atomic_compare_exchange_shared(
                             .unwrap_or_else(|v| v)
                     })
                     .unwrap_or(0);
-                Completion::Normal(JsValue::Number(old as f64))
+                Completion::Normal(JsValue::number(old as f64))
             }
             TypedArrayKind::Int32 => {
-                let exp = converted_number_to_i64_val(
-                    kind,
-                    match expected {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as i32;
-                let rep = converted_number_to_i64_val(
-                    kind,
-                    match replacement {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as i32;
+                let exp =
+                    converted_number_to_i64_val(kind, expected.as_number().unwrap_or(0.0)) as i32;
+                let rep = converted_number_to_i64_val(kind, replacement.as_number().unwrap_or(0.0))
+                    as i32;
                 let old = sab
                     .with_atomic_ptr::<i32, _>(offset, 4, |ptr| unsafe {
                         AtomicI32::from_ptr(ptr)
@@ -1003,23 +929,13 @@ fn atomic_compare_exchange_shared(
                             .unwrap_or_else(|v| v)
                     })
                     .unwrap_or(0);
-                Completion::Normal(JsValue::Number(old as f64))
+                Completion::Normal(JsValue::number(old as f64))
             }
             TypedArrayKind::Uint32 => {
-                let exp = converted_number_to_i64_val(
-                    kind,
-                    match expected {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as u32;
-                let rep = converted_number_to_i64_val(
-                    kind,
-                    match replacement {
-                        JsValue::Number(n) => *n,
-                        _ => 0.0,
-                    },
-                ) as u32;
+                let exp =
+                    converted_number_to_i64_val(kind, expected.as_number().unwrap_or(0.0)) as u32;
+                let rep = converted_number_to_i64_val(kind, replacement.as_number().unwrap_or(0.0))
+                    as u32;
                 let old = sab
                     .with_atomic_ptr::<u32, _>(offset, 4, |ptr| unsafe {
                         AtomicU32::from_ptr(ptr)
@@ -1027,9 +943,9 @@ fn atomic_compare_exchange_shared(
                             .unwrap_or_else(|v| v)
                     })
                     .unwrap_or(0);
-                Completion::Normal(JsValue::Number(old as f64))
+                Completion::Normal(JsValue::number(old as f64))
             }
-            _ => Completion::Normal(JsValue::Number(0.0)),
+            _ => Completion::Normal(JsValue::number(0.0)),
         }
     }
 }
@@ -1044,10 +960,9 @@ fn atomic_rmw_shared(
     bigint_op: fn(i64, i64) -> i64,
 ) -> Completion {
     if is_bigint {
-        let new_i64 = match converted {
-            JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
-            _ => 0,
-        };
+        let new_i64 = converted
+            .with_bigint(|b| i64::try_from(b).unwrap_or(0))
+            .unwrap_or(0);
         let old = sab
             .with_atomic_ptr::<i64, _>(offset, 8, |ptr| unsafe {
                 let atomic = AtomicI64::from_ptr(ptr);
@@ -1068,19 +983,16 @@ fn atomic_rmw_shared(
             .unwrap_or(0);
         let bv = match kind {
             TypedArrayKind::BigInt64 => {
-                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(old)))
+                JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(old)))
             }
             TypedArrayKind::BigUint64 => {
-                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(old as u64)))
+                JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(old as u64)))
             }
-            _ => JsValue::Number(0.0),
+            _ => JsValue::number(0.0),
         };
         Completion::Normal(bv)
     } else {
-        let n = match converted {
-            JsValue::Number(n) => *n,
-            _ => 0.0,
-        };
+        let n = converted.as_number().unwrap_or(0.0);
         let new_i64 = converted_number_to_i64_val(kind, n);
         macro_rules! do_rmw {
             ($ty:ty, $size:expr, $atomic_ty:ty) => {{
@@ -1102,7 +1014,7 @@ fn atomic_rmw_shared(
                         }
                     })
                     .unwrap_or(0 as $ty);
-                Completion::Normal(JsValue::Number(old as f64))
+                Completion::Normal(JsValue::number(old as f64))
             }};
         }
         match kind {
@@ -1112,7 +1024,7 @@ fn atomic_rmw_shared(
             TypedArrayKind::Uint16 => do_rmw!(u16, 2, AtomicU16),
             TypedArrayKind::Int32 => do_rmw!(i32, 4, AtomicI32),
             TypedArrayKind::Uint32 => do_rmw!(u32, 4, AtomicU32),
-            _ => Completion::Normal(JsValue::Number(0.0)),
+            _ => Completion::Normal(JsValue::number(0.0)),
         }
     }
 }
@@ -1156,8 +1068,8 @@ fn validate_integer_typed_array(
     ),
     JsValue,
 > {
-    let info_snapshot = if let JsValue::Object(o) = ta_val {
-        interp.get_object_cell(o.id).and_then(|cell| {
+    let info_snapshot = if let Some(ta_id) = ta_val.as_object_id() {
+        interp.get_object_cell(ta_id).and_then(|cell| {
             let obj_ref = cell.borrow();
             obj_ref.typed_array_info().map(|info| {
                 (
@@ -1215,12 +1127,12 @@ fn validate_atomic_access(
     element_size: usize,
 ) -> Result<usize, JsValue> {
     let idx = match interp.to_index(index_val) {
-        Completion::Normal(JsValue::Number(n)) => n as usize,
+        Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
         Completion::Throw(e) => return Err(e),
         _ => 0,
     };
-    let array_length = if let JsValue::Object(o) = ta_val
-        && let Some(obj) = interp.get_object_cell(o.id)
+    let array_length = if let Some(ta_id) = ta_val.as_object_id()
+        && let Some(obj) = interp.get_object_cell(ta_id)
     {
         let obj_ref = obj.borrow();
         if let Some(info) = obj_ref.typed_array_info() {
@@ -1243,9 +1155,9 @@ fn atomics_rmw(
     num_op: fn(i64, i64) -> i64,
     bigint_op: fn(i64, i64) -> i64,
 ) -> Completion {
-    let ta_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-    let index_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-    let value = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+    let ta_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+    let index_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+    let value = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
     let (kind, buffer, byte_offset, element_size, is_bigint) =
         match validate_integer_typed_array(interp, &ta_val, false, true) {
             Ok(info) => info,
@@ -1262,7 +1174,7 @@ fn atomics_rmw(
         }
     } else {
         match interp.to_number_value(&value) {
-            Ok(n) => JsValue::Number(n),
+            Ok(n) => JsValue::number(n),
             Err(e) => return Completion::Throw(e),
         }
     };
@@ -1279,10 +1191,9 @@ fn atomics_rmw(
         if is_bigint {
             let old_bytes = read_bigint_raw_bytes(buf, offset, kind);
             let old_i64 = i64::from_le_bytes(old_bytes);
-            let new_i64 = match &converted {
-                JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
-                _ => 0,
-            };
+            let new_i64 = converted
+                .with_bigint(|b| i64::try_from(b).unwrap_or(0))
+                .unwrap_or(0);
             let result_i64 = bigint_op(old_i64, new_i64);
             let result_bytes = result_i64.to_le_bytes();
             buf[offset..offset + 8].copy_from_slice(&result_bytes);
@@ -1329,38 +1240,38 @@ fn read_bigint_raw_bytes(buf: &[u8], offset: usize, _kind: TypedArrayKind) -> [u
 
 fn number_from_raw_bytes(kind: TypedArrayKind, raw: &[u8; 8]) -> JsValue {
     match kind {
-        TypedArrayKind::Int8 => JsValue::Number(raw[0] as i8 as f64),
-        TypedArrayKind::Uint8 => JsValue::Number(raw[0] as f64),
-        TypedArrayKind::Uint8Clamped => JsValue::Number(raw[0] as f64),
+        TypedArrayKind::Int8 => JsValue::number(raw[0] as i8 as f64),
+        TypedArrayKind::Uint8 => JsValue::number(raw[0] as f64),
+        TypedArrayKind::Uint8Clamped => JsValue::number(raw[0] as f64),
         TypedArrayKind::Int16 => {
             let v = i16::from_le_bytes([raw[0], raw[1]]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }
         TypedArrayKind::Uint16 => {
             let v = u16::from_le_bytes([raw[0], raw[1]]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }
         TypedArrayKind::Int32 => {
             let v = i32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }
         TypedArrayKind::Uint32 => {
             let v = u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]);
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         }
-        _ => JsValue::Number(0.0),
+        _ => JsValue::number(0.0),
     }
 }
 
 fn bigint_from_raw_bytes(kind: TypedArrayKind, raw: &[u8; 8]) -> JsValue {
     let i = i64::from_le_bytes(*raw);
     match kind {
-        TypedArrayKind::BigInt64 => JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(i))),
+        TypedArrayKind::BigInt64 => JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(i))),
         TypedArrayKind::BigUint64 => {
             let u = u64::from_le_bytes(*raw);
-            JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(u)))
+            JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(u)))
         }
-        _ => JsValue::Number(0.0),
+        _ => JsValue::number(0.0),
     }
 }
 
@@ -1374,17 +1285,15 @@ fn number_to_raw_bytes(kind: TypedArrayKind, val: &JsValue) -> [u8; 8] {
 }
 
 fn bigint_to_raw_bytes(kind: TypedArrayKind, val: &JsValue) -> [u8; 8] {
-    match val {
-        JsValue::BigInt(b) => {
-            let i = i64::try_from(b.value.as_ref()).unwrap_or(0);
-            match kind {
-                TypedArrayKind::BigInt64 => i.to_le_bytes(),
-                TypedArrayKind::BigUint64 => (i as u64).to_le_bytes(),
-                _ => [0u8; 8],
-            }
+    val.with_bigint(|b| {
+        let i = i64::try_from(b).unwrap_or(0);
+        match kind {
+            TypedArrayKind::BigInt64 => i.to_le_bytes(),
+            TypedArrayKind::BigUint64 => (i as u64).to_le_bytes(),
+            _ => [0u8; 8],
         }
-        _ => [0u8; 8],
-    }
+    })
+    .unwrap_or([0u8; 8])
 }
 
 fn write_number_to_buffer(buf: &mut [u8], offset: usize, kind: TypedArrayKind, val: &JsValue) {
@@ -1397,8 +1306,7 @@ fn write_number_to_buffer(buf: &mut [u8], offset: usize, kind: TypedArrayKind, v
 }
 
 fn write_bigint_to_buffer(buf: &mut [u8], offset: usize, kind: TypedArrayKind, val: &JsValue) {
-    if let JsValue::BigInt(b) = val {
-        let i = i64::try_from(b.value.as_ref()).unwrap_or(0);
+    if let Some(i) = val.with_bigint(|b| i64::try_from(b).unwrap_or(0)) {
         match kind {
             TypedArrayKind::BigInt64 | TypedArrayKind::BigUint64 => {
                 let bytes = i.to_le_bytes();
@@ -1425,10 +1333,7 @@ fn number_raw_to_i64(kind: TypedArrayKind, raw: &[u8; 8]) -> i64 {
 }
 
 fn converted_number_to_i64(kind: TypedArrayKind, val: &JsValue) -> i64 {
-    let n = match val {
-        JsValue::Number(n) => *n,
-        _ => 0.0,
-    };
+    let n = val.as_number().unwrap_or(0.0);
     converted_number_to_i64_val(kind, n)
 }
 

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -16,11 +16,11 @@ fn zip_next_inner(interp: &mut Interpreter, state: &ZipState) -> Completion {
         (s.0.clone(), s.1.clone(), s.2.clone(), s.3.clone(), s.4)
     };
     if !alive {
-        return Completion::Normal(interp.create_iter_result_object(JsValue::Undefined, true));
+        return Completion::Normal(interp.create_iter_result_object(JsValue::UNDEFINED, true));
     }
     if iters.is_empty() {
         state.borrow_mut().4 = false;
-        return Completion::Normal(interp.create_iter_result_object(JsValue::Undefined, true));
+        return Completion::Normal(interp.create_iter_result_object(JsValue::UNDEFINED, true));
     }
 
     let mut values = Vec::with_capacity(iters.len());
@@ -28,7 +28,7 @@ fn zip_next_inner(interp: &mut Interpreter, state: &ZipState) -> Completion {
 
     for (i, (it, nm)) in iters.iter().enumerate() {
         if exhausted[i] {
-            values.push(padding_values.get(i).cloned().unwrap_or(JsValue::Undefined));
+            values.push(padding_values.get(i).cloned().unwrap_or(JsValue::UNDEFINED));
             continue;
         }
         match iterator_step_value_getter(interp, it, nm) {
@@ -48,7 +48,7 @@ fn zip_next_inner(interp: &mut Interpreter, state: &ZipState) -> Completion {
                         return Completion::Throw(e);
                     }
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 } else if mode == "strict" {
                     if i != 0 {
@@ -101,10 +101,10 @@ fn zip_next_inner(interp: &mut Interpreter, state: &ZipState) -> Completion {
                     }
                     state.borrow_mut().4 = false;
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 } else {
-                    values.push(padding_values.get(i).cloned().unwrap_or(JsValue::Undefined));
+                    values.push(padding_values.get(i).cloned().unwrap_or(JsValue::UNDEFINED));
                 }
             }
             Err(e) => {
@@ -126,7 +126,7 @@ fn zip_next_inner(interp: &mut Interpreter, state: &ZipState) -> Completion {
 
     if mode == "longest" && new_exhausted.iter().all(|e| *e) {
         state.borrow_mut().4 = false;
-        return Completion::Normal(interp.create_iter_result_object(JsValue::Undefined, true));
+        return Completion::Normal(interp.create_iter_result_object(JsValue::UNDEFINED, true));
     }
 
     let arr = interp.create_array(values);
@@ -157,11 +157,11 @@ fn zip_keyed_next_inner(interp: &mut Interpreter, state: &ZipKeyedState) -> Comp
         )
     };
     if !alive {
-        return Completion::Normal(interp.create_iter_result_object(JsValue::Undefined, true));
+        return Completion::Normal(interp.create_iter_result_object(JsValue::UNDEFINED, true));
     }
     if iters.is_empty() {
         state.borrow_mut().5 = false;
-        return Completion::Normal(interp.create_iter_result_object(JsValue::Undefined, true));
+        return Completion::Normal(interp.create_iter_result_object(JsValue::UNDEFINED, true));
     }
 
     let mut values: Vec<(JsPropertyKey, JsValue)> = Vec::with_capacity(iters.len());
@@ -171,7 +171,7 @@ fn zip_keyed_next_inner(interp: &mut Interpreter, state: &ZipKeyedState) -> Comp
         if exhausted[i] {
             values.push((
                 keys[i].clone(),
-                padding_values.get(i).cloned().unwrap_or(JsValue::Undefined),
+                padding_values.get(i).cloned().unwrap_or(JsValue::UNDEFINED),
             ));
             continue;
         }
@@ -192,7 +192,7 @@ fn zip_keyed_next_inner(interp: &mut Interpreter, state: &ZipKeyedState) -> Comp
                         return Completion::Throw(e);
                     }
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 } else if mode == "strict" {
                     if i != 0 {
@@ -245,13 +245,13 @@ fn zip_keyed_next_inner(interp: &mut Interpreter, state: &ZipKeyedState) -> Comp
                     }
                     state.borrow_mut().5 = false;
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 } else {
                     // longest mode: append padding value
                     values.push((
                         keys[i].clone(),
-                        padding_values.get(i).cloned().unwrap_or(JsValue::Undefined),
+                        padding_values.get(i).cloned().unwrap_or(JsValue::UNDEFINED),
                     ));
                 }
             }
@@ -275,7 +275,7 @@ fn zip_keyed_next_inner(interp: &mut Interpreter, state: &ZipKeyedState) -> Comp
     // For longest mode: check if ALL are now exhausted
     if mode == "longest" && new_exhausted.iter().all(|e| *e) {
         state.borrow_mut().5 = false;
-        return Completion::Normal(interp.create_iter_result_object(JsValue::Undefined, true));
+        return Completion::Normal(interp.create_iter_result_object(JsValue::UNDEFINED, true));
     }
 
     // Create null-prototype result object with key-value pairs
@@ -294,7 +294,7 @@ fn zip_keyed_next_inner(interp: &mut Interpreter, state: &ZipKeyedState) -> Comp
             );
     }
     let result_id = result_obj_id;
-    let result_val = JsValue::Object(crate::types::JsObject { id: result_id });
+    let result_val = JsValue::object(result_id);
     Completion::Normal(interp.create_iter_result_object(result_val, false))
 }
 
@@ -303,33 +303,32 @@ fn get_iterator_direct_getter(
     interp: &mut Interpreter,
     obj: &JsValue,
 ) -> Result<(JsValue, JsValue), JsValue> {
-    match obj {
-        JsValue::Object(o) => {
-            let next_method = match interp.get_object_property(o.id, "next", obj) {
-                Completion::Normal(v) => v,
-                Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
-            };
-            Ok((obj.clone(), next_method))
-        }
-        _ => Err(interp.create_type_error("Iterator is not an object")),
+    if let Some(obj_id) = obj.as_object_id() {
+        let next_method = match interp.get_object_property(obj_id, "next", obj) {
+            Completion::Normal(v) => v,
+            Completion::Throw(e) => return Err(e),
+            _ => JsValue::UNDEFINED,
+        };
+        Ok((obj.clone(), next_method))
+    } else {
+        Err(interp.create_type_error("Iterator is not an object"))
     }
 }
 
 // IteratorClose that uses get_object_property for .return (invokes getters)
 fn iterator_close_getter(interp: &mut Interpreter, iterator: &JsValue) -> Result<(), JsValue> {
-    if let JsValue::Object(io) = iterator {
-        let return_method = match interp.get_object_property(io.id, "return", iterator) {
+    if let Some(io_id) = iterator.as_object_id() {
+        let return_method = match interp.get_object_property(io_id, "return", iterator) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(e),
             _ => return Ok(()),
         };
-        if matches!(return_method, JsValue::Undefined | JsValue::Null) {
+        if return_method.is_nullish() {
             return Ok(());
         }
         match interp.call_function(&return_method, iterator, &[]) {
             Completion::Normal(inner_result) => {
-                if !matches!(inner_result, JsValue::Object(_)) {
+                if !inner_result.is_object() {
                     return Err(interp.create_type_error("Iterator result is not an object"));
                 }
                 Ok(())
@@ -349,14 +348,14 @@ fn get_iterator_flattenable(
     obj: &JsValue,
     reject_primitives: bool,
 ) -> Result<(JsValue, JsValue), JsValue> {
-    if !matches!(obj, JsValue::Object(_)) {
+    if !obj.is_object() {
         if reject_primitives {
             return Err(
                 interp.create_type_error("Iterator.prototype.flatMap mapper returned a non-object")
             );
         }
         // iterate-strings mode: GetMethod(obj, @@iterator) on primitive
-        if matches!(obj, JsValue::String(_)) {
+        if obj.is_string() {
             // GetMethod on primitive: ToObject for lookup, but use original as receiver
             let wrapped = match interp.to_object(obj) {
                 Completion::Normal(v) => v,
@@ -364,18 +363,18 @@ fn get_iterator_flattenable(
                 _ => return Err(interp.create_type_error("Cannot convert to object")),
             };
             let sym_key = interp.get_symbol_iterator_key();
-            let method = if let JsValue::Object(ref o) = wrapped
+            let method = if let Some(wrapped_id) = wrapped.as_object_id()
                 && let Some(ref key) = sym_key
             {
-                match interp.get_object_property(o.id, key, obj) {
+                match interp.get_object_property(wrapped_id, key, obj) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 }
             } else {
-                JsValue::Undefined
+                JsValue::UNDEFINED
             };
-            if matches!(method, JsValue::Undefined | JsValue::Null) {
+            if method.is_nullish() {
                 return Err(interp.create_type_error("String iterator method is undefined"));
             }
             // Call(method, obj) — use original primitive as this
@@ -384,7 +383,7 @@ fn get_iterator_flattenable(
                 Completion::Throw(e) => return Err(e),
                 _ => return Err(interp.create_type_error("Iterator did not return a value")),
             };
-            if !matches!(iter_obj, JsValue::Object(_)) {
+            if !iter_obj.is_object() {
                 return Err(interp.create_type_error("Result of Symbol.iterator is not an object"));
             }
             return get_iterator_direct_getter(interp, &iter_obj);
@@ -394,27 +393,27 @@ fn get_iterator_flattenable(
 
     // Get @@iterator method
     let sym_key = interp.get_symbol_iterator_key();
-    let iter_method = if let JsValue::Object(o) = obj {
+    let iter_method = if let Some(obj_id) = obj.as_object_id() {
         if let Some(ref key) = sym_key {
-            match interp.get_object_property(o.id, key, obj) {
+            match interp.get_object_property(obj_id, key, obj) {
                 Completion::Normal(v) => Some(v),
                 Completion::Throw(e) => return Err(e),
-                _ => Some(JsValue::Undefined),
+                _ => Some(JsValue::UNDEFINED),
             }
         } else {
-            Some(JsValue::Undefined)
+            Some(JsValue::UNDEFINED)
         }
     } else {
-        Some(JsValue::Undefined)
+        Some(JsValue::UNDEFINED)
     };
 
     if let Some(method) = iter_method
-        && !matches!(method, JsValue::Undefined | JsValue::Null)
+        && !method.is_nullish()
     {
         // Has @@iterator - check it's callable and call it
-        if let JsValue::Object(mo) = &method {
+        if let Some(method_id) = method.as_object_id() {
             if !interp
-                .get_object_cell(mo.id)
+                .get_object_cell(method_id)
                 .map(|od| od.borrow().callable.is_some())
                 .unwrap_or(false)
             {
@@ -428,7 +427,7 @@ fn get_iterator_flattenable(
             Completion::Throw(e) => return Err(e),
             _ => return Err(interp.create_type_error("Symbol.iterator did not return a value")),
         };
-        if !matches!(iter_obj, JsValue::Object(_)) {
+        if !iter_obj.is_object() {
             return Err(interp.create_type_error("Result of Symbol.iterator is not an object"));
         }
         return get_iterator_direct_getter(interp, &iter_obj);
@@ -444,28 +443,26 @@ fn get_iterator_getter(
     obj: &JsValue,
 ) -> Result<(JsValue, JsValue), JsValue> {
     let sym_key = interp.get_symbol_iterator_key();
-    let method = match obj {
-        JsValue::Object(o) => {
-            if let Some(ref key) = sym_key {
-                match interp.get_object_property(o.id, key, obj) {
-                    Completion::Normal(v) => v,
-                    Completion::Throw(e) => return Err(e),
-                    _ => JsValue::Undefined,
-                }
-            } else {
-                return Err(interp.create_type_error("is not iterable"));
+    let method = if let Some(obj_id) = obj.as_object_id() {
+        if let Some(ref key) = sym_key {
+            match interp.get_object_property(obj_id, key, obj) {
+                Completion::Normal(v) => v,
+                Completion::Throw(e) => return Err(e),
+                _ => JsValue::UNDEFINED,
             }
+        } else {
+            return Err(interp.create_type_error("is not iterable"));
         }
-        JsValue::String(_) => {
-            // For strings, use the string prototype's @@iterator
-            return match interp.get_iterator(obj) {
-                Ok(iter) => get_iterator_direct_getter(interp, &iter),
-                Err(e) => Err(e),
-            };
-        }
-        _ => return Err(interp.create_type_error("is not iterable")),
+    } else if obj.is_string() {
+        // For strings, use the string prototype's @@iterator
+        return match interp.get_iterator(obj) {
+            Ok(iter) => get_iterator_direct_getter(interp, &iter),
+            Err(e) => Err(e),
+        };
+    } else {
+        return Err(interp.create_type_error("is not iterable"));
     };
-    if matches!(method, JsValue::Undefined | JsValue::Null) {
+    if method.is_nullish() {
         return Err(interp.create_type_error("is not iterable"));
     }
     // Call the method
@@ -474,7 +471,7 @@ fn get_iterator_getter(
         Completion::Throw(e) => return Err(e),
         _ => return Err(interp.create_type_error("Symbol.iterator did not return a value")),
     };
-    if !matches!(iterator, JsValue::Object(_)) {
+    if !iterator.is_object() {
         return Err(interp.create_type_error("Result of Symbol.iterator is not an object"));
     }
     get_iterator_direct_getter(interp, &iterator)
@@ -492,24 +489,23 @@ fn iterator_step_value_getter(
         Completion::Throw(e) => return Err(e),
         _ => return Err(interp.create_type_error("Iterator next failed")),
     };
-    let obj_ref = match &result {
-        JsValue::Object(o) => o,
-        _ => return Err(interp.create_type_error("Iterator result is not an object")),
+    let Some(result_id) = result.as_object_id() else {
+        return Err(interp.create_type_error("Iterator result is not an object"));
     };
     // Read .done via getter
-    let done = match interp.get_object_property(obj_ref.id, "done", &result) {
+    let done = match interp.get_object_property(result_id, "done", &result) {
         Completion::Normal(v) => v,
         Completion::Throw(e) => return Err(e),
-        _ => JsValue::Undefined,
+        _ => JsValue::UNDEFINED,
     };
     if interp.to_boolean_val(&done) {
         return Ok(None);
     }
     // Read .value via getter
-    let value = match interp.get_object_property(obj_ref.id, "value", &result) {
+    let value = match interp.get_object_property(result_id, "value", &result) {
         Completion::Normal(v) => v,
         Completion::Throw(e) => return Err(e),
-        _ => JsValue::Undefined,
+        _ => JsValue::UNDEFINED,
     };
     Ok(Some(value))
 }
@@ -521,8 +517,8 @@ fn iterator_close_with_completion(
     iterator: &JsValue,
     completion: Result<(), JsValue>,
 ) -> Result<(), JsValue> {
-    if let JsValue::Object(io) = iterator {
-        let return_method = match interp.get_object_property(io.id, "return", iterator) {
+    if let Some(io_id) = iterator.as_object_id() {
+        let return_method = match interp.get_object_property(io_id, "return", iterator) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => {
                 // Step 5: If completion is a throw completion, return ? completion.
@@ -531,9 +527,9 @@ fn iterator_close_with_completion(
                 }
                 return Err(e);
             }
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
-        if matches!(return_method, JsValue::Undefined | JsValue::Null) {
+        if return_method.is_nullish() {
             return completion;
         }
         let inner_result = interp.call_function(&return_method, iterator, &[]);
@@ -544,7 +540,7 @@ fn iterator_close_with_completion(
                     return Err(e);
                 }
                 // Step 7: If innerResult.[[Value]] is not an Object, throw TypeError
-                if !matches!(v, JsValue::Object(_)) {
+                if !v.is_object() {
                     return Err(interp.create_type_error("Iterator result is not an object"));
                 }
                 // Step 8: Return completion
@@ -605,9 +601,7 @@ impl Interpreter {
             let tst_getter = self.create_function(JsFunction::native(
                 "get [Symbol.toStringTag]".to_string(),
                 0,
-                |_interp, _this, _args| {
-                    Completion::Normal(JsValue::String(JsString::from_str("Iterator")))
-                },
+                |_interp, _this, _args| Completion::Normal(JsValue::from_str("Iterator")),
             ));
             let ip_id = iter_proto_id;
             let tst_key_for_setter = self.get_symbol_key("toStringTag");
@@ -615,13 +609,10 @@ impl Interpreter {
                 "set [Symbol.toStringTag]".to_string(),
                 1,
                 move |interp, this, args| {
-                    let v = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let this_id = match this {
-                        JsValue::Object(o) => o.id,
-                        _ => {
-                            let err = interp.create_type_error("setter called on non-object");
-                            return Completion::Throw(err);
-                        }
+                    let v = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let Some(this_id) = this.as_object_id() else {
+                        let err = interp.create_type_error("setter called on non-object");
+                        return Completion::Throw(err);
                     };
                     if this_id == ip_id {
                         let err = interp.create_type_error(
@@ -661,7 +652,7 @@ impl Interpreter {
                             Err(err) => return Completion::Throw(err),
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             self.get_object_cell_expect(iter_proto_id)
@@ -684,14 +675,18 @@ impl Interpreter {
             "[Symbol.dispose]".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let return_method = interp.get_property_on_id(o.id, "return");
-                    if matches!(&return_method, JsValue::Object(ro) if interp.get_object_cell(ro.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                    {
+                if let Some(this_id) = this.as_object_id() {
+                    let return_method = interp.get_property_on_id(this_id, "return");
+                    if return_method.as_object_id().is_some_and(|ro_id| {
+                        interp
+                            .get_object_cell(ro_id)
+                            .map(|od| od.borrow().callable.is_some())
+                            .unwrap_or(false)
+                    }) {
                         return interp.call_function(&return_method, this, &[]);
                     }
                 }
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
         if let Some(key) = self.get_symbol_key("dispose") {
@@ -715,17 +710,13 @@ impl Interpreter {
                 }
                 // If new_target is the Iterator constructor itself, throw TypeError
                 // (abstract class cannot be instantiated directly)
-                let nt_id = if let Some(JsValue::Object(nt)) = &interp.new_target {
-                    Some(nt.id)
-                } else {
-                    None
-                };
+                let nt_id = interp.new_target.as_ref().and_then(JsValue::as_object_id);
                 if let Some(nt_id) = nt_id {
                     // Check if new.target is the Iterator constructor by checking if
                     // looking up "Iterator" from global gives the same object
                     let global_iter = interp.get_global_var("Iterator");
-                    if let Some(JsValue::Object(gi)) = global_iter
-                        && gi.id == nt_id
+                    if let Some(gi_id) = global_iter.as_ref().and_then(JsValue::as_object_id)
+                        && gi_id == nt_id
                     {
                         let err = interp.create_type_error(
                             "Abstract class Iterator not directly constructable",
@@ -734,8 +725,8 @@ impl Interpreter {
                     }
                 }
                 // OrdinaryCreateFromConstructor — realm-aware prototype
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(this_id) = this.as_object_id()
+                    && let Some(obj) = interp.get_object(this_id)
                 {
                     let proto = match interp
                         .get_prototype_from_new_target_realm(|realm| realm.iterator_prototype)
@@ -752,17 +743,12 @@ impl Interpreter {
         ));
 
         // Set Iterator.prototype_id
-        if let JsValue::Object(ctor_obj) = &iterator_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_id) = iterator_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_id)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject { id: iter_proto_id }),
-                    false,
-                    false,
-                    false,
-                ),
+                PropertyDescriptor::data(JsValue::object(iter_proto_id), false, false, false),
             );
         }
 
@@ -780,14 +766,11 @@ impl Interpreter {
                 "set constructor".to_string(),
                 1,
                 move |interp, this, args| {
-                    let v = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let v = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     // Step 1: If this is not an Object, throw TypeError
-                    let this_id = match this {
-                        JsValue::Object(o) => o.id,
-                        _ => {
-                            let err = interp.create_type_error("setter called on non-object");
-                            return Completion::Throw(err);
-                        }
+                    let Some(this_id) = this.as_object_id() else {
+                        let err = interp.create_type_error("setter called on non-object");
+                        return Completion::Throw(err);
                     };
                     // Step 2: If this is home (Iterator.prototype), throw TypeError
                     if this_id == ip_id {
@@ -828,7 +811,7 @@ impl Interpreter {
                             Err(err) => return Completion::Throw(err),
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             self.get_object_cell_expect(iter_proto_id)
@@ -873,8 +856,8 @@ impl Interpreter {
             "next".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    if let Some(obj) = interp.get_object(o.id) {
+                if let Some(this_id) = this.as_object_id() {
+                    if let Some(obj) = interp.get_object(this_id) {
                         let state = obj.borrow().iterator_state().cloned();
                         if let Some(IteratorState::ArrayIterator {
                             array_id,
@@ -885,24 +868,24 @@ impl Interpreter {
                         {
                             if done {
                                 return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
                             let is_proxy = interp
                                 .get_object_cell(array_id)
                                 .is_some_and(|o| o.borrow().is_proxy());
                             if is_proxy {
-                                let arr_val =
-                                    JsValue::Object(crate::types::JsObject { id: array_id });
+                                let arr_val = JsValue::object(array_id);
                                 let len = match interp
                                     .get_object_property(array_id, "length", &arr_val)
                                 {
-                                    Completion::Normal(JsValue::Number(n)) => n as usize,
-                                    Completion::Normal(_) => 0,
+                                    Completion::Normal(v) => {
+                                        v.as_number().map_or(0, |n| n as usize)
+                                    }
                                     c => return c,
                                 };
                                 if index >= len {
-                                    if let Some(obj) = interp.get_object_cell(o.id) {
+                                    if let Some(obj) = interp.get_object_cell(this_id) {
                                         obj.borrow_mut().kind =
                                             crate::interpreter::types::ObjectKind::Iterator(
                                                 IteratorState::ArrayIterator {
@@ -914,12 +897,12 @@ impl Interpreter {
                                             );
                                     }
                                     return Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::Undefined, true),
+                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     );
                                 }
                                 let idx_str = index.to_string();
                                 let v = match kind {
-                                    IteratorKind::Key => JsValue::Number(index as f64),
+                                    IteratorKind::Key => JsValue::number(index as f64),
                                     IteratorKind::Value => {
                                         match interp
                                             .get_object_property(array_id, &idx_str, &arr_val)
@@ -936,10 +919,10 @@ impl Interpreter {
                                             c => return c,
                                         };
                                         let pair = interp.create_array(vec![
-                                            JsValue::Number(index as f64),
+                                            JsValue::number(index as f64),
                                             elem,
                                         ]);
-                                        if let Some(obj) = interp.get_object_cell(o.id) {
+                                        if let Some(obj) = interp.get_object_cell(this_id) {
                                             obj.borrow_mut().kind =
                                                 crate::interpreter::types::ObjectKind::Iterator(
                                                     IteratorState::ArrayIterator {
@@ -955,7 +938,7 @@ impl Interpreter {
                                         );
                                     }
                                 };
-                                if let Some(obj) = interp.get_object_cell(o.id) {
+                                if let Some(obj) = interp.get_object_cell(this_id) {
                                     obj.borrow_mut().kind =
                                         crate::interpreter::types::ObjectKind::Iterator(
                                             IteratorState::ArrayIterator {
@@ -977,7 +960,7 @@ impl Interpreter {
                                     && is_typed_array_out_of_bounds(ta)
                                 {
                                     drop(borrowed);
-                                    if let Some(obj) = interp.get_object_cell(o.id) {
+                                    if let Some(obj) = interp.get_object_cell(this_id) {
                                         obj.borrow_mut().kind =
                                             crate::interpreter::types::ObjectKind::Iterator(
                                                 IteratorState::ArrayIterator {
@@ -997,8 +980,9 @@ impl Interpreter {
                                 let borrowed = arr_obj.borrow();
                                 let len = if let Some(ta) = borrowed.typed_array_info() {
                                     typed_array_length(ta)
-                                } else if let Some(JsValue::Number(n)) =
-                                    borrowed.get_property_value("length")
+                                } else if let Some(n) = borrowed
+                                    .get_property_value("length")
+                                    .and_then(|v| v.as_number())
                                 {
                                     n as usize
                                 } else if let Some(elems) = borrowed.array_elements() {
@@ -1025,10 +1009,9 @@ impl Interpreter {
                                         None
                                     };
                                     drop(borrowed);
-                                    let arr_val =
-                                        JsValue::Object(crate::types::JsObject { id: array_id });
+                                    let arr_val = JsValue::object(array_id);
                                     let v = match kind {
-                                        IteratorKind::Key => JsValue::Number(index as f64),
+                                        IteratorKind::Key => JsValue::number(index as f64),
                                         IteratorKind::Value => {
                                             if let Some(fv) = fast_val {
                                                 fv
@@ -1053,7 +1036,7 @@ impl Interpreter {
                                                 }
                                             };
                                             let pair = interp.create_array(vec![
-                                                JsValue::Number(index as f64),
+                                                JsValue::number(index as f64),
                                                 elem,
                                             ]);
                                             return {
@@ -1101,7 +1084,7 @@ impl Interpreter {
                                             },
                                         );
                                     Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::Undefined, true),
+                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     )
                                 }
                             }
@@ -1114,7 +1097,7 @@ impl Interpreter {
                         {
                             if done {
                                 return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
                             let ta_obj = interp.get_object(typed_array_id);
@@ -1129,7 +1112,7 @@ impl Interpreter {
                                         },
                                     );
                                 return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
                             let ta_obj = ta_obj.unwrap();
@@ -1157,16 +1140,16 @@ impl Interpreter {
                                             },
                                         );
                                     return Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::Undefined, true),
+                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     );
                                 }
                                 let v = match kind {
-                                    IteratorKind::Key => JsValue::Number(index as f64),
+                                    IteratorKind::Key => JsValue::number(index as f64),
                                     IteratorKind::Value => typed_array_get_index(ta, index),
                                     IteratorKind::KeyValue => {
                                         let elem = typed_array_get_index(ta, index);
                                         let pair = interp.create_array(vec![
-                                            JsValue::Number(index as f64),
+                                            JsValue::number(index as f64),
                                             elem,
                                         ]);
                                         obj.borrow_mut().kind =
@@ -1201,7 +1184,7 @@ impl Interpreter {
                             Completion::Throw(err)
                         }
                     } else {
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     }
                 } else {
                     let err = interp.create_type_error("next called on non-object");
@@ -1231,8 +1214,8 @@ impl Interpreter {
             "next".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                if let Some(this_id) = this.as_object_id() {
+                    if let Some(obj) = interp.get_object_cell(this_id) {
                         let state = obj.borrow().iterator_state().cloned();
                         if let Some(IteratorState::StringIterator {
                             ref string,
@@ -1250,7 +1233,7 @@ impl Interpreter {
                                         },
                                     );
                                 return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
                             let cu = string.code_units[position];
@@ -1276,7 +1259,7 @@ impl Interpreter {
                             let result_js_str = JsString::from_vec(result_units);
                             Completion::Normal(
                                 interp.create_iter_result_object(
-                                    JsValue::String(result_js_str),
+                                    JsValue::string(result_js_str),
                                     false,
                                 ),
                             )
@@ -1286,7 +1269,7 @@ impl Interpreter {
                             Completion::Throw(err)
                         }
                     } else {
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     }
                 } else {
                     let err = interp.create_type_error("next called on non-object");
@@ -1320,13 +1303,10 @@ impl Interpreter {
             "next".to_string(),
             0,
             |interp, this, args| {
-                let this_id = match this {
-                    JsValue::Object(o) => o.id,
-                    _ => {
-                        return Completion::Throw(
-                            interp.create_type_error("Iterator Helper next called on non-object"),
-                        );
-                    }
+                let Some(this_id) = this.as_object_id() else {
+                    return Completion::Throw(
+                        interp.create_type_error("Iterator Helper next called on non-object"),
+                    );
                 };
                 let (next_closure, gen_state) = {
                     let obj = match interp.get_object(this_id) {
@@ -1360,17 +1340,17 @@ impl Interpreter {
                 }
                 if s == 3 {
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 }
                 gen_state.set(2);
                 let result = interp.call_function(&next_closure, this, args);
                 let is_done = if let Completion::Normal(ref v) = result {
-                    if let JsValue::Object(o) = v {
-                        matches!(
-                            interp.get_object_property(o.id, "done", v),
-                            Completion::Normal(JsValue::Boolean(true))
-                        )
+                    if let Some(v_id) = v.as_object_id() {
+                        match interp.get_object_property(v_id, "done", v) {
+                            Completion::Normal(d) => d.as_boolean() == Some(true),
+                            _ => false,
+                        }
                     } else {
                         false
                     }
@@ -1390,13 +1370,10 @@ impl Interpreter {
             "return".to_string(),
             0,
             |interp, this, args| {
-                let this_id = match this {
-                    JsValue::Object(o) => o.id,
-                    _ => {
-                        return Completion::Throw(
-                            interp.create_type_error("Iterator Helper return called on non-object"),
-                        );
-                    }
+                let Some(this_id) = this.as_object_id() else {
+                    return Completion::Throw(
+                        interp.create_type_error("Iterator Helper return called on non-object"),
+                    );
                 };
                 let (return_closure, gen_state) =
                     {
@@ -1430,7 +1407,7 @@ impl Interpreter {
                 }
                 if s == 3 {
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 }
                 if s == 0 {
@@ -1489,12 +1466,12 @@ impl Interpreter {
         }
 
         let id = obj_id;
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     fn set_helper_gc_roots(&mut self, helper: &JsValue, roots: Vec<JsValue>) {
-        if let JsValue::Object(ho) = helper
-            && let Some(obj) = self.get_object_cell(ho.id)
+        if let Some(helper_id) = helper.as_object_id()
+            && let Some(obj) = self.get_object_cell(helper_id)
         {
             obj.borrow_mut().gc_native_roots = Some(roots);
         }
@@ -1540,9 +1517,13 @@ impl Interpreter {
             "forEach".to_string(),
             1,
             |interp, this, args| {
-                let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&callback, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                {
+                let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !callback.as_object_id().is_some_and(|id| {
+                    interp
+                        .get_object_cell(id)
+                        .map(|od| od.borrow().callable.is_some())
+                        .unwrap_or(false)
+                }) {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("callback is not a function");
                     return Completion::Throw(err);
@@ -1556,13 +1537,13 @@ impl Interpreter {
                     match interp.iterator_step_direct(&iter, &next_method) {
                         Ok(Some(result)) => {
                             let value = match interp.iterator_value(&result) {
-                                    Ok(v) => v,
-                                    Err(e) => return Completion::Throw(e),
-                                };
+                                Ok(v) => v,
+                                Err(e) => return Completion::Throw(e),
+                            };
                             if let Completion::Throw(e) = interp.call_function(
                                 &callback,
-                                &JsValue::Undefined,
-                                &[value, JsValue::Number(counter)],
+                                &JsValue::UNDEFINED,
+                                &[value, JsValue::number(counter)],
                             ) {
                                 let _ = iterator_close_getter(interp, &iter);
                                 return Completion::Throw(e);
@@ -1573,7 +1554,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     }
                 }
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
         self.get_object_cell_expect(iter_proto_id)
@@ -1585,9 +1566,13 @@ impl Interpreter {
             "some".to_string(),
             1,
             |interp, this, args| {
-                let predicate = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&predicate, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                {
+                let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !predicate.as_object_id().is_some_and(|id| {
+                    interp
+                        .get_object_cell(id)
+                        .map(|od| od.borrow().callable.is_some())
+                        .unwrap_or(false)
+                }) {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("predicate is not a function");
                     return Completion::Throw(err);
@@ -1601,31 +1586,34 @@ impl Interpreter {
                     match interp.iterator_step_direct(&iter, &next_method) {
                         Ok(Some(result)) => {
                             let value = match interp.iterator_value(&result) {
-                                    Ok(v) => v,
-                                    Err(e) => return Completion::Throw(e),
-                                };
+                                Ok(v) => v,
+                                Err(e) => return Completion::Throw(e),
+                            };
                             match interp.call_function(
                                 &predicate,
-                                &JsValue::Undefined,
-                                &[value, JsValue::Number(counter)],
+                                &JsValue::UNDEFINED,
+                                &[value, JsValue::number(counter)],
                             ) {
-                                Completion::Normal(v)
-                                    if interp.to_boolean_val(&v) => {
-                                        // Propagate IteratorClose errors
-                                        if let Err(e) = iterator_close_getter(interp, &iter) {
-                                            return Completion::Throw(e);
-                                        }
-                                        return Completion::Normal(JsValue::Boolean(true));
+                                Completion::Normal(v) if interp.to_boolean_val(&v) => {
+                                    // Propagate IteratorClose errors
+                                    if let Err(e) = iterator_close_getter(interp, &iter) {
+                                        return Completion::Throw(e);
                                     }
+                                    return Completion::Normal(JsValue::TRUE);
+                                }
                                 Completion::Throw(e) => {
-                                    let _ = iterator_close_with_completion(interp, &iter, Err(e.clone()));
+                                    let _ = iterator_close_with_completion(
+                                        interp,
+                                        &iter,
+                                        Err(e.clone()),
+                                    );
                                     return Completion::Throw(e);
                                 }
                                 _ => {}
                             }
                             counter += 1.0;
                         }
-                        Ok(None) => return Completion::Normal(JsValue::Boolean(false)),
+                        Ok(None) => return Completion::Normal(JsValue::FALSE),
                         Err(e) => return Completion::Throw(e),
                     }
                 }
@@ -1640,9 +1628,13 @@ impl Interpreter {
             "every".to_string(),
             1,
             |interp, this, args| {
-                let predicate = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&predicate, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                {
+                let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !predicate.as_object_id().is_some_and(|id| {
+                    interp
+                        .get_object_cell(id)
+                        .map(|od| od.borrow().callable.is_some())
+                        .unwrap_or(false)
+                }) {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("predicate is not a function");
                     return Completion::Throw(err);
@@ -1656,30 +1648,33 @@ impl Interpreter {
                     match interp.iterator_step_direct(&iter, &next_method) {
                         Ok(Some(result)) => {
                             let value = match interp.iterator_value(&result) {
-                                    Ok(v) => v,
-                                    Err(e) => return Completion::Throw(e),
-                                };
+                                Ok(v) => v,
+                                Err(e) => return Completion::Throw(e),
+                            };
                             match interp.call_function(
                                 &predicate,
-                                &JsValue::Undefined,
-                                &[value, JsValue::Number(counter)],
+                                &JsValue::UNDEFINED,
+                                &[value, JsValue::number(counter)],
                             ) {
-                                Completion::Normal(v)
-                                    if !interp.to_boolean_val(&v) => {
-                                        if let Err(e) = iterator_close_getter(interp, &iter) {
-                                            return Completion::Throw(e);
-                                        }
-                                        return Completion::Normal(JsValue::Boolean(false));
+                                Completion::Normal(v) if !interp.to_boolean_val(&v) => {
+                                    if let Err(e) = iterator_close_getter(interp, &iter) {
+                                        return Completion::Throw(e);
                                     }
+                                    return Completion::Normal(JsValue::FALSE);
+                                }
                                 Completion::Throw(e) => {
-                                    let _ = iterator_close_with_completion(interp, &iter, Err(e.clone()));
+                                    let _ = iterator_close_with_completion(
+                                        interp,
+                                        &iter,
+                                        Err(e.clone()),
+                                    );
                                     return Completion::Throw(e);
                                 }
                                 _ => {}
                             }
                             counter += 1.0;
                         }
-                        Ok(None) => return Completion::Normal(JsValue::Boolean(true)),
+                        Ok(None) => return Completion::Normal(JsValue::TRUE),
                         Err(e) => return Completion::Throw(e),
                     }
                 }
@@ -1694,9 +1689,13 @@ impl Interpreter {
             "find".to_string(),
             1,
             |interp, this, args| {
-                let predicate = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&predicate, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                {
+                let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !predicate.as_object_id().is_some_and(|id| {
+                    interp
+                        .get_object_cell(id)
+                        .map(|od| od.borrow().callable.is_some())
+                        .unwrap_or(false)
+                }) {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("predicate is not a function");
                     return Completion::Throw(err);
@@ -1710,30 +1709,33 @@ impl Interpreter {
                     match interp.iterator_step_direct(&iter, &next_method) {
                         Ok(Some(result)) => {
                             let value = match interp.iterator_value(&result) {
-                                    Ok(v) => v,
-                                    Err(e) => return Completion::Throw(e),
-                                };
+                                Ok(v) => v,
+                                Err(e) => return Completion::Throw(e),
+                            };
                             match interp.call_function(
                                 &predicate,
-                                &JsValue::Undefined,
-                                &[value.clone(), JsValue::Number(counter)],
+                                &JsValue::UNDEFINED,
+                                &[value.clone(), JsValue::number(counter)],
                             ) {
-                                Completion::Normal(v)
-                                    if interp.to_boolean_val(&v) => {
-                                        if let Err(e) = iterator_close_getter(interp, &iter) {
-                                            return Completion::Throw(e);
-                                        }
-                                        return Completion::Normal(value);
+                                Completion::Normal(v) if interp.to_boolean_val(&v) => {
+                                    if let Err(e) = iterator_close_getter(interp, &iter) {
+                                        return Completion::Throw(e);
                                     }
+                                    return Completion::Normal(value);
+                                }
                                 Completion::Throw(e) => {
-                                    let _ = iterator_close_with_completion(interp, &iter, Err(e.clone()));
+                                    let _ = iterator_close_with_completion(
+                                        interp,
+                                        &iter,
+                                        Err(e.clone()),
+                                    );
                                     return Completion::Throw(e);
                                 }
                                 _ => {}
                             }
                             counter += 1.0;
                         }
-                        Ok(None) => return Completion::Normal(JsValue::Undefined),
+                        Ok(None) => return Completion::Normal(JsValue::UNDEFINED),
                         Err(e) => return Completion::Throw(e),
                     }
                 }
@@ -1748,9 +1750,13 @@ impl Interpreter {
             "reduce".to_string(),
             1,
             |interp, this, args| {
-                let reducer = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&reducer, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                {
+                let reducer = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !reducer.as_object_id().is_some_and(|id| {
+                    interp
+                        .get_object_cell(id)
+                        .map(|od| od.borrow().callable.is_some())
+                        .unwrap_or(false)
+                }) {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("reducer is not a function");
                     return Completion::Throw(err);
@@ -1774,8 +1780,9 @@ impl Interpreter {
                             counter = 1.0;
                         }
                         Ok(None) => {
-                            let err =
-                                interp.create_type_error("Reduce of empty iterator with no initial value");
+                            let err = interp.create_type_error(
+                                "Reduce of empty iterator with no initial value",
+                            );
                             return Completion::Throw(err);
                         }
                         Err(e) => return Completion::Throw(e),
@@ -1785,13 +1792,13 @@ impl Interpreter {
                     match interp.iterator_step_direct(&iter, &next_method) {
                         Ok(Some(result)) => {
                             let value = match interp.iterator_value(&result) {
-                                    Ok(v) => v,
-                                    Err(e) => return Completion::Throw(e),
-                                };
+                                Ok(v) => v,
+                                Err(e) => return Completion::Throw(e),
+                            };
                             match interp.call_function(
                                 &reducer,
-                                &JsValue::Undefined,
-                                &[accumulator.clone(), value, JsValue::Number(counter)],
+                                &JsValue::UNDEFINED,
+                                &[accumulator.clone(), value, JsValue::number(counter)],
                             ) {
                                 Completion::Normal(v) => accumulator = v,
                                 Completion::Throw(e) => {
@@ -1823,13 +1830,17 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 // Step 1-2: Require this to be an object
-                if !matches!(this, JsValue::Object(_)) {
+                if !this.is_object() {
                     let err = interp.create_type_error("Iterator.prototype.map called on non-object");
                     return Completion::Throw(err);
                 }
-                let mapper = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&mapper, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                {
+                let mapper = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !mapper.as_object_id().is_some_and(|id| {
+                    interp
+                        .get_object_cell(id)
+                        .map(|od| od.borrow().callable.is_some())
+                        .unwrap_or(false)
+                }) {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("mapper is not a function");
                     return Completion::Throw(err);
@@ -1855,7 +1866,7 @@ impl Interpreter {
                         };
                         if !alive {
                             return Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             );
                         }
                         if running {
@@ -1872,8 +1883,8 @@ impl Interpreter {
                                     };
                                     let mapped = interp.call_function(
                                         &mapper,
-                                        &JsValue::Undefined,
-                                        &[value, JsValue::Number(counter)],
+                                        &JsValue::UNDEFINED,
+                                        &[value, JsValue::number(counter)],
                                     );
                                     state_next.borrow_mut().3 = counter + 1.0;
                                     match mapped {
@@ -1886,14 +1897,14 @@ impl Interpreter {
                                             Completion::Throw(e)
                                         }
                                         _ => Completion::Normal(
-                                            interp.create_iter_result_object(JsValue::Undefined, true),
+                                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                         ),
                                     }
                                 }
                                 Ok(None) => {
                                     state_next.borrow_mut().4 = false;
                                     Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::Undefined, true),
+                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     )
                                 }
                                 Err(e) => {
@@ -1927,7 +1938,7 @@ impl Interpreter {
                                 Completion::Throw(e)
                             } else {
                                 Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 )
                             };
                         state_ret.borrow_mut().5 = false;
@@ -1952,13 +1963,17 @@ impl Interpreter {
             "filter".to_string(),
             1,
             |interp, this, args| {
-                if !matches!(this, JsValue::Object(_)) {
+                if !this.is_object() {
                     let err = interp.create_type_error("Iterator.prototype.filter called on non-object");
                     return Completion::Throw(err);
                 }
-                let predicate = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&predicate, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                {
+                let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !predicate.as_object_id().is_some_and(|id| {
+                    interp
+                        .get_object_cell(id)
+                        .map(|od| od.borrow().callable.is_some())
+                        .unwrap_or(false)
+                }) {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("predicate is not a function");
                     return Completion::Throw(err);
@@ -1984,7 +1999,7 @@ impl Interpreter {
                         };
                         if !alive {
                             return Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             );
                         }
                         if running {
@@ -2002,8 +2017,8 @@ impl Interpreter {
                                     };
                                         let test_result = interp.call_function(
                                             &pred,
-                                            &JsValue::Undefined,
-                                            &[value.clone(), JsValue::Number(counter)],
+                                            &JsValue::UNDEFINED,
+                                            &[value.clone(), JsValue::number(counter)],
                                         );
                                         counter += 1.0;
                                         state_next.borrow_mut().3 = counter;
@@ -2025,7 +2040,7 @@ impl Interpreter {
                                     Ok(None) => {
                                         state_next.borrow_mut().4 = false;
                                         return Completion::Normal(
-                                            interp.create_iter_result_object(JsValue::Undefined, true),
+                                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                         );
                                     }
                                     Err(e) => {
@@ -2060,12 +2075,12 @@ impl Interpreter {
                                 Completion::Throw(e)
                             } else {
                                 Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 )
                             }
                         } else {
                             Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
                         state_ret.borrow_mut().5 = false;
@@ -2091,13 +2106,13 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 // Step 2: If this is not an Object, throw TypeError
-                if !matches!(this, JsValue::Object(_)) {
+                if !this.is_object() {
                     let err =
                         interp.create_type_error("Iterator.prototype.take called on non-object");
                     return Completion::Throw(err);
                 }
                 // Step 3: numLimit = ToNumber(limit) — can throw via valueOf
-                let limit_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let limit_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let num_limit = match interp.to_number_value(&limit_val) {
                     Ok(n) => n,
                     Err(e) => {
@@ -2147,7 +2162,7 @@ impl Interpreter {
                         };
                         if !alive {
                             return Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             );
                         }
                         if running {
@@ -2163,7 +2178,7 @@ impl Interpreter {
                                     return Completion::Throw(e);
                                 }
                                 return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
                             // Decrement remaining
@@ -2180,7 +2195,7 @@ impl Interpreter {
                                 Ok(None) => {
                                     state_next.borrow_mut().3 = false;
                                     Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::Undefined, true),
+                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     )
                                 }
                                 Err(e) => {
@@ -2214,12 +2229,12 @@ impl Interpreter {
                                 Completion::Throw(e)
                             } else {
                                 Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 )
                             }
                         } else {
                             Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
                         state_ret.borrow_mut().4 = false;
@@ -2245,13 +2260,13 @@ impl Interpreter {
             1,
             |interp, this, args| {
                 // Step 2: If this is not an Object, throw TypeError
-                if !matches!(this, JsValue::Object(_)) {
+                if !this.is_object() {
                     let err =
                         interp.create_type_error("Iterator.prototype.drop called on non-object");
                     return Completion::Throw(err);
                 }
                 // Step 3: numLimit = ToNumber(limit)
-                let limit_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let limit_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let num_limit = match interp.to_number_value(&limit_val) {
                     Ok(n) => n,
                     Err(e) => {
@@ -2301,7 +2316,7 @@ impl Interpreter {
                         };
                         if !alive {
                             return Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             );
                         }
                         if running {
@@ -2321,7 +2336,7 @@ impl Interpreter {
                                             state_next.borrow_mut().4 = false;
                                             return Completion::Normal(
                                                 interp.create_iter_result_object(
-                                                    JsValue::Undefined,
+                                                    JsValue::UNDEFINED,
                                                     true,
                                                 ),
                                             );
@@ -2345,7 +2360,7 @@ impl Interpreter {
                                 Ok(None) => {
                                     state_next.borrow_mut().4 = false;
                                     Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::Undefined, true),
+                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     )
                                 }
                                 Err(e) => {
@@ -2379,12 +2394,12 @@ impl Interpreter {
                                 Completion::Throw(e)
                             } else {
                                 Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 )
                             }
                         } else {
                             Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
                         state_ret.borrow_mut().5 = false;
@@ -2409,13 +2424,17 @@ impl Interpreter {
             "flatMap".to_string(),
             1,
             |interp, this, args| {
-                if !matches!(this, JsValue::Object(_)) {
+                if !this.is_object() {
                     let err = interp.create_type_error("Iterator.prototype.flatMap called on non-object");
                     return Completion::Throw(err);
                 }
-                let mapper = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(&mapper, JsValue::Object(o) if interp.get_object_cell(o.id).map(|od| od.borrow().callable.is_some()).unwrap_or(false))
-                {
+                let mapper = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !mapper.as_object_id().is_some_and(|id| {
+                    interp
+                        .get_object_cell(id)
+                        .map(|od| od.borrow().callable.is_some())
+                        .unwrap_or(false)
+                }) {
                     let _ = iterator_close_getter(interp, this);
                     let err = interp.create_type_error("mapper is not a function");
                     return Completion::Throw(err);
@@ -2458,7 +2477,7 @@ impl Interpreter {
                         let running = state_next.borrow().7;
                         if !alive {
                             return Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             );
                         }
                         if running {
@@ -2529,8 +2548,8 @@ impl Interpreter {
                                         };
                                         let mapped = interp.call_function(
                                             &mapper,
-                                            &JsValue::Undefined,
-                                            &[value, JsValue::Number(counter)],
+                                            &JsValue::UNDEFINED,
+                                            &[value, JsValue::number(counter)],
                                         );
                                         state_next.borrow_mut().3 = counter + 1.0;
                                         match mapped {
@@ -2557,7 +2576,7 @@ impl Interpreter {
                                                 state_next.borrow_mut().6 = false;
                                                 return Completion::Normal(
                                                     interp.create_iter_result_object(
-                                                        JsValue::Undefined,
+                                                        JsValue::UNDEFINED,
                                                         true,
                                                     ),
                                                 );
@@ -2568,7 +2587,7 @@ impl Interpreter {
                                         state_next.borrow_mut().6 = false;
                                         return Completion::Normal(
                                             interp
-                                                .create_iter_result_object(JsValue::Undefined, true),
+                                                .create_iter_result_object(JsValue::UNDEFINED, true),
                                         );
                                     }
                                     Err(e) => {
@@ -2608,12 +2627,12 @@ impl Interpreter {
                                 Completion::Throw(e)
                             } else {
                                 Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 )
                             }
                         } else {
                             Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
                         state_ret.borrow_mut().7 = false;
@@ -2649,12 +2668,9 @@ impl Interpreter {
             "next".to_string(),
             0,
             move |interp, this, _args| {
-                let this_id = match this {
-                    JsValue::Object(o) => o.id,
-                    _ => {
-                        let err = interp.create_type_error("next requires an Iterator wrapper");
-                        return Completion::Throw(err);
-                    }
+                let Some(this_id) = this.as_object_id() else {
+                    let err = interp.create_type_error("next requires an Iterator wrapper");
+                    return Completion::Throw(err);
                 };
                 let record = interp.get_object_cell(this_id).and_then(|o| {
                     if let Some(crate::interpreter::types::IterHelperData::Delegation {
@@ -2685,12 +2701,9 @@ impl Interpreter {
             "return".to_string(),
             0,
             move |interp, this, _args| {
-                let this_id = match this {
-                    JsValue::Object(o) => o.id,
-                    _ => {
-                        let err = interp.create_type_error("return requires an Iterator wrapper");
-                        return Completion::Throw(err);
-                    }
+                let Some(this_id) = this.as_object_id() else {
+                    let err = interp.create_type_error("return requires an Iterator wrapper");
+                    return Completion::Throw(err);
                 };
                 let record = interp.get_object_cell(this_id).and_then(|o| {
                     if let Some(crate::interpreter::types::IterHelperData::Delegation {
@@ -2710,20 +2723,20 @@ impl Interpreter {
                         return Completion::Throw(err);
                     }
                 };
-                if let JsValue::Object(io) = &iter {
-                    let return_method = match interp.get_object_property(io.id, "return", &iter) {
+                if let Some(iter_id) = iter.as_object_id() {
+                    let return_method = match interp.get_object_property(iter_id, "return", &iter) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
-                    if matches!(return_method, JsValue::Undefined | JsValue::Null) {
+                    if return_method.is_nullish() {
                         return Completion::Normal(
-                            interp.create_iter_result_object(JsValue::Undefined, true),
+                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                         );
                     }
                     interp.call_function(&return_method, &iter, &[])
                 } else {
-                    Completion::Normal(interp.create_iter_result_object(JsValue::Undefined, true))
+                    Completion::Normal(interp.create_iter_result_object(JsValue::UNDEFINED, true))
                 }
             },
         ));
@@ -2737,7 +2750,7 @@ impl Interpreter {
             "from".to_string(),
             1,
             move |interp, _this, args| {
-                let obj = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let obj = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // Use GetIteratorFlattenable(obj, iterate-strings) per spec
                 let (iter_val, next_method) = match get_iterator_flattenable(interp, &obj, false) {
@@ -2746,10 +2759,11 @@ impl Interpreter {
                 };
 
                 // OrdinaryHasInstance(%Iterator%, iteratorRecord.[[Iterator]])
-                let has_iter_proto = matches!(
-                    interp.ordinary_has_instance(&iterator_ctor_for_from, &iter_val),
-                    Completion::Normal(JsValue::Boolean(true))
-                );
+                let has_iter_proto =
+                    match interp.ordinary_has_instance(&iterator_ctor_for_from, &iter_val) {
+                        Completion::Normal(v) => v.as_boolean() == Some(true),
+                        _ => false,
+                    };
 
                 if has_iter_proto {
                     return Completion::Normal(iter_val);
@@ -2776,12 +2790,12 @@ impl Interpreter {
                     wrapper.gc_native_roots = Some(vec![iter_val, next_method]);
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: wrapper_id }))
+                Completion::Normal(JsValue::object(wrapper_id))
             },
         ));
 
-        if let JsValue::Object(ctor_obj) = iterator_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_id) = iterator_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_id)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -2796,28 +2810,28 @@ impl Interpreter {
                 let mut iterables: Vec<(JsValue, JsValue)> = Vec::new();
                 for arg in args {
                     // Per spec: each argument must NOT be a primitive (reject-primitives)
-                    if !matches!(arg, JsValue::Object(_)) {
+                    if !arg.is_object() {
                         let err = interp.create_type_error("value is not iterable");
                         return Completion::Throw(err);
                     }
                     if let Some(ref key) = sym_key {
-                        let iter_fn = if let JsValue::Object(o) = arg {
-                            match interp.get_object_property(o.id, key, arg) {
+                        let iter_fn = if let Some(arg_id) = arg.as_object_id() {
+                            match interp.get_object_property(arg_id, key, arg) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             }
                         } else {
-                            JsValue::Undefined
+                            JsValue::UNDEFINED
                         };
-                        if matches!(iter_fn, JsValue::Undefined | JsValue::Null) {
+                        if iter_fn.is_nullish() {
                             let err = interp.create_type_error("value is not iterable");
                             return Completion::Throw(err);
                         }
                         // Verify it's callable
-                        let is_callable = if let JsValue::Object(fo) = &iter_fn {
+                        let is_callable = if let Some(iter_fn_id) = iter_fn.as_object_id() {
                             interp
-                                .get_object_cell(fo.id)
+                                .get_object_cell(iter_fn_id)
                                 .map(|od| od.borrow().callable.is_some())
                                 .unwrap_or(false)
                         } else {
@@ -2856,7 +2870,7 @@ impl Interpreter {
                         let running = state_next.borrow().5;
                         if !alive {
                             return Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             );
                         }
                         if running {
@@ -2872,7 +2886,7 @@ impl Interpreter {
                             };
                             if !alive {
                                 return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
 
@@ -2906,14 +2920,14 @@ impl Interpreter {
                             if idx >= iterables.len() {
                                 state_next.borrow_mut().4 = false;
                                 return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
 
                             let (ref iterable, ref iter_fn) = iterables[idx];
                             match interp.call_function(iter_fn, iterable, &[]) {
                                 Completion::Normal(new_iter) => {
-                                    if !matches!(new_iter, JsValue::Object(_)) {
+                                    if !new_iter.is_object() {
                                         state_next.borrow_mut().4 = false;
                                         let err = interp.create_type_error(
                                             "Result of Symbol.iterator is not an object",
@@ -2939,7 +2953,7 @@ impl Interpreter {
                                 _ => {
                                     state_next.borrow_mut().4 = false;
                                     return Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::Undefined, true),
+                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     );
                                 }
                             }
@@ -2974,7 +2988,7 @@ impl Interpreter {
                             Completion::Throw(e)
                         } else {
                             Completion::Normal(
-                                interp.create_iter_result_object(JsValue::Undefined, true),
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
                         state_ret.borrow_mut().5 = false; // clear running
@@ -2996,17 +3010,17 @@ impl Interpreter {
         ));
 
         // Fix concat.length to 0 (spec says rest parameter = length 0)
-        if let JsValue::Object(concat_obj) = &concat_fn
-            && let Some(obj) = self.get_object_cell(concat_obj.id)
+        if let Some(concat_id) = concat_fn.as_object_id()
+            && let Some(obj) = self.get_object_cell(concat_id)
         {
             obj.borrow_mut().insert_property(
                 "length".to_string(),
-                PropertyDescriptor::data(JsValue::Number(0.0), false, false, true),
+                PropertyDescriptor::data(JsValue::number(0.0), false, false, true),
             );
         }
 
-        if let JsValue::Object(ctor_obj) = iterator_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_id) = iterator_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_id)
         {
             obj.borrow_mut()
                 .insert_builtin("concat".to_string(), concat_fn);
@@ -3017,33 +3031,33 @@ impl Interpreter {
             "zip".to_string(),
             1,
             |interp, _this, args| {
-                let iterables_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterables_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // Step 1: If iterables is not an Object, throw a TypeError
-                if !matches!(iterables_arg, JsValue::Object(_)) {
+                if !iterables_arg.is_object() {
                     let err = interp.create_type_error("iterables is not an object");
                     return Completion::Throw(err);
                 }
 
                 // Step 2: GetOptionsObject(options)
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(options, JsValue::Undefined | JsValue::Object(_)) {
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                if !options.is_undefined() && !options.is_object() {
                     let err = interp.create_type_error("options must be an object or undefined");
                     return Completion::Throw(err);
                 }
 
                 // Step 3: Get mode — NOT ToString, direct string comparison
-                let mode = if matches!(options, JsValue::Undefined) {
+                let mode = if options.is_undefined() {
                     "shortest".to_string()
-                } else if let JsValue::Object(o) = &options {
-                    let mode_val = match interp.get_object_property(o.id, "mode", &options) {
+                } else if let Some(options_id) = options.as_object_id() {
+                    let mode_val = match interp.get_object_property(options_id, "mode", &options) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
-                    if matches!(mode_val, JsValue::Undefined) {
+                    if mode_val.is_undefined() {
                         "shortest".to_string()
-                    } else if let JsValue::String(ref s) = mode_val {
+                    } else if let Some(s) = mode_val.as_string() {
                         let rs = s.to_rust_string();
                         match rs.as_str() {
                             "shortest" | "longest" | "strict" => rs,
@@ -3065,14 +3079,14 @@ impl Interpreter {
 
                 // Step 7: Get padding from options (for "longest" mode)
                 let padding_option = if mode == "longest" {
-                    if let JsValue::Object(o) = &options {
-                        let p = match interp.get_object_property(o.id, "padding", &options) {
+                    if let Some(options_id) = options.as_object_id() {
+                        let p = match interp.get_object_property(options_id, "padding", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
-                        if !matches!(p, JsValue::Undefined) {
-                            if !matches!(p, JsValue::Object(_)) {
+                        if !p.is_undefined() {
+                            if !p.is_object() {
                                 let err = interp
                                     .create_type_error("padding must be an object or undefined");
                                 return Completion::Throw(err);
@@ -3104,13 +3118,13 @@ impl Interpreter {
                         Ok(Some(next_val)) => {
                             match get_iterator_flattenable(interp, &next_val, true) {
                                 Ok(pair) => {
-                                    if let JsValue::Object(o) = &pair.0 {
-                                        collection_temp_ids.push(o.id);
-                                        interp.gc_temp_roots.push(o.id);
+                                    if let Some(id) = pair.0.as_object_id() {
+                                        collection_temp_ids.push(id);
+                                        interp.gc_temp_roots.push(id);
                                     }
-                                    if let JsValue::Object(o) = &pair.1 {
-                                        collection_temp_ids.push(o.id);
-                                        interp.gc_temp_roots.push(o.id);
+                                    if let Some(id) = pair.1.as_object_id() {
+                                        collection_temp_ids.push(id);
+                                        interp.gc_temp_roots.push(id);
                                     }
                                     iters.push(pair);
                                 }
@@ -3166,7 +3180,7 @@ impl Interpreter {
                                     Ok(Some(v)) => pads.push(v),
                                     Ok(None) => {
                                         using_iterator = false;
-                                        pads.push(JsValue::Undefined);
+                                        pads.push(JsValue::UNDEFINED);
                                     }
                                     Err(e) => {
                                         let _ = iterator_close_all(interp, &iters, Err(e.clone()));
@@ -3174,7 +3188,7 @@ impl Interpreter {
                                     }
                                 }
                             } else {
-                                pads.push(JsValue::Undefined);
+                                pads.push(JsValue::UNDEFINED);
                             }
                         }
                         if using_iterator && let Err(e) = iterator_close_getter(interp, &pi) {
@@ -3183,17 +3197,17 @@ impl Interpreter {
                         }
                         pads
                     } else {
-                        vec![JsValue::Undefined; iter_count]
+                        vec![JsValue::UNDEFINED; iter_count]
                     }
                 } else {
-                    vec![JsValue::Undefined; iter_count]
+                    vec![JsValue::UNDEFINED; iter_count]
                 };
 
                 // Also temp-root padding object ids during padding collection
                 for pad_val in &padding_values {
-                    if let JsValue::Object(o) = pad_val {
-                        collection_temp_ids.push(o.id);
-                        interp.gc_temp_roots.push(o.id);
+                    if let Some(id) = pad_val.as_object_id() {
+                        collection_temp_ids.push(id);
+                        interp.gc_temp_roots.push(id);
                     }
                 }
 
@@ -3225,16 +3239,16 @@ impl Interpreter {
                             let s = state_next.borrow();
                             let mut ids = Vec::new();
                             for (io, nm) in &s.0 {
-                                if let JsValue::Object(o) = io {
-                                    ids.push(o.id);
+                                if let Some(id) = io.as_object_id() {
+                                    ids.push(id);
                                 }
-                                if let JsValue::Object(o) = nm {
-                                    ids.push(o.id);
+                                if let Some(id) = nm.as_object_id() {
+                                    ids.push(id);
                                 }
                             }
                             for pad in &s.3 {
-                                if let JsValue::Object(o) = pad {
-                                    ids.push(o.id);
+                                if let Some(id) = pad.as_object_id() {
+                                    ids.push(id);
                                 }
                             }
                             ids
@@ -3276,7 +3290,7 @@ impl Interpreter {
                             }
                         }
                         Completion::Normal(
-                            interp.create_iter_result_object(JsValue::Undefined, true),
+                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                         )
                     },
                 ));
@@ -3304,8 +3318,8 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(ctor_obj) = iterator_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_id) = iterator_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_id)
         {
             obj.borrow_mut().insert_builtin("zip".to_string(), zip_fn);
         }
@@ -3315,36 +3329,33 @@ impl Interpreter {
             "zipKeyed".to_string(),
             1,
             |interp, _this, args| {
-                let iterables_obj = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterables_obj = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // Step 1: iterables must be an object
-                let obj_id = match &iterables_obj {
-                    JsValue::Object(o) => o.id,
-                    _ => {
-                        let err = interp.create_type_error("iterables must be an object");
-                        return Completion::Throw(err);
-                    }
+                let Some(obj_id) = iterables_obj.as_object_id() else {
+                    let err = interp.create_type_error("iterables must be an object");
+                    return Completion::Throw(err);
                 };
 
                 // Step 2: GetOptionsObject(options)
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(options, JsValue::Undefined | JsValue::Object(_)) {
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                if !options.is_undefined() && !options.is_object() {
                     let err = interp.create_type_error("options must be an object or undefined");
                     return Completion::Throw(err);
                 }
 
                 // Step 3: Get mode — direct string comparison, no ToString
-                let mode = if matches!(options, JsValue::Undefined) {
+                let mode = if options.is_undefined() {
                     "shortest".to_string()
-                } else if let JsValue::Object(o) = &options {
-                    let mode_val = match interp.get_object_property(o.id, "mode", &options) {
+                } else if let Some(options_id) = options.as_object_id() {
+                    let mode_val = match interp.get_object_property(options_id, "mode", &options) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
-                    if matches!(mode_val, JsValue::Undefined) {
+                    if mode_val.is_undefined() {
                         "shortest".to_string()
-                    } else if let JsValue::String(ref s) = mode_val {
+                    } else if let Some(s) = mode_val.as_string() {
                         let rs = s.to_rust_string();
                         match rs.as_str() {
                             "shortest" | "longest" | "strict" => rs,
@@ -3366,14 +3377,14 @@ impl Interpreter {
 
                 // Step 7: Get padding from options (for "longest" mode)
                 let padding_option = if mode == "longest" {
-                    if let JsValue::Object(o) = &options {
-                        let p = match interp.get_object_property(o.id, "padding", &options) {
+                    if let Some(options_id) = options.as_object_id() {
+                        let p = match interp.get_object_property(options_id, "padding", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
-                        if !matches!(p, JsValue::Undefined) {
-                            if !matches!(p, JsValue::Object(_)) {
+                        if !p.is_undefined() {
+                            if !p.is_object() {
                                 let err = interp
                                     .create_type_error("padding must be an object or undefined");
                                 return Completion::Throw(err);
@@ -3408,15 +3419,11 @@ impl Interpreter {
                     let is_enumerable = match interp.proxy_get_own_property_descriptor(obj_id, &key)
                     {
                         Ok(desc_val) => {
-                            if matches!(desc_val, JsValue::Undefined) {
+                            if desc_val.is_undefined() {
                                 false
-                            } else if let JsValue::Object(desc_obj) = &desc_val {
+                            } else if let Some(desc_id) = desc_val.as_object_id() {
                                 // Read enumerable from descriptor object
-                                match interp.get_object_property(
-                                    desc_obj.id,
-                                    "enumerable",
-                                    &desc_val,
-                                ) {
+                                match interp.get_object_property(desc_id, "enumerable", &desc_val) {
                                     Completion::Normal(v) => {
                                         crate::interpreter::helpers::to_boolean(&v)
                                     }
@@ -3459,23 +3466,23 @@ impl Interpreter {
                             }
                             return Completion::Throw(e);
                         }
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
 
                     // Step 12.c.iii: If value is not undefined
-                    if matches!(iterable, JsValue::Undefined) {
+                    if iterable.is_undefined() {
                         continue;
                     }
 
                     match get_iterator_flattenable(interp, &iterable, true) {
                         Ok(pair) => {
-                            if let JsValue::Object(o) = &pair.0 {
-                                collection_temp_ids.push(o.id);
-                                interp.gc_temp_roots.push(o.id);
+                            if let Some(id) = pair.0.as_object_id() {
+                                collection_temp_ids.push(id);
+                                interp.gc_temp_roots.push(id);
                             }
-                            if let JsValue::Object(o) = &pair.1 {
-                                collection_temp_ids.push(o.id);
-                                interp.gc_temp_roots.push(o.id);
+                            if let Some(id) = pair.1.as_object_id() {
+                                collection_temp_ids.push(id);
+                                interp.gc_temp_roots.push(id);
                             }
                             key_names.push(key.clone());
                             iters.push(pair);
@@ -3499,35 +3506,35 @@ impl Interpreter {
                 // Step 14: Get padding values per key (for longest mode)
                 let padding_values: Vec<JsValue> = if mode == "longest" {
                     if let Some(ref pad_obj) = padding_option {
-                        if let JsValue::Object(po) = pad_obj {
+                        if let Some(pad_id) = pad_obj.as_object_id() {
                             let mut pads = Vec::with_capacity(iter_count);
                             for key in &key_names {
-                                let val = match interp.get_object_property(po.id, key, pad_obj) {
+                                let val = match interp.get_object_property(pad_id, key, pad_obj) {
                                     Completion::Normal(v) => v,
                                     Completion::Throw(e) => {
                                         let _ = iterator_close_all(interp, &iters, Err(e.clone()));
                                         return Completion::Throw(e);
                                     }
-                                    _ => JsValue::Undefined,
+                                    _ => JsValue::UNDEFINED,
                                 };
                                 pads.push(val);
                             }
                             pads
                         } else {
-                            vec![JsValue::Undefined; iter_count]
+                            vec![JsValue::UNDEFINED; iter_count]
                         }
                     } else {
-                        vec![JsValue::Undefined; iter_count]
+                        vec![JsValue::UNDEFINED; iter_count]
                     }
                 } else {
-                    vec![JsValue::Undefined; iter_count]
+                    vec![JsValue::UNDEFINED; iter_count]
                 };
 
                 // Also temp-root padding object ids
                 for pad_val in &padding_values {
-                    if let JsValue::Object(o) = pad_val {
-                        collection_temp_ids.push(o.id);
-                        interp.gc_temp_roots.push(o.id);
+                    if let Some(id) = pad_val.as_object_id() {
+                        collection_temp_ids.push(id);
+                        interp.gc_temp_roots.push(id);
                     }
                 }
 
@@ -3549,16 +3556,16 @@ impl Interpreter {
                             let s = state_next.borrow();
                             let mut ids = Vec::new();
                             for (io, nm) in &s.1 {
-                                if let JsValue::Object(o) = io {
-                                    ids.push(o.id);
+                                if let Some(id) = io.as_object_id() {
+                                    ids.push(id);
                                 }
-                                if let JsValue::Object(o) = nm {
-                                    ids.push(o.id);
+                                if let Some(id) = nm.as_object_id() {
+                                    ids.push(id);
                                 }
                             }
                             for pad in &s.4 {
-                                if let JsValue::Object(o) = pad {
-                                    ids.push(o.id);
+                                if let Some(id) = pad.as_object_id() {
+                                    ids.push(id);
                                 }
                             }
                             ids
@@ -3598,7 +3605,7 @@ impl Interpreter {
                             }
                         }
                         Completion::Normal(
-                            interp.create_iter_result_object(JsValue::Undefined, true),
+                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                         )
                     },
                 ));
@@ -3626,8 +3633,8 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(ctor_obj) = iterator_ctor
-            && let Some(obj) = self.get_object_cell(ctor_obj.id)
+        if let Some(ctor_id) = iterator_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(ctor_id)
         {
             obj.borrow_mut()
                 .insert_builtin("zipKeyed".to_string(), zip_keyed_fn);
@@ -3650,7 +3657,7 @@ impl Interpreter {
                 done: false,
             });
         let id = self.alloc_object(obj_data);
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     pub(crate) fn create_typed_array_iterator(
@@ -3673,7 +3680,7 @@ impl Interpreter {
                 done: false,
             });
         let id = self.alloc_object(obj_data);
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     pub(crate) fn create_string_iterator(&mut self, string: JsString) -> JsValue {
@@ -3691,7 +3698,7 @@ impl Interpreter {
                 done: false,
             });
         let id = self.alloc_object(obj_data);
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     pub(crate) fn setup_generator_prototype(&mut self) {
@@ -3708,10 +3715,10 @@ impl Interpreter {
             "next".to_string(),
             1,
             |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // Check which variant we have
-                if let JsValue::Object(o) = this
-                    && let Some(obj_rc) = interp.get_object_cell(o.id)
+                if let Some(this_id) = this.as_object_id()
+                    && let Some(obj_rc) = interp.get_object_cell(this_id)
                 {
                     let is_state_machine = matches!(
                         obj_rc.borrow().iterator_state(),
@@ -3736,10 +3743,10 @@ impl Interpreter {
             "return".to_string(),
             1,
             |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // Check which variant we have
-                if let JsValue::Object(o) = this
-                    && let Some(obj_rc) = interp.get_object_cell(o.id)
+                if let Some(this_id) = this.as_object_id()
+                    && let Some(obj_rc) = interp.get_object_cell(this_id)
                 {
                     let is_state_machine = matches!(
                         obj_rc.borrow().iterator_state(),
@@ -3764,10 +3771,10 @@ impl Interpreter {
             "throw".to_string(),
             1,
             |interp, this, args| {
-                let exception = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let exception = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // Check which variant we have
-                if let JsValue::Object(o) = this
-                    && let Some(obj_rc) = interp.get_object_cell(o.id)
+                if let Some(this_id) = this.as_object_id()
+                    && let Some(obj_rc) = interp.get_object_cell(this_id)
                 {
                     let is_state_machine = matches!(
                         obj_rc.borrow().iterator_state(),
@@ -3803,10 +3810,10 @@ impl Interpreter {
         // [[Prototype]] = Function.prototype_id
         // Get Function.prototype from global Function
         if let Some(func_val) = self.get_global_var("Function")
-            && let JsValue::Object(func_obj) = func_val
-            && let JsValue::Object(func_proto_obj) =
-                self.get_property_on_id(func_obj.id, "prototype")
-            && let Some(func_proto) = self.get_object_cell(func_proto_obj.id)
+            && let Some(func_id) = func_val.as_object_id()
+            && let Some(func_proto_id) =
+                self.get_property_on_id(func_id, "prototype").as_object_id()
+            && let Some(func_proto) = self.get_object_cell(func_proto_id)
         {
             self.get_object_cell_expect(gf_proto_id)
                 .borrow_mut()
@@ -3818,12 +3825,7 @@ impl Interpreter {
             .borrow_mut()
             .insert_property(
                 "prototype".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject { id: gen_proto_id }),
-                    false,
-                    false,
-                    true,
-                ),
+                PropertyDescriptor::data(JsValue::object(gen_proto_id), false, false, true),
             );
 
         // Symbol.toStringTag = "GeneratorFunction"
@@ -3834,12 +3836,7 @@ impl Interpreter {
             .borrow_mut()
             .insert_property(
                 "constructor".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject { id: gf_proto_id }),
-                    false,
-                    false,
-                    true,
-                ),
+                PropertyDescriptor::data(JsValue::object(gf_proto_id), false, false, true),
             );
 
         self.realm_mut().generator_function_prototype = Some(gf_proto_id);
@@ -3875,16 +3872,12 @@ impl Interpreter {
                 // 2. Let promiseCapability be ! NewPromiseCapability(%Promise%).
                 let promise_ctor = interp
                     .get_global_var("Promise")
-                    .unwrap_or(JsValue::Undefined);
+                    .unwrap_or(JsValue::UNDEFINED);
                 let cap = match interp.new_promise_capability(&promise_ctor) {
                     Ok(c) => c,
                     Err(e) => return Completion::Throw(e),
                 };
-                let cap_promise_id = if let JsValue::Object(ref o) = cap.promise {
-                    o.id
-                } else {
-                    0
-                };
+                let cap_promise_id = cap.promise.as_object_id().unwrap_or(0);
 
                 // 3. Let return be GetMethod(O, "return").
                 // 4. IfAbruptRejectPromise(return, promiseCapability).
@@ -3897,9 +3890,9 @@ impl Interpreter {
                 };
                 let return_method = if interp.is_callable(&return_method) {
                     Some(return_method)
-                } else if matches!(return_method, JsValue::Undefined | JsValue::Null) {
+                } else if return_method.is_nullish() {
                     None
-                } else if !matches!(return_method, JsValue::Undefined | JsValue::Null) {
+                } else if !return_method.is_nullish() {
                     let e = interp.create_type_error("return is not a function");
                     interp.reject_promise(cap_promise_id, e);
                     return Completion::Normal(cap.promise);
@@ -3912,8 +3905,8 @@ impl Interpreter {
                 if return_method.is_none() {
                     let _ = interp.call_function(
                         &cap.resolve,
-                        &JsValue::Undefined,
-                        &[JsValue::Undefined],
+                        &JsValue::UNDEFINED,
+                        &[JsValue::UNDEFINED],
                     );
                     return Completion::Normal(cap.promise);
                 }
@@ -3946,15 +3939,11 @@ impl Interpreter {
                 let on_fulfilled = interp.create_function(JsFunction::native(
                     "".to_string(),
                     1,
-                    |_interp, _this, _args| Completion::Normal(JsValue::Undefined),
+                    |_interp, _this, _args| Completion::Normal(JsValue::UNDEFINED),
                 ));
 
                 //   g. Perform PerformPromiseThen(resultWrapper, onFulfilled, undefined, promiseCapability).
-                let wrapper_id = if let JsValue::Object(ref o) = result_wrapper {
-                    o.id
-                } else {
-                    0
-                };
+                let wrapper_id = result_wrapper.as_object_id().unwrap_or(0);
                 let fulfill_reaction = crate::interpreter::types::PromiseReaction {
                     handler: Some(on_fulfilled),
                     promise_id: Some(cap_promise_id),
@@ -4033,7 +4022,7 @@ impl Interpreter {
             "next".to_string(),
             1,
             |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.async_generator_next(this, value)
             },
         ));
@@ -4049,7 +4038,7 @@ impl Interpreter {
             "return".to_string(),
             1,
             |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.async_generator_return(this, value)
             },
         ));
@@ -4065,7 +4054,7 @@ impl Interpreter {
             "throw".to_string(),
             1,
             |interp, this, args| {
-                let exception = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let exception = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 interp.async_generator_throw(this, exception)
             },
         ));
@@ -4091,12 +4080,7 @@ impl Interpreter {
             .borrow_mut()
             .insert_property(
                 "prototype".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject { id: gen_proto_id }),
-                    false,
-                    false,
-                    true,
-                ),
+                PropertyDescriptor::data(JsValue::object(gen_proto_id), false, false, true),
             );
         // Symbol.toStringTag
         self.define_to_string_tag(agf_proto_id, "AsyncGeneratorFunction");
@@ -4105,12 +4089,7 @@ impl Interpreter {
             .borrow_mut()
             .insert_property(
                 "constructor".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(crate::types::JsObject { id: agf_proto_id }),
-                    false,
-                    false,
-                    true,
-                ),
+                PropertyDescriptor::data(JsValue::object(agf_proto_id), false, false, true),
             );
         self.realm_mut().async_generator_function_prototype = Some(agf_proto_id);
     }
@@ -4128,86 +4107,80 @@ impl Interpreter {
             .insert_value("value".to_string(), value);
         self.get_object_cell_expect(obj_id)
             .borrow_mut()
-            .insert_value("done".to_string(), JsValue::Boolean(done));
+            .insert_value("done".to_string(), JsValue::boolean(done));
         let id = obj_id;
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     pub(crate) fn get_iterator(&mut self, obj: &JsValue) -> Result<JsValue, JsValue> {
         let sym_key = self.get_symbol_iterator_key();
-        let iter_fn = match obj {
-            JsValue::Object(o) => {
-                if let Some(key) = &sym_key {
-                    let val = match self.get_object_property(o.id, key, obj) {
+        let iter_fn = if let Some(obj_id) = obj.as_object_id() {
+            if let Some(key) = &sym_key {
+                let val = match self.get_object_property(obj_id, key, obj) {
+                    Completion::Normal(v) => v,
+                    Completion::Throw(e) => return Err(e),
+                    _ => JsValue::UNDEFINED,
+                };
+                if val.is_undefined() {
+                    return Err(self.create_type_error("is not iterable"));
+                }
+                val
+            } else {
+                return Err(self.create_type_error("is not iterable"));
+            }
+        } else if obj.is_string() {
+            if let Some(key) = &sym_key {
+                let str_proto_id = self.realm().string_prototype;
+                if let Some(proto_id) = str_proto_id {
+                    let proto_val = JsValue::object(proto_id);
+                    let val = match self.get_object_property(proto_id, key, &proto_val) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Err(e),
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
-                    if matches!(val, JsValue::Undefined) {
+                    if !val.is_undefined() {
+                        val
+                    } else {
                         return Err(self.create_type_error("is not iterable"));
                     }
+                } else {
+                    return Err(self.create_type_error("is not iterable"));
+                }
+            } else {
+                return Err(self.create_type_error("is not iterable"));
+            }
+        } else if let Some(key) = &sym_key {
+            let wrapped = match self.to_object(obj) {
+                Completion::Normal(v) => v,
+                Completion::Throw(e) => return Err(e),
+                _ => return Err(self.create_type_error("is not iterable")),
+            };
+            if let Some(wrapped_id) = wrapped.as_object_id() {
+                let val = match self.get_object_property(wrapped_id, key, &wrapped) {
+                    Completion::Normal(v) => v,
+                    Completion::Throw(e) => return Err(e),
+                    _ => JsValue::UNDEFINED,
+                };
+                if !val.is_nullish() {
                     val
                 } else {
                     return Err(self.create_type_error("is not iterable"));
                 }
+            } else {
+                return Err(self.create_type_error("is not iterable"));
             }
-            JsValue::String(_) => {
-                if let Some(key) = &sym_key {
-                    let str_proto_id = self.realm().string_prototype;
-                    if let Some(proto_id) = str_proto_id {
-                        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
-                        let val = match self.get_object_property(proto_id, key, &proto_val) {
-                            Completion::Normal(v) => v,
-                            Completion::Throw(e) => return Err(e),
-                            _ => JsValue::Undefined,
-                        };
-                        if !matches!(val, JsValue::Undefined) {
-                            val
-                        } else {
-                            return Err(self.create_type_error("is not iterable"));
-                        }
-                    } else {
-                        return Err(self.create_type_error("is not iterable"));
-                    }
-                } else {
-                    return Err(self.create_type_error("is not iterable"));
-                }
-            }
-            _ => {
-                if let Some(key) = &sym_key {
-                    let wrapped = match self.to_object(obj) {
-                        Completion::Normal(v) => v,
-                        Completion::Throw(e) => return Err(e),
-                        _ => return Err(self.create_type_error("is not iterable")),
-                    };
-                    if let JsValue::Object(wo) = &wrapped {
-                        let val = match self.get_object_property(wo.id, key, &wrapped) {
-                            Completion::Normal(v) => v,
-                            Completion::Throw(e) => return Err(e),
-                            _ => JsValue::Undefined,
-                        };
-                        if !matches!(val, JsValue::Undefined | JsValue::Null) {
-                            val
-                        } else {
-                            return Err(self.create_type_error("is not iterable"));
-                        }
-                    } else {
-                        return Err(self.create_type_error("is not iterable"));
-                    }
-                } else {
-                    return Err(self.create_type_error("is not iterable"));
-                }
-            }
+        } else {
+            return Err(self.create_type_error("is not iterable"));
         };
         match self.call_function(&iter_fn, obj, &[]) {
             Completion::Normal(v) => {
-                if let JsValue::Object(o) = &v {
-                    let next_method = match self.get_object_property(o.id, "next", &v) {
+                if let Some(v_id) = v.as_object_id() {
+                    let next_method = match self.get_object_property(v_id, "next", &v) {
                         Completion::Normal(n) => n,
                         Completion::Throw(e) => return Err(e),
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
-                    self.iterator_next_cache.insert(o.id, next_method);
+                    self.iterator_next_cache.insert(v_id, next_method);
                     Ok(v)
                 } else {
                     Err(self
@@ -4222,31 +4195,26 @@ impl Interpreter {
     pub(crate) fn get_async_iterator(&mut self, obj: &JsValue) -> Result<JsValue, JsValue> {
         let async_sym_key = self.get_symbol_key("asyncIterator");
         if let Some(key) = &async_sym_key {
-            let iter_fn = match obj {
-                JsValue::Object(o) => {
-                    let val = match self.get_object_property(o.id, key, obj) {
-                        Completion::Normal(v) => v,
-                        Completion::Throw(e) => return Err(e),
-                        _ => JsValue::Undefined,
-                    };
-                    if !matches!(val, JsValue::Undefined | JsValue::Null) {
-                        Some(val)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
+            let iter_fn = if let Some(obj_id) = obj.as_object_id() {
+                let val = match self.get_object_property(obj_id, key, obj) {
+                    Completion::Normal(v) => v,
+                    Completion::Throw(e) => return Err(e),
+                    _ => JsValue::UNDEFINED,
+                };
+                if !val.is_nullish() { Some(val) } else { None }
+            } else {
+                None
             };
             if let Some(iter_fn) = iter_fn {
                 return match self.call_function(&iter_fn, obj, &[]) {
                     Completion::Normal(v) => {
-                        if let JsValue::Object(o) = &v {
-                            let next_method = match self.get_object_property(o.id, "next", &v) {
+                        if let Some(v_id) = v.as_object_id() {
+                            let next_method = match self.get_object_property(v_id, "next", &v) {
                                 Completion::Normal(n) => n,
                                 Completion::Throw(e) => return Err(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
-                            self.iterator_next_cache.insert(o.id, next_method);
+                            self.iterator_next_cache.insert(v_id, next_method);
                             Ok(v)
                         } else {
                             Err(self.create_type_error(
@@ -4266,17 +4234,17 @@ impl Interpreter {
 
     pub(crate) fn create_async_from_sync_iterator(&mut self, sync_iter: JsValue) -> JsValue {
         let wrapper_id = self.create_object_id();
-        let cached_next = if let JsValue::Object(io) = &sync_iter {
-            if let Some(cached) = self.iterator_next_cache.get(&io.id).cloned() {
+        let cached_next = if let Some(sync_id) = sync_iter.as_object_id() {
+            if let Some(cached) = self.iterator_next_cache.get(&sync_id).cloned() {
                 cached
             } else {
-                match self.get_object_property(io.id, "next", &sync_iter) {
-                    Completion::Normal(v) if !matches!(v, JsValue::Undefined) => v,
-                    _ => JsValue::Undefined,
+                match self.get_object_property(sync_id, "next", &sync_iter) {
+                    Completion::Normal(v) if !v.is_undefined() => v,
+                    _ => JsValue::UNDEFINED,
                 }
             }
         } else {
-            JsValue::Undefined
+            JsValue::UNDEFINED
         };
 
         // §27.1.2.1 next()
@@ -4291,7 +4259,7 @@ impl Interpreter {
                     std::slice::from_ref(&args[0])
                 };
                 let result = match interp.call_function(&cached_next, &sync_for_next, call_args) {
-                    Completion::Normal(v) if matches!(v, JsValue::Object(_)) => v,
+                    Completion::Normal(v) if v.is_object() => v,
                     Completion::Normal(_) => {
                         let e = interp.create_type_error("Iterator result is not an object");
                         return interp.create_rejected_promise(e);
@@ -4316,16 +4284,16 @@ impl Interpreter {
             "return".to_string(),
             1,
             move |interp, _this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let value_present = !args.is_empty();
-                if let JsValue::Object(io) = &sync_for_return {
+                if let Some(sync_id) = sync_for_return.as_object_id() {
                     // GetMethod(syncIterator, "return")
-                    let ret_fn = match interp.get_object_property(io.id, "return", &sync_for_return)
-                    {
-                        Completion::Normal(v) if interp.is_callable(&v) => Some(v),
-                        Completion::Throw(e) => return interp.create_rejected_promise(e),
-                        _ => None,
-                    };
+                    let ret_fn =
+                        match interp.get_object_property(sync_id, "return", &sync_for_return) {
+                            Completion::Normal(v) if interp.is_callable(&v) => Some(v),
+                            Completion::Throw(e) => return interp.create_rejected_promise(e),
+                            _ => None,
+                        };
                     if let Some(ret_fn) = ret_fn {
                         // §27.1.2.2 step 8-9: pass value only if present
                         let call_args: &[JsValue] = if value_present {
@@ -4339,9 +4307,9 @@ impl Interpreter {
                                 Completion::Throw(e) => {
                                     return interp.create_rejected_promise(e);
                                 }
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
-                        if !matches!(return_result, JsValue::Object(_)) {
+                        if !return_result.is_object() {
                             let e = interp.create_type_error("Iterator result is not an object");
                             return interp.create_rejected_promise(e);
                         }
@@ -4355,16 +4323,16 @@ impl Interpreter {
                         // return is undefined: resolve with {value, done: true}
                         let iter_result = interp.create_iter_result_object(value, true);
                         let promise = interp.create_promise_object();
-                        if let JsValue::Object(ref o) = promise {
-                            interp.fulfill_promise(o.id, iter_result);
+                        if let Some(promise_id) = promise.as_object_id() {
+                            interp.fulfill_promise(promise_id, iter_result);
                         }
                         Completion::Normal(promise)
                     }
                 } else {
-                    let iter_result = interp.create_iter_result_object(JsValue::Undefined, true);
+                    let iter_result = interp.create_iter_result_object(JsValue::UNDEFINED, true);
                     let promise = interp.create_promise_object();
-                    if let JsValue::Object(ref o) = promise {
-                        interp.fulfill_promise(o.id, iter_result);
+                    if let Some(promise_id) = promise.as_object_id() {
+                        interp.fulfill_promise(promise_id, iter_result);
                     }
                     Completion::Normal(promise)
                 }
@@ -4380,11 +4348,11 @@ impl Interpreter {
             "throw".to_string(),
             1,
             move |interp, _this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(io) = &sync_for_throw {
+                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(sync_id) = sync_for_throw.as_object_id() {
                     // GetMethod(syncIterator, "throw")
                     let throw_method =
-                        match interp.get_object_property(io.id, "throw", &sync_for_throw) {
+                        match interp.get_object_property(sync_id, "throw", &sync_for_throw) {
                             Completion::Normal(v) if interp.is_callable(&v) => Some(v),
                             Completion::Throw(e) => return interp.create_rejected_promise(e),
                             _ => None,
@@ -4394,9 +4362,9 @@ impl Interpreter {
                             match interp.call_function(&throw_method, &sync_for_throw, &[value]) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return interp.create_rejected_promise(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
-                        if !matches!(throw_result, JsValue::Object(_)) {
+                        if !throw_result.is_object() {
                             let e = interp.create_type_error("Iterator result is not an object");
                             return interp.create_rejected_promise(e);
                         }
@@ -4428,7 +4396,7 @@ impl Interpreter {
             .insert_builtin("throw".to_string(), throw_fn);
 
         let id = wrapper_id;
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     }
 
     /// §27.1.2.4 AsyncFromSyncIteratorContinuation(result, promiseCap, syncIterRec, closeOnRejection)
@@ -4448,10 +4416,10 @@ impl Interpreter {
             Ok(v) => v,
             Err(e) => return self.create_rejected_promise(e),
         };
-        let done_bool = matches!(done, JsValue::Boolean(true));
+        let done_bool = done.as_boolean() == Some(true);
 
         // Step 5: valueWrapper = PromiseResolve(%Promise%, value)
-        let promise_ctor = self.get_global_var("Promise").unwrap_or(JsValue::Undefined);
+        let promise_ctor = self.get_global_var("Promise").unwrap_or(JsValue::UNDEFINED);
         let value_wrapper = match self.promise_resolve_with_constructor(&promise_ctor, &value) {
             Ok(w) => w,
             Err(e) => {
@@ -4475,12 +4443,12 @@ impl Interpreter {
             "".to_string(),
             1,
             move |interp, _this, args| {
-                let resolved_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let resolved_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let iter_result = interp.create_iter_result_object(resolved_val, done_bool);
-                if let JsValue::Object(ref op) = outer_clone1 {
-                    interp.fulfill_promise(op.id, iter_result);
+                if let Some(op_id) = outer_clone1.as_object_id() {
+                    interp.fulfill_promise(op_id, iter_result);
                 }
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
 
@@ -4492,12 +4460,12 @@ impl Interpreter {
                 "".to_string(),
                 1,
                 move |interp, _this, args| {
-                    let err = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let err = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let _ = interp.iterator_close_result(&sync_for_close);
-                    if let JsValue::Object(ref op) = outer_clone2 {
-                        interp.reject_promise(op.id, err);
+                    if let Some(op_id) = outer_clone2.as_object_id() {
+                        interp.reject_promise(op_id, err);
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ))
         } else {
@@ -4505,20 +4473,16 @@ impl Interpreter {
                 "".to_string(),
                 1,
                 move |interp, _this, args| {
-                    let err = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if let JsValue::Object(ref op) = outer_clone2 {
-                        interp.reject_promise(op.id, err);
+                    let err = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if let Some(op_id) = outer_clone2.as_object_id() {
+                        interp.reject_promise(op_id, err);
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ))
         };
 
-        let outer_id = if let JsValue::Object(ref o) = outer_promise {
-            o.id
-        } else {
-            0
-        };
+        let outer_id = outer_promise.as_object_id().unwrap_or(0);
         let (outer_resolve, outer_reject) = self.create_resolving_functions(outer_id);
         let _ = self.perform_promise_then(
             &value_wrapper,
@@ -4532,16 +4496,16 @@ impl Interpreter {
     }
 
     pub(crate) fn iterator_next(&mut self, iterator: &JsValue) -> Result<JsValue, JsValue> {
-        if let JsValue::Object(io) = iterator {
-            let next_fn = if let Some(cached) = self.iterator_next_cache.get(&io.id).cloned() {
-                if matches!(cached, JsValue::Undefined) {
+        if let Some(iter_id) = iterator.as_object_id() {
+            let next_fn = if let Some(cached) = self.iterator_next_cache.get(&iter_id).cloned() {
+                if cached.is_undefined() {
                     None
                 } else {
                     Some(cached)
                 }
             } else {
-                match self.get_object_property(io.id, "next", iterator) {
-                    Completion::Normal(v) if !matches!(v, JsValue::Undefined) => Some(v),
+                match self.get_object_property(iter_id, "next", iterator) {
+                    Completion::Normal(v) if !v.is_undefined() => Some(v),
                     Completion::Throw(e) => return Err(e),
                     _ => None,
                 }
@@ -4549,7 +4513,7 @@ impl Interpreter {
             if let Some(next_fn) = next_fn {
                 match self.call_function(&next_fn, iterator, &[]) {
                     Completion::Normal(v) => {
-                        if matches!(v, JsValue::Object(_)) {
+                        if v.is_object() {
                             Ok(v)
                         } else {
                             Err(self.create_type_error("Iterator result is not an object"))
@@ -4567,11 +4531,11 @@ impl Interpreter {
     }
 
     pub(crate) fn iterator_complete(&mut self, result: &JsValue) -> Result<bool, JsValue> {
-        if let JsValue::Object(o) = result {
-            let done = match self.get_object_property(o.id, "done", result) {
+        if let Some(result_id) = result.as_object_id() {
+            let done = match self.get_object_property(result_id, "done", result) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             return Ok(self.to_boolean_val(&done));
         }
@@ -4579,14 +4543,14 @@ impl Interpreter {
     }
 
     pub(crate) fn iterator_value(&mut self, result: &JsValue) -> Result<JsValue, JsValue> {
-        if let JsValue::Object(o) = result {
-            match self.get_object_property(o.id, "value", result) {
+        if let Some(result_id) = result.as_object_id() {
+            match self.get_object_property(result_id, "value", result) {
                 Completion::Normal(v) => Ok(v),
                 Completion::Throw(e) => Err(e),
-                _ => Ok(JsValue::Undefined),
+                _ => Ok(JsValue::UNDEFINED),
             }
         } else {
-            Ok(JsValue::Undefined)
+            Ok(JsValue::UNDEFINED)
         }
     }
 
@@ -4604,9 +4568,9 @@ impl Interpreter {
         iterator: &JsValue,
         value: &JsValue,
     ) -> Result<Option<JsValue>, JsValue> {
-        if let JsValue::Object(io) = iterator {
-            let return_fn = match self.get_object_property(io.id, "return", iterator) {
-                Completion::Normal(v) if matches!(v, JsValue::Object(_)) => Some(v),
+        if let Some(iter_id) = iterator.as_object_id() {
+            let return_fn = match self.get_object_property(iter_id, "return", iterator) {
+                Completion::Normal(v) if v.is_object() => Some(v),
                 Completion::Normal(_) => None,
                 Completion::Throw(e) => return Err(e),
                 _ => None,
@@ -4614,7 +4578,7 @@ impl Interpreter {
             if let Some(return_fn) = return_fn {
                 match self.call_function(&return_fn, iterator, std::slice::from_ref(value)) {
                     Completion::Normal(v) => {
-                        if matches!(v, JsValue::Object(_)) {
+                        if v.is_object() {
                             Ok(Some(v))
                         } else {
                             Err(self.create_type_error("Iterator return result is not an object"))
@@ -4636,9 +4600,9 @@ impl Interpreter {
         iterator: &JsValue,
         exception: &JsValue,
     ) -> Result<Option<JsValue>, JsValue> {
-        if let JsValue::Object(io) = iterator {
-            let throw_fn = match self.get_object_property(io.id, "throw", iterator) {
-                Completion::Normal(v) if matches!(v, JsValue::Object(_)) => Some(v),
+        if let Some(iter_id) = iterator.as_object_id() {
+            let throw_fn = match self.get_object_property(iter_id, "throw", iterator) {
+                Completion::Normal(v) if v.is_object() => Some(v),
                 Completion::Normal(_) => None,
                 Completion::Throw(e) => return Err(e),
                 _ => None,
@@ -4646,7 +4610,7 @@ impl Interpreter {
             if let Some(throw_fn) = throw_fn {
                 match self.call_function(&throw_fn, iterator, std::slice::from_ref(exception)) {
                     Completion::Normal(v) => {
-                        if matches!(v, JsValue::Object(_)) {
+                        if v.is_object() {
                             Ok(Some(v))
                         } else {
                             Err(self.create_type_error("Iterator throw result is not an object"))
@@ -4673,9 +4637,9 @@ impl Interpreter {
         // itself calls `__host_exit`, that boundary returns a `JsValue` and so
         // cannot carry the exit — record it in the terminal `pending_exit`
         // sink instead. Inert unless the node host floor is enabled.
-        if let JsValue::Object(io) = iterator {
+        if let Some(iter_id) = iterator.as_object_id() {
             // GetMethod(iterator, "return"): undefined/null → no-op, non-callable → TypeError
-            let return_val = match self.get_object_property(io.id, "return", iterator) {
+            let return_val = match self.get_object_property(iter_id, "return", iterator) {
                 Completion::Normal(v) => v,
                 Completion::Throw(_e) => return _completion, // original completion takes priority
                 _ => return _completion,
@@ -4701,9 +4665,9 @@ impl Interpreter {
         // unwinding a body `Completion::Exit`. If `return()` itself calls
         // `__host_exit`, record it in the terminal sink — this `Result`-typed
         // boundary cannot carry a `Completion::Exit`. Inert off-path.
-        if let JsValue::Object(io) = iterator {
+        if let Some(iter_id) = iterator.as_object_id() {
             // GetMethod(iterator, "return"): undefined/null → no-op, non-callable → TypeError
-            let return_val = match self.get_object_property(io.id, "return", iterator) {
+            let return_val = match self.get_object_property(iter_id, "return", iterator) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
                 _ => return Ok(()),
@@ -4715,7 +4679,7 @@ impl Interpreter {
                 return Err(self.create_type_error("iterator.return is not a function"));
             }
             match self.call_function(&return_val, iterator, &[]) {
-                Completion::Normal(inner_result) if !matches!(inner_result, JsValue::Object(_)) => {
+                Completion::Normal(inner_result) if !inner_result.is_object() => {
                     return Err(self.create_type_error("Iterator result is not an object"));
                 }
                 Completion::Throw(e) => return Err(e),
@@ -4733,7 +4697,7 @@ impl Interpreter {
     ) -> Result<Option<JsValue>, JsValue> {
         match self.call_function(next_method, iterator, &[]) {
             Completion::Normal(result) => {
-                if !matches!(result, JsValue::Object(_)) {
+                if !result.is_object() {
                     return Err(self.create_type_error("Iterator result is not an object"));
                 }
                 if self.iterator_complete(&result)? {
@@ -4776,14 +4740,13 @@ impl Interpreter {
         &mut self,
         obj: &JsValue,
     ) -> Result<Vec<JsValue>, JsValue> {
-        let obj_id = match obj {
-            JsValue::Object(o) => o.id,
-            _ => return Err(self.create_type_error("CreateListFromArrayLike called on non-object")),
+        let Some(obj_id) = obj.as_object_id() else {
+            return Err(self.create_type_error("CreateListFromArrayLike called on non-object"));
         };
         let len_val = match self.get_object_property(obj_id, "length", obj) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(e),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
         let n = self.to_number_value(&len_val)?;
         let len = if n.is_nan() || n <= 0.0 {
@@ -4797,7 +4760,7 @@ impl Interpreter {
             let next = match self.get_object_property(obj_id, &index_name, obj) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             list.push(next);
         }

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -380,12 +380,9 @@ fn to_regex_input_with_units(
     interp: &mut Interpreter,
     val: &JsValue,
 ) -> Result<(String, Vec<u16>), JsValue> {
-    match val {
-        JsValue::String(s) => Ok((
-            js_string_to_regex_input(&s.code_units),
-            s.code_units.to_vec(),
-        )),
-        _ => {
+    match val.with_string(|units| (js_string_to_regex_input(units), units.to_vec())) {
+        Some(pair) => Ok(pair),
+        None => {
             let s = interp.to_string_value(val)?;
             let js = JsString::from_str(&s);
             Ok((js_string_to_regex_input(&js.code_units), js.into_vec()))
@@ -7389,15 +7386,15 @@ fn bytes_regex_captures_at(
 }
 
 fn extract_source_flags(interp: &Interpreter, this_val: &JsValue) -> Option<(String, String, u64)> {
-    if let JsValue::Object(o) = this_val
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(obj_id) = this_val.as_object_id()
+        && let Some(obj) = interp.get_object_cell(obj_id)
     {
         let b = obj.borrow();
         let r = b.regexp()?;
         let source = js_string_to_regex_input(&r.source.code_units);
         let flags = r.flags.to_rust_string();
         drop(b);
-        Some((source, flags, o.id))
+        Some((source, flags, obj_id))
     } else {
         None
     }
@@ -7434,9 +7431,9 @@ fn is_pristine_regexp(interp: &Interpreter, rx_id: u64) -> bool {
     };
     let bp = realm_proto.borrow();
     if let Some(pd) = bp.properties.get("exec")
-        && let Some(JsValue::Object(o)) = &pd.value
+        && let Some(exec_id) = pd.value.as_ref().and_then(JsValue::as_object_id)
     {
-        return o.id == builtin_exec_id;
+        return exec_id == builtin_exec_id;
     }
     false
 }
@@ -7449,7 +7446,7 @@ fn spec_set(
     value: JsValue,
     throw: bool,
 ) -> Result<(), JsValue> {
-    let obj_val = JsValue::Object(crate::types::JsObject { id: obj_id });
+    let obj_val = JsValue::object(obj_id);
     if let Some(obj) = interp.get_object_cell(obj_id) {
         // Proxy set trap
         if obj.borrow().is_proxy() || obj.borrow().is_proxy_revoked() {
@@ -7466,7 +7463,7 @@ fn spec_set(
         let desc = interp.get_property_descriptor_on_id(obj_id, key);
         if let Some(ref d) = desc
             && let Some(ref setter) = d.set
-            && !matches!(setter, JsValue::Undefined)
+            && !setter.is_undefined()
         {
             let setter = setter.clone();
             return match interp.call_function(&setter, &obj_val, &[value]) {
@@ -7498,7 +7495,7 @@ fn spec_set(
 }
 
 fn set_last_index_strict(interp: &mut Interpreter, obj_id: u64, val: f64) -> Result<(), JsValue> {
-    spec_set(interp, obj_id, "lastIndex", JsValue::Number(val), true)
+    spec_set(interp, obj_id, "lastIndex", JsValue::number(val), true)
 }
 
 fn regexp_exec_abstract(
@@ -7507,7 +7504,7 @@ fn regexp_exec_abstract(
     s: &str,
     code_units: &[u16],
 ) -> Completion {
-    let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
+    let rx_val = JsValue::object(rx_id);
     let exec_val = match interp.get_object_property(rx_id, "exec", &rx_val) {
         Completion::Normal(v) => v,
         other => return other,
@@ -7516,11 +7513,11 @@ fn regexp_exec_abstract(
         let result = interp.call_function(
             &exec_val,
             &rx_val,
-            &[JsValue::String(JsString::from_vec(code_units.to_vec()))],
+            &[JsValue::string(JsString::from_vec(code_units.to_vec()))],
         );
         match result {
             Completion::Normal(ref v) => {
-                if matches!(v, JsValue::Object(_)) || matches!(v, JsValue::Null) {
+                if v.is_object() || v.is_null() {
                     result
                 } else {
                     Completion::Throw(interp.create_type_error(
@@ -7555,7 +7552,7 @@ fn regexp_exec_abstract(
             drop(b);
             (src, fl)
         } else {
-            return Completion::Normal(JsValue::Null);
+            return Completion::Normal(JsValue::NULL);
         };
         regexp_exec_raw(interp, rx_id, &source, &flags, s, code_units)
     }
@@ -7663,7 +7660,7 @@ fn get_substitution(
                     i += 2;
                 }
                 '<' => {
-                    if matches!(named_captures, JsValue::Undefined) {
+                    if named_captures.is_undefined() {
                         result.push('$');
                         result.push('<');
                         i += 2;
@@ -7675,9 +7672,9 @@ fn get_substitution(
                                 [start..start + rest[..end_pos].chars().count()]
                                 .iter()
                                 .collect();
-                            let nc_obj = match named_captures {
-                                JsValue::Object(o) => o.id,
-                                _ => {
+                            let nc_obj = match named_captures.as_object_id() {
+                                Some(id) => id,
+                                None => {
                                     result.push('$');
                                     result.push('<');
                                     i += 2;
@@ -7691,7 +7688,7 @@ fn get_substitution(
                             ) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Err(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
                             if !capture.is_undefined() {
                                 let cap_js = interp.to_js_string(&capture)?;
@@ -7785,7 +7782,7 @@ fn regexp_exec_raw(
     // Spec: Let lastIndex be ? ToLength(? Get(R, "lastIndex")).
     // ToLength may trigger valueOf side effects that recompile the regexp,
     // so we re-read source/flags from internal slots afterward.
-    let this_val = JsValue::Object(crate::types::JsObject { id: this_id });
+    let this_val = JsValue::object(this_id);
     let li_val = match interp.get_object_property(this_id, "lastIndex", &this_val) {
         Completion::Normal(v) => v,
         other => return other,
@@ -7840,7 +7837,7 @@ fn regexp_exec_raw(
             if let Err(e) = set_last_index_strict(interp, this_id, 0.0) {
                 return Completion::Throw(e);
             }
-            return Completion::Normal(JsValue::Null);
+            return Completion::Normal(JsValue::NULL);
         }
         li_int as usize
     } else {
@@ -7848,7 +7845,7 @@ fn regexp_exec_raw(
     };
     let cached = match build_regex_cached(interp, source, flags) {
         Ok(r) => r,
-        Err(_) => return Completion::Normal(JsValue::Null),
+        Err(_) => return Completion::Normal(JsValue::NULL),
     };
 
     let is_bytes_mode = matches!(cached.compiled, CompiledRegex::Bytes(_));
@@ -7873,7 +7870,7 @@ fn regexp_exec_raw(
                     {
                         return Completion::Throw(e);
                     }
-                    return Completion::Normal(JsValue::Null);
+                    return Completion::Normal(JsValue::NULL);
                 }
             }
         } else {
@@ -7888,7 +7885,7 @@ fn regexp_exec_raw(
                 {
                     return Completion::Throw(e);
                 }
-                return Completion::Normal(JsValue::Null);
+                return Completion::Normal(JsValue::NULL);
             }
         }
     };
@@ -7917,7 +7914,7 @@ fn regexp_exec_raw(
         if let Err(e) = set_last_index_strict(interp, this_id, 0.0) {
             return Completion::Throw(e);
         }
-        return Completion::Normal(JsValue::Null);
+        return Completion::Normal(JsValue::NULL);
     }
 
     if (global || sticky)
@@ -7955,11 +7952,11 @@ fn regexp_exec_raw(
     }
 
     let mut elements: Vec<JsValue> = Vec::new();
-    elements.push(JsValue::String(regex_output_to_js_string(&full_match.text)));
+    elements.push(JsValue::string(regex_output_to_js_string(&full_match.text)));
     for i in 1..caps.len() {
         match caps.get(i) {
-            Some(m) => elements.push(JsValue::String(regex_output_to_js_string(&m.text))),
-            None => elements.push(JsValue::Undefined),
+            Some(m) => elements.push(JsValue::string(regex_output_to_js_string(&m.text))),
+            None => elements.push(JsValue::UNDEFINED),
         }
     }
 
@@ -7977,8 +7974,8 @@ fn regexp_exec_raw(
             .prototype_id = None;
         for (name, m) in resolved {
             let val = match m {
-                Some(m) => JsValue::String(regex_output_to_js_string(&m.text)),
-                None => JsValue::Undefined,
+                Some(m) => JsValue::string(regex_output_to_js_string(&m.text)),
+                None => JsValue::UNDEFINED,
             };
             interp
                 .get_object_cell_expect(groups_obj_id)
@@ -7986,22 +7983,22 @@ fn regexp_exec_raw(
                 .insert_value(name.clone(), val);
         }
         let id = groups_obj_id;
-        JsValue::Object(crate::types::JsObject { id })
+        JsValue::object(id)
     } else {
-        JsValue::Undefined
+        JsValue::UNDEFINED
     };
 
     let result = interp.create_array(elements);
-    if let JsValue::Object(ref ro) = result
-        && let Some(robj) = interp.get_object(ro.id)
+    if let Some(ro_id) = result.as_object_id()
+        && let Some(robj) = interp.get_object(ro_id)
     {
         robj.borrow_mut().insert_value(
             "index".to_string(),
-            JsValue::Number(match_start_utf16 as f64),
+            JsValue::number(match_start_utf16 as f64),
         );
         robj.borrow_mut().insert_value(
             "input".to_string(),
-            JsValue::String(JsString::from_str(input)),
+            JsValue::string(JsString::from_str(input)),
         );
         robj.borrow_mut()
             .insert_value("groups".to_string(), groups_val.clone());
@@ -8021,12 +8018,12 @@ fn regexp_exec_raw(
                         let cap_start = cap_byte_to_utf16(m.start);
                         let cap_end = cap_byte_to_utf16(m.end);
                         let pair = interp.create_array(vec![
-                            JsValue::Number(cap_start as f64),
-                            JsValue::Number(cap_end as f64),
+                            JsValue::number(cap_start as f64),
+                            JsValue::number(cap_end as f64),
                         ]);
                         index_pairs.push(pair);
                     }
-                    None => index_pairs.push(JsValue::Undefined),
+                    None => index_pairs.push(JsValue::UNDEFINED),
                 }
             }
             let indices_arr = interp.create_array(index_pairs);
@@ -8042,30 +8039,28 @@ fn regexp_exec_raw(
                             let cap_start = cap_byte_to_utf16(m.start);
                             let cap_end = cap_byte_to_utf16(m.end);
                             interp.create_array(vec![
-                                JsValue::Number(cap_start as f64),
-                                JsValue::Number(cap_end as f64),
+                                JsValue::number(cap_start as f64),
+                                JsValue::number(cap_end as f64),
                             ])
                         }
-                        None => JsValue::Undefined,
+                        None => JsValue::UNDEFINED,
                     };
                     interp
                         .get_object_cell_expect(idx_groups_id)
                         .borrow_mut()
                         .insert_value(name.clone(), val);
                 }
-                if let JsValue::Object(ref io) = indices_arr
-                    && let Some(iobj) = interp.get_object_cell(io.id)
+                if let Some(io_id) = indices_arr.as_object_id()
+                    && let Some(iobj) = interp.get_object_cell(io_id)
                 {
-                    iobj.borrow_mut().insert_value(
-                        "groups".to_string(),
-                        JsValue::Object(crate::types::JsObject { id: idx_groups_id }),
-                    );
+                    iobj.borrow_mut()
+                        .insert_value("groups".to_string(), JsValue::object(idx_groups_id));
                 }
-            } else if let JsValue::Object(ref io) = indices_arr
-                && let Some(iobj) = interp.get_object_cell(io.id)
+            } else if let Some(io_id) = indices_arr.as_object_id()
+                && let Some(iobj) = interp.get_object_cell(io_id)
             {
                 iobj.borrow_mut()
-                    .insert_value("groups".to_string(), JsValue::Undefined);
+                    .insert_value("groups".to_string(), JsValue::UNDEFINED);
             }
             robj.borrow_mut()
                 .insert_value("indices".to_string(), indices_arr);
@@ -8090,9 +8085,9 @@ impl Interpreter {
             "exec".to_string(),
             1,
             |interp, this_val, args| {
-                let obj_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let obj_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype.exec requires that 'this' be an Object",
                         ));
@@ -8105,7 +8100,7 @@ impl Interpreter {
                         "RegExp.prototype.exec requires that 'this' be a RegExp object",
                     ));
                 }
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (input, code_units) = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
@@ -8113,11 +8108,11 @@ impl Interpreter {
                 if let Some((source, flags, obj_id)) = extract_source_flags(interp, this_val) {
                     return regexp_exec_raw(interp, obj_id, &source, &flags, &input, &code_units);
                 }
-                Completion::Normal(JsValue::Null)
+                Completion::Normal(JsValue::NULL)
             },
         ));
-        if let JsValue::Object(ref o) = exec_fn {
-            self.realm_mut().builtin_regexp_exec_id = Some(o.id);
+        if let Some(exec_id) = exec_fn.as_object_id() {
+            self.realm_mut().builtin_regexp_exec_id = Some(exec_id);
         }
         self.get_object_cell_expect(regexp_proto_id)
             .borrow_mut()
@@ -8128,24 +8123,22 @@ impl Interpreter {
             "test".to_string(),
             1,
             |interp, this_val, args| {
-                let obj_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let obj_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype.test requires that 'this' be an Object",
                         ));
                     }
                 };
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (input, input_cu) = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
                 let result = regexp_exec_abstract(interp, obj_id, &input, &input_cu);
                 match result {
-                    Completion::Normal(v) => {
-                        Completion::Normal(JsValue::Boolean(!matches!(v, JsValue::Null)))
-                    }
+                    Completion::Normal(v) => Completion::Normal(JsValue::boolean(!v.is_null())),
                     other => other,
                 }
             },
@@ -8159,9 +8152,9 @@ impl Interpreter {
             "toString".to_string(),
             0,
             |interp, this_val, _args| {
-                let obj_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let obj_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype.toString requires that 'this' be an Object",
                         ));
@@ -8185,7 +8178,7 @@ impl Interpreter {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
                 };
-                Completion::Normal(JsValue::String(JsString::from_str(&format!(
+                Completion::Normal(JsValue::string(JsString::from_str(&format!(
                     "/{}/{}",
                     source, flags
                 ))))
@@ -8202,9 +8195,9 @@ impl Interpreter {
             2,
             move |interp, this_val, args| {
                 // 1. Let O be the this value.
-                let obj_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let obj_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype.compile requires that 'this' be an Object",
                         ));
@@ -8230,16 +8223,16 @@ impl Interpreter {
                     ));
                 }
 
-                let pattern_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let flags_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let pattern_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let flags_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let (pattern_str, flags_str);
                 let pattern_js: Option<JsString>;
 
                 // 3. If pattern is a RegExp object
-                let pattern_is_regexp = if let JsValue::Object(po) = &pattern_arg {
+                let pattern_is_regexp = if let Some(po_id) = pattern_arg.as_object_id() {
                     interp
-                        .get_object_cell(po.id)
+                        .get_object_cell(po_id)
                         .map(|o| o.borrow().class_name == "RegExp")
                         .unwrap_or(false)
                 } else {
@@ -8248,15 +8241,15 @@ impl Interpreter {
 
                 if pattern_is_regexp {
                     // a. If flags is not undefined, throw a TypeError exception.
-                    if !matches!(flags_arg, JsValue::Undefined) {
+                    if !flags_arg.is_undefined() {
                         return Completion::Throw(interp.create_type_error(
                             "Cannot supply flags when constructing one RegExp from another",
                         ));
                     }
                     // b. Let P be pattern.[[OriginalSource]].
                     // c. Let F be pattern.[[OriginalFlags]].
-                    let po_id = if let JsValue::Object(po) = &pattern_arg {
-                        po.id
+                    let po_id = if let Some(id) = pattern_arg.as_object_id() {
+                        id
                     } else {
                         unreachable!()
                     };
@@ -8278,7 +8271,7 @@ impl Interpreter {
                     }
                 } else {
                     // 4. Let P be pattern, let F be flags.
-                    let p_js = if matches!(pattern_arg, JsValue::Undefined) {
+                    let p_js = if pattern_arg.is_undefined() {
                         JsString::from_str("")
                     } else {
                         match interp.to_js_string(&pattern_arg) {
@@ -8288,7 +8281,7 @@ impl Interpreter {
                     };
                     pattern_str = js_string_to_regex_input(&p_js.code_units);
                     pattern_js = Some(p_js);
-                    flags_str = if matches!(flags_arg, JsValue::Undefined) {
+                    flags_str = if flags_arg.is_undefined() {
                         String::new()
                     } else {
                         match interp.to_string_value(&flags_arg) {
@@ -8358,15 +8351,15 @@ impl Interpreter {
             "[Symbol.match]".to_string(),
             1,
             |interp, this_val, args| {
-                let rx_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let rx_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype[@@match] requires that 'this' be an Object",
                         ));
                     }
                 };
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (s, s_cu) = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
@@ -8376,7 +8369,7 @@ impl Interpreter {
                 // Per spec, must invoke the flags accessor chain so user overrides of
                 // `flags`/`global`/`unicode`/etc. on the instance or prototype take effect.
                 let flags_str = {
-                    let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
+                    let rx_val = JsValue::object(rx_id);
                     let flags_val = match interp.get_object_property(rx_id, "flags", &rx_val) {
                         Completion::Normal(v) => v,
                         other => return other,
@@ -8421,7 +8414,7 @@ impl Interpreter {
                     };
                     let cached = match build_regex_cached(interp, &source, &flags_owned) {
                         Ok(r) => r,
-                        Err(_) => return Completion::Normal(JsValue::Null),
+                        Err(_) => return Completion::Normal(JsValue::NULL),
                     };
                     let is_bytes_mode = matches!(cached.compiled, CompiledRegex::Bytes(_));
                     let sticky = flags_owned.contains('y');
@@ -8484,7 +8477,7 @@ impl Interpreter {
                             byte_offset_to_utf16(input, full_match.end)
                         };
 
-                        results.push(JsValue::String(regex_output_to_js_string(match_text)));
+                        results.push(JsValue::string(regex_output_to_js_string(match_text)));
 
                         if match_text.is_empty() {
                             let match_start_utf16 = if is_bytes_mode {
@@ -8506,7 +8499,7 @@ impl Interpreter {
                         return Completion::Throw(e);
                     }
                     return if results.is_empty() {
-                        Completion::Normal(JsValue::Null)
+                        Completion::Normal(JsValue::NULL)
                     } else {
                         Completion::Normal(interp.create_array(results))
                     };
@@ -8517,12 +8510,10 @@ impl Interpreter {
                 loop {
                     let result = regexp_exec_abstract(interp, rx_id, &s, &s_cu);
                     match result {
-                        Completion::Normal(JsValue::Null) => break,
-                        Completion::Normal(ref result_val)
-                            if matches!(result_val, JsValue::Object(_)) =>
-                        {
-                            let result_id = if let JsValue::Object(o) = result_val {
-                                o.id
+                        Completion::Normal(ref v) if v.is_null() => break,
+                        Completion::Normal(ref result_val) if result_val.is_object() => {
+                            let result_id = if let Some(id) = result_val.as_object_id() {
+                                id
                             } else {
                                 unreachable!()
                             };
@@ -8537,9 +8528,9 @@ impl Interpreter {
                                 Err(e) => return Completion::Throw(e),
                             };
                             let is_empty = match_js_str.code_units.is_empty();
-                            results.push(JsValue::String(match_js_str));
+                            results.push(JsValue::string(match_js_str));
                             if is_empty {
-                                let rx_val2 = JsValue::Object(crate::types::JsObject { id: rx_id });
+                                let rx_val2 = JsValue::object(rx_id);
                                 let li_val = match interp.get_object_property(
                                     rx_id,
                                     "lastIndex",
@@ -8570,7 +8561,7 @@ impl Interpreter {
                     }
                 }
                 if results.is_empty() {
-                    Completion::Normal(JsValue::Null)
+                    Completion::Normal(JsValue::NULL)
                 } else {
                     Completion::Normal(interp.create_array(results))
                 }
@@ -8587,20 +8578,20 @@ impl Interpreter {
             "[Symbol.search]".to_string(),
             1,
             |interp, this_val, args| {
-                let rx_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let rx_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype[@@search] requires that 'this' be an Object",
                         ));
                     }
                 };
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (s, s_cu) = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
-                let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
+                let rx_val = JsValue::object(rx_id);
 
                 // 4. Let previousLastIndex be ? Get(rx, "lastIndex").
                 let previous_last_index =
@@ -8611,8 +8602,8 @@ impl Interpreter {
 
                 // 5. If SameValue(previousLastIndex, +0𝔽) is false, then
                 //    a. Perform ? Set(rx, "lastIndex", +0𝔽, true).
-                if !same_value(&previous_last_index, &JsValue::Number(0.0))
-                    && let Err(e) = spec_set(interp, rx_id, "lastIndex", JsValue::Number(0.0), true)
+                if !same_value(&previous_last_index, &JsValue::number(0.0))
+                    && let Err(e) = spec_set(interp, rx_id, "lastIndex", JsValue::number(0.0), true)
                 {
                     return Completion::Throw(e);
                 }
@@ -8640,18 +8631,18 @@ impl Interpreter {
                 }
 
                 // 9. If result is null, return -1𝔽.
-                if matches!(result_val, JsValue::Null) {
-                    return Completion::Normal(JsValue::Number(-1.0));
+                if result_val.is_null() {
+                    return Completion::Normal(JsValue::number(-1.0));
                 }
 
                 // 10. Return ? Get(result, "index").
-                if let JsValue::Object(ref o) = result_val {
-                    match interp.get_object_property(o.id, "index", &result_val) {
+                if let Some(res_id) = result_val.as_object_id() {
+                    match interp.get_object_property(res_id, "index", &result_val) {
                         Completion::Normal(v) => Completion::Normal(v),
                         other => other,
                     }
                 } else {
-                    Completion::Normal(JsValue::Number(-1.0))
+                    Completion::Normal(JsValue::number(-1.0))
                 }
             },
         ));
@@ -8668,9 +8659,9 @@ impl Interpreter {
             |interp, this_val, args| {
                 // 1. Let rx be the this value.
                 // 2. If Type(rx) is not Object, throw a TypeError.
-                let rx_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let rx_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         let err = interp.create_type_error(
                             "RegExp.prototype[@@replace] requires that 'this' be an Object",
                         );
@@ -8679,22 +8670,22 @@ impl Interpreter {
                 };
 
                 // 3. Let S be ? ToString(string).
-                let string_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let string_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (s, s_cu) = match to_regex_input_with_units(interp, &string_arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
                 // Non-unicode version for string slicing (surrogates kept as
                 // individual PUA chars so UTF-16 indexing works correctly)
-                let s_slice = match &string_arg {
-                    JsValue::String(js) => js_string_to_regex_input_non_unicode(&js.code_units),
-                    _ => s.clone(),
+                let s_slice = match string_arg.with_string(js_string_to_regex_input_non_unicode) {
+                    Some(sliced) => sliced,
+                    None => s.clone(),
                 };
                 let length_s = s_slice.len();
                 let s_utf16_len = pua_aware_utf16_len(&s_slice);
 
                 // 5. Let functionalReplace be IsCallable(replaceValue).
-                let replace_value = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let replace_value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let functional_replace = interp.is_callable(&replace_value);
 
                 // 6. If functionalReplace is false, set replaceValue to ? ToString(replaceValue).
@@ -8709,7 +8700,7 @@ impl Interpreter {
 
                 // 7. Let flags be ? ToString(? Get(rx, "flags")).
                 let flags = {
-                    let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
+                    let rx_val = JsValue::object(rx_id);
                     let flags_val = match interp.get_object_property(rx_id, "flags", &rx_val) {
                         Completion::Normal(v) => v,
                         other => return other,
@@ -8761,7 +8752,7 @@ impl Interpreter {
                     let cached = match build_regex_cached(interp, &source, &flags_owned) {
                         Ok(r) => r,
                         Err(_) => {
-                            return Completion::Normal(JsValue::String(regex_output_to_js_string(
+                            return Completion::Normal(JsValue::string(regex_output_to_js_string(
                                 &s_slice,
                             )));
                         }
@@ -8857,8 +8848,8 @@ impl Interpreter {
                         for i in 1..caps.len() {
                             match caps.get(i) {
                                 Some(m) => capture_vals
-                                    .push(JsValue::String(regex_output_to_js_string(&m.text))),
-                                None => capture_vals.push(JsValue::Undefined),
+                                    .push(JsValue::string(regex_output_to_js_string(&m.text))),
+                                None => capture_vals.push(JsValue::UNDEFINED),
                             }
                         }
 
@@ -8872,7 +8863,7 @@ impl Interpreter {
                                 .prototype_id = None;
                             for orig_name in &cached.name_order {
                                 if let Some(variants) = cached.dup_map.get(orig_name as &str) {
-                                    let mut matched_val = JsValue::Undefined;
+                                    let mut matched_val = JsValue::UNDEFINED;
                                     for (internal_name, _) in variants {
                                         let sanitized = sanitize_group_name(internal_name);
                                         for (i, name_opt) in caps.names.iter().enumerate() {
@@ -8880,13 +8871,13 @@ impl Interpreter {
                                                 && *n == sanitized
                                                 && let Some(m) = caps.get(i)
                                             {
-                                                matched_val = JsValue::String(
+                                                matched_val = JsValue::string(
                                                     regex_output_to_js_string(&m.text),
                                                 );
                                                 break;
                                             }
                                         }
-                                        if !matches!(matched_val, JsValue::Undefined) {
+                                        if !matched_val.is_undefined() {
                                             break;
                                         }
                                     }
@@ -8896,16 +8887,16 @@ impl Interpreter {
                                         .insert_value(orig_name.clone(), matched_val);
                                 } else {
                                     let sanitized = sanitize_group_name(orig_name);
-                                    let mut val = JsValue::Undefined;
+                                    let mut val = JsValue::UNDEFINED;
                                     for (i, name_opt) in caps.names.iter().enumerate() {
                                         if let Some(n) = name_opt
                                             && *n == sanitized
                                         {
                                             val = match caps.get(i) {
-                                                Some(m) => JsValue::String(
+                                                Some(m) => JsValue::string(
                                                     regex_output_to_js_string(&m.text),
                                                 ),
-                                                None => JsValue::Undefined,
+                                                None => JsValue::UNDEFINED,
                                             };
                                             break;
                                         }
@@ -8917,18 +8908,18 @@ impl Interpreter {
                                 }
                             }
                             let groups_id = groups_obj_id;
-                            JsValue::Object(crate::types::JsObject { id: groups_id })
+                            JsValue::object(groups_id)
                         } else {
-                            JsValue::Undefined
+                            JsValue::UNDEFINED
                         };
 
                         let named_captures_for_sub = if !named_captures_obj.is_undefined() {
                             match interp.to_object(&named_captures_obj) {
                                 Completion::Normal(v) => v,
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             }
                         } else {
-                            JsValue::Undefined
+                            JsValue::UNDEFINED
                         };
                         let tail_pos = utf16_to_byte_offset(
                             &s_slice,
@@ -8970,7 +8961,7 @@ impl Interpreter {
                     if next_source_position < length_s {
                         accumulated_result.push_str(&s_slice[next_source_position..]);
                     }
-                    return Completion::Normal(JsValue::String(regex_output_to_js_string(
+                    return Completion::Normal(JsValue::string(regex_output_to_js_string(
                         &accumulated_result,
                     )));
                 }
@@ -8982,13 +8973,11 @@ impl Interpreter {
                     // 11a. Let result be ? RegExpExec(rx, S).
                     let result = regexp_exec_abstract(interp, rx_id, &s, &s_cu);
                     match result {
-                        Completion::Normal(JsValue::Null) => break,
-                        Completion::Normal(ref result_val)
-                            if matches!(result_val, JsValue::Object(_)) =>
-                        {
+                        Completion::Normal(ref v) if v.is_null() => break,
+                        Completion::Normal(ref result_val) if result_val.is_object() => {
                             let result_obj = result_val.clone();
-                            if let JsValue::Object(ref o) = result_obj {
-                                interp.gc_temp_roots.push(o.id);
+                            if let Some(res_id) = result_obj.as_object_id() {
+                                interp.gc_temp_roots.push(res_id);
                             }
                             results.push(result_obj.clone());
 
@@ -8997,8 +8986,8 @@ impl Interpreter {
                             }
 
                             // For global: check if match is empty and advance
-                            let result_id = if let JsValue::Object(ref o) = result_obj {
-                                o.id
+                            let result_id = if let Some(id) = result_obj.as_object_id() {
+                                id
                             } else {
                                 unreachable!()
                             };
@@ -9019,7 +9008,7 @@ impl Interpreter {
                             };
                             if match_str.is_empty() {
                                 // a. Let thisIndex be ? ToLength(? Get(rx, "lastIndex")).
-                                let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
+                                let rx_val = JsValue::object(rx_id);
                                 let li_val =
                                     match interp.get_object_property(rx_id, "lastIndex", &rx_val) {
                                         Completion::Normal(v) => v,
@@ -9066,8 +9055,8 @@ impl Interpreter {
                 let mut next_source_position: usize = 0;
 
                 for result_val in &results {
-                    let result_id = if let JsValue::Object(o) = result_val {
-                        o.id
+                    let result_id = if let Some(id) = result_val.as_object_id() {
+                        id
                     } else {
                         continue;
                     };
@@ -9165,9 +9154,9 @@ impl Interpreter {
                                     return Completion::Throw(e);
                                 }
                             };
-                            captures.push(JsValue::String(cap_str));
+                            captures.push(JsValue::string(cap_str));
                         } else {
-                            captures.push(JsValue::Undefined);
+                            captures.push(JsValue::UNDEFINED);
                         }
                     }
 
@@ -9184,19 +9173,19 @@ impl Interpreter {
                     let replacement = if functional_replace {
                         // k. If functionalReplace is true, then
                         let mut replacer_args: Vec<JsValue> = Vec::new();
-                        replacer_args.push(JsValue::String(matched_js));
+                        replacer_args.push(JsValue::string(matched_js));
                         for cap in &captures {
                             replacer_args.push(cap.clone());
                         }
                         // Pass UTF-16 position and the primitive string S (non-PUA)
-                        replacer_args.push(JsValue::Number(position_utf16 as f64));
-                        replacer_args.push(JsValue::String(regex_output_to_js_string(&s_slice)));
+                        replacer_args.push(JsValue::number(position_utf16 as f64));
+                        replacer_args.push(JsValue::string(regex_output_to_js_string(&s_slice)));
                         if !named_captures.is_undefined() {
                             replacer_args.push(named_captures.clone());
                         }
                         let repl_val = interp.call_function(
                             &replace_value,
-                            &JsValue::Undefined,
+                            &JsValue::UNDEFINED,
                             &replacer_args,
                         );
                         match repl_val {
@@ -9223,10 +9212,10 @@ impl Interpreter {
                                     interp.gc_temp_roots.truncate(gc_root_start);
                                     return Completion::Throw(e);
                                 }
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             }
                         } else {
-                            JsValue::Undefined
+                            JsValue::UNDEFINED
                         };
                         let tail_pos = utf16_to_byte_offset(
                             &s_slice,
@@ -9268,7 +9257,7 @@ impl Interpreter {
                 if next_source_position < length_s {
                     accumulated_result.push_str(&s_slice[next_source_position..]);
                 }
-                Completion::Normal(JsValue::String(regex_output_to_js_string(
+                Completion::Normal(JsValue::string(regex_output_to_js_string(
                     &accumulated_result,
                 )))
             },
@@ -9285,26 +9274,26 @@ impl Interpreter {
             2,
             |interp, this_val, args| {
                 // 1. Let rx be the this value.
-                let rx_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let rx_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype[@@split] requires that 'this' be an Object",
                         ));
                     }
                 };
                 // 2. Let S be ? ToString(string).
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (s, s_cu) = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
 
                 // 3. Let C be ? SpeciesConstructor(rx, %RegExp%).
-                let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
+                let rx_val = JsValue::object(rx_id);
                 let regexp_ctor = interp
                     .get_global_var("RegExp")
-                    .unwrap_or(JsValue::Undefined);
+                    .unwrap_or(JsValue::UNDEFINED);
                 let c = match interp.species_constructor(&rx_val, &regexp_ctor) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
@@ -9335,17 +9324,17 @@ impl Interpreter {
                     &c,
                     &[
                         rx_val.clone(),
-                        JsValue::String(JsString::from_str(&new_flags)),
+                        JsValue::string(JsString::from_str(&new_flags)),
                     ],
                     c.clone(),
                 ) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
-                let splitter_id = match &splitter_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let splitter_id = match splitter_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(
                             interp.create_type_error("splitter is not an object"),
                         );
@@ -9358,8 +9347,8 @@ impl Interpreter {
                 let mut length_a: u32 = 0;
 
                 // 10. Let lim = limit is undefined ? 2^32-1 : ToUint32(limit).
-                let limit = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                let lim: u32 = if matches!(limit, JsValue::Undefined) {
+                let limit = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                let lim: u32 = if limit.is_undefined() {
                     0xFFFFFFFF
                 } else {
                     match interp.to_number_value(&limit) {
@@ -9380,8 +9369,8 @@ impl Interpreter {
                     // a. Let z be ? RegExpExec(splitter, S).
                     let z = regexp_exec_abstract(interp, splitter_id, &s, &s_cu);
                     match z {
-                        Completion::Normal(ref v) if matches!(v, JsValue::Null) => {
-                            a.push(JsValue::String(regex_output_to_js_string(&s)));
+                        Completion::Normal(ref v) if v.is_null() => {
+                            a.push(JsValue::string(regex_output_to_js_string(&s)));
                         }
                         Completion::Normal(_) => {}
                         other => return other,
@@ -9401,7 +9390,7 @@ impl Interpreter {
                         interp,
                         splitter_id,
                         "lastIndex",
-                        JsValue::Number(q as f64),
+                        JsValue::number(q as f64),
                         true,
                     ) {
                         return Completion::Throw(e);
@@ -9415,14 +9404,14 @@ impl Interpreter {
                     };
 
                     // c. If z is null, set q to AdvanceStringIndex(S, q, unicodeMatching).
-                    if matches!(z_val, JsValue::Null) {
+                    if z_val.is_null() {
                         q = advance_string_index(&s, q, unicode_matching);
                         continue;
                     }
 
                     // d. Else,
                     //   i. Let e be ℝ(? ToLength(? Get(splitter, "lastIndex"))).
-                    let splitter_val2 = JsValue::Object(crate::types::JsObject { id: splitter_id });
+                    let splitter_val2 = JsValue::object(splitter_id);
                     let e_val = match interp.get_object_property(
                         splitter_id,
                         "lastIndex",
@@ -9452,7 +9441,7 @@ impl Interpreter {
                     let p_byte = utf16_to_byte_offset(&s, p);
                     let q_byte = utf16_to_byte_offset(&s, q);
                     let t = &s[p_byte..q_byte];
-                    a.push(JsValue::String(regex_output_to_js_string(t)));
+                    a.push(JsValue::string(regex_output_to_js_string(t)));
                     length_a += 1;
                     if length_a == lim {
                         return Completion::Normal(interp.create_array(a));
@@ -9462,9 +9451,9 @@ impl Interpreter {
                     p = e_length;
 
                     // Get captures from z
-                    let z_id = match &z_val {
-                        JsValue::Object(o) => o.id,
-                        _ => {
+                    let z_id = match z_val.as_object_id() {
+                        Some(id) => id,
+                        None => {
                             q = advance_string_index(&s, q, unicode_matching);
                             continue;
                         }
@@ -9507,7 +9496,7 @@ impl Interpreter {
                 // 16. Push remaining substring
                 let p_byte = utf16_to_byte_offset(&s, p);
                 let t = &s[p_byte..];
-                a.push(JsValue::String(regex_output_to_js_string(t)));
+                a.push(JsValue::string(regex_output_to_js_string(t)));
                 Completion::Normal(interp.create_array(a))
             },
         ));
@@ -9523,26 +9512,26 @@ impl Interpreter {
             1,
             |interp, this_val, args| {
                 // 1. Let R be the this value.
-                let rx_id = match this_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let rx_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "RegExp.prototype[@@matchAll] requires that 'this' be an Object",
                         ));
                     }
                 };
                 // 2. Let S be ? ToString(string).
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (s, _s_cu) = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
 
                 // 3. Let C be ? SpeciesConstructor(R, %RegExp%).
-                let rx_val = JsValue::Object(crate::types::JsObject { id: rx_id });
+                let rx_val = JsValue::object(rx_id);
                 let regexp_ctor = interp
                     .get_global_var("RegExp")
-                    .unwrap_or(JsValue::Undefined);
+                    .unwrap_or(JsValue::UNDEFINED);
                 let c = match interp.species_constructor(&rx_val, &regexp_ctor) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
@@ -9563,16 +9552,16 @@ impl Interpreter {
                 // 5. Let matcher be ? Construct(C, « R, flags »).
                 let matcher_val = match interp.construct_with_new_target(
                     &c,
-                    &[rx_val.clone(), JsValue::String(JsString::from_str(&flags))],
+                    &[rx_val.clone(), JsValue::string(JsString::from_str(&flags))],
                     c.clone(),
                 ) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
-                let matcher_id = match &matcher_val {
-                    JsValue::Object(o) => o.id,
-                    _ => {
+                let matcher_id = match matcher_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(
                             interp.create_type_error("matcher is not an object"),
                         );
@@ -9599,7 +9588,7 @@ impl Interpreter {
                     interp,
                     matcher_id,
                     "lastIndex",
-                    JsValue::Number(last_index),
+                    JsValue::number(last_index),
                     true,
                 ) {
                     return Completion::Throw(e);
@@ -9637,14 +9626,14 @@ impl Interpreter {
                     .borrow_mut()
                     .insert_value(
                         "__matcher__".to_string(),
-                        JsValue::Number(matcher_id as f64),
+                        JsValue::number(matcher_id as f64),
                     );
                 interp
                     .get_object_cell_expect(iter_obj_id)
                     .borrow_mut()
                     .insert_value(
                         "__full_unicode__".to_string(),
-                        JsValue::Boolean(full_unicode),
+                        JsValue::boolean(full_unicode),
                     );
 
                 interp.get_object_cell_expect(iter_obj_id).borrow_mut().kind =
@@ -9660,7 +9649,7 @@ impl Interpreter {
                     );
 
                 let id = iter_obj_id;
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
         if let Some(key) = get_symbol_key(self, "matchAll") {
@@ -9688,15 +9677,15 @@ impl Interpreter {
             "next".to_string(),
             0,
             |interp, this_val, _args| {
-                let o = match this_val {
-                    JsValue::Object(o) => o,
-                    _ => {
+                let o_id = match this_val.as_object_id() {
+                    Some(id) => id,
+                    None => {
                         return Completion::Throw(interp.create_type_error(
                             "%RegExpStringIteratorPrototype%.next requires that 'this' be an Object",
                         ));
                     }
                 };
-                let obj = match interp.get_object_cell(o.id) {
+                let obj = match interp.get_object_cell(o_id) {
                     Some(obj) => obj,
                     None => {
                         return Completion::Throw(interp.create_type_error(
@@ -9705,9 +9694,9 @@ impl Interpreter {
                     }
                 };
                 let state = obj.borrow().iterator_state().cloned();
-                let matcher_id_val = interp.get_property_on_id(o.id, "__matcher__");
-                let full_unicode_val = interp.get_property_on_id(o.id, "__full_unicode__");
-                let full_unicode = matches!(full_unicode_val, JsValue::Boolean(true));
+                let matcher_id_val = interp.get_property_on_id(o_id, "__matcher__");
+                let full_unicode_val = interp.get_property_on_id(o_id, "__full_unicode__");
+                let full_unicode = full_unicode_val.as_boolean() == Some(true);
 
                 let (source, flags, string, global, last_index, done) =
                     if let Some(IteratorState::RegExpStringIterator {
@@ -9735,12 +9724,12 @@ impl Interpreter {
 
                 if done {
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 }
 
                 // If we have a matcher object, use RegExpExec
-                if let JsValue::Number(mid) = matcher_id_val {
+                if let Some(mid) = matcher_id_val.as_number() {
                     let mid = mid as u64;
                     let string_cu = regex_output_to_js_string(&string).code_units;
                     let result = regexp_exec_abstract(interp, mid, &string, &string_cu);
@@ -9749,20 +9738,20 @@ impl Interpreter {
                         other => return other,
                     };
 
-                    if matches!(result_val, JsValue::Null) {
-                        if let Some(obj2) = interp.get_object_cell(o.id) {
+                    if result_val.is_null() {
+                        if let Some(obj2) = interp.get_object_cell(o_id) {
                             obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
                                     last_index, done: true,
                                 });
                         }
                         return Completion::Normal(
-                            interp.create_iter_result_object(JsValue::Undefined, true),
+                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                         );
                     }
 
                     if !global {
-                        if let Some(obj2) = interp.get_object_cell(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o_id) {
                             obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
                                     last_index, done: true,
@@ -9774,10 +9763,10 @@ impl Interpreter {
                     }
 
                     // Global: check for empty match, advance if needed
-                    let result_id = if let JsValue::Object(ro) = &result_val {
-                        ro.id
+                    let result_id = if let Some(ro_id) = result_val.as_object_id() {
+                        ro_id
                     } else {
-                        if let Some(obj2) = interp.get_object_cell(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o_id) {
                             obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
                                     last_index, done: true,
@@ -9799,7 +9788,7 @@ impl Interpreter {
                     };
                     if match_str.is_empty() {
                         let matcher_val2 =
-                            JsValue::Object(crate::types::JsObject { id: mid });
+                            JsValue::object(mid);
                         let li_val = match interp.get_object_property(
                             mid, "lastIndex", &matcher_val2,
                         ) {
@@ -9819,13 +9808,13 @@ impl Interpreter {
                             advance_string_index(&string, this_index, full_unicode);
                         if let Err(e) = spec_set(
                             interp, mid, "lastIndex",
-                            JsValue::Number(next_index as f64), true,
+                            JsValue::number(next_index as f64), true,
                         ) {
                             return Completion::Throw(e);
                         }
                     }
 
-                    if let Some(obj2) = interp.get_object_cell(o.id) {
+                    if let Some(obj2) = interp.get_object_cell(o_id) {
                         obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
                                 source, flags, string, global,
                                 last_index, done: false,
@@ -9840,40 +9829,40 @@ impl Interpreter {
                 let re = match build_regex(&source, &flags) {
                     Ok(r) => r,
                     Err(_) => {
-                        if let Some(obj2) = interp.get_object_cell(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o_id) {
                             obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
                                     last_index, done: true,
                                 });
                         }
                         return Completion::Normal(
-                            interp.create_iter_result_object(JsValue::Undefined, true),
+                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                         );
                     }
                 };
 
                 if last_index > string.len() {
-                    if let Some(obj2) = interp.get_object_cell(o.id) {
+                    if let Some(obj2) = interp.get_object_cell(o_id) {
                         obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
                                 source, flags, string, global,
                                 last_index, done: true,
                             });
                     }
                     return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::Undefined, true),
+                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
                     );
                 }
 
                 match regex_captures(&re, &string[last_index..]) {
                     None => {
-                        if let Some(obj2) = interp.get_object_cell(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o_id) {
                             obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
                                     last_index, done: true,
                                 });
                         }
                         Completion::Normal(
-                            interp.create_iter_result_object(JsValue::Undefined, true),
+                            interp.create_iter_result_object(JsValue::UNDEFINED, true),
                         )
                     }
                     Some(mut caps) => {
@@ -9883,31 +9872,31 @@ impl Interpreter {
                         let match_end = last_index + full.end;
 
                         let mut elements: Vec<JsValue> = Vec::new();
-                        elements.push(JsValue::String(JsString::from_str(&full.text)));
+                        elements.push(JsValue::string(JsString::from_str(&full.text)));
                         for i in 1..caps.len() {
                             match caps.get(i) {
-                                Some(m) => elements.push(JsValue::String(
+                                Some(m) => elements.push(JsValue::string(
                                     JsString::from_str(&m.text),
                                 )),
-                                None => elements.push(JsValue::Undefined),
+                                None => elements.push(JsValue::UNDEFINED),
                             }
                         }
 
                         let result_arr = interp.create_array(elements);
-                        if let JsValue::Object(ref ro) = result_arr
-                            && let Some(robj) = interp.get_object_cell(ro.id)
+                        if let Some(ro_id) = result_arr.as_object_id()
+                            && let Some(robj) = interp.get_object_cell(ro_id)
                         {
                             robj.borrow_mut().insert_value(
                                 "index".to_string(),
-                                JsValue::Number(match_start as f64),
+                                JsValue::number(match_start as f64),
                             );
                             robj.borrow_mut().insert_value(
                                 "input".to_string(),
-                                JsValue::String(JsString::from_str(&string)),
+                                JsValue::string(JsString::from_str(&string)),
                             );
                             robj.borrow_mut().insert_value(
                                 "groups".to_string(),
-                                JsValue::Undefined,
+                                JsValue::UNDEFINED,
                             );
                         }
 
@@ -9918,7 +9907,7 @@ impl Interpreter {
                         };
                         let new_done = !global;
 
-                        if let Some(obj2) = interp.get_object_cell(o.id) {
+                        if let Some(obj2) = interp.get_object_cell(o_id) {
                             obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
                                     source, flags, string, global,
                                     last_index: new_last_index,
@@ -9947,7 +9936,7 @@ impl Interpreter {
                 .insert_property(
                     key,
                     PropertyDescriptor::data(
-                        JsValue::String(JsString::from_str("RegExp String Iterator")),
+                        JsValue::string(JsString::from_str("RegExp String Iterator")),
                         false,
                         false,
                         true,
@@ -9959,9 +9948,9 @@ impl Interpreter {
 
         // RegExp.prototype.flags getter (§22.2.5.3)
         self.define_getter(regexp_proto_id, "flags", |interp, this_val, _args| {
-            let obj_id = match this_val {
-                JsValue::Object(o) => o.id,
-                _ => {
+            let obj_id = match this_val.as_object_id() {
+                Some(id) => id,
+                None => {
                     let err = interp.create_type_error(
                         "RegExp.prototype.flags requires that 'this' be an Object",
                     );
@@ -9993,7 +9982,7 @@ impl Interpreter {
                     result.push(*ch);
                 }
             }
-            Completion::Normal(JsValue::String(JsString::from_str(&result)))
+            Completion::Normal(JsValue::string(JsString::from_str(&result)))
         });
 
         // Flag property getters on prototype (§22.2.5.x)
@@ -10014,9 +10003,9 @@ impl Interpreter {
                 format!("get {}", name),
                 0,
                 move |interp, this_val, _args| {
-                    let obj_ref = match this_val {
-                        JsValue::Object(o) => o,
-                        _ => {
+                    let obj_ref_id = match this_val.as_object_id() {
+                        Some(id) => id,
+                        None => {
                             return Completion::Throw(interp.create_error_in_realm(
                                 my_realm_id,
                                 "TypeError",
@@ -10027,13 +10016,13 @@ impl Interpreter {
                             ));
                         }
                     };
-                    let obj = match interp.get_object_cell(obj_ref.id) {
+                    let obj = match interp.get_object_cell(obj_ref_id) {
                         Some(o) => o,
-                        None => return Completion::Normal(JsValue::Undefined),
+                        None => return Completion::Normal(JsValue::UNDEFINED),
                     };
                     if obj.borrow().class_name != "RegExp" {
-                        if obj_ref.id == regexp_proto_id {
-                            return Completion::Normal(JsValue::Undefined);
+                        if obj_ref_id == regexp_proto_id {
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
                         return Completion::Throw(interp.create_error_in_realm(
                             my_realm_id,
@@ -10046,9 +10035,9 @@ impl Interpreter {
                     }
                     let flags_opt = obj.borrow().regexp().map(|r| r.flags.clone());
                     if let Some(s) = flags_opt {
-                        Completion::Normal(JsValue::Boolean(s.to_rust_string().contains(flag_char)))
+                        Completion::Normal(JsValue::boolean(s.to_rust_string().contains(flag_char)))
                     } else {
-                        Completion::Normal(JsValue::Undefined)
+                        Completion::Normal(JsValue::UNDEFINED)
                     }
                 },
             ));
@@ -10069,9 +10058,9 @@ impl Interpreter {
 
         // source getter (§22.2.5.10)
         self.define_getter(regexp_proto_id, "source", move |interp, this_val, _args| {
-            let obj_ref = match this_val {
-                JsValue::Object(o) => o,
-                _ => {
+            let obj_ref_id = match this_val.as_object_id() {
+                Some(id) => id,
+                None => {
                     return Completion::Throw(interp.create_error_in_realm(
                         my_realm_id,
                         "TypeError",
@@ -10079,13 +10068,13 @@ impl Interpreter {
                     ));
                 }
             };
-            let obj = match interp.get_object_cell(obj_ref.id) {
+            let obj = match interp.get_object_cell(obj_ref_id) {
                 Some(o) => o,
-                None => return Completion::Normal(JsValue::Undefined),
+                None => return Completion::Normal(JsValue::UNDEFINED),
             };
             if obj.borrow().class_name != "RegExp" {
-                if obj_ref.id == regexp_proto_id {
-                    return Completion::Normal(JsValue::String(JsString::from_str("(?:)")));
+                if obj_ref_id == regexp_proto_id {
+                    return Completion::Normal(JsValue::string(JsString::from_str("(?:)")));
                 }
                 return Completion::Throw(interp.create_error_in_realm(
                     my_realm_id,
@@ -10096,9 +10085,9 @@ impl Interpreter {
             let source_opt = obj.borrow().regexp().map(|r| r.source.clone());
             if let Some(ref s) = source_opt {
                 let escaped = escape_regexp_pattern_code_units(&s.code_units);
-                Completion::Normal(JsValue::String(escaped))
+                Completion::Normal(JsValue::string(escaped))
             } else {
-                Completion::Normal(JsValue::String(JsString::from_str("(?:)")))
+                Completion::Normal(JsValue::string(JsString::from_str("(?:)")))
             }
         });
 
@@ -10109,29 +10098,29 @@ impl Interpreter {
             "RegExp".to_string(),
             2,
             move |interp, _this, args| {
-                let pattern_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let flags_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let pattern_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let flags_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // IsRegExp check per §7.2.8
-                let is_regexp_obj = if let JsValue::Object(ref o) = pattern_arg {
+                let is_regexp_obj = if let Some(pat_id) = pattern_arg.as_object_id() {
                     let match_key = get_symbol_key(interp, "match");
                     if let Some(key) = match_key {
-                        let matcher = match interp.get_object_property(o.id, &key, &pattern_arg) {
+                        let matcher = match interp.get_object_property(pat_id, &key, &pattern_arg) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
-                        if !matches!(matcher, JsValue::Undefined) {
+                        if !matcher.is_undefined() {
                             interp.to_boolean_val(&matcher)
                         } else {
                             // Symbol.match is undefined, check [[RegExpMatcher]]
-                            if let Some(obj) = interp.get_object_cell(o.id) {
+                            if let Some(obj) = interp.get_object_cell(pat_id) {
                                 obj.borrow().class_name == "RegExp"
                             } else {
                                 false
                             }
                         }
-                    } else if let Some(obj) = interp.get_object_cell(o.id) {
+                    } else if let Some(obj) = interp.get_object_cell(pat_id) {
                         obj.borrow().class_name == "RegExp"
                     } else {
                         false
@@ -10143,19 +10132,20 @@ impl Interpreter {
                 // §22.2.3.1 step 2: If NewTarget is undefined (called as function, not new)
                 if interp.new_target.is_none()
                     && is_regexp_obj
-                    && matches!(flags_arg, JsValue::Undefined)
-                    && let JsValue::Object(ref o) = pattern_arg
+                    && flags_arg.is_undefined()
+                    && let Some(pat_id) = pattern_arg.as_object_id()
                 {
                     // Get pattern.constructor
-                    let ctor = match interp.get_object_property(o.id, "constructor", &pattern_arg) {
+                    let ctor = match interp.get_object_property(pat_id, "constructor", &pattern_arg)
+                    {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     };
                     // Get the active function object (RegExp constructor)
                     let regexp_fn = interp
                         .get_global_var("RegExp")
-                        .unwrap_or(JsValue::Undefined);
+                        .unwrap_or(JsValue::UNDEFINED);
                     if same_value(&regexp_fn, &ctor) {
                         return Completion::Normal(pattern_arg.clone());
                     }
@@ -10164,9 +10154,9 @@ impl Interpreter {
                 // §22.2.3.1 steps 3-4: Extract P and F from arguments.
                 // Source is extracted fully (freezing it before prototype lookup),
                 // but flags ToString is deferred until after RegExpAlloc (step 5).
-                let has_regexp_matcher = if let JsValue::Object(ref o) = pattern_arg {
+                let has_regexp_matcher = if let Some(pat_id) = pattern_arg.as_object_id() {
                     interp
-                        .get_object_cell(o.id)
+                        .get_object_cell(pat_id)
                         .is_some_and(|obj| obj.borrow().class_name == "RegExp")
                 } else {
                     false
@@ -10178,17 +10168,17 @@ impl Interpreter {
                     NeedsToString(JsValue),
                 }
                 let (pattern_js, pattern_str, raw_flags) = if has_regexp_matcher
-                    && let JsValue::Object(ref o) = pattern_arg
+                    && let Some(pat_id) = pattern_arg.as_object_id()
                 {
                     let src_js = interp
-                        .get_object_cell(o.id)
+                        .get_object_cell(pat_id)
                         .and_then(|obj| obj.borrow().regexp().map(|r| r.source.clone()))
                         .unwrap_or_else(|| JsString::from_str(""));
                     let src = js_string_to_regex_input(&src_js.code_units);
-                    let flg = if matches!(flags_arg, JsValue::Undefined) {
+                    let flg = if flags_arg.is_undefined() {
                         RawFlags::Resolved(
                             interp
-                                .get_object_cell(o.id)
+                                .get_object_cell(pat_id)
                                 .and_then(|obj| obj.borrow().regexp().map(|r| r.flags.to_string()))
                                 .unwrap_or_default(),
                         )
@@ -10196,8 +10186,8 @@ impl Interpreter {
                         RawFlags::NeedsToString(flags_arg.clone())
                     };
                     (src_js, src, flg)
-                } else if is_regexp_obj && let JsValue::Object(ref o) = pattern_arg {
-                    let src = match interp.get_object_property(o.id, "source", &pattern_arg) {
+                } else if is_regexp_obj && let Some(pat_id) = pattern_arg.as_object_id() {
+                    let src = match interp.get_object_property(pat_id, "source", &pattern_arg) {
                         Completion::Normal(v) => match interp.to_js_string(&v) {
                             Ok(s) => s,
                             Err(e) => return Completion::Throw(e),
@@ -10206,11 +10196,11 @@ impl Interpreter {
                         _ => JsString::from_str(""),
                     };
                     let src_str = js_string_to_regex_input(&src.code_units);
-                    let flg = if matches!(flags_arg, JsValue::Undefined) {
-                        let f = match interp.get_object_property(o.id, "flags", &pattern_arg) {
+                    let flg = if flags_arg.is_undefined() {
+                        let f = match interp.get_object_property(pat_id, "flags", &pattern_arg) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         RawFlags::NeedsToString(f)
                     } else {
@@ -10218,7 +10208,7 @@ impl Interpreter {
                     };
                     (src, src_str, flg)
                 } else {
-                    let p_js = if matches!(pattern_arg, JsValue::Undefined) {
+                    let p_js = if pattern_arg.is_undefined() {
                         JsString::from_str("")
                     } else {
                         match interp.to_js_string(&pattern_arg) {
@@ -10227,7 +10217,7 @@ impl Interpreter {
                         }
                     };
                     let p_str = js_string_to_regex_input(&p_js.code_units);
-                    let flg = if matches!(flags_arg, JsValue::Undefined) {
+                    let flg = if flags_arg.is_undefined() {
                         RawFlags::Resolved(String::new())
                     } else {
                         RawFlags::NeedsToString(flags_arg.clone())
@@ -10304,10 +10294,10 @@ impl Interpreter {
                 );
                 obj.insert_property(
                     "lastIndex".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(0.0), true, false, false),
+                    PropertyDescriptor::data(JsValue::number(0.0), true, false, false),
                 );
                 let id = interp.alloc_object(obj);
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
         // RegExp.escape (§22.2.5.1)
@@ -10315,10 +10305,10 @@ impl Interpreter {
             "escape".to_string(),
             1,
             |interp, _this, args| {
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let code_units = match &arg {
-                    JsValue::String(s) => s.code_units.clone(),
-                    _ => {
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let code_units = match arg.as_string() {
+                    Some(s) => s.code_units,
+                    None => {
                         let err =
                             interp.create_type_error("RegExp.escape requires a string argument");
                         return Completion::Throw(err);
@@ -10366,20 +10356,16 @@ impl Interpreter {
                     }
                     is_first = false;
                 }
-                Completion::Normal(JsValue::String(JsString::from_vec(result_units)))
+                Completion::Normal(JsValue::string(JsString::from_vec(result_units)))
             },
         ));
 
-        if let JsValue::Object(ref o) = regexp_ctor
-            && let Some(obj) = self.get_object(o.id)
+        if let Some(ctor_obj_id) = regexp_ctor.as_object_id()
+            && let Some(obj) = self.get_object(ctor_obj_id)
         {
             obj.borrow_mut().deferred_construct = true;
-            obj.borrow_mut().insert_builtin(
-                "prototype".to_string(),
-                JsValue::Object(crate::types::JsObject {
-                    id: regexp_proto_id,
-                }),
-            );
+            obj.borrow_mut()
+                .insert_builtin("prototype".to_string(), JsValue::object(regexp_proto_id));
             obj.borrow_mut()
                 .insert_builtin("escape".to_string(), escape_fn);
 
@@ -10402,7 +10388,7 @@ impl Interpreter {
             );
 
             // Annex B legacy static accessor properties (B.2.4)
-            let ctor_id = o.id;
+            let ctor_id = ctor_obj_id;
             self.regexp_legacy.constructor_id = Some(ctor_id);
 
             // Helper macro for legacy accessor property getters/setters
@@ -10414,14 +10400,14 @@ impl Interpreter {
                         format!("get ${}", idx),
                         0,
                         move |interp, this_val, _args| {
-                            match this_val {
-                                JsValue::Object(o) if o.id == ctor_id => {}
+                            match this_val.as_object_id() {
+                                Some(id) if id == ctor_id => {}
                                 _ => return Completion::Throw(interp.create_type_error(
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
                             let val = interp.regexp_legacy.parens[(idx - 1) as usize].clone();
-                            Completion::Normal(JsValue::String(JsString::from_str(&val)))
+                            Completion::Normal(JsValue::string(JsString::from_str(&val)))
                         },
                     ));
                 obj.borrow_mut().insert_property(
@@ -10445,13 +10431,13 @@ impl Interpreter {
                         format!("get {}", pn),
                         0,
                         move |interp, this_val, _args| {
-                            match this_val {
-                                JsValue::Object(o) if o.id == ctor_id => {}
+                            match this_val.as_object_id() {
+                                Some(id) if id == ctor_id => {}
                                 _ => return Completion::Throw(interp.create_type_error(
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            Completion::Normal(JsValue::String(JsString::from_str(
+                            Completion::Normal(JsValue::string(JsString::from_str(
                                 &interp.regexp_legacy.input,
                             )))
                         },
@@ -10461,19 +10447,19 @@ impl Interpreter {
                         format!("set {}", pn),
                         1,
                         move |interp, this_val, args| {
-                            match this_val {
-                                JsValue::Object(o) if o.id == ctor_id => {}
+                            match this_val.as_object_id() {
+                                Some(id) if id == ctor_id => {}
                                 _ => return Completion::Throw(interp.create_type_error(
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                            let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                             let s = match interp.to_string_value(&val) {
                                 Ok(s) => s,
                                 Err(e) => return Completion::Throw(e),
                             };
                             interp.regexp_legacy.input = s;
-                            Completion::Normal(JsValue::Undefined)
+                            Completion::Normal(JsValue::UNDEFINED)
                         },
                     ));
                 obj.borrow_mut().insert_property(
@@ -10497,13 +10483,13 @@ impl Interpreter {
                         format!("get {}", pn),
                         0,
                         move |interp, this_val, _args| {
-                            match this_val {
-                                JsValue::Object(o) if o.id == ctor_id => {}
+                            match this_val.as_object_id() {
+                                Some(id) if id == ctor_id => {}
                                 _ => return Completion::Throw(interp.create_type_error(
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            Completion::Normal(JsValue::String(JsString::from_str(
+                            Completion::Normal(JsValue::string(JsString::from_str(
                                 &interp.regexp_legacy.last_match,
                             )))
                         },
@@ -10529,13 +10515,13 @@ impl Interpreter {
                         format!("get {}", pn),
                         0,
                         move |interp, this_val, _args| {
-                            match this_val {
-                                JsValue::Object(o) if o.id == ctor_id => {}
+                            match this_val.as_object_id() {
+                                Some(id) if id == ctor_id => {}
                                 _ => return Completion::Throw(interp.create_type_error(
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            Completion::Normal(JsValue::String(JsString::from_str(
+                            Completion::Normal(JsValue::string(JsString::from_str(
                                 &interp.regexp_legacy.last_paren,
                             )))
                         },
@@ -10561,13 +10547,13 @@ impl Interpreter {
                         format!("get {}", pn),
                         0,
                         move |interp, this_val, _args| {
-                            match this_val {
-                                JsValue::Object(o) if o.id == ctor_id => {}
+                            match this_val.as_object_id() {
+                                Some(id) if id == ctor_id => {}
                                 _ => return Completion::Throw(interp.create_type_error(
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            Completion::Normal(JsValue::String(JsString::from_str(
+                            Completion::Normal(JsValue::string(JsString::from_str(
                                 &interp.regexp_legacy.left_context,
                             )))
                         },
@@ -10593,13 +10579,13 @@ impl Interpreter {
                         format!("get {}", pn),
                         0,
                         move |interp, this_val, _args| {
-                            match this_val {
-                                JsValue::Object(o) if o.id == ctor_id => {}
+                            match this_val.as_object_id() {
+                                Some(id) if id == ctor_id => {}
                                 _ => return Completion::Throw(interp.create_type_error(
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            Completion::Normal(JsValue::String(JsString::from_str(
+                            Completion::Normal(JsValue::string(JsString::from_str(
                                 &interp.regexp_legacy.right_context,
                             )))
                         },

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use crate::interpreter::types::BufferData;
-use crate::types::{JsBigInt, JsObject, JsString, JsValue, number_ops};
+use crate::types::{JsBigInt, JsValue, ValueKind, number_ops};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -46,9 +46,9 @@ impl Interpreter {
                 Detached,
                 Bytes(usize),
             }
-            let probe = if let JsValue::Object(o) = this_val {
+            let probe = if let Some(o) = this_val.as_object_id() {
                 interp
-                    .get_object_cell(o.id)
+                    .get_object_cell(o)
                     .map(|cell| {
                         let r = cell.borrow();
                         if let Some(buf_data) = r.arraybuffer_data() {
@@ -71,8 +71,8 @@ impl Interpreter {
                 Probe::Shared | Probe::NotAB => {
                     Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-                Probe::Detached => Completion::Normal(JsValue::Number(0.0)),
-                Probe::Bytes(n) => Completion::Normal(JsValue::Number(n as f64)),
+                Probe::Detached => Completion::Normal(JsValue::number(0.0)),
+                Probe::Bytes(n) => Completion::Normal(JsValue::number(n as f64)),
             }
         });
 
@@ -83,9 +83,9 @@ impl Interpreter {
                 Shared,
                 Detached(bool),
             }
-            let probe = if let JsValue::Object(o) = this_val {
+            let probe = if let Some(o) = this_val.as_object_id() {
                 interp
-                    .get_object_cell(o.id)
+                    .get_object_cell(o)
                     .map(|cell| {
                         let r = cell.borrow();
                         if r.arraybuffer_data().is_some() {
@@ -108,7 +108,7 @@ impl Interpreter {
                 Probe::NotAB | Probe::Shared => {
                     Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-                Probe::Detached(b) => Completion::Normal(JsValue::Boolean(b)),
+                Probe::Detached(b) => Completion::Normal(JsValue::boolean(b)),
             }
         });
 
@@ -119,9 +119,9 @@ impl Interpreter {
                 Shared,
                 Resizable(bool),
             }
-            let probe = if let JsValue::Object(o) = this_val {
+            let probe = if let Some(o) = this_val.as_object_id() {
                 interp
-                    .get_object_cell(o.id)
+                    .get_object_cell(o)
                     .map(|cell| {
                         let r = cell.borrow();
                         if r.arraybuffer_data().is_some() {
@@ -142,7 +142,7 @@ impl Interpreter {
                 Probe::NotAB | Probe::Shared => {
                     Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-                Probe::Resizable(b) => Completion::Normal(JsValue::Boolean(b)),
+                Probe::Resizable(b) => Completion::Normal(JsValue::boolean(b)),
             }
         });
 
@@ -153,9 +153,9 @@ impl Interpreter {
                 Shared,
                 Immutable(bool),
             }
-            let probe = if let JsValue::Object(o) = this_val {
+            let probe = if let Some(o) = this_val.as_object_id() {
                 interp
-                    .get_object_cell(o.id)
+                    .get_object_cell(o)
                     .map(|cell| {
                         let r = cell.borrow();
                         if r.arraybuffer_data().is_some() {
@@ -176,7 +176,7 @@ impl Interpreter {
                 Probe::NotAB | Probe::Shared => {
                     Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-                Probe::Immutable(b) => Completion::Normal(JsValue::Boolean(b)),
+                Probe::Immutable(b) => Completion::Normal(JsValue::boolean(b)),
             }
         });
 
@@ -188,9 +188,9 @@ impl Interpreter {
                 Detached,
                 Max(usize),
             }
-            let probe = if let JsValue::Object(o) = this_val {
+            let probe = if let Some(o) = this_val.as_object_id() {
                 interp
-                    .get_object_cell(o.id)
+                    .get_object_cell(o)
                     .map(|cell| {
                         let r = cell.borrow();
                         if r.arraybuffer_data().is_some() {
@@ -216,8 +216,8 @@ impl Interpreter {
                 Probe::NotAB | Probe::Shared => {
                     Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
                 }
-                Probe::Detached => Completion::Normal(JsValue::Number(0.0)),
-                Probe::Max(n) => Completion::Normal(JsValue::Number(n as f64)),
+                Probe::Detached => Completion::Normal(JsValue::number(0.0)),
+                Probe::Max(n) => Completion::Normal(JsValue::number(n as f64)),
             }
         });
 
@@ -227,8 +227,8 @@ impl Interpreter {
                 "slice".to_string(),
                 2,
                 |interp, this_val, args| {
-                    if let JsValue::Object(o) = this_val
-                        && let Some(obj) = interp.get_object(o.id)
+                    if let Some(o) = this_val.as_object_id()
+                        && let Some(obj) = interp.get_object(o)
                     {
                         {
                             let obj_ref = obj.borrow();
@@ -270,7 +270,7 @@ impl Interpreter {
                         } else {
                             (start_arg as usize).min(buf_len)
                         };
-                        let end_arg = if args.len() > 1 && !matches!(args[1], JsValue::Undefined) {
+                        let end_arg = if args.len() > 1 && !args[1].is_undefined() {
                             match interp.to_number_value(&args[1]) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
@@ -290,7 +290,7 @@ impl Interpreter {
                         // SpeciesConstructor(O, %ArrayBuffer%)
                         let ab_ctor = interp
                             .get_global_var("ArrayBuffer")
-                            .unwrap_or(JsValue::Undefined);
+                            .unwrap_or(JsValue::UNDEFINED);
                         let ctor = match interp.species_constructor(this_val, &ab_ctor) {
                             Ok(c) => c,
                             Err(e) => return Completion::Throw(e),
@@ -298,16 +298,16 @@ impl Interpreter {
                         // Construct(ctor, «newLen»)
                         let new_val = match interp.construct_with_new_target(
                             &ctor,
-                            &[JsValue::Number(new_len as f64)],
+                            &[JsValue::number(new_len as f64)],
                             ctor.clone(),
                         ) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => return Completion::Normal(JsValue::Undefined),
+                            _ => return Completion::Normal(JsValue::UNDEFINED),
                         };
                         // Validate: must be an ArrayBuffer, not shared, not detached, not same, byteLength >= newLen
-                        let new_id = if let JsValue::Object(ref no) = new_val {
-                            no.id
+                        let new_id = if let Some(no) = new_val.as_object_id() {
+                            no
                         } else {
                             return Completion::Throw(interp.create_type_error(
                                 "species constructor must return an ArrayBuffer",
@@ -342,7 +342,7 @@ impl Interpreter {
                                 "species constructor must return an ArrayBuffer",
                             ));
                         }
-                        if new_id == o.id {
+                        if new_id == o {
                             return Completion::Throw(interp.create_type_error(
                                 "species constructor must not return the same ArrayBuffer",
                             ));
@@ -393,8 +393,8 @@ impl Interpreter {
             "transfer".to_string(),
             0,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let (is_ab, is_shared) = {
                         let obj_ref = obj.borrow();
@@ -412,16 +412,16 @@ impl Interpreter {
                         );
                     }
                     // Step 3-4: newByteLength
-                    let new_len_arg = args.first().unwrap_or(&JsValue::Undefined);
+                    let new_len_arg = args.first().unwrap_or(&JsValue::UNDEFINED);
                     let old_len = {
                         let obj_ref = obj.borrow();
                         buffer_len(obj_ref.arraybuffer_data().unwrap())
                     };
-                    let new_len = if matches!(new_len_arg, JsValue::Undefined) {
+                    let new_len = if new_len_arg.is_undefined() {
                         old_len
                     } else {
                         match interp.to_index(new_len_arg) {
-                            Completion::Normal(JsValue::Number(n)) => n as usize,
+                            Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => 0,
                         }
@@ -479,7 +479,7 @@ impl Interpreter {
                     }
                     interp.gc_untrack_external_bytes(old_data_len);
                     let id = interp.create_arraybuffer_resizable(new_data, max_byte_length);
-                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
@@ -493,8 +493,8 @@ impl Interpreter {
             "transferToFixedLength".to_string(),
             0,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let (is_ab, is_shared) = {
                         let obj_ref = obj.borrow();
@@ -515,12 +515,12 @@ impl Interpreter {
                         let obj_ref = obj.borrow();
                         buffer_len(obj_ref.arraybuffer_data().unwrap())
                     };
-                    let new_len_arg = args.first().unwrap_or(&JsValue::Undefined);
-                    let new_len = if matches!(new_len_arg, JsValue::Undefined) {
+                    let new_len_arg = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let new_len = if new_len_arg.is_undefined() {
                         old_len
                     } else {
                         match interp.to_index(new_len_arg) {
-                            Completion::Normal(JsValue::Number(n)) => n as usize,
+                            Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => 0,
                         }
@@ -563,7 +563,7 @@ impl Interpreter {
                     }
                     interp.gc_untrack_external_bytes(old_data_len);
                     let id = interp.create_arraybuffer(new_data);
-                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
@@ -577,8 +577,8 @@ impl Interpreter {
             "transferToImmutable".to_string(),
             0,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let (is_ab, is_shared) = {
                         let obj_ref = obj.borrow();
@@ -599,12 +599,12 @@ impl Interpreter {
                         let obj_ref = obj.borrow();
                         buffer_len(obj_ref.arraybuffer_data().unwrap())
                     };
-                    let new_len_arg = args.first().unwrap_or(&JsValue::Undefined);
-                    let new_len = if matches!(new_len_arg, JsValue::Undefined) {
+                    let new_len_arg = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let new_len = if new_len_arg.is_undefined() {
                         old_len
                     } else {
                         match interp.to_index(new_len_arg) {
-                            Completion::Normal(JsValue::Number(n)) => n as usize,
+                            Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => 0,
                         }
@@ -655,7 +655,7 @@ impl Interpreter {
                     {
                         ab.is_immutable = true;
                     }
-                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
@@ -673,12 +673,12 @@ impl Interpreter {
             2,
             |interp, this_val, args| {
                 // Step 1-2: RequireInternalSlot(O, [[ArrayBufferData]])
-                let JsValue::Object(o) = this_val else {
+                let Some(o) = this_val.as_object_id() else {
                     return Completion::Throw(interp.create_type_error(
                         "ArrayBuffer.prototype.sliceToImmutable called on non-object",
                     ));
                 };
-                let Some(obj) = interp.get_object(o.id) else {
+                let Some(obj) = interp.get_object(o) else {
                     return Completion::Throw(interp.create_type_error(
                         "ArrayBuffer.prototype.sliceToImmutable called on invalid receiver",
                     ));
@@ -749,7 +749,7 @@ impl Interpreter {
                 };
                 let first = resolve(start_num);
 
-                let end_undefined = args.len() < 2 || matches!(args[1], JsValue::Undefined);
+                let end_undefined = args.len() < 2 || args[1].is_undefined();
                 let end_num = if end_undefined {
                     len_f
                 } else {
@@ -803,7 +803,7 @@ impl Interpreter {
                 {
                     ab.is_immutable = true;
                 }
-                Completion::Normal(JsValue::Object(JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
         self.get_object_cell_expect(ab_proto_id)
@@ -815,8 +815,8 @@ impl Interpreter {
             "resize".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let (is_ab, is_shared, is_immutable, max_byte_length) = {
                         let obj_ref = obj.borrow();
@@ -836,9 +836,9 @@ impl Interpreter {
                         );
                     }
                     // Step 4: ToIndex(newLength) — BEFORE detach check
-                    let new_len_val = args.first().unwrap_or(&JsValue::Undefined);
+                    let new_len_val = args.first().unwrap_or(&JsValue::UNDEFINED);
                     let new_len = match interp.to_index(new_len_val) {
-                        Completion::Normal(JsValue::Number(n)) => n as usize,
+                        Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                         Completion::Throw(e) => return Completion::Throw(e),
                         _ => 0,
                     };
@@ -873,7 +873,7 @@ impl Interpreter {
                     } else {
                         interp.gc_untrack_external_bytes(old_len - new_len);
                     }
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 Completion::Throw(interp.create_type_error("not an ArrayBuffer"))
             },
@@ -896,25 +896,24 @@ impl Interpreter {
                         interp.create_type_error("Constructor ArrayBuffer requires 'new'"),
                     );
                 }
-                let len_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let len_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = match interp.to_index(&len_val) {
-                    Completion::Normal(JsValue::Number(n)) => n as usize,
+                    Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                     Completion::Throw(e) => return Completion::Throw(e),
                     _ => 0,
                 };
                 let max_byte_length = if args.len() > 1 {
-                    if let JsValue::Object(opts_o) = &args[1] {
-                        let opts_val = JsValue::Object(opts_o.clone());
+                    if let Some(opts_o) = args[1].as_object_id() {
+                        let opts_val = JsValue::object(opts_o);
                         let max_val =
-                            match interp.get_object_property(opts_o.id, "maxByteLength", &opts_val)
-                            {
+                            match interp.get_object_property(opts_o, "maxByteLength", &opts_val) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
-                        if !matches!(max_val, JsValue::Undefined) {
+                        if !max_val.is_undefined() {
                             let max = match interp.to_index(&max_val) {
-                                Completion::Normal(JsValue::Number(n)) => n as usize,
+                                Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 _ => 0,
                             };
@@ -977,7 +976,7 @@ impl Interpreter {
                 }
                 interp.gc_track_external_bytes(buf_len);
                 let id = obj_id;
-                Completion::Normal(JsValue::Object(JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
 
@@ -986,27 +985,27 @@ impl Interpreter {
             "isView".to_string(),
             1,
             |interp, _this, args| {
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = &arg
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(o) = arg.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     let obj_ref = obj.borrow();
                     if obj_ref.typed_array_info().is_some() || obj_ref.data_view_info().is_some() {
-                        return Completion::Normal(JsValue::Boolean(true));
+                        return Completion::Normal(JsValue::boolean(true));
                     }
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         // Wire ArrayBuffer.prototype to the proto object with all the methods
         let ab_proto_val = {
             let id = ab_proto_id;
-            JsValue::Object(crate::types::JsObject { id })
+            JsValue::object(id)
         };
-        if let JsValue::Object(o) = &ctor
-            && self.get_object_cell(o.id).is_some()
+        if let Some(o) = ctor.as_object_id()
+            && self.get_object_cell(o).is_some()
         {
-            let ctor_id = o.id;
+            let ctor_id = o;
             {
                 let mut b = self.get_object_cell_expect(ctor_id).borrow_mut();
                 b.insert_property(
@@ -1044,8 +1043,8 @@ impl Interpreter {
             );
 
         // Mark deferred_construct: ArrayBuffer validates args before OrdinaryCreateFromConstructor
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj.borrow_mut().deferred_construct = true;
         }
@@ -1092,8 +1091,8 @@ impl Interpreter {
     }
 
     pub(crate) fn detach_arraybuffer(&mut self, ab_val: &JsValue) -> Completion {
-        if let JsValue::Object(o) = ab_val
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = ab_val.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             let old_len;
             {
@@ -1128,7 +1127,7 @@ impl Interpreter {
                 }
             }
             self.gc_untrack_external_bytes(old_len);
-            return Completion::Normal(JsValue::Undefined);
+            return Completion::Normal(JsValue::UNDEFINED);
         }
         Completion::Throw(self.create_type_error("not an ArrayBuffer"))
     }
@@ -1142,14 +1141,14 @@ impl Interpreter {
 
         // byteLength getter
         self.define_getter(sab_proto_id, "byteLength", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let obj_ref = obj.borrow();
                 if obj_ref.arraybuffer_is_shared()
                     && let Some(buf) = obj_ref.arraybuffer_data()
                 {
-                    return Completion::Normal(JsValue::Number(buffer_len(buf) as f64));
+                    return Completion::Normal(JsValue::number(buffer_len(buf) as f64));
                 }
             }
             Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
@@ -1157,8 +1156,8 @@ impl Interpreter {
 
         // maxByteLength getter
         self.define_getter(sab_proto_id, "maxByteLength", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let obj_ref = obj.borrow();
                 if obj_ref.arraybuffer_is_shared()
@@ -1167,7 +1166,7 @@ impl Interpreter {
                     let max = obj_ref
                         .arraybuffer_max_byte_length()
                         .unwrap_or_else(|| buffer_len(buf));
-                    return Completion::Normal(JsValue::Number(max as f64));
+                    return Completion::Normal(JsValue::number(max as f64));
                 }
             }
             Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
@@ -1175,12 +1174,12 @@ impl Interpreter {
 
         // growable getter
         self.define_getter(sab_proto_id, "growable", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object(o)
             {
                 let obj_ref = obj.borrow();
                 if obj_ref.arraybuffer_is_shared() {
-                    return Completion::Normal(JsValue::Boolean(
+                    return Completion::Normal(JsValue::boolean(
                         obj_ref.arraybuffer_max_byte_length().is_some(),
                     ));
                 }
@@ -1193,8 +1192,8 @@ impl Interpreter {
             "grow".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let (is_shared, max_byte_length) = {
                         let obj_ref = obj.borrow();
@@ -1213,9 +1212,9 @@ impl Interpreter {
                             interp.create_type_error("SharedArrayBuffer is not growable"),
                         );
                     }
-                    let new_len_val = args.first().unwrap_or(&JsValue::Undefined);
+                    let new_len_val = args.first().unwrap_or(&JsValue::UNDEFINED);
                     let new_len = match interp.to_index(new_len_val) {
-                        Completion::Normal(JsValue::Number(n)) => n as usize,
+                        Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                         Completion::Throw(e) => return Completion::Throw(e),
                         _ => 0,
                     };
@@ -1236,7 +1235,7 @@ impl Interpreter {
                         );
                     }
                     buf.borrow_mut().resize(new_len, 0u8);
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 Completion::Throw(interp.create_type_error("not a SharedArrayBuffer"))
             },
@@ -1250,8 +1249,8 @@ impl Interpreter {
             "slice".to_string(),
             2,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let buf_len = {
                         let obj_ref = obj.borrow();
@@ -1284,7 +1283,7 @@ impl Interpreter {
                     } else {
                         (start_arg as usize).min(buf_len)
                     };
-                    let end_arg = if args.len() > 1 && !matches!(args[1], JsValue::Undefined) {
+                    let end_arg = if args.len() > 1 && !args[1].is_undefined() {
                         match interp.to_number_value(&args[1]) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
@@ -1304,23 +1303,23 @@ impl Interpreter {
                     // SpeciesConstructor(O, %SharedArrayBuffer%)
                     let sab_ctor = interp
                         .get_global_var("SharedArrayBuffer")
-                        .unwrap_or(JsValue::Undefined);
+                        .unwrap_or(JsValue::UNDEFINED);
                     let ctor = match interp.species_constructor(this_val, &sab_ctor) {
                         Ok(c) => c,
                         Err(e) => return Completion::Throw(e),
                     };
                     let new_val = match interp.construct_with_new_target(
                         &ctor,
-                        &[JsValue::Number(new_len as f64)],
+                        &[JsValue::number(new_len as f64)],
                         ctor.clone(),
                     ) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => return Completion::Normal(JsValue::Undefined),
+                        _ => return Completion::Normal(JsValue::UNDEFINED),
                     };
                     // Validate result
-                    let new_id = if let JsValue::Object(ref no) = new_val {
-                        no.id
+                    let new_id = if let Some(no) = new_val.as_object_id() {
+                        no
                     } else {
                         return Completion::Throw(
                             interp.create_type_error("species constructor must return a SharedArrayBuffer"),
@@ -1338,7 +1337,7 @@ impl Interpreter {
                             interp.create_type_error("species constructor must return a SharedArrayBuffer"),
                         );
                     }
-                    if new_id == o.id {
+                    if new_id == o {
                         return Completion::Throw(
                             interp.create_type_error("species constructor must not return the same SharedArrayBuffer"),
                         );
@@ -1390,26 +1389,25 @@ impl Interpreter {
                         interp.create_type_error("Constructor SharedArrayBuffer requires 'new'"),
                     );
                 }
-                let len_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let len_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = match interp.to_index(&len_val) {
-                    Completion::Normal(JsValue::Number(n)) => n as usize,
+                    Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                     Completion::Throw(e) => return Completion::Throw(e),
                     _ => 0,
                 };
                 let max_byte_length = if args.len() > 1 {
-                    if let JsValue::Object(opts_o) = &args[1] {
-                        let opts_val = JsValue::Object(opts_o.clone());
+                    if let Some(opts_o) = args[1].as_object_id() {
+                        let opts_val = JsValue::object(opts_o);
                         // Use Get() (get_object_property) to trigger getters
                         let max_val =
-                            match interp.get_object_property(opts_o.id, "maxByteLength", &opts_val)
-                            {
+                            match interp.get_object_property(opts_o, "maxByteLength", &opts_val) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
-                        if !matches!(max_val, JsValue::Undefined) {
+                        if !max_val.is_undefined() {
                             let max = match interp.to_index(&max_val) {
-                                Completion::Normal(JsValue::Number(n)) => n as usize,
+                                Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 _ => 0,
                             };
@@ -1466,19 +1464,19 @@ impl Interpreter {
                     );
                 }
                 let id = obj_id;
-                Completion::Normal(JsValue::Object(JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
 
         // Wire SharedArrayBuffer.prototype_id
         let sab_proto_val = {
             let id = sab_proto_id;
-            JsValue::Object(crate::types::JsObject { id })
+            JsValue::object(id)
         };
-        if let JsValue::Object(o) = &ctor
-            && self.get_object_cell(o.id).is_some()
+        if let Some(o) = ctor.as_object_id()
+            && self.get_object_cell(o).is_some()
         {
-            let ctor_id = o.id;
+            let ctor_id = o;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -1513,8 +1511,8 @@ impl Interpreter {
                 PropertyDescriptor::data(ctor.clone(), true, false, true),
             );
 
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj.borrow_mut().deferred_construct = true;
         }
@@ -1536,45 +1534,45 @@ impl Interpreter {
 
         // byteOffset getter
         self.define_getter(proto_id, "byteOffset", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let obj_ref = obj.borrow();
                 if let Some(ta) = obj_ref.typed_array_info() {
                     if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                        return Completion::Normal(JsValue::Number(0.0));
+                        return Completion::Normal(JsValue::number(0.0));
                     }
-                    return Completion::Normal(JsValue::Number(ta.byte_offset as f64));
+                    return Completion::Normal(JsValue::number(ta.byte_offset as f64));
                 }
             }
             Completion::Throw(interp.create_type_error("not a TypedArray"))
         });
         // byteLength getter
         self.define_getter(proto_id, "byteLength", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let obj_ref = obj.borrow();
                 if let Some(ta) = obj_ref.typed_array_info() {
                     if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                        return Completion::Normal(JsValue::Number(0.0));
+                        return Completion::Normal(JsValue::number(0.0));
                     }
-                    return Completion::Normal(JsValue::Number(typed_array_byte_length(ta) as f64));
+                    return Completion::Normal(JsValue::number(typed_array_byte_length(ta) as f64));
                 }
             }
             Completion::Throw(interp.create_type_error("not a TypedArray"))
         });
         // length getter
         self.define_getter(proto_id, "length", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object_cell(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object_cell(o)
             {
                 let obj_ref = obj.borrow();
                 if let Some(ta) = obj_ref.typed_array_info() {
                     if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                        return Completion::Normal(JsValue::Number(0.0));
+                        return Completion::Normal(JsValue::number(0.0));
                     }
-                    return Completion::Normal(JsValue::Number(typed_array_length(ta) as f64));
+                    return Completion::Normal(JsValue::number(typed_array_length(ta) as f64));
                 }
             }
             Completion::Throw(interp.create_type_error("not a TypedArray"))
@@ -1582,14 +1580,14 @@ impl Interpreter {
 
         // buffer getter (returns the ArrayBuffer object - we need to find it)
         self.define_getter(proto_id, "buffer", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object(o)
             {
                 let obj_ref = obj.borrow();
                 if obj_ref.typed_array_info().is_some()
                     && let Some(buf_id) = obj_ref.view_buffer_object_id()
                 {
-                    return Completion::Normal(JsValue::Object(JsObject { id: buf_id }));
+                    return Completion::Normal(JsValue::object(buf_id));
                 }
             }
             Completion::Throw(interp.create_type_error("not a TypedArray"))
@@ -1607,8 +1605,8 @@ impl Interpreter {
             "at".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -1623,18 +1621,18 @@ impl Interpreter {
                     };
                     // Capture len BEFORE argument coercion (may resize buffer)
                     let len = typed_array_length(&ta) as i64;
-                    let idx_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let idx_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let idx = match interp.to_integer_or_infinity_value(&idx_val) {
                         Ok(n) => n as i64,
                         Err(e) => return Completion::Throw(e),
                     };
                     let actual = if idx < 0 { len + idx } else { idx };
                     if actual < 0 || actual >= len {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     // Use Get semantics (checks OOB post-resize via is_valid_integer_index)
                     let key = actual.to_string();
-                    return interp.get_object_property(o.id, &key, this_val);
+                    return interp.get_object_property(o, &key, this_val);
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
@@ -1649,8 +1647,8 @@ impl Interpreter {
             1,
             |interp, this_val, args| {
                 // Step 1: ValidateTypedArray(this)
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -1664,7 +1662,7 @@ impl Interpreter {
                         return c;
                     }
 
-                    let source = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let source = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
                     // Step 2: ToIntegerOrInfinity(offset) BEFORE detach check
                     let offset_f = if args.len() > 1 {
@@ -1688,8 +1686,8 @@ impl Interpreter {
                     }
 
                     // Check if source is a TypedArray
-                    if let JsValue::Object(src_o) = &source
-                        && let Some(src_obj) = interp.get_object_cell(src_o.id)
+                    if let Some(src_o) = source.as_object_id()
+                        && let Some(src_obj) = interp.get_object_cell(src_o)
                     {
                         let is_ta = src_obj.borrow().typed_array_info().is_some();
                         if is_ta {
@@ -1750,7 +1748,7 @@ impl Interpreter {
                                     typed_array_set_index(&ta, offset + i, &val);
                                 }
                             }
-                            return Completion::Normal(JsValue::Undefined);
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
                     }
 
@@ -1761,9 +1759,8 @@ impl Interpreter {
                         Completion::Normal(v) => v,
                         other => return other,
                     };
-                    if let JsValue::Object(src_o) = &src_obj {
-                        let len_val = match interp.get_object_property(src_o.id, "length", &src_obj)
-                        {
+                    if let Some(src_o) = src_obj.as_object_id() {
+                        let len_val = match interp.get_object_property(src_o, "length", &src_obj) {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
@@ -1777,14 +1774,11 @@ impl Interpreter {
                             );
                         }
                         for i in 0..src_len {
-                            let val = match interp.get_object_property(
-                                src_o.id,
-                                &i.to_string(),
-                                &src_obj,
-                            ) {
-                                Completion::Normal(v) => v,
-                                other => return other,
-                            };
+                            let val =
+                                match interp.get_object_property(src_o, &i.to_string(), &src_obj) {
+                                    Completion::Normal(v) => v,
+                                    other => return other,
+                                };
                             // Coerce with proper ContentType
                             let coerced = match interp.typed_array_coerce_value(ta.kind, &val) {
                                 Ok(v) => v,
@@ -1796,7 +1790,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
@@ -1810,16 +1804,16 @@ impl Interpreter {
             "subarray".to_string(),
             2,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let (ta, buf_val) = {
                         let obj_ref = obj.borrow();
                         if let Some(ta) = obj_ref.typed_array_info() {
                             let bv = obj_ref
                                 .view_buffer_object_id()
-                                .map(|id| JsValue::Object(JsObject { id }))
-                                .unwrap_or(JsValue::Undefined);
+                                .map(JsValue::object)
+                                .unwrap_or(JsValue::UNDEFINED);
                             (ta.clone(), bv)
                         } else {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
@@ -1843,7 +1837,7 @@ impl Interpreter {
                         resolve_relative_index(n, src_len as usize)
                     };
                     let end_is_undefined =
-                        args.len() <= 1 || matches!(args.get(1), Some(JsValue::Undefined));
+                        args.len() <= 1 || args.get(1).is_some_and(|v| v.is_undefined());
                     let end = {
                         let n = if !end_is_undefined {
                             match interp.to_integer_or_infinity_value(&args[1]) {
@@ -1859,11 +1853,11 @@ impl Interpreter {
                     let bpe = ta.kind.bytes_per_element();
                     let new_offset = ta.byte_offset + begin * bpe;
 
-                    let offset_val = JsValue::Number(new_offset as f64);
+                    let offset_val = JsValue::number(new_offset as f64);
                     let ctor_args: Vec<JsValue> = if end_is_undefined && ta.is_length_tracking {
                         vec![buf_val, offset_val]
                     } else {
-                        vec![buf_val, offset_val, JsValue::Number(new_len as f64)]
+                        vec![buf_val, offset_val, JsValue::number(new_len as f64)]
                     };
                     return match interp.typed_array_species_create(this_val, &ctor_args) {
                         Ok(v) => Completion::Normal(v),
@@ -1882,8 +1876,8 @@ impl Interpreter {
             "slice".to_string(),
             2,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -1909,7 +1903,7 @@ impl Interpreter {
                         resolve_relative_index(n, len as usize)
                     };
                     let end = {
-                        let n = if args.len() > 1 && !matches!(args[1], JsValue::Undefined) {
+                        let n = if args.len() > 1 && !args[1].is_undefined() {
                             match interp.to_integer_or_infinity_value(&args[1]) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
@@ -1923,16 +1917,16 @@ impl Interpreter {
 
                     // Use TypedArraySpeciesCreate
                     let new_ta_val = match interp
-                        .typed_array_species_create(this_val, &[JsValue::Number(count as f64)])
+                        .typed_array_species_create(this_val, &[JsValue::number(count as f64)])
                     {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
                     // TypedArrayCreateFromConstructor(..., accessMode=~write~):
                     // reject result backed by immutable buffer before any writes.
-                    if let JsValue::Object(new_o) = &new_ta_val {
+                    if let Some(new_o) = new_ta_val.as_object_id() {
                         let new_info_opt = interp
-                            .get_object_cell(new_o.id)
+                            .get_object_cell(new_o)
                             .and_then(|cell| cell.borrow().typed_array_info().cloned());
                         if let Some(info) = new_info_opt
                             && ta_buffer_is_immutable(interp, &info)
@@ -1961,8 +1955,8 @@ impl Interpreter {
                         let count = end.saturating_sub(begin);
 
                         if count > 0
-                            && let JsValue::Object(new_o) = &new_ta_val
-                            && let Some(new_obj) = interp.get_object(new_o.id)
+                            && let Some(new_o) = new_ta_val.as_object_id()
+                            && let Some(new_obj) = interp.get_object(new_o)
                         {
                             let new_ta = {
                                 let obj_ref = new_obj.borrow();
@@ -2017,8 +2011,8 @@ impl Interpreter {
             "copyWithin".to_string(),
             2,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2037,7 +2031,7 @@ impl Interpreter {
                     let len = typed_array_length(&ta) as i64;
                     let target = {
                         let n = match interp.to_integer_or_infinity_value(
-                            args.first().unwrap_or(&JsValue::Undefined),
+                            args.first().unwrap_or(&JsValue::UNDEFINED),
                         ) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
@@ -2046,7 +2040,7 @@ impl Interpreter {
                     };
                     let start = {
                         let n = match interp.to_integer_or_infinity_value(
-                            args.get(1).unwrap_or(&JsValue::Undefined),
+                            args.get(1).unwrap_or(&JsValue::UNDEFINED),
                         ) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
@@ -2054,7 +2048,7 @@ impl Interpreter {
                         resolve_relative_index(n, len as usize)
                     };
                     let end = {
-                        let n = if args.len() > 2 && !matches!(args[2], JsValue::Undefined) {
+                        let n = if args.len() > 2 && !args[2].is_undefined() {
                             match interp.to_integer_or_infinity_value(&args[2]) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
@@ -2105,8 +2099,8 @@ impl Interpreter {
             "fill".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2127,7 +2121,7 @@ impl Interpreter {
                     // Step 3: compute len BEFORE coercion
                     let len = typed_array_length(&ta);
                     // Per spec: coerce value BEFORE start/end
-                    let raw_value = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let raw_value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let coerced = match interp.typed_array_coerce_value(ta.kind, &raw_value) {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
@@ -2145,7 +2139,7 @@ impl Interpreter {
                         resolve_relative_index(v, len)
                     };
                     let end = {
-                        let v = if args.len() > 2 && !matches!(args[2], JsValue::Undefined) {
+                        let v = if args.len() > 2 && !args[2].is_undefined() {
                             match interp.to_integer_or_infinity_value(&args[2]) {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
@@ -2185,8 +2179,8 @@ impl Interpreter {
             "indexOf".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2201,9 +2195,9 @@ impl Interpreter {
                     };
                     let len = typed_array_length(&ta) as i64;
                     if len == 0 {
-                        return Completion::Normal(JsValue::Number(-1.0));
+                        return Completion::Normal(JsValue::number(-1.0));
                     }
-                    let search = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let from = if args.len() > 1 {
                         (match interp.to_integer_or_infinity_value(&args[1]) {
                             Ok(n) => n,
@@ -2224,10 +2218,10 @@ impl Interpreter {
                         }
                         let elem = typed_array_get_index(&ta, i);
                         if strict_eq(&elem, &search) {
-                            return Completion::Normal(JsValue::Number(i as f64));
+                            return Completion::Normal(JsValue::number(i as f64));
                         }
                     }
-                    return Completion::Normal(JsValue::Number(-1.0));
+                    return Completion::Normal(JsValue::number(-1.0));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
@@ -2241,8 +2235,8 @@ impl Interpreter {
             "lastIndexOf".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2257,9 +2251,9 @@ impl Interpreter {
                     };
                     let len = typed_array_length(&ta) as i64;
                     if len == 0 {
-                        return Completion::Normal(JsValue::Number(-1.0));
+                        return Completion::Normal(JsValue::number(-1.0));
                     }
-                    let search = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let from = if args.len() > 1 {
                         (match interp.to_integer_or_infinity_value(&args[1]) {
                             Ok(n) => n,
@@ -2279,12 +2273,12 @@ impl Interpreter {
                         if is_valid_integer_index(&ta, i as f64) {
                             let elem = typed_array_get_index(&ta, i as usize);
                             if strict_eq(&elem, &search) {
-                                return Completion::Normal(JsValue::Number(i as f64));
+                                return Completion::Normal(JsValue::number(i as f64));
                             }
                         }
                         i -= 1;
                     }
-                    return Completion::Normal(JsValue::Number(-1.0));
+                    return Completion::Normal(JsValue::number(-1.0));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
@@ -2298,8 +2292,8 @@ impl Interpreter {
             "includes".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2314,9 +2308,9 @@ impl Interpreter {
                     };
                     let len = typed_array_length(&ta) as i64;
                     if len == 0 {
-                        return Completion::Normal(JsValue::Boolean(false));
+                        return Completion::Normal(JsValue::boolean(false));
                     }
-                    let search = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let from = if args.len() > 1 {
                         (match interp.to_integer_or_infinity_value(&args[1]) {
                             Ok(n) => n,
@@ -2333,10 +2327,10 @@ impl Interpreter {
                     for i in start..len as usize {
                         let elem = typed_array_get_index(&ta, i);
                         if same_value_zero(&elem, &search) {
-                            return Completion::Normal(JsValue::Boolean(true));
+                            return Completion::Normal(JsValue::boolean(true));
                         }
                     }
-                    return Completion::Normal(JsValue::Boolean(false));
+                    return Completion::Normal(JsValue::boolean(false));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
@@ -2355,8 +2349,8 @@ impl Interpreter {
             "reverse".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2396,8 +2390,8 @@ impl Interpreter {
             "sort".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2415,11 +2409,11 @@ impl Interpreter {
                     }
                     let comparefn = args.first().cloned();
                     if let Some(ref cmp) = comparefn
-                        && !matches!(cmp, JsValue::Undefined)
+                        && !cmp.is_undefined()
                     {
-                        let is_callable = if let JsValue::Object(co) = cmp {
+                        let is_callable = if let Some(co) = cmp.as_object_id() {
                             interp
-                                .get_object_cell(co.id)
+                                .get_object_cell(co)
                                 .is_some_and(|obj| obj.borrow().callable.is_some())
                         } else {
                             false
@@ -2440,11 +2434,11 @@ impl Interpreter {
                             return std::cmp::Ordering::Equal;
                         }
                         if let Some(ref cmp) = comparefn
-                            && !matches!(cmp, JsValue::Undefined)
+                            && !cmp.is_undefined()
                         {
                             match interp.call_function(
                                 cmp,
-                                &JsValue::Undefined,
+                                &JsValue::UNDEFINED,
                                 &[a.clone(), b.clone()],
                             ) {
                                 Completion::Normal(v) => match interp.to_number_value(&v) {
@@ -2473,9 +2467,9 @@ impl Interpreter {
                             }
                         }
                         // Default sort: numeric for Number types, BigInt comparison for BigInt types
-                        match (a, b) {
-                            (JsValue::BigInt(ba), JsValue::BigInt(bb)) => ba.value.cmp(&bb.value),
-                            _ => {
+                        match a.with_bigint(|ba| b.with_bigint(|bb| ba.cmp(bb))).flatten() {
+                            Some(ord) => ord,
+                            None => {
                                 let na = to_number(a);
                                 let nb = to_number(b);
                                 // Per spec: -0 < +0 is false, +0 < -0 is false
@@ -2517,8 +2511,8 @@ impl Interpreter {
             "join".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2532,7 +2526,7 @@ impl Interpreter {
                         }
                     };
                     let len = typed_array_length(&ta);
-                    let sep = if args.is_empty() || matches!(args[0], JsValue::Undefined) {
+                    let sep = if args.is_empty() || args[0].is_undefined() {
                         ",".to_string()
                     } else {
                         match interp.to_string_value(&args[0]) {
@@ -2543,7 +2537,7 @@ impl Interpreter {
                     let mut parts: Vec<String> = Vec::with_capacity(len);
                     for i in 0..len {
                         let elem = typed_array_get_index(&ta, i);
-                        let s = if matches!(elem, JsValue::Undefined | JsValue::Null) {
+                        let s = if elem.is_nullish() {
                             String::new()
                         } else {
                             match interp.to_string_value(&elem) {
@@ -2553,7 +2547,7 @@ impl Interpreter {
                         };
                         parts.push(s);
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&parts.join(&sep))))
+                    Completion::Normal(JsValue::from_str(&parts.join(&sep)))
                 } else {
                     Completion::Throw(interp.create_type_error("not a TypedArray"))
                 }
@@ -2578,11 +2572,11 @@ impl Interpreter {
             0,
             |interp, this_val, args| {
                 // ValidateTypedArray: Type(O) must be Object
-                if !matches!(this_val, JsValue::Object(_)) {
+                if !this_val.is_object() {
                     return Completion::Throw(interp.create_type_error("not a TypedArray"));
                 }
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2597,14 +2591,14 @@ impl Interpreter {
                         }
                     };
                     let separator = ",";
-                    let locales = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let pass_args = vec![locales, options];
                     let len = typed_array_length(&ta);
                     let mut parts: Vec<String> = Vec::with_capacity(len);
                     for k in 0..len {
                         let next_element = typed_array_get_index(&ta, k);
-                        if matches!(next_element, JsValue::Undefined | JsValue::Null) {
+                        if next_element.is_nullish() {
                             parts.push(String::new());
                         } else {
                             // Convert to object to get toLocaleString method
@@ -2612,9 +2606,9 @@ impl Interpreter {
                                 Completion::Normal(v) => v,
                                 other => return other,
                             };
-                            if let JsValue::Object(ref elem_ref) = element_obj {
+                            if let Some(elem_ref) = element_obj.as_object_id() {
                                 let to_locale_str_method = match interp.get_object_property(
-                                    elem_ref.id,
+                                    elem_ref,
                                     "toLocaleString",
                                     &element_obj,
                                 ) {
@@ -2644,7 +2638,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&parts.join(separator))))
+                    Completion::Normal(JsValue::from_str(&parts.join(separator)))
                 } else {
                     Completion::Throw(interp.create_type_error("not a TypedArray"))
                 }
@@ -2659,8 +2653,8 @@ impl Interpreter {
             "toReversed".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2712,9 +2706,9 @@ impl Interpreter {
                     }
                     interp.gc_track_external_bytes(buf_byte_len);
                     let ab_id = ab_obj_id;
-                    let buf_val = JsValue::Object(JsObject { id: ab_id });
+                    let buf_val = JsValue::object(ab_id);
                     let id = interp.create_typed_array_object(new_ta, buf_val);
-                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
@@ -2728,8 +2722,8 @@ impl Interpreter {
             "toSorted".to_string(),
             1,
             |interp, this_val, args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -2744,11 +2738,11 @@ impl Interpreter {
                     };
                     let comparefn = args.first().cloned();
                     if let Some(ref cmp) = comparefn
-                        && !matches!(cmp, JsValue::Undefined)
+                        && !cmp.is_undefined()
                     {
-                        let is_callable = if let JsValue::Object(co) = cmp {
+                        let is_callable = if let Some(co) = cmp.as_object_id() {
                             interp
-                                .get_object_cell(co.id)
+                                .get_object_cell(co)
                                 .is_some_and(|obj| obj.borrow().callable.is_some())
                         } else {
                             false
@@ -2768,11 +2762,11 @@ impl Interpreter {
                             return std::cmp::Ordering::Equal;
                         }
                         if let Some(ref cmp) = comparefn
-                            && !matches!(cmp, JsValue::Undefined)
+                            && !cmp.is_undefined()
                         {
                             match interp.call_function(
                                 cmp,
-                                &JsValue::Undefined,
+                                &JsValue::UNDEFINED,
                                 &[a.clone(), b.clone()],
                             ) {
                                 Completion::Normal(v) => match interp.to_number_value(&v) {
@@ -2801,9 +2795,9 @@ impl Interpreter {
                             }
                         }
                         // Default sort: numeric for Number types, BigInt comparison for BigInt types
-                        match (a, b) {
-                            (JsValue::BigInt(ba), JsValue::BigInt(bb)) => ba.value.cmp(&bb.value),
-                            _ => {
+                        match a.with_bigint(|ba| b.with_bigint(|bb| ba.cmp(bb))).flatten() {
+                            Some(ord) => ord,
+                            None => {
                                 let na = to_number(a);
                                 let nb = to_number(b);
                                 if na.is_nan() && nb.is_nan() {
@@ -2861,9 +2855,9 @@ impl Interpreter {
                     }
                     interp.gc_track_external_bytes(buf_byte_len);
                     let ab_id = ab_obj_id;
-                    let buf_val = JsValue::Object(JsObject { id: ab_id });
+                    let buf_val = JsValue::object(ab_id);
                     let id = interp.create_typed_array_object(new_ta, buf_val);
-                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
@@ -2882,16 +2876,17 @@ impl Interpreter {
                     interp: &mut Interpreter,
                     val: &JsValue,
                 ) -> Result<f64, JsValue> {
-                    match val {
-                        JsValue::Object(o) => {
+                    match val.kind() {
+                        ValueKind::Object => {
+                            let obj_id = val.as_object_id().unwrap();
                             let method = interp
-                                .get_property_descriptor_on_id(o.id, "valueOf")
+                                .get_property_descriptor_on_id(obj_id, "valueOf")
                                 .and_then(|d| d.value);
                             if let Some(func) = method
                                 && interp.is_callable(&func)
                             {
                                 match interp.call_function(&func, val, &[]) {
-                                    Completion::Normal(v) if !matches!(v, JsValue::Object(_)) => {
+                                    Completion::Normal(v) if !v.is_object() => {
                                         return to_number_throwing(interp, &v);
                                     }
                                     Completion::Normal(_) => {}
@@ -2900,13 +2895,13 @@ impl Interpreter {
                                 }
                             }
                             let tostring_method = interp
-                                .get_property_descriptor_on_id(o.id, "toString")
+                                .get_property_descriptor_on_id(obj_id, "toString")
                                 .and_then(|d| d.value);
                             if let Some(func) = tostring_method
                                 && interp.is_callable(&func)
                             {
                                 match interp.call_function(&func, val, &[]) {
-                                    Completion::Normal(v) if !matches!(v, JsValue::Object(_)) => {
+                                    Completion::Normal(v) if !v.is_object() => {
                                         return to_number_throwing(interp, &v);
                                     }
                                     Completion::Normal(_) => {}
@@ -2916,11 +2911,11 @@ impl Interpreter {
                             }
                             Ok(f64::NAN)
                         }
-                        JsValue::Symbol(_) => {
+                        ValueKind::Symbol => {
                             Err(interp
                                 .create_type_error("Cannot convert a Symbol value to a number"))
                         }
-                        JsValue::BigInt(_) => {
+                        ValueKind::BigInt => {
                             Err(interp
                                 .create_type_error("Cannot convert a BigInt value to a number"))
                         }
@@ -2933,17 +2928,20 @@ impl Interpreter {
                     interp: &mut Interpreter,
                     val: &JsValue,
                 ) -> Result<JsValue, JsValue> {
-                    match val {
-                        JsValue::BigInt(_) => Ok(val.clone()),
-                        JsValue::Object(o) => {
+                    match val.kind() {
+                        ValueKind::BigInt => Ok(val.clone()),
+                        ValueKind::Object => {
                             let method = interp
-                                .get_property_descriptor_on_id(o.id, "valueOf")
+                                .get_property_descriptor_on_id(
+                                    val.as_object_id().unwrap(),
+                                    "valueOf",
+                                )
                                 .and_then(|d| d.value);
                             if let Some(func) = method
                                 && interp.is_callable(&func)
                             {
                                 match interp.call_function(&func, val, &[]) {
-                                    Completion::Normal(v) if !matches!(v, JsValue::Object(_)) => {
+                                    Completion::Normal(v) if !v.is_object() => {
                                         return to_bigint_throwing(interp, &v);
                                     }
                                     Completion::Normal(_) => {}
@@ -2953,16 +2951,17 @@ impl Interpreter {
                             }
                             Err(interp.create_type_error("Cannot convert value to a BigInt"))
                         }
-                        JsValue::Boolean(b) => Ok(JsValue::BigInt(JsBigInt::new(
-                            num_bigint::BigInt::from(if *b { 1 } else { 0 }),
+                        ValueKind::Boolean => Ok(JsValue::bigint(JsBigInt::new(
+                            num_bigint::BigInt::from(if val.as_boolean().unwrap() { 1 } else { 0 }),
                         ))),
-                        JsValue::Number(n) => {
+                        ValueKind::Number => {
                             // ToBigInt throws TypeError for Number values
+                            let n = val.as_number().unwrap();
                             Err(interp
                                 .create_type_error(&format!("Cannot convert {} to a BigInt", n)))
                         }
-                        JsValue::String(s) => {
-                            let text = s.to_rust_string().trim().to_string();
+                        ValueKind::String => {
+                            let text = val.as_string().unwrap().to_rust_string().trim().to_string();
                             if text.is_empty() {
                                 return Err(interp.create_error(
                                     "SyntaxError",
@@ -2985,7 +2984,7 @@ impl Interpreter {
                                 text.parse::<num_bigint::BigInt>().ok()
                             };
                             match parsed {
-                                Some(v) => Ok(JsValue::BigInt(JsBigInt::new(v))),
+                                Some(v) => Ok(JsValue::bigint(JsBigInt::new(v))),
                                 None => Err(interp.create_error(
                                     "SyntaxError",
                                     &format!("Cannot convert {} to a BigInt", text),
@@ -2996,8 +2995,8 @@ impl Interpreter {
                     }
                 }
 
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let ta = {
                         let obj_ref = obj.borrow();
@@ -3013,7 +3012,7 @@ impl Interpreter {
                     let len = typed_array_length(&ta) as i64;
 
                     // Step 4: ToIntegerOrInfinity(index) - must call valueOf on objects
-                    let index_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let index_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let relative_index = match to_number_throwing(interp, &index_arg) {
                         Ok(n) => to_integer_or_infinity(n) as i64,
                         Err(e) => return Completion::Throw(e),
@@ -3025,7 +3024,7 @@ impl Interpreter {
                     };
 
                     // Steps 7-8: Coerce value BEFORE checking index bounds
-                    let value_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let value_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let numeric_value = if ta.kind.is_bigint() {
                         match to_bigint_throwing(interp, &value_arg) {
                             Ok(v) => v,
@@ -3033,7 +3032,7 @@ impl Interpreter {
                         }
                     } else {
                         match to_number_throwing(interp, &value_arg) {
-                            Ok(n) => JsValue::Number(n),
+                            Ok(n) => JsValue::number(n),
                             Err(e) => return Completion::Throw(e),
                         }
                     };
@@ -3088,9 +3087,9 @@ impl Interpreter {
                     }
                     interp.gc_track_external_bytes(buf_byte_len);
                     let ab_id = ab_obj_id;
-                    let buf_val = JsValue::Object(JsObject { id: ab_id });
+                    let buf_val = JsValue::object(ab_id);
                     let id = interp.create_typed_array_object(new_ta, buf_val);
-                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
             },
@@ -3104,17 +3103,15 @@ impl Interpreter {
             "get [Symbol.toStringTag]".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let obj_ref = obj.borrow();
                     if let Some(ta) = obj_ref.typed_array_info() {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            ta.kind.name(),
-                        )));
+                        return Completion::Normal(JsValue::from_str(ta.kind.name()));
                     }
                 }
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3137,8 +3134,8 @@ impl Interpreter {
             "values".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     {
                         let obj_ref = obj.borrow();
@@ -3150,7 +3147,7 @@ impl Interpreter {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
                         }
                     }
-                    let iter = interp.create_typed_array_iterator(o.id, IteratorKind::Value);
+                    let iter = interp.create_typed_array_iterator(o, IteratorKind::Value);
                     return Completion::Normal(iter);
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
@@ -3169,8 +3166,8 @@ impl Interpreter {
             "entries".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     {
                         let obj_ref = obj.borrow();
@@ -3182,7 +3179,7 @@ impl Interpreter {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
                         }
                     }
-                    let iter = interp.create_typed_array_iterator(o.id, IteratorKind::KeyValue);
+                    let iter = interp.create_typed_array_iterator(o, IteratorKind::KeyValue);
                     return Completion::Normal(iter);
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
@@ -3196,8 +3193,8 @@ impl Interpreter {
             "keys".to_string(),
             0,
             |interp, this_val, _args| {
-                if let JsValue::Object(o) = this_val
-                    && let Some(obj) = interp.get_object(o.id)
+                if let Some(o) = this_val.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     {
                         let obj_ref = obj.borrow();
@@ -3209,7 +3206,7 @@ impl Interpreter {
                             return Completion::Throw(interp.create_type_error("not a TypedArray"));
                         }
                     }
-                    let iter = interp.create_typed_array_iterator(o.id, IteratorKind::Key);
+                    let iter = interp.create_typed_array_iterator(o, IteratorKind::Key);
                     return Completion::Normal(iter);
                 }
                 Completion::Throw(interp.create_type_error("not a TypedArray"))
@@ -3230,14 +3227,14 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = typed_array_length(&ta);
                 for i in 0..len {
                     let val = typed_array_get_index(&ta, i);
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val.clone(), JsValue::Number(i as f64), this_val.clone()],
+                        &[val.clone(), JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => {
                             if interp.to_boolean_val(&result) {
@@ -3247,7 +3244,7 @@ impl Interpreter {
                         other => return other,
                     }
                 }
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3263,24 +3260,24 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = typed_array_length(&ta);
                 for i in 0..len {
                     let val = typed_array_get_index(&ta, i);
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val, JsValue::Number(i as f64), this_val.clone()],
+                        &[val, JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => {
                             if interp.to_boolean_val(&result) {
-                                return Completion::Normal(JsValue::Number(i as f64));
+                                return Completion::Normal(JsValue::number(i as f64));
                             }
                         }
                         other => return other,
                     }
                 }
-                Completion::Normal(JsValue::Number(-1.0))
+                Completion::Normal(JsValue::number(-1.0))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3296,7 +3293,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = typed_array_length(&ta);
                 let mut i = len as i64 - 1;
                 while i >= 0 {
@@ -3304,7 +3301,7 @@ impl Interpreter {
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val.clone(), JsValue::Number(i as f64), this_val.clone()],
+                        &[val.clone(), JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => {
                             if interp.to_boolean_val(&result) {
@@ -3315,7 +3312,7 @@ impl Interpreter {
                     }
                     i -= 1;
                 }
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3331,7 +3328,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = typed_array_length(&ta);
                 let mut i = len as i64 - 1;
                 while i >= 0 {
@@ -3339,18 +3336,18 @@ impl Interpreter {
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val, JsValue::Number(i as f64), this_val.clone()],
+                        &[val, JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => {
                             if interp.to_boolean_val(&result) {
-                                return Completion::Normal(JsValue::Number(i as f64));
+                                return Completion::Normal(JsValue::number(i as f64));
                             }
                         }
                         other => return other,
                     }
                     i -= 1;
                 }
-                Completion::Normal(JsValue::Number(-1.0))
+                Completion::Normal(JsValue::number(-1.0))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3366,20 +3363,20 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = typed_array_length(&ta);
                 for i in 0..len {
                     let val = typed_array_get_index(&ta, i);
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val, JsValue::Number(i as f64), this_val.clone()],
+                        &[val, JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(_) => {}
                         other => return other,
                     }
                 }
-                Completion::Normal(JsValue::Undefined)
+                Completion::Normal(JsValue::UNDEFINED)
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3395,20 +3392,20 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = typed_array_length(&ta);
 
                 // Use TypedArraySpeciesCreate
                 let new_ta_val = match interp
-                    .typed_array_species_create(this_val, &[JsValue::Number(len as f64)])
+                    .typed_array_species_create(this_val, &[JsValue::number(len as f64)])
                 {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 };
                 interp.gc_root_value(&new_ta_val);
 
-                let new_ta = if let JsValue::Object(o) = &new_ta_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                let new_ta = if let Some(o) = new_ta_val.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     obj.borrow().typed_array_info().unwrap().clone()
                 } else {
@@ -3425,7 +3422,7 @@ impl Interpreter {
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val, JsValue::Number(i as f64), this_val.clone()],
+                        &[val, JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => {
                             typed_array_set_index(&new_ta, i, &result);
@@ -3449,7 +3446,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let mut kept: Vec<JsValue> = Vec::new();
                 let len = typed_array_length(&ta);
                 for i in 0..len {
@@ -3457,7 +3454,7 @@ impl Interpreter {
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val.clone(), JsValue::Number(i as f64), this_val.clone()],
+                        &[val.clone(), JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => {
                             if interp.to_boolean_val(&result) {
@@ -3471,14 +3468,14 @@ impl Interpreter {
 
                 // Use TypedArraySpeciesCreate
                 let new_ta_val = match interp
-                    .typed_array_species_create(this_val, &[JsValue::Number(len as f64)])
+                    .typed_array_species_create(this_val, &[JsValue::number(len as f64)])
                 {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
                 };
 
-                if let JsValue::Object(o) = &new_ta_val
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = new_ta_val.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     let new_ta = obj.borrow().typed_array_info().unwrap().clone();
                     // TypedArrayCreateFromConstructor(..., accessMode=~write~):
@@ -3506,24 +3503,24 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = typed_array_length(&ta);
                 for i in 0..len {
                     let val = typed_array_get_index(&ta, i);
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val, JsValue::Number(i as f64), this_val.clone()],
+                        &[val, JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => {
                             if !interp.to_boolean_val(&result) {
-                                return Completion::Normal(JsValue::Boolean(false));
+                                return Completion::Normal(JsValue::boolean(false));
                             }
                         }
                         other => return other,
                     }
                 }
-                Completion::Normal(JsValue::Boolean(true))
+                Completion::Normal(JsValue::boolean(true))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3539,24 +3536,24 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let this_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let len = typed_array_length(&ta);
                 for i in 0..len {
                     let val = typed_array_get_index(&ta, i);
                     match interp.call_function(
                         &callback,
                         &this_arg,
-                        &[val, JsValue::Number(i as f64), this_val.clone()],
+                        &[val, JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => {
                             if interp.to_boolean_val(&result) {
-                                return Completion::Normal(JsValue::Boolean(true));
+                                return Completion::Normal(JsValue::boolean(true));
                             }
                         }
                         other => return other,
                     }
                 }
-                Completion::Normal(JsValue::Boolean(false))
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3591,8 +3588,8 @@ impl Interpreter {
                     let val = typed_array_get_index(&ta, i);
                     match interp.call_function(
                         &callback,
-                        &JsValue::Undefined,
-                        &[acc, val, JsValue::Number(i as f64), this_val.clone()],
+                        &JsValue::UNDEFINED,
+                        &[acc, val, JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => acc = result,
                         other => return other,
@@ -3634,8 +3631,8 @@ impl Interpreter {
                     let val = typed_array_get_index(&ta, i as usize);
                     match interp.call_function(
                         &callback,
-                        &JsValue::Undefined,
-                        &[acc, val, JsValue::Number(i as f64), this_val.clone()],
+                        &JsValue::UNDEFINED,
+                        &[acc, val, JsValue::number(i as f64), this_val.clone()],
                     ) {
                         Completion::Normal(result) => acc = result,
                         other => return other,
@@ -3684,13 +3681,15 @@ impl Interpreter {
             1,
             |interp, this_val, args| {
                 // Step 1: C = this value
-                let source = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let source = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let map_fn_arg = args.get(1).cloned();
-                let this_arg = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let this_arg = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // Step 2: IsConstructor(C)
-                let is_ctor = matches!(this_val, JsValue::Object(o) if {
-                    interp.get_object_cell(o.id).is_some_and(|obj| obj.borrow().callable.is_some())
+                let is_ctor = this_val.as_object_id().is_some_and(|o| {
+                    interp
+                        .get_object_cell(o)
+                        .is_some_and(|obj| obj.borrow().callable.is_some())
                 });
                 if !is_ctor {
                     return Completion::Throw(
@@ -3700,10 +3699,12 @@ impl Interpreter {
 
                 // Step 3: If mapfn is provided and not undefined, check callable
                 let mapping = if let Some(ref mf) = map_fn_arg
-                    && !matches!(mf, JsValue::Undefined)
+                    && !mf.is_undefined()
                 {
-                    let is_callable = matches!(mf, JsValue::Object(o) if {
-                        interp.get_object_cell(o.id).is_some_and(|obj| obj.borrow().callable.is_some())
+                    let is_callable = mf.as_object_id().is_some_and(|o| {
+                        interp
+                            .get_object_cell(o)
+                            .is_some_and(|obj| obj.borrow().callable.is_some())
                     });
                     if !is_callable {
                         return Completion::Throw(
@@ -3716,21 +3717,17 @@ impl Interpreter {
                 };
 
                 // Step 4: Get @@iterator from raw source (before ToObject)
-                let using_iterator = if let JsValue::Object(ref o) = source {
+                let using_iterator = if let Some(o) = source.as_object_id() {
                     match interp.get_object_property(
-                        o.id,
+                        o,
                         &JsPropertyKey::well_known_symbol("iterator"),
                         &source,
                     ) {
-                        Completion::Normal(v)
-                            if !matches!(v, JsValue::Undefined | JsValue::Null) =>
-                        {
-                            Some(v)
-                        }
+                        Completion::Normal(v) if !v.is_nullish() => Some(v),
                         Completion::Throw(e) => return Completion::Throw(e),
                         _ => None,
                     }
-                } else if matches!(source, JsValue::Undefined | JsValue::Null) {
+                } else if source.is_nullish() {
                     // GetMethod on non-object primitive: need ToObject first for null/undefined → TypeError
                     return Completion::Throw(
                         interp.create_type_error("Cannot convert undefined or null to object"),
@@ -3746,17 +3743,13 @@ impl Interpreter {
                             );
                         }
                     };
-                    if let JsValue::Object(ref wo) = wrapped {
+                    if let Some(wo) = wrapped.as_object_id() {
                         match interp.get_object_property(
-                            wo.id,
+                            wo,
                             &JsPropertyKey::well_known_symbol("iterator"),
                             &wrapped,
                         ) {
-                            Completion::Normal(v)
-                                if !matches!(v, JsValue::Undefined | JsValue::Null) =>
-                            {
-                                Some(v)
-                            }
+                            Completion::Normal(v) if !v.is_nullish() => Some(v),
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => None,
                         }
@@ -3779,10 +3772,10 @@ impl Interpreter {
                     if let Err(c) = check_target_ta_writable(interp, &target_obj) {
                         return c;
                     }
-                    let ta_kind = if let JsValue::Object(ref o) = target_obj {
-                        interp.get_object_cell(o.id).and_then(|obj| {
-                            obj.borrow().typed_array_info().map(|ta| ta.kind)
-                        })
+                    let ta_kind = if let Some(o) = target_obj.as_object_id() {
+                        interp
+                            .get_object_cell(o)
+                            .and_then(|obj| obj.borrow().typed_array_info().map(|ta| ta.kind))
                     } else {
                         None
                     };
@@ -3801,7 +3794,7 @@ impl Interpreter {
                             match interp.call_function(
                                 mf,
                                 &this_arg,
-                                &[val.clone(), JsValue::Number(k as f64)],
+                                &[val.clone(), JsValue::number(k as f64)],
                             ) {
                                 Completion::Normal(v) => v,
                                 other => return other,
@@ -3814,8 +3807,8 @@ impl Interpreter {
                             Err(e) => return Completion::Throw(e),
                         };
                         let key = k.to_string();
-                        if let JsValue::Object(ref o) = target_obj
-                            && let Some(obj) = interp.get_object_cell(o.id)
+                        if let Some(o) = target_obj.as_object_id()
+                            && let Some(obj) = interp.get_object_cell(o)
                         {
                             obj.borrow_mut().set_property_value(&key, coerced);
                         }
@@ -3833,12 +3826,11 @@ impl Interpreter {
                         }
                     };
                     // Step 7: len = LengthOfArrayLike (ToLength calls ToNumber which invokes valueOf)
-                    let len = if let JsValue::Object(ref o) = array_like {
-                        let len_val = match interp.get_object_property(o.id, "length", &array_like)
-                        {
+                    let len = if let Some(o) = array_like.as_object_id() {
+                        let len_val = match interp.get_object_property(o, "length", &array_like) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         let n = match interp.to_number_value(&len_val) {
                             Ok(v) => v,
@@ -3862,10 +3854,10 @@ impl Interpreter {
                     if let Err(c) = check_target_ta_writable(interp, &target_obj) {
                         return c;
                     }
-                    let ta_kind = if let JsValue::Object(ref o) = target_obj {
-                        interp.get_object_cell(o.id).and_then(|obj| {
-                            obj.borrow().typed_array_info().map(|ta| ta.kind)
-                        })
+                    let ta_kind = if let Some(o) = target_obj.as_object_id() {
+                        interp
+                            .get_object_cell(o)
+                            .and_then(|obj| obj.borrow().typed_array_info().map(|ta| ta.kind))
                     } else {
                         None
                     };
@@ -3880,21 +3872,21 @@ impl Interpreter {
                         };
                     // Step 9: For each k, get element from source
                     for k in 0..len {
-                        let val = if let JsValue::Object(ref o) = array_like {
-                            match interp.get_object_property(o.id, &k.to_string(), &array_like) {
+                        let val = if let Some(o) = array_like.as_object_id() {
+                            match interp.get_object_property(o, &k.to_string(), &array_like) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             }
                         } else {
-                            JsValue::Undefined
+                            JsValue::UNDEFINED
                         };
                         let mapped_val = if mapping {
                             let mf = map_fn_arg.as_ref().unwrap();
                             match interp.call_function(
                                 mf,
                                 &this_arg,
-                                &[val.clone(), JsValue::Number(k as f64)],
+                                &[val.clone(), JsValue::number(k as f64)],
                             ) {
                                 Completion::Normal(v) => v,
                                 other => return other,
@@ -3907,8 +3899,8 @@ impl Interpreter {
                             Err(e) => return Completion::Throw(e),
                         };
                         let key = k.to_string();
-                        if let JsValue::Object(ref o) = target_obj
-                            && let Some(obj) = interp.get_object_cell(o.id)
+                        if let Some(o) = target_obj.as_object_id()
+                            && let Some(obj) = interp.get_object_cell(o)
                         {
                             obj.borrow_mut().set_property_value(&key, coerced);
                         }
@@ -3917,8 +3909,8 @@ impl Interpreter {
                 }
             },
         ));
-        if let JsValue::Object(o) = &ta_ctor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = ta_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("from".to_string(), ta_from_fn);
@@ -3938,9 +3930,9 @@ impl Interpreter {
                     return c;
                 }
                 // Get ta_kind for coercion
-                let ta_kind = if let JsValue::Object(ref o) = new_obj {
+                let ta_kind = if let Some(o) = new_obj.as_object_id() {
                     interp
-                        .get_object_cell(o.id)
+                        .get_object_cell(o)
                         .and_then(|obj| obj.borrow().typed_array_info().map(|ta| ta.kind))
                 } else {
                     None
@@ -3960,8 +3952,8 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
                     let key = k.to_string();
-                    if let JsValue::Object(ref o) = new_obj
-                        && let Some(obj) = interp.get_object_cell(o.id)
+                    if let Some(o) = new_obj.as_object_id()
+                        && let Some(obj) = interp.get_object_cell(o)
                     {
                         obj.borrow_mut().set_property_value(&key, coerced);
                     }
@@ -3969,24 +3961,19 @@ impl Interpreter {
                 Completion::Normal(new_obj)
             },
         ));
-        if let JsValue::Object(o) = &ta_ctor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = ta_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_builtin("of".to_string(), ta_of_fn);
         }
 
         // Set %TypedArray%.prototype → %TypedArray.prototype%
-        if let JsValue::Object(o) = &ta_ctor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = ta_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
-                PropertyDescriptor::data(
-                    JsValue::Object(JsObject { id: ta_proto_id }),
-                    false,
-                    false,
-                    false,
-                ),
+                PropertyDescriptor::data(JsValue::object(ta_proto_id), false, false, false),
             );
         }
 
@@ -4004,8 +3991,8 @@ impl Interpreter {
             0,
             |_interp, this_val, _args| Completion::Normal(this_val.clone()),
         ));
-        if let JsValue::Object(o) = &ta_ctor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = ta_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_property(
                 JsPropertyKey::well_known_symbol("species"),
@@ -4036,7 +4023,7 @@ impl Interpreter {
                 p.class_name = name.clone();
                 p.insert_property(
                     "BYTES_PER_ELEMENT".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(bpe as f64), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(bpe as f64), false, false, false),
                 );
             }
 
@@ -4079,9 +4066,9 @@ impl Interpreter {
                         return interp.create_typed_array_from_length(kind, 0, proto);
                     }
                     let first = &args[0];
-                    match first {
-                        JsValue::Object(o) => {
-                            if let Some(src_obj) = interp.get_object_cell(o.id) {
+                    match first.as_object_id() {
+                        Some(o) => {
+                            if let Some(src_obj) = interp.get_object_cell(o) {
                                 let src_ref = src_obj.borrow();
                                 // Case: new XArray(arraybuffer, byteOffset?, length?)
                                 if let Some(ab_data) = src_ref.arraybuffer_data() {
@@ -4097,13 +4084,13 @@ impl Interpreter {
                                         Ok(p) => p,
                                         Err(e) => return Completion::Throw(e),
                                     };
-                                    let byte_offset = if args.len() > 1 && !matches!(args[1], JsValue::Undefined) {
+                                    let byte_offset = if args.len() > 1 && !args[1].is_undefined() {
                                         let offset_val = match interp.to_index(&args[1]) {
                                             Completion::Normal(v) => v,
                                             Completion::Throw(e) => return Completion::Throw(e),
-                                            _ => return Completion::Normal(JsValue::Undefined),
+                                            _ => return Completion::Normal(JsValue::UNDEFINED),
                                         };
-                                        if let JsValue::Number(n) = offset_val { n as usize } else { 0 }
+                                        offset_val.as_number().map_or(0, |n| n as usize)
                                     } else { 0 };
                                     // §22.2.4.5 step 7: modulo check before detach check
                                     if byte_offset % bpe != 0 {
@@ -4111,13 +4098,13 @@ impl Interpreter {
                                             "start offset of typed array should be a multiple of BYTES_PER_ELEMENT"
                                         ));
                                     }
-                                    let has_length_arg = args.len() > 2 && !matches!(args[2], JsValue::Undefined);
+                                    let has_length_arg = args.len() > 2 && !args[2].is_undefined();
                                     let is_length_tracking = is_resizable && !has_length_arg;
                                     let array_length = if has_length_arg {
                                         let len_val = match interp.to_index(&args[2]) {
                                             Completion::Normal(v) => v,
                                             Completion::Throw(e) => return Completion::Throw(e),
-                                            _ => return Completion::Normal(JsValue::Undefined),
+                                            _ => return Completion::Normal(JsValue::UNDEFINED),
                                         };
                                         // §22.2.4.5 step 9: check detach after length ToIndex
                                         if detached.get() {
@@ -4125,7 +4112,7 @@ impl Interpreter {
                                                 "Cannot construct TypedArray from detached ArrayBuffer"
                                             ));
                                         }
-                                        if let JsValue::Number(n) = len_val { n as usize } else { 0 }
+                                        len_val.as_number().map_or(0, |n| n as usize)
                                     } else {
                                         // §22.2.4.5 step 9: detach check (no length arg path)
                                         if detached.get() {
@@ -4165,7 +4152,7 @@ impl Interpreter {
                                     };
                                     let buf_val = first.clone();
                                     let id = interp.create_typed_array_object_with_proto(ta_info, buf_val, proto);
-                                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                                    return Completion::Normal(JsValue::object(id));
                                 }
                                 // Case: new XArray(typedArray)
                                 if let Some(src_ta) = src_ref.typed_array_info() {
@@ -4227,9 +4214,9 @@ impl Interpreter {
                                         Err(e) => return Completion::Throw(e),
                                     };
                                     let ab_id = ab_obj_id;
-                                    let buf_val = JsValue::Object(JsObject { id: ab_id });
+                                    let buf_val = JsValue::object(ab_id);
                                     let id = interp.create_typed_array_object_with_proto(new_ta, buf_val, proto);
-                                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                                    return Completion::Normal(JsValue::object(id));
                                 }
                                 // Case: new XArray(arrayLike/iterable)
                                 drop(src_ref);
@@ -4281,9 +4268,9 @@ impl Interpreter {
                                     Err(e) => return Completion::Throw(e),
                                 };
                                 let ab_id = ab_obj_id;
-                                let buf_val = JsValue::Object(JsObject { id: ab_id });
+                                let buf_val = JsValue::object(ab_id);
                                 let id = interp.create_typed_array_object_with_proto(new_ta, buf_val, proto);
-                                return Completion::Normal(JsValue::Object(JsObject { id }));
+                                return Completion::Normal(JsValue::object(id));
                             }
                             Completion::Throw(interp.create_type_error("invalid argument"))
                         }
@@ -4292,9 +4279,9 @@ impl Interpreter {
                             let len_val = match interp.to_index(first) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
-                                _ => return Completion::Normal(JsValue::Undefined),
+                                _ => return Completion::Normal(JsValue::UNDEFINED),
                             };
-                            let len = if let JsValue::Number(n) = len_val { n as usize } else { 0 };
+                            let len = len_val.as_number().map_or(0, |n| n as usize);
                             let proto = match get_proto(interp) {
                                 Ok(p) => p,
                                 Err(e) => return Completion::Throw(e),
@@ -4307,34 +4294,29 @@ impl Interpreter {
 
             // Set deferred_construct so construct_with_new_target doesn't access
             // newTarget.prototype before the constructor body runs (spec ordering)
-            if let JsValue::Object(o) = &ctor
-                && let Some(obj) = self.get_object_cell(o.id)
+            if let Some(o) = ctor.as_object_id()
+                && let Some(obj) = self.get_object_cell(o)
             {
                 obj.borrow_mut().deferred_construct = true;
             }
 
             // Set BYTES_PER_ELEMENT on constructor
-            if let JsValue::Object(o) = &ctor
-                && let Some(obj) = self.get_object_cell(o.id)
+            if let Some(o) = ctor.as_object_id()
+                && let Some(obj) = self.get_object_cell(o)
             {
                 obj.borrow_mut().insert_property(
                     "BYTES_PER_ELEMENT".to_string(),
-                    PropertyDescriptor::data(JsValue::Number(bpe as f64), false, false, false),
+                    PropertyDescriptor::data(JsValue::number(bpe as f64), false, false, false),
                 );
                 // Set prototype property
                 let proto_id = type_proto_id;
                 obj.borrow_mut().insert_property(
                     "prototype".to_string(),
-                    PropertyDescriptor::data(
-                        JsValue::Object(JsObject { id: proto_id }),
-                        false,
-                        false,
-                        false,
-                    ),
+                    PropertyDescriptor::data(JsValue::object(proto_id), false, false, false),
                 );
                 // Set __proto__ to %TypedArray% so from/of are inherited
-                if let JsValue::Object(ta_o) = &ta_ctor_clone
-                    && let Some(ta_obj) = self.get_object_cell(ta_o.id)
+                if let Some(ta_o) = ta_ctor_clone.as_object_id()
+                    && let Some(ta_obj) = self.get_object_cell(ta_o)
                 {
                     obj.borrow_mut().prototype_id = Some(ta_obj.borrow().id.unwrap());
                 }
@@ -4407,15 +4389,15 @@ impl Interpreter {
             "fromBase64".to_string(),
             1,
             |interp, _this, args| {
-                let input = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(input, JsValue::String(_)) {
+                let input = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !input.is_string() {
                     return Completion::Throw(
                         interp.create_type_error("fromBase64 requires a string argument"),
                     );
                 }
                 let input_str = to_js_string(&input);
 
-                let opts = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let opts = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let (alphabet, last_chunk) = match parse_base64_options(interp, &opts) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -4434,8 +4416,8 @@ impl Interpreter {
             "fromHex".to_string(),
             1,
             |interp, _this, args| {
-                let input = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(input, JsValue::String(_)) {
+                let input = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !input.is_string() {
                     return Completion::Throw(
                         interp.create_type_error("fromHex requires a string argument"),
                     );
@@ -4450,8 +4432,8 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(o) = &uint8_ctor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = uint8_ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("fromBase64".to_string(), from_base64_fn);
@@ -4478,7 +4460,7 @@ impl Interpreter {
                         result.push_str(&format!("{:02x}", b));
                     }
                 });
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(uint8_proto_id)
@@ -4495,7 +4477,7 @@ impl Interpreter {
                     Err(c) => return c,
                 };
 
-                let opts = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let opts = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (alphabet, omit_padding) = match parse_to_base64_options(interp, &opts) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -4510,7 +4492,7 @@ impl Interpreter {
                 let result = with_buffer_read(&ta.buffer, |buf| {
                     encode_base64(&buf[start..end], &alphabet, omit_padding)
                 });
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(uint8_proto_id)
@@ -4530,8 +4512,8 @@ impl Interpreter {
                     return c;
                 }
 
-                let input = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(input, JsValue::String(_)) {
+                let input = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !input.is_string() {
                     return Completion::Throw(
                         interp.create_type_error("setFromHex requires a string argument"),
                     );
@@ -4572,15 +4554,15 @@ impl Interpreter {
                     return c;
                 }
 
-                let input = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(input, JsValue::String(_)) {
+                let input = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !input.is_string() {
                     return Completion::Throw(
                         interp.create_type_error("setFromBase64 requires a string argument"),
                     );
                 }
                 let input_str = to_js_string(&input);
 
-                let opts = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let opts = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let (alphabet, last_chunk) = match parse_base64_options(interp, &opts) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -4619,8 +4601,8 @@ impl Interpreter {
         exemplar: &JsValue,
         args: &[JsValue],
     ) -> Result<JsValue, JsValue> {
-        let snapshot = if let JsValue::Object(o) = exemplar {
-            self.get_object_cell(o.id)
+        let snapshot = if let Some(o) = exemplar.as_object_id() {
+            self.get_object_cell(o)
                 .and_then(|cell| cell.borrow().typed_array_info().cloned())
         } else {
             None
@@ -4633,7 +4615,7 @@ impl Interpreter {
         let default_ctor_name = kind.name();
         let default_ctor = self
             .get_global_var(default_ctor_name)
-            .unwrap_or(JsValue::Undefined);
+            .unwrap_or(JsValue::UNDEFINED);
 
         let ctor = self.species_constructor(exemplar, &default_ctor)?;
 
@@ -4650,8 +4632,8 @@ impl Interpreter {
             Detached,
             Kind(TypedArrayKind),
         }
-        let kind_probe = if let JsValue::Object(o) = &result_val {
-            self.get_object_cell(o.id)
+        let kind_probe = if let Some(o) = result_val.as_object_id() {
+            self.get_object_cell(o)
                 .map(|cell| {
                     let r = cell.borrow();
                     if let Some(ta) = r.typed_array_info() {
@@ -4688,10 +4670,10 @@ impl Interpreter {
         }
 
         // Validate length >= requested
-        if let Some(JsValue::Number(requested_len)) = args.first() {
-            let requested = *requested_len as usize;
-            let too_small = if let JsValue::Object(o) = &result_val {
-                self.get_object_cell(o.id)
+        if let Some(requested_len) = args.first().and_then(JsValue::as_number) {
+            let requested = requested_len as usize;
+            let too_small = if let Some(o) = result_val.as_object_id() {
+                self.get_object_cell(o)
                     .and_then(|cell| {
                         cell.borrow()
                             .typed_array_info()
@@ -4722,7 +4704,7 @@ impl Interpreter {
         if kind.is_bigint() {
             self.to_bigint_value(value)
         } else {
-            self.to_number_value(value).map(JsValue::Number)
+            self.to_number_value(value).map(JsValue::number)
         }
     }
 
@@ -4766,9 +4748,9 @@ impl Interpreter {
         }
         self.gc_track_external_bytes(buf_byte_len);
         let ab_id = ab_obj_id;
-        let buf_val = JsValue::Object(JsObject { id: ab_id });
+        let buf_val = JsValue::object(ab_id);
         let id = self.create_typed_array_object_with_proto(ta_info, buf_val, type_proto_id);
-        Completion::Normal(JsValue::Object(JsObject { id }))
+        Completion::Normal(JsValue::object(id))
     }
 
     pub(crate) fn create_typed_array_object(
@@ -4778,8 +4760,8 @@ impl Interpreter {
     ) -> u64 {
         let proto = self.get_typed_array_prototype(info.kind);
         let obj_id = self.create_object_id();
-        if let JsValue::Object(ref bobj) = buf_val {
-            info.buffer_object_id = Some(bobj.id);
+        if let Some(bobj) = buf_val.as_object_id() {
+            info.buffer_object_id = Some(bobj);
         }
         {
             let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
@@ -4797,8 +4779,8 @@ impl Interpreter {
         proto_id: u64,
     ) -> u64 {
         let obj_id = self.create_object_id();
-        if let JsValue::Object(ref bobj) = buf_val {
-            info.buffer_object_id = Some(bobj.id);
+        if let Some(bobj) = buf_val.as_object_id() {
+            info.buffer_object_id = Some(bobj);
         }
         {
             let mut o = self.get_object_cell_expect(obj_id).borrow_mut();
@@ -4830,8 +4812,8 @@ impl Interpreter {
     /// Creates a TypedArray by calling C with argumentList. Validates result is a TypedArray.
     fn typed_array_create(&mut self, ctor: &JsValue, len: usize) -> Completion {
         // Fast path for known built-in TypedArray constructors
-        if let JsValue::Object(o) = ctor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             let name = {
                 let obj_ref = obj.borrow();
@@ -4863,12 +4845,11 @@ impl Interpreter {
                 if let Some(kind) = kind {
                     // Get prototype from the constructor's .prototype property
                     // (handles cross-realm constructors correctly)
-                    let proto: Option<u64> =
-                        match self.get_object_property(o.id, "prototype", ctor) {
-                            Completion::Normal(JsValue::Object(po)) => Some(po.id),
-                            _ => None,
-                        }
-                        .or_else(|| self.get_typed_array_prototype(kind));
+                    let proto: Option<u64> = match self.get_object_property(o, "prototype", ctor) {
+                        Completion::Normal(v) => v.as_object_id(),
+                        _ => None,
+                    }
+                    .or_else(|| self.get_typed_array_prototype(kind));
                     let bpe = kind.bytes_per_element();
                     let buf_byte_len = len * bpe;
                     let new_buf = vec![0u8; buf_byte_len];
@@ -4910,21 +4891,21 @@ impl Interpreter {
                         r.kind = crate::interpreter::types::ObjectKind::TypedArray(ta);
                     }
                     let id = result_id;
-                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
             }
         }
         // Generic path: call ctor(len), validate result is TypedArray
         let new_obj = match self.construct_with_new_target(
             ctor,
-            &[JsValue::Number(len as f64)],
+            &[JsValue::number(len as f64)],
             ctor.clone(),
         ) {
             Completion::Normal(v) => v,
             other => return other,
         };
-        if let JsValue::Object(ref o) = new_obj
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = new_obj.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             let ta_len = obj.borrow().typed_array_info().map(|ti| ti.array_length);
             if let Some(ta_len) = ta_len {
@@ -4957,14 +4938,14 @@ impl Interpreter {
             Completion::Throw(e) => return Err(Completion::Throw(e)),
             _ => return Err(Completion::Throw(self.create_type_error("bad iterator"))),
         };
-        if !matches!(iter, JsValue::Object(_)) {
+        if !iter.is_object() {
             return Err(Completion::Throw(self.create_type_error(
                 "Result of the Symbol.iterator method is not an object",
             )));
         }
         // Cache `next` once per IteratorRecord (spec §7.4.5 GetIteratorFromMethod step 3).
-        let next_fn = if let JsValue::Object(io) = &iter {
-            match self.get_object_property(io.id, "next", &iter) {
+        let next_fn = if let Some(io) = iter.as_object_id() {
+            match self.get_object_property(io, "next", &iter) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(Completion::Throw(e)),
                 _ => return Err(Completion::Throw(self.create_type_error("bad iterator"))),
@@ -4973,29 +4954,29 @@ impl Interpreter {
             return Err(Completion::Throw(self.create_type_error("bad iterator")));
         };
         let mut values = Vec::new();
-        while let JsValue::Object(_) = &iter {
+        while iter.is_object() {
             let result = match self.call_function(&next_fn, &iter, &[]) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(Completion::Throw(e)),
                 _ => break,
             };
-            if !matches!(result, JsValue::Object(_)) {
+            if !result.is_object() {
                 return Err(Completion::Throw(
                     self.create_type_error("Iterator result is not an object"),
                 ));
             }
-            if let JsValue::Object(ro) = &result {
-                let done = match self.get_object_property(ro.id, "done", &result) {
+            if let Some(ro) = result.as_object_id() {
+                let done = match self.get_object_property(ro, "done", &result) {
                     Completion::Normal(v) => self.to_boolean_val(&v),
                     _ => true,
                 };
                 if done {
                     break;
                 }
-                let value = match self.get_object_property(ro.id, "value", &result) {
+                let value = match self.get_object_property(ro, "value", &result) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(Completion::Throw(e)),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 };
                 values.push(value);
             } else {
@@ -5020,21 +5001,21 @@ impl Interpreter {
         &mut self,
         val: &JsValue,
     ) -> Result<Vec<JsValue>, Completion> {
-        if let JsValue::Object(o) = val
-            && let Some(_obj) = self.get_object_cell(o.id)
+        if let Some(o) = val.as_object_id()
+            && let Some(_obj) = self.get_object_cell(o)
         {
             // Step 5: Let usingIterator be ? GetMethod(object, @@iterator).
             let iter_fn = match self.get_object_property(
-                o.id,
+                o,
                 &JsPropertyKey::well_known_symbol("iterator"),
                 val,
             ) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(Completion::Throw(e)),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             // GetMethod: if null or undefined, treat as no iterator (array-like)
-            let using_iterator = if matches!(iter_fn, JsValue::Undefined | JsValue::Null) {
+            let using_iterator = if iter_fn.is_nullish() {
                 None
             } else if self.is_callable(&iter_fn) {
                 Some(iter_fn)
@@ -5050,14 +5031,14 @@ impl Interpreter {
                     Completion::Throw(e) => return Err(Completion::Throw(e)),
                     _ => return Err(Completion::Throw(self.create_type_error("bad iterator"))),
                 };
-                if !matches!(iter, JsValue::Object(_)) {
+                if !iter.is_object() {
                     return Err(Completion::Throw(self.create_type_error(
                         "Result of the Symbol.iterator method is not an object",
                     )));
                 }
                 let mut values = Vec::new();
-                while let JsValue::Object(io) = &iter {
-                    let next_fn = match self.get_object_property(io.id, "next", &iter) {
+                while let Some(io) = iter.as_object_id() {
+                    let next_fn = match self.get_object_property(io, "next", &iter) {
                         Completion::Normal(v) => v,
                         _ => break,
                     };
@@ -5066,23 +5047,23 @@ impl Interpreter {
                         Completion::Throw(e) => return Err(Completion::Throw(e)),
                         _ => break,
                     };
-                    if !matches!(result, JsValue::Object(_)) {
+                    if !result.is_object() {
                         return Err(Completion::Throw(
                             self.create_type_error("Iterator result is not an object"),
                         ));
                     }
-                    if let JsValue::Object(ro) = &result {
-                        let done = match self.get_object_property(ro.id, "done", &result) {
+                    if let Some(ro) = result.as_object_id() {
+                        let done = match self.get_object_property(ro, "done", &result) {
                             Completion::Normal(v) => self.to_boolean_val(&v),
                             _ => true,
                         };
                         if done {
                             break;
                         }
-                        let value = match self.get_object_property(ro.id, "value", &result) {
+                        let value = match self.get_object_property(ro, "value", &result) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Err(Completion::Throw(e)),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         values.push(value);
                     } else {
@@ -5093,7 +5074,7 @@ impl Interpreter {
             }
 
             // Array-like
-            let len_val = match self.get_object_property(o.id, "length", val) {
+            let len_val = match self.get_object_property(o, "length", val) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(Completion::Throw(e)),
                 _ => return Ok(Vec::new()),
@@ -5111,10 +5092,10 @@ impl Interpreter {
             let len = len_f as usize;
             let mut values = Vec::new();
             for i in 0..len {
-                let v = match self.get_object_property(o.id, &i.to_string(), val) {
+                let v = match self.get_object_property(o, &i.to_string(), val) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(Completion::Throw(e)),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 };
                 values.push(v);
             }
@@ -5132,15 +5113,15 @@ impl Interpreter {
 
         // Getters: buffer, byteOffset, byteLength
         self.define_getter(dv_proto_id, "buffer", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object(o)
             {
                 let obj_ref = obj.borrow();
                 if obj_ref.data_view_info().is_some() {
                     if let Some(buf_id) = obj_ref.view_buffer_object_id() {
-                        return Completion::Normal(JsValue::Object(JsObject { id: buf_id }));
+                        return Completion::Normal(JsValue::object(buf_id));
                     }
-                    return Completion::Normal(JsValue::Undefined);
+                    return Completion::Normal(JsValue::UNDEFINED);
                 }
             }
             Completion::Throw(interp.create_type_error("not a DataView"))
@@ -5148,8 +5129,8 @@ impl Interpreter {
 
         // byteOffset getter
         self.define_getter(dv_proto_id, "byteOffset", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object(o)
             {
                 let obj_ref = obj.borrow();
                 if let Some(dv) = obj_ref.data_view_info() {
@@ -5170,15 +5151,15 @@ impl Interpreter {
                             interp.create_type_error("DataView is out of bounds"),
                         );
                     }
-                    return Completion::Normal(JsValue::Number(dv.byte_offset as f64));
+                    return Completion::Normal(JsValue::number(dv.byte_offset as f64));
                 }
             }
             Completion::Throw(interp.create_type_error("not a DataView"))
         });
         // byteLength getter
         self.define_getter(dv_proto_id, "byteLength", |interp, this_val, _args| {
-            if let JsValue::Object(o) = this_val
-                && let Some(obj) = interp.get_object(o.id)
+            if let Some(o) = this_val.as_object_id()
+                && let Some(obj) = interp.get_object(o)
             {
                 let obj_ref = obj.borrow();
                 if let Some(dv) = obj_ref.data_view_info() {
@@ -5194,7 +5175,7 @@ impl Interpreter {
                                 interp.create_type_error("DataView is out of bounds"),
                             );
                         }
-                        return Completion::Normal(JsValue::Number(
+                        return Completion::Normal(JsValue::number(
                             (buf_len - dv.byte_offset) as f64,
                         ));
                     } else {
@@ -5203,7 +5184,7 @@ impl Interpreter {
                                 interp.create_type_error("DataView is out of bounds"),
                             );
                         }
-                        return Completion::Normal(JsValue::Number(dv.byte_length as f64));
+                        return Completion::Normal(JsValue::number(dv.byte_length as f64));
                     }
                 }
             }
@@ -5223,8 +5204,8 @@ impl Interpreter {
                     $method_name.to_string(),
                     1,
                     |interp, this_val, args| {
-                        if let JsValue::Object(o) = this_val
-                            && let Some(obj) = interp.get_object(o.id)
+                        if let Some(o) = this_val.as_object_id()
+                            && let Some(obj) = interp.get_object(o)
                         {
                             {
                                 let obj_ref = obj.borrow();
@@ -5235,9 +5216,9 @@ impl Interpreter {
                                 }
                             }
                             let byte_offset = match interp
-                                .to_index(args.first().unwrap_or(&JsValue::Undefined))
+                                .to_index(args.first().unwrap_or(&JsValue::UNDEFINED))
                             {
-                                Completion::Normal(JsValue::Number(n)) => n as usize,
+                                Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 _ => 0,
                             };
@@ -5293,10 +5274,10 @@ impl Interpreter {
         }
 
         dv_get_method!("getInt8", 1, |buf: &[u8], _le: bool| -> JsValue {
-            JsValue::Number(buf[0] as i8 as f64)
+            JsValue::number(buf[0] as i8 as f64)
         });
         dv_get_method!("getUint8", 1, |buf: &[u8], _le: bool| -> JsValue {
-            JsValue::Number(buf[0] as f64)
+            JsValue::number(buf[0] as f64)
         });
         dv_get_method!("getInt16", 2, |buf: &[u8], le: bool| -> JsValue {
             let v = if le {
@@ -5304,7 +5285,7 @@ impl Interpreter {
             } else {
                 i16::from_be_bytes([buf[0], buf[1]])
             };
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         });
         dv_get_method!("getUint16", 2, |buf: &[u8], le: bool| -> JsValue {
             let v = if le {
@@ -5312,7 +5293,7 @@ impl Interpreter {
             } else {
                 u16::from_be_bytes([buf[0], buf[1]])
             };
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         });
         dv_get_method!("getInt32", 4, |buf: &[u8], le: bool| -> JsValue {
             let v = if le {
@@ -5320,7 +5301,7 @@ impl Interpreter {
             } else {
                 i32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]])
             };
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         });
         dv_get_method!("getUint32", 4, |buf: &[u8], le: bool| -> JsValue {
             let v = if le {
@@ -5328,7 +5309,7 @@ impl Interpreter {
             } else {
                 u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]])
             };
-            JsValue::Number(v as f64)
+            JsValue::number(v as f64)
         });
         dv_get_method!("getFloat32", 4, |buf: &[u8], le: bool| -> JsValue {
             let v = if le {
@@ -5356,7 +5337,7 @@ impl Interpreter {
             } else {
                 i64::from_be_bytes(bytes)
             };
-            JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(v)))
+            JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(v)))
         });
         dv_get_method!("getBigUint64", 8, |buf: &[u8], le: bool| -> JsValue {
             let mut bytes = [0u8; 8];
@@ -5366,7 +5347,7 @@ impl Interpreter {
             } else {
                 u64::from_be_bytes(bytes)
             };
-            JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(v)))
+            JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(v)))
         });
         dv_get_method!("getFloat16", 2, |buf: &[u8], le: bool| -> JsValue {
             let bits = if le {
@@ -5392,8 +5373,8 @@ impl Interpreter {
                     2,
                     |interp, this_val, args| {
                         // Step 1: Require this to be a DataView (no detach check)
-                        if let JsValue::Object(o) = this_val
-                            && let Some(obj) = interp.get_object(o.id)
+                        if let Some(o) = this_val.as_object_id()
+                            && let Some(obj) = interp.get_object(o)
                         {
                             {
                                 let obj_ref = obj.borrow();
@@ -5413,15 +5394,15 @@ impl Interpreter {
                             }
                             // Step 4: ToIndex(byteOffset) — before detach check
                             let byte_offset = match interp
-                                .to_index(args.first().unwrap_or(&JsValue::Undefined))
+                                .to_index(args.first().unwrap_or(&JsValue::UNDEFINED))
                             {
-                                Completion::Normal(JsValue::Number(n)) => n as usize,
+                                Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 _ => 0,
                             };
                             // Step 3: ToNumber(value) — before detach check
                             let num_value = match interp
-                                .to_number_value(args.get(1).unwrap_or(&JsValue::Undefined))
+                                .to_number_value(args.get(1).unwrap_or(&JsValue::UNDEFINED))
                             {
                                 Ok(n) => n,
                                 Err(e) => return Completion::Throw(e),
@@ -5467,7 +5448,7 @@ impl Interpreter {
                             with_buffer_write(&dv.buffer, |buf| {
                                 $write_fn(&mut buf[idx..idx + $size], num_value, little_endian);
                             });
-                            return Completion::Normal(JsValue::Undefined);
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
                         Completion::Throw(interp.create_type_error("not a DataView"))
                     },
@@ -5482,8 +5463,8 @@ impl Interpreter {
                     2,
                     |interp, this_val, args| {
                         // Step 1: Require this to be a DataView (no detach check)
-                        if let JsValue::Object(o) = this_val
-                            && let Some(obj) = interp.get_object(o.id)
+                        if let Some(o) = this_val.as_object_id()
+                            && let Some(obj) = interp.get_object(o)
                         {
                             {
                                 let obj_ref = obj.borrow();
@@ -5503,15 +5484,15 @@ impl Interpreter {
                             }
                             // Step 2: ToIndex(byteOffset) — before detach check
                             let byte_offset = match interp
-                                .to_index(args.first().unwrap_or(&JsValue::Undefined))
+                                .to_index(args.first().unwrap_or(&JsValue::UNDEFINED))
                             {
-                                Completion::Normal(JsValue::Number(n)) => n as usize,
+                                Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 _ => 0,
                             };
                             // Step 3: ToBigInt(value) — before detach check
                             let bigint_value = match interp
-                                .to_bigint_value(args.get(1).unwrap_or(&JsValue::Undefined))
+                                .to_bigint_value(args.get(1).unwrap_or(&JsValue::UNDEFINED))
                             {
                                 Ok(v) => v,
                                 Err(e) => return Completion::Throw(e),
@@ -5557,7 +5538,7 @@ impl Interpreter {
                             with_buffer_write(&dv.buffer, |buf| {
                                 $write_fn(&mut buf[idx..idx + $size], &bigint_value, little_endian);
                             });
-                            return Completion::Normal(JsValue::Undefined);
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
                         Completion::Throw(interp.create_type_error("not a DataView"))
                     },
@@ -5647,10 +5628,9 @@ impl Interpreter {
             8,
             bigint,
             |buf: &mut [u8], v: &JsValue, le: bool| {
-                let n = match v {
-                    JsValue::BigInt(b) => i64::try_from(b.value.as_ref()).unwrap_or(0),
-                    _ => 0,
-                };
+                let n = v
+                    .with_bigint(|b| i64::try_from(b).unwrap_or(0))
+                    .unwrap_or(0);
                 let bytes = if le { n.to_le_bytes() } else { n.to_be_bytes() };
                 buf.copy_from_slice(&bytes);
             }
@@ -5660,10 +5640,9 @@ impl Interpreter {
             8,
             bigint,
             |buf: &mut [u8], v: &JsValue, le: bool| {
-                let n = match v {
-                    JsValue::BigInt(b) => u64::try_from(b.value.as_ref()).unwrap_or(0),
-                    _ => 0,
-                };
+                let n = v
+                    .with_bigint(|b| u64::try_from(b).unwrap_or(0))
+                    .unwrap_or(0);
                 let bytes = if le { n.to_le_bytes() } else { n.to_be_bytes() };
                 buf.copy_from_slice(&bytes);
             }
@@ -5683,9 +5662,9 @@ impl Interpreter {
                         interp.create_type_error("Constructor DataView requires 'new'"),
                     );
                 }
-                let buf_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if let JsValue::Object(o) = &buf_arg
-                    && let Some(obj) = interp.get_object(o.id)
+                let buf_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if let Some(o) = buf_arg.as_object_id()
+                    && let Some(obj) = interp.get_object(o)
                 {
                     let is_arraybuffer = {
                         let obj_ref = obj.borrow();
@@ -5698,8 +5677,8 @@ impl Interpreter {
                     }
                     // ToIndex(byteOffset) BEFORE detach check
                     let byte_offset =
-                        match interp.to_index(args.get(1).unwrap_or(&JsValue::Undefined)) {
-                            Completion::Normal(JsValue::Number(n)) => n as usize,
+                        match interp.to_index(args.get(1).unwrap_or(&JsValue::UNDEFINED)) {
+                            Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => 0,
                         };
@@ -5728,23 +5707,26 @@ impl Interpreter {
                             "offset is outside the bounds of the buffer",
                         ));
                     }
-                    let byte_length_arg = args.get(2).unwrap_or(&JsValue::Undefined);
-                    let has_byte_length = !matches!(byte_length_arg, JsValue::Undefined);
+                    let byte_length_arg = args.get(2).unwrap_or(&JsValue::UNDEFINED);
+                    let has_byte_length = !byte_length_arg.is_undefined();
                     let is_length_tracking = is_resizable && !has_byte_length;
                     let byte_length = if !has_byte_length {
                         buf_len - byte_offset
                     } else {
                         match interp.to_index(byte_length_arg) {
-                            Completion::Normal(JsValue::Number(n)) => {
-                                let bl = n as usize;
-                                if byte_offset + bl > buf_len {
-                                    return Completion::Throw(
-                                        interp
-                                            .create_error("RangeError", "invalid DataView length"),
-                                    );
+                            Completion::Normal(v) => match v.as_number() {
+                                Some(n) => {
+                                    let bl = n as usize;
+                                    if byte_offset + bl > buf_len {
+                                        return Completion::Throw(interp.create_error(
+                                            "RangeError",
+                                            "invalid DataView length",
+                                        ));
+                                    }
+                                    bl
                                 }
-                                bl
-                            }
+                                None => 0,
+                            },
                             Completion::Throw(e) => return Completion::Throw(e),
                             _ => 0,
                         }
@@ -5790,8 +5772,8 @@ impl Interpreter {
                         }
                     }
                     let mut dv_info = dv_info;
-                    if let JsValue::Object(ref bobj) = buf_arg {
-                        dv_info.buffer_object_id = Some(bobj.id);
+                    if let Some(bobj) = buf_arg.as_object_id() {
+                        dv_info.buffer_object_id = Some(bobj);
                     }
                     let result_id = interp.create_object_id();
                     {
@@ -5801,7 +5783,7 @@ impl Interpreter {
                         r.kind = crate::interpreter::types::ObjectKind::DataView(dv_info);
                     }
                     let id = result_id;
-                    return Completion::Normal(JsValue::Object(JsObject { id }));
+                    return Completion::Normal(JsValue::object(id));
                 }
                 Completion::Throw(interp.create_type_error(
                     "First argument to DataView constructor must be an ArrayBuffer",
@@ -5812,10 +5794,10 @@ impl Interpreter {
         // Wire DataView.prototype to the proto object with all the methods
         let dv_proto_val = {
             let id = dv_proto_id;
-            JsValue::Object(crate::types::JsObject { id })
+            JsValue::object(id)
         };
-        if let JsValue::Object(o) = &ctor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
@@ -5829,8 +5811,8 @@ impl Interpreter {
                 PropertyDescriptor::data(ctor.clone(), true, false, true),
             );
 
-        if let JsValue::Object(ref o) = ctor
-            && let Some(func_obj) = self.get_object_cell(o.id)
+        if let Some(o) = ctor.as_object_id()
+            && let Some(func_obj) = self.get_object_cell(o)
         {
             func_obj.borrow_mut().deferred_construct = true;
         }
@@ -5849,8 +5831,8 @@ fn extract_ta_and_callback(
     this_val: &JsValue,
     args: &[JsValue],
 ) -> Result<(TypedArrayInfo, JsValue), Completion> {
-    if let JsValue::Object(o) = this_val
-        && let Some(obj) = interp.get_object(o.id)
+    if let Some(o) = this_val.as_object_id()
+        && let Some(obj) = interp.get_object(o)
     {
         let ta = {
             let obj_ref = obj.borrow();
@@ -5863,10 +5845,10 @@ fn extract_ta_and_callback(
                 ));
             }
         };
-        let callback = args.first().cloned().unwrap_or(JsValue::Undefined);
-        let is_callable = if let JsValue::Object(co) = &callback {
+        let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+        let is_callable = if let Some(co) = callback.as_object_id() {
             interp
-                .get_object_cell(co.id)
+                .get_object_cell(co)
                 .is_some_and(|obj| obj.borrow().callable.is_some())
         } else {
             false
@@ -6014,12 +5996,12 @@ fn is_bigint_kind(kind: TypedArrayKind) -> bool {
 }
 
 fn same_value_zero(x: &JsValue, y: &JsValue) -> bool {
-    match (x, y) {
-        (JsValue::Number(a), JsValue::Number(b)) => {
+    match (x.as_number(), y.as_number()) {
+        (Some(a), Some(b)) => {
             if a.is_nan() && b.is_nan() {
                 return true;
             }
-            if *a == 0.0 && *b == 0.0 {
+            if a == 0.0 && b == 0.0 {
                 return true;
             }
             a == b
@@ -6029,13 +6011,18 @@ fn same_value_zero(x: &JsValue, y: &JsValue) -> bool {
 }
 
 fn strict_eq(x: &JsValue, y: &JsValue) -> bool {
-    match (x, y) {
-        (JsValue::Undefined, JsValue::Undefined) | (JsValue::Null, JsValue::Null) => true,
-        (JsValue::Boolean(a), JsValue::Boolean(b)) => a == b,
-        (JsValue::Number(a), JsValue::Number(b)) => a == b,
-        (JsValue::String(a), JsValue::String(b)) => a.to_rust_string() == b.to_rust_string(),
-        (JsValue::BigInt(a), JsValue::BigInt(b)) => a.value == b.value,
-        (JsValue::Object(a), JsValue::Object(b)) => a.id == b.id,
+    if x.kind() != y.kind() {
+        return false;
+    }
+    match x.kind() {
+        ValueKind::Undefined | ValueKind::Null => true,
+        ValueKind::Boolean => x.as_boolean() == y.as_boolean(),
+        ValueKind::Number => x.as_number() == y.as_number(),
+        ValueKind::String => {
+            x.as_string().map(|s| s.to_rust_string()) == y.as_string().map(|s| s.to_rust_string())
+        }
+        ValueKind::BigInt => x.as_bigint().map(|b| b.value) == y.as_bigint().map(|b| b.value),
+        ValueKind::Object => x.as_object_id() == y.as_object_id(),
         _ => false,
     }
 }
@@ -6044,8 +6031,8 @@ fn validate_uint8array(
     interp: &mut Interpreter,
     this_val: &JsValue,
 ) -> Result<TypedArrayInfo, Completion> {
-    if let JsValue::Object(o) = this_val
-        && let Some(obj) = interp.get_object(o.id)
+    if let Some(o) = this_val.as_object_id()
+        && let Some(obj) = interp.get_object(o)
     {
         let obj_ref = obj.borrow();
         if let Some(ta) = obj_ref.typed_array_info() {
@@ -6071,8 +6058,8 @@ fn validate_uint8array_no_detach_check(
     interp: &mut Interpreter,
     this_val: &JsValue,
 ) -> Result<TypedArrayInfo, Completion> {
-    if let JsValue::Object(o) = this_val
-        && let Some(obj) = interp.get_object(o.id)
+    if let Some(o) = this_val.as_object_id()
+        && let Some(obj) = interp.get_object(o)
     {
         let obj_ref = obj.borrow();
         if let Some(ta) = obj_ref.typed_array_info() {
@@ -6142,11 +6129,11 @@ fn check_ta_buffer_writable(
 /// Like check_ta_buffer_writable but accepts a JsValue (the target TA), used after
 /// TypedArrayCreateFromConstructor returns. No-op for non-TypedArray values.
 fn check_target_ta_writable(interp: &mut Interpreter, target: &JsValue) -> Result<(), Completion> {
-    let JsValue::Object(o) = target else {
+    let Some(o) = target.as_object_id() else {
         return Ok(());
     };
     let info_opt = interp
-        .get_object_cell(o.id)
+        .get_object_cell(o)
         .and_then(|cell| cell.borrow().typed_array_info().cloned());
     let Some(info) = info_opt else {
         return Ok(());
@@ -6161,15 +6148,15 @@ fn parse_base64_options(
     let mut alphabet = "base64".to_string();
     let mut last_chunk = "loose".to_string();
 
-    if !matches!(opts, JsValue::Undefined | JsValue::Null)
-        && let JsValue::Object(o) = opts
+    if !opts.is_nullish()
+        && let Some(o) = opts.as_object_id()
     {
-        let alpha_val = match interp.get_object_property(o.id, "alphabet", opts) {
+        let alpha_val = match interp.get_object_property(o, "alphabet", opts) {
             Completion::Normal(v) => v,
             other => return Err(other),
         };
-        if !matches!(alpha_val, JsValue::Undefined) {
-            if !matches!(alpha_val, JsValue::String(_)) {
+        if !alpha_val.is_undefined() {
+            if !alpha_val.is_string() {
                 return Err(Completion::Throw(
                     interp.create_type_error("alphabet must be a string"),
                 ));
@@ -6183,12 +6170,12 @@ fn parse_base64_options(
             alphabet = s;
         }
 
-        let lch_val = match interp.get_object_property(o.id, "lastChunkHandling", opts) {
+        let lch_val = match interp.get_object_property(o, "lastChunkHandling", opts) {
             Completion::Normal(v) => v,
             other => return Err(other),
         };
-        if !matches!(lch_val, JsValue::Undefined) {
-            if !matches!(lch_val, JsValue::String(_)) {
+        if !lch_val.is_undefined() {
+            if !lch_val.is_string() {
                 return Err(Completion::Throw(
                     interp.create_type_error("lastChunkHandling must be a string"),
                 ));
@@ -6212,15 +6199,15 @@ fn parse_to_base64_options(
     let mut alphabet = "base64".to_string();
     let mut omit_padding = false;
 
-    if !matches!(opts, JsValue::Undefined | JsValue::Null)
-        && let JsValue::Object(o) = opts
+    if !opts.is_nullish()
+        && let Some(o) = opts.as_object_id()
     {
-        let alpha_val = match interp.get_object_property(o.id, "alphabet", opts) {
+        let alpha_val = match interp.get_object_property(o, "alphabet", opts) {
             Completion::Normal(v) => v,
             other => return Err(other),
         };
-        if !matches!(alpha_val, JsValue::Undefined) {
-            if !matches!(alpha_val, JsValue::String(_)) {
+        if !alpha_val.is_undefined() {
+            if !alpha_val.is_string() {
                 return Err(Completion::Throw(
                     interp.create_type_error("alphabet must be a string"),
                 ));
@@ -6234,7 +6221,7 @@ fn parse_to_base64_options(
             alphabet = s;
         }
 
-        let omit_val = match interp.get_object_property(o.id, "omitPadding", opts) {
+        let omit_val = match interp.get_object_property(o, "omitPadding", opts) {
             Completion::Normal(v) => v,
             other => return Err(other),
         };
@@ -6703,11 +6690,11 @@ pub(crate) fn create_uint8array_from_bytes(interp: &mut Interpreter, bytes: &[u8
     }
     interp.gc_track_external_bytes(len);
     let ab_id = ab_obj_id;
-    let buf_val = JsValue::Object(JsObject { id: ab_id });
+    let buf_val = JsValue::object(ab_id);
 
     let proto_id = interp.realm().uint8array_prototype.unwrap();
     let id = interp.create_typed_array_object_with_proto(ta_info, buf_val, proto_id);
-    Completion::Normal(JsValue::Object(JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }
 
 fn make_read_written_result(interp: &mut Interpreter, read: usize, written: usize) -> Completion {
@@ -6715,11 +6702,11 @@ fn make_read_written_result(interp: &mut Interpreter, read: usize, written: usiz
     interp
         .get_object_cell_expect(obj_id)
         .borrow_mut()
-        .set_property_value("read", JsValue::Number(read as f64));
+        .set_property_value("read", JsValue::number(read as f64));
     interp
         .get_object_cell_expect(obj_id)
         .borrow_mut()
-        .set_property_value("written", JsValue::Number(written as f64));
+        .set_property_value("written", JsValue::number(written as f64));
     let id = obj_id;
-    Completion::Normal(JsValue::Object(JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }


### PR DESCRIPTION
## Summary

- Converts direct `JsValue::Variant` construction/pattern-matching to PR #154's accessor API (`as_*`/`with_*`/`into_*`/`kind()`/`discriminant()`, plus the `is_*` predicates) in `src/interpreter/builtins/typedarray.rs`, `src/interpreter/builtins/atomics.rs`, `src/interpreter/builtins/regexp.rs`, and `src/interpreter/builtins/iterators.rs`.
- Includes the `dv_get_method!`/`dv_set_method!` macro definitions and their integer/BigInt call-site closures in `typedarray.rs`; the 3 float-read closures (`getFloat32`/`getFloat64`/`getFloat16`) were already converted by #425 and are untouched.
- Mechanical, zero-behavior-change: exhaustive multi-arm dispatch (e.g. `strict_eq`, `to_bigint_throwing`) now matches on `.kind()` to preserve compile-time exhaustiveness ahead of the Phase 3 representation swap. Fallible accessors (`as_number`, `as_object_id`, etc.) keep their original fallback/throw paths — no new panicking `unwrap()`/`expect()` outside a `match x.kind()` arm that already proves the tag.
- `#[cfg(test)]` module bodies (e.g. `atomics.rs`'s unit tests) are left on the raw enum, matching the precedent set by #421/#423/#429 — test-scope conversion is a separate, later pass.

This is Phase 2.4 of the NaN-boxing epic (#69, design in #402) — one of 7 independent conversion PRs splitting ~5,700 call sites across 54 files.

Fixes #410

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 453 unit tests + integration tests pass
- [x] Full test262 (`scripts/run-test262.py -j 32`) — 100.00% (99,568/99,568), 0 regressions vs `origin/main:test262-pass.txt`
- [x] test262-extra (`scripts/run-test262.py test262-extra/`) — 100.00% (118/118)
- [x] Custom tests (`scripts/run-custom-tests.py`) — 11/11 pass