### PR TITLE
perf(bytecode): extend call-site IC to the bytecode Call/ReturnCall opcodes

### DIFF
--- a/src/interpreter/bytecode/compiler.rs
+++ b/src/interpreter/bytecode/compiler.rs
@@ -1,8 +1,8 @@
 use super::chunk::{Chunk, Constant};
 use super::op::Op;
 use crate::ast::{
-    AssignOp, BinaryOp, Expression, ForInit, Literal, LogicalOp, MemberProperty, Pattern,
-    Statement, UnaryOp, UpdateOp, VarKind, VariableDeclaration,
+    AssignOp, BinaryOp, CallSiteId, Expression, ForInit, Literal, LogicalOp, MemberProperty,
+    Pattern, Statement, UnaryOp, UpdateOp, VarKind, VariableDeclaration,
 };
 
 #[derive(Debug)]
@@ -76,6 +76,10 @@ impl Compiler {
     fn emit_u16(&mut self, n: u16) {
         self.code.push((n & 0xff) as u8);
         self.code.push((n >> 8) as u8);
+    }
+
+    fn emit_u32(&mut self, n: u32) {
+        self.code.extend_from_slice(&n.to_le_bytes());
     }
 
     /// Emit a forward jump with a placeholder offset; returns the patch site
@@ -368,7 +372,9 @@ impl Compiler {
                 }
                 MemberProperty::Private(_) => Err(CompileError::Unsupported("private field")),
             },
-            Expression::Call(callee, args, _) => self.compile_call(callee, args, Op::Call),
+            Expression::Call(callee, args, site_id) => {
+                self.compile_call(callee, args, Op::Call, *site_id)
+            }
             _ => Err(CompileError::Unsupported("expression")),
         }
     }
@@ -378,6 +384,7 @@ impl Compiler {
         callee: &Expression,
         args: &[Expression],
         op: Op,
+        site_id: CallSiteId,
     ) -> Result<(), CompileError> {
         let Expression::Identifier(name) = callee else {
             return Err(CompileError::Unsupported("call callee"));
@@ -409,6 +416,7 @@ impl Compiler {
         }
         self.emit(op);
         self.emit_u16(argc);
+        self.emit_u32(site_id.0);
         self.pop_n(argc + 2);
         if matches!(op, Op::Call | Op::ReturnCall) {
             self.push_n(1);
@@ -565,8 +573,8 @@ impl Compiler {
                 self.emit(Op::ReturnUndefined);
                 Ok(())
             }
-            Statement::Return(Some(Expression::Call(callee, args, _))) => {
-                self.compile_call(callee, args, Op::ReturnCall)?;
+            Statement::Return(Some(Expression::Call(callee, args, site_id))) => {
+                self.compile_call(callee, args, Op::ReturnCall, *site_id)?;
                 self.emit(Op::Return);
                 self.pop_n(1);
                 Ok(())

--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -1311,6 +1311,50 @@ fn direct_call_checks_global_proxy_binding_once() {
 }
 
 #[test]
+fn direct_call_hits_call_site_ic_in_bytecode() {
+    // Issue #432: the bytecode Call opcode must drive the same call-site IC
+    // as the tree-walker's eval_call, not run cold on every iteration. A
+    // 100-iteration hot loop on the same plain user function must register
+    // IC hits and route through the fast-dispatch entry that skips the
+    // proxy/wrapped/class-ctor checks (mirrors the tree-walker's
+    // `call_ic_records_after_repeated_call` / `call_ic_fast_dispatch_actually_skips_entry_checks`
+    // in `interpreter::tests`).
+    use crate::parser::Parser;
+    let source = "
+        function f() { return 7; }
+        var __r = (function() {
+            var sum = 0;
+            for (var i = 0; i < 100; i++) { sum = sum + f(); }
+            return sum;
+        })();
+    ";
+    let mut p = Parser::new(source).expect("parser init");
+    let program = p.parse_program().expect("parse");
+    let mut interp = Interpreter::new();
+    interp.bytecode_enabled = true;
+    let _ = interp.run(&program);
+    let v = interp
+        .get_global_var_ref("__r")
+        .unwrap_or(JsValue::Undefined);
+    assert!(matches!(v, JsValue::Number(n) if n == 700.0));
+    assert!(
+        interp.bytecode_chunks_executed >= 1,
+        "loop must execute through bytecode"
+    );
+    assert!(
+        interp.call_ic_hit_count() > 0,
+        "expected call-IC hits from the bytecode Call opcode after a \
+         100-iteration hot loop; dispatch_body must thread current_ic_handle \
+         into the bytecode branch for this to fire"
+    );
+    assert!(
+        interp.call_ic_fast_dispatch_count() > 0,
+        "expected the bytecode Call opcode to route IC hits through \
+         call_function_ic_validated, not the slow call_function path"
+    );
+}
+
+#[test]
 fn pending_argument_survives_gc_during_later_call_argument() {
     let source = "\
         var collect = $262.gc; \

--- a/src/interpreter/bytecode/vm.rs
+++ b/src/interpreter/bytecode/vm.rs
@@ -1,7 +1,8 @@
 use super::chunk::Chunk;
 use super::op::Op;
-use crate::ast::{BinaryOp, UnaryOp, UpdateOp};
+use crate::ast::{BinaryOp, CallSiteId, UnaryOp, UpdateOp};
 use crate::interpreter::eval::IdentifierRef;
+use crate::interpreter::ic::CallIcSlot;
 use crate::interpreter::types::{BindingKind, Completion, Environment};
 use crate::interpreter::{EnvRef, Interpreter};
 use crate::types::JsValue;
@@ -16,6 +17,10 @@ fn decode_u16(chunk: &Chunk, pc: usize) -> u16 {
     let lo = chunk.code[pc] as u16;
     let hi = chunk.code[pc + 1] as u16;
     (hi << 8) | lo
+}
+
+fn decode_u32(chunk: &Chunk, pc: usize) -> u32 {
+    u32::from_le_bytes(chunk.code[pc..pc + 4].try_into().unwrap())
 }
 
 /// Roots every `JsValue::Object` currently on the operand stack, not just the
@@ -367,6 +372,8 @@ fn run_chunk_inner(
             Op::Call | Op::ReturnCall => {
                 let argc = decode_u16(chunk, pc) as usize;
                 pc += 2;
+                let site_id = CallSiteId(decode_u32(chunk, pc));
+                pc += 4;
                 let (callee, this_value, args) = take_call_operands(&mut stack, argc);
                 if op == Op::ReturnCall && env.borrow().strict {
                     release_call_operands(interp, &callee, &this_value, &args);
@@ -376,11 +383,75 @@ fn run_chunk_inner(
                         args,
                     };
                 }
+                // Call-site IC probe + record, mirroring eval_call's tree-walker
+                // sequence (issue #432). `with_scope_depth != 0` is excluded
+                // because a `with`-resolved binding can dynamically pick a
+                // different callee per invocation, defeating monomorphic
+                // caching.
+                let ic_callee_id =
+                    if site_id != CallSiteId::UNASSIGNED && interp.with_scope_depth == 0 {
+                        callee.as_object_id()
+                    } else {
+                        None
+                    };
+                let mut probe_hit = false;
+                if let Some(callee_id) = ic_callee_id {
+                    let slot = *interp.call_slot(site_id);
+                    if let CallIcSlot::Mono {
+                        callee_obj_id,
+                        callee_shape_id,
+                        ..
+                    } = slot
+                        && callee_id == callee_obj_id
+                        && let Some(obj_rc) = interp.get_object(callee_id)
+                        && obj_rc.borrow().shape_id == callee_shape_id
+                    {
+                        interp
+                            .call_ic_hit_count
+                            .set(interp.call_ic_hit_count.get() + 1);
+                        probe_hit = true;
+                    }
+                    if !probe_hit {
+                        interp
+                            .call_ic_slow_path_count
+                            .set(interp.call_ic_slow_path_count.get() + 1);
+                    }
+                }
                 // The operands remain in gc_bytecode_roots for the complete
                 // nested invocation even though they have been removed from
                 // the operand Vec. A callee can execute arbitrary JS and hit
                 // any number of safepoints before returning.
-                let result = interp.call_function(&callee, &this_value, &args);
+                let result = if probe_hit {
+                    interp.call_function_ic_validated(&callee, &this_value, &args)
+                } else {
+                    interp.call_function(&callee, &this_value, &args)
+                };
+                // Record only on success to avoid caching error-paths.
+                if let Some(callee_id) = ic_callee_id
+                    && !probe_hit
+                    && matches!(result, Completion::Normal(_))
+                {
+                    let slot = *interp.call_slot(site_id);
+                    let new_slot = interp.classify_for_call_ic(callee_id);
+                    let next = match (slot, new_slot) {
+                        (CallIcSlot::Megamorphic, _) => CallIcSlot::Megamorphic,
+                        (_, None) => CallIcSlot::Empty,
+                        (CallIcSlot::Empty, Some(s)) => s,
+                        (
+                            CallIcSlot::Mono {
+                                callee_obj_id: prev,
+                                ..
+                            },
+                            Some(
+                                s @ CallIcSlot::Mono {
+                                    callee_obj_id: new, ..
+                                },
+                            ),
+                        ) if prev == new => s,
+                        (CallIcSlot::Mono { .. }, Some(_)) => CallIcSlot::Megamorphic,
+                    };
+                    *interp.call_slot(site_id) = next;
+                }
                 release_call_operands(interp, &callee, &this_value, &args);
                 match result {
                     Completion::Normal(value) | Completion::Return(value) => {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2113,7 +2113,12 @@ impl Interpreter {
                 },
             };
             if let Some(chunk) = chunk {
-                return vm::run_chunk(self, &chunk, exec_env, this_val.clone());
+                let handle = self.ic_store.for_body(body);
+                let prev = self.current_ic_handle;
+                self.current_ic_handle = handle;
+                let result = vm::run_chunk(self, &chunk, exec_env, this_val.clone());
+                self.current_ic_handle = prev;
+                return result;
             }
         }
         // #72: cache the hoisting *name collection* for this function body,
@@ -5607,10 +5612,10 @@ impl Interpreter {
                 args: evaluated_args,
             };
         }
-        // Phase 3 call-IC probe + record. Issue #71. v1 scope:
-        //  - Probe HIT increments call_ic_hit_count; dispatch is unchanged
-        //    (the fast path that skips proxy/wrapped/class-ctor checks is a
-        //    follow-up — see plan Step 15).
+        // Phase 3 call-IC probe + record. Issue #71.
+        //  - Probe HIT increments call_ic_hit_count and dispatches through
+        //    call_function_ic_validated, which skips the proxy/wrapped/
+        //    class-ctor entry checks (9a6246f, #71 Phase-3 follow-up).
         //  - Probe MISS classifies the callable; if it's a plain native or
         //    user function (no proxy, no wrapped, not a class ctor without
         //    `new`, not bound), records Mono. Otherwise transitions to
@@ -5683,7 +5688,11 @@ impl Interpreter {
     /// `CallIcSlot::Mono { kind: ... }` ready for caching, or `None` if the
     /// site is not IC-able under the v1 narrow scope (proxy, wrapped, bound,
     /// or class-ctor-without-new). Phase 3, plan Step 14.
-    fn classify_for_call_ic(
+    ///
+    /// `pub(super)` so the bytecode VM's `Call`/`ReturnCall` handling
+    /// (`bytecode::vm`) can share this classification with the tree-walker's
+    /// probe in `eval_call` (issue #432).
+    pub(super) fn classify_for_call_ic(
         &self,
         callee_obj_id: u64,
     ) -> Option<crate::interpreter::ic::CallIcSlot> {


### PR DESCRIPTION
## Summary

- Threads each call's `CallSiteId` through `compiler.rs`'s call compilation and the `Call`/`ReturnCall` opcode encoding (previously discarded — only `argc` was kept).
- `dispatch_body` now sets/restores `current_ic_handle` around the bytecode branch (`vm::run_chunk`) the same way it already does around the tree-walker's `exec_statements_cached`, instead of returning before that assignment.
- `vm.rs`'s `Op::Call`/`Op::ReturnCall` handling mirrors `eval_call`'s existing probe/hit/record sequence: on an IC `Mono` hit (same callee object id + shape id at that site), dispatch routes through `call_function_ic_validated` (skips the proxy/wrapped/class-ctor entry checks); a miss falls back to `call_function` and records the classification on success only.
- Fixes a stale comment block in `eval.rs` that still described the pre-follow-up state of the tree-walker's own call IC ("dispatch is unchanged... fast path is a follow-up") three lines above the code that already implements it — this is what led to #432 originally being filed with an inaccurate "no consumer exists" premise (corrected on the issue before this PR).

## Why

Issue #398 (bytecode direct-call slice, delivered by #399) left this as a known follow-up. `call_function_ic_validated` has been a real, working fast path in the tree-walker since `9a6246f` — bytecode-compiled calls simply forfeited it entirely. `IcStore::call_slots` indexing is safe by construction here the same way it already is in the tree-walker: `CallSiteId` is dense and body-local, and `current_ic_handle` is always derived from the same `body` via `for_body`, so no additional bounds-checking was needed.

Expected benefit is modest and is not the point — the fast path skips ~10ns of entry-check overhead per hit (per `9a6246f`'s own measurement) against microsecond-scale call overhead in bytecode loops. This is about dispatch **parity**: the bytecode path no longer forfeits an optimization the tree-walker gets for free on repeat monomorphic calls.

Fixes #432

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release` — 453 unit tests + host_time_zone + smoke oracle, all passing; includes a new `direct_call_hits_call_site_ic_in_bytecode` test proving a 100-iteration hot loop on a compiled function registers IC hits *and* fires the fast-dispatch counter (proof it's `call_function_ic_validated`, not a slow-path hit)
- [x] `./scripts/lint.sh` — clean
- [x] `uv run python scripts/run-test262.py --bytecode -j 16 test262/test/language/expressions/call/` — 171/171
- [x] `uv run python scripts/run-test262.py -j 32` (default mode) — 99,568/99,568, 0 regressions
- [x] `uv run python scripts/run-test262.py --bytecode -j 32` (bytecode mode) — 99,560/99,568; the 8 failures are the pre-existing, already-tracked bytecode-only gaps from #416/#417 (confirmed identical scenario list), not new regressions from this change