### PR TITLE
refactor(nan-box): migrate Temporal/Intl builtins to JsValue accessors

### DIFF
--- a/src/interpreter/builtins/intl/collator.rs
+++ b/src/interpreter/builtins/intl/collator.rs
@@ -226,8 +226,8 @@ impl Interpreter {
             "get compare".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    if let Some(cell) = interp.get_object_cell(o.id) {
+                if let Some(o) = this.as_object_id() {
+                    if let Some(cell) = interp.get_object_cell(o) {
                         enum Probe {
                             NotCollator,
                             Cached(JsValue),
@@ -258,7 +258,7 @@ impl Interpreter {
                         }
                     }
 
-                    let snapshot = interp.get_object_cell(o.id).and_then(|cell| {
+                    let snapshot = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Collator {
                             locale,
@@ -305,8 +305,8 @@ impl Interpreter {
                         "".to_string(),
                         2,
                         move |interp2, _this2, args2| {
-                            let x_val = args2.first().cloned().unwrap_or(JsValue::Undefined);
-                            let y_val = args2.get(1).cloned().unwrap_or(JsValue::Undefined);
+                            let x_val = args2.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                            let y_val = args2.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                             let x_str = match interp2.to_string_value(&x_val) {
                                 Ok(s) => s,
                                 Err(e) => return Completion::Throw(e),
@@ -327,11 +327,11 @@ impl Interpreter {
                                 &x_str,
                                 &y_str,
                             );
-                            Completion::Normal(JsValue::Number(result))
+                            Completion::Normal(JsValue::number(result))
                         },
                     ));
 
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o) {
                         obj.borrow_mut().properties.insert(
                             crate::interpreter::key_intern::intern_key("[[BoundCompare]]"),
                             PropertyDescriptor::data(compare_fn.clone(), false, false, false),
@@ -357,8 +357,8 @@ impl Interpreter {
             "resolvedOptions".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = this.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -383,19 +383,13 @@ impl Interpreter {
                         }
 
                         let props = vec![
-                            ("locale", JsValue::String(JsString::from_str(&locale))),
-                            ("usage", JsValue::String(JsString::from_str(&usage))),
-                            (
-                                "sensitivity",
-                                JsValue::String(JsString::from_str(&sensitivity)),
-                            ),
-                            ("ignorePunctuation", JsValue::Boolean(ignore_punctuation)),
-                            ("collation", JsValue::String(JsString::from_str(&collation))),
-                            ("numeric", JsValue::Boolean(numeric)),
-                            (
-                                "caseFirst",
-                                JsValue::String(JsString::from_str(&case_first)),
-                            ),
+                            ("locale", JsValue::from_str(&locale)),
+                            ("usage", JsValue::from_str(&usage)),
+                            ("sensitivity", JsValue::from_str(&sensitivity)),
+                            ("ignorePunctuation", JsValue::boolean(ignore_punctuation)),
+                            ("collation", JsValue::from_str(&collation)),
+                            ("numeric", JsValue::boolean(numeric)),
+                            ("caseFirst", JsValue::from_str(&case_first)),
                         ];
                         for (key, val) in props {
                             interp
@@ -407,9 +401,7 @@ impl Interpreter {
                                 );
                         }
 
-                        return Completion::Normal(JsValue::Object(crate::types::JsObject {
-                            id: result_id,
-                        }));
+                        return Completion::Normal(JsValue::object(result_id));
                     }
                 }
                 Completion::Throw(interp.create_type_error(
@@ -424,15 +416,15 @@ impl Interpreter {
         self.realm_mut().intl_collator_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let collator_ctor = self.create_function(JsFunction::constructor(
             "Collator".to_string(),
             0,
             move |interp, _this, args| {
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -472,16 +464,16 @@ impl Interpreter {
                 };
 
                 let opt_numeric = {
-                    let num_val = if let JsValue::Object(o) = &options {
-                        match interp.get_object_property(o.id, "numeric", &options) {
+                    let num_val = if let Some(o) = options.as_object_id() {
+                        match interp.get_object_property(o, "numeric", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         }
                     } else {
-                        JsValue::Undefined
+                        JsValue::UNDEFINED
                     };
-                    if matches!(num_val, JsValue::Undefined) {
+                    if num_val.is_undefined() {
                         None
                     } else {
                         Some(interp.to_boolean_val(&num_val))
@@ -632,16 +624,16 @@ impl Interpreter {
 
                 // ignorePunctuation: boolean option with locale-dependent default
                 let ignore_punctuation = {
-                    let ip_val = if let JsValue::Object(o) = &options {
-                        match interp.get_object_property(o.id, "ignorePunctuation", &options) {
+                    let ip_val = if let Some(o) = options.as_object_id() {
+                        match interp.get_object_property(o, "ignorePunctuation", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         }
                     } else {
-                        JsValue::Undefined
+                        JsValue::UNDEFINED
                     };
-                    if matches!(ip_val, JsValue::Undefined) {
+                    if ip_val.is_undefined() {
                         is_thai_locale(&locale)
                     } else {
                         interp.to_boolean_val(&ip_val)
@@ -675,15 +667,14 @@ impl Interpreter {
                         case_first,
                     }));
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set Collator.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &collator_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = collator_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -696,8 +687,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),
@@ -755,16 +746,16 @@ impl Interpreter {
         let opt_collation = self.intl_get_option(&opts, "collation", &[], None)?;
 
         let opt_numeric = {
-            let num_val = if let JsValue::Object(o) = &opts {
-                match self.get_object_property(o.id, "numeric", &opts) {
+            let num_val = if let Some(o) = opts.as_object_id() {
+                match self.get_object_property(o, "numeric", &opts) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 }
             } else {
-                JsValue::Undefined
+                JsValue::UNDEFINED
             };
-            if matches!(num_val, JsValue::Undefined) {
+            if num_val.is_undefined() {
                 None
             } else {
                 Some(self.to_boolean_val(&num_val))
@@ -842,16 +833,16 @@ impl Interpreter {
         let locale = base_locale(&raw_locale);
 
         let ignore_punctuation = {
-            let ip_val = if let JsValue::Object(o) = &opts {
-                match self.get_object_property(o.id, "ignorePunctuation", &opts) {
+            let ip_val = if let Some(o) = opts.as_object_id() {
+                match self.get_object_property(o, "ignorePunctuation", &opts) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 }
             } else {
-                JsValue::Undefined
+                JsValue::UNDEFINED
             };
-            if matches!(ip_val, JsValue::Undefined) {
+            if ip_val.is_undefined() {
                 is_thai_locale(&locale)
             } else {
                 self.to_boolean_val(&ip_val)

--- a/src/interpreter/builtins/intl/datetimeformat.rs
+++ b/src/interpreter/builtins/intl/datetimeformat.rs
@@ -5006,9 +5006,9 @@ fn format_to_parts_with_options_raw(ms: f64, opts: &DtfOptions) -> Vec<(String, 
 /// %Intl%.[[FallbackSymbol]] via the ordinary [[Get]] (so Proxy traps fire) and
 /// require the result to carry the slot; otherwise throw a TypeError.
 fn unwrap_dtf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsValue> {
-    if let JsValue::Object(o) = this {
+    if let Some(o) = this.as_object_id() {
         let has_slot = interp
-            .get_object_cell(o.id)
+            .get_object_cell(o)
             .map(|c| {
                 matches!(
                     c.borrow().intl_data(),
@@ -5023,25 +5023,25 @@ fn unwrap_dtf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsVal
         // ? OrdinaryHasInstance(%DateTimeFormat%, this) — propagate abrupt completions.
         let is_instance = match &ctor {
             Some(c) => match interp.ordinary_has_instance(c, this) {
-                Completion::Normal(JsValue::Boolean(b)) => b,
+                Completion::Normal(v) => v.as_boolean().unwrap_or(false),
                 Completion::Throw(e) => return Err(e),
                 _ => false,
             },
             None => false,
         };
         if is_instance {
-            let key = match interp.intl_fallback_symbol() {
-                JsValue::Symbol(s) => s.to_property_key(),
-                _ => unreachable!(),
+            let key = match interp.intl_fallback_symbol().as_symbol() {
+                Some(s) => s.to_property_key(),
+                None => unreachable!(),
             };
-            let fb = match interp.get_object_property(o.id, &key, this) {
+            let fb = match interp.get_object_property(o, &key, this) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
-            if let JsValue::Object(fo) = &fb {
+            if let Some(fo) = fb.as_object_id() {
                 let fb_has_slot = interp
-                    .get_object_cell(fo.id)
+                    .get_object_cell(fo)
                     .map(|c| {
                         matches!(
                             c.borrow().intl_data(),
@@ -5062,8 +5062,8 @@ fn unwrap_dtf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsVal
 fn extract_dtf_data(interp: &mut Interpreter, this: &JsValue) -> Result<DtfOptions, JsValue> {
     let recv = unwrap_dtf(interp, this)?;
     let this = &recv;
-    if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(o) = this.as_object_id()
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let b = obj.borrow();
         if let Some(IntlData::DateTimeFormat {
@@ -5133,12 +5133,12 @@ fn time_clip(t: f64) -> f64 {
 }
 
 fn resolve_date_value(interp: &mut Interpreter, date_arg: &JsValue) -> Result<f64, JsValue> {
-    if matches!(date_arg, JsValue::Undefined) {
+    if date_arg.is_undefined() {
         return Ok(now_ms().floor());
     }
     // Check if it's a Temporal object
-    if let JsValue::Object(o) = date_arg
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(o) = date_arg.as_object_id()
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let temporal = obj.borrow().temporal_data().cloned();
         if let Some(td) = temporal {
@@ -5165,8 +5165,8 @@ enum TemporalType {
 }
 
 fn detect_temporal_type(interp: &Interpreter, val: &JsValue) -> Option<TemporalType> {
-    if let JsValue::Object(o) = val
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(o) = val.as_object_id()
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let td = obj.borrow().temporal_data().cloned();
         return match td {
@@ -5184,8 +5184,8 @@ fn detect_temporal_type(interp: &Interpreter, val: &JsValue) -> Option<TemporalT
 }
 
 fn detect_temporal_calendar(interp: &Interpreter, val: &JsValue) -> Option<String> {
-    if let JsValue::Object(o) = val
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(o) = val.as_object_id()
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let td = obj.borrow().temporal_data().cloned();
         return match td {
@@ -5557,7 +5557,7 @@ fn temporal_to_epoch_ms(td: &TemporalData) -> Result<f64, JsValue> {
             Ok(ms)
         }
         TemporalData::Duration { .. } => {
-            Err(JsValue::Undefined) // Duration is not a date type
+            Err(JsValue::UNDEFINED) // Duration is not a date type
         }
     }
 }
@@ -5626,14 +5626,14 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 let this = &recv;
-                if let JsValue::Object(o) = this {
+                if let Some(o) = this.as_object_id() {
                     enum Probe {
                         NotDtf,
                         Cached(JsValue),
                         Uncached,
                     }
                     let probe = interp
-                        .get_object_cell(o.id)
+                        .get_object_cell(o)
                         .map(|cell| {
                             let b = cell.borrow();
                             if !matches!(b.intl_data(), Some(IntlData::DateTimeFormat { .. })) {
@@ -5659,7 +5659,7 @@ impl Interpreter {
                         Probe::Uncached => {}
                     }
 
-                    let opts_snapshot = interp.get_object_cell(o.id).and_then(|cell| {
+                    let opts_snapshot = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::DateTimeFormat {
                             locale,
@@ -5725,7 +5725,7 @@ impl Interpreter {
                         1,
                         move |interp2, _this2, args2| {
                             let date_arg =
-                                args2.first().cloned().unwrap_or(JsValue::Undefined);
+                                args2.first().cloned().unwrap_or(JsValue::UNDEFINED);
                             let temporal_type = detect_temporal_type(interp2, &date_arg);
                             if matches!(temporal_type, Some(TemporalType::ZonedDateTime)) {
                                 return Completion::Throw(interp2.create_type_error(
@@ -5753,11 +5753,11 @@ impl Interpreter {
                                 ms
                             };
                             let result = format_with_options(ms, &effective_opts);
-                            Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                            Completion::Normal(JsValue::from_str(&result))
                         },
                     ));
 
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                    if let Some(obj) = interp.get_object_cell(o) {
                         obj.borrow_mut().properties.insert(
                             crate::interpreter::key_intern::intern_key("[[BoundFormat]]"),
                             PropertyDescriptor::data(format_fn.clone(), false, false, false),
@@ -5788,7 +5788,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let date_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let date_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let temporal_type = detect_temporal_type(interp, &date_arg);
                 if matches!(temporal_type, Some(TemporalType::ZonedDateTime)) {
                     return Completion::Throw(interp.create_type_error(
@@ -5835,7 +5835,7 @@ impl Interpreter {
                             .insert_property(
                                 "type".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&ptype)),
+                                    JsValue::from_str(&ptype),
                                     true,
                                     true,
                                     true,
@@ -5847,14 +5847,14 @@ impl Interpreter {
                             .insert_property(
                                 "value".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&value)),
+                                    JsValue::from_str(&value),
                                     true,
                                     true,
                                     true,
                                 ),
                             );
                         let id = part_obj_id;
-                        JsValue::Object(crate::types::JsObject { id })
+                        JsValue::object(id)
                     })
                     .collect();
 
@@ -5875,11 +5875,10 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let start_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let end_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let start_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let end_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
-                if matches!(start_arg, JsValue::Undefined) || matches!(end_arg, JsValue::Undefined)
-                {
+                if start_arg.is_undefined() || end_arg.is_undefined() {
                     return Completion::Throw(
                         interp.create_type_error("startDate and endDate are required"),
                     );
@@ -5967,7 +5966,7 @@ impl Interpreter {
                     end_ms
                 };
                 let result = format_range_with_options(start_ms, end_ms, &effective_opts);
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -5984,10 +5983,10 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let start_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let end_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let start_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let end_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
-                if matches!(start_arg, JsValue::Undefined) || matches!(end_arg, JsValue::Undefined) {
+                if start_arg.is_undefined() || end_arg.is_undefined() {
                     return Completion::Throw(
                         interp.create_type_error("startDate and endDate are required"),
                     );
@@ -6078,7 +6077,7 @@ impl Interpreter {
                         interp.get_object_cell_expect(part_obj_id).borrow_mut().insert_property(
                             "type".to_string(),
                             PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&ptype)),
+                                JsValue::from_str(&ptype),
                                 true,
                                 true,
                                 true,
@@ -6087,7 +6086,7 @@ impl Interpreter {
                         interp.get_object_cell_expect(part_obj_id).borrow_mut().insert_property(
                             "value".to_string(),
                             PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&value)),
+                                JsValue::from_str(&value),
                                 true,
                                 true,
                                 true,
@@ -6096,14 +6095,14 @@ impl Interpreter {
                         interp.get_object_cell_expect(part_obj_id).borrow_mut().insert_property(
                             "source".to_string(),
                             PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(&source)),
+                                JsValue::from_str(&source),
                                 true,
                                 true,
                                 true,
                             ),
                         );
                         let id = part_obj_id;
-                        JsValue::Object(crate::types::JsObject { id })
+                        JsValue::object(id)
                     })
                     .collect();
 
@@ -6134,68 +6133,59 @@ impl Interpreter {
 
                 // Properties in spec order
                 let mut props: Vec<(&str, JsValue)> = vec![
-                    ("locale", JsValue::String(JsString::from_str(&opts.locale))),
-                    (
-                        "calendar",
-                        JsValue::String(JsString::from_str(&opts.calendar)),
-                    ),
-                    (
-                        "numberingSystem",
-                        JsValue::String(JsString::from_str(&opts.numbering_system)),
-                    ),
-                    (
-                        "timeZone",
-                        JsValue::String(JsString::from_str(&opts.time_zone)),
-                    ),
+                    ("locale", JsValue::from_str(&opts.locale)),
+                    ("calendar", JsValue::from_str(&opts.calendar)),
+                    ("numberingSystem", JsValue::from_str(&opts.numbering_system)),
+                    ("timeZone", JsValue::from_str(&opts.time_zone)),
                 ];
 
                 // hourCycle and hour12 only present if hour is used
                 let has_hour = opts.hour.is_some() || opts.time_style.is_some();
                 if has_hour {
                     let hc = resolve_hour_cycle(&opts);
-                    props.push(("hourCycle", JsValue::String(JsString::from_str(hc))));
+                    props.push(("hourCycle", JsValue::from_str(hc)));
                     let h12 = hc == "h12" || hc == "h11";
-                    props.push(("hour12", JsValue::Boolean(h12)));
+                    props.push(("hour12", JsValue::boolean(h12)));
                 }
 
                 if let Some(ref v) = opts.weekday {
-                    props.push(("weekday", JsValue::String(JsString::from_str(v))));
+                    props.push(("weekday", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.era {
-                    props.push(("era", JsValue::String(JsString::from_str(v))));
+                    props.push(("era", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.year {
-                    props.push(("year", JsValue::String(JsString::from_str(v))));
+                    props.push(("year", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.month {
-                    props.push(("month", JsValue::String(JsString::from_str(v))));
+                    props.push(("month", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.day {
-                    props.push(("day", JsValue::String(JsString::from_str(v))));
+                    props.push(("day", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.day_period {
-                    props.push(("dayPeriod", JsValue::String(JsString::from_str(v))));
+                    props.push(("dayPeriod", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.hour {
-                    props.push(("hour", JsValue::String(JsString::from_str(v))));
+                    props.push(("hour", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.minute {
-                    props.push(("minute", JsValue::String(JsString::from_str(v))));
+                    props.push(("minute", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.second {
-                    props.push(("second", JsValue::String(JsString::from_str(v))));
+                    props.push(("second", JsValue::from_str(v)));
                 }
                 if let Some(v) = opts.fractional_second_digits {
-                    props.push(("fractionalSecondDigits", JsValue::Number(v as f64)));
+                    props.push(("fractionalSecondDigits", JsValue::number(v as f64)));
                 }
                 if let Some(ref v) = opts.time_zone_name {
-                    props.push(("timeZoneName", JsValue::String(JsString::from_str(v))));
+                    props.push(("timeZoneName", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.date_style {
-                    props.push(("dateStyle", JsValue::String(JsString::from_str(v))));
+                    props.push(("dateStyle", JsValue::from_str(v)));
                 }
                 if let Some(ref v) = opts.time_style {
-                    props.push(("timeStyle", JsValue::String(JsString::from_str(v))));
+                    props.push(("timeStyle", JsValue::from_str(v)));
                 }
 
                 for (key, val) in props {
@@ -6208,7 +6198,7 @@ impl Interpreter {
                         );
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
+                Completion::Normal(JsValue::object(result_id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -6218,15 +6208,15 @@ impl Interpreter {
         self.realm_mut().intl_date_time_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let dtf_ctor = self.create_function(JsFunction::constructor(
             "DateTimeFormat".to_string(),
             0,
             move |interp, _this, args| {
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -6280,16 +6270,16 @@ impl Interpreter {
                 }
 
                 // Step 12: hour12
-                let hour12_raw = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "hour12", &options) {
+                let hour12_raw = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "hour12", &options) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Completion::Throw(e),
-                        _ => JsValue::Undefined,
+                        _ => JsValue::UNDEFINED,
                     }
                 } else {
-                    JsValue::Undefined
+                    JsValue::UNDEFINED
                 };
-                let hour12 = if matches!(hour12_raw, JsValue::Undefined) {
+                let hour12 = if hour12_raw.is_undefined() {
                     None
                 } else {
                     Some(interp.to_boolean_val(&hour12_raw))
@@ -6638,71 +6628,68 @@ impl Interpreter {
                 // freshly-initialized formatter under %Intl%.[[FallbackSymbol]]
                 // and return the receiver instead of a fresh object.
                 if interp.new_target.is_none()
-                    && let JsValue::Object(recv) = _this
+                    && let Some(recv_id) = _this.as_object_id()
+                    && let Some(ctor) = interp.realm().intl_date_time_format_ctor.clone()
                 {
-                    let recv_id = recv.id;
-                    if let Some(ctor) = interp.realm().intl_date_time_format_ctor.clone() {
-                        // ? OrdinaryHasInstance(%DateTimeFormat%, this) — an abrupt
-                        // completion (e.g. revoked Proxy / throwing getPrototypeOf
-                        // trap) must propagate, not fall through to a fresh object.
-                        let is_instance = match interp.ordinary_has_instance(&ctor, _this) {
-                            Completion::Normal(JsValue::Boolean(b)) => b,
-                            Completion::Throw(e) => return Completion::Throw(e),
-                            _ => false,
+                    // ? OrdinaryHasInstance(%DateTimeFormat%, this) — an abrupt
+                    // completion (e.g. revoked Proxy / throwing getPrototypeOf
+                    // trap) must propagate, not fall through to a fresh object.
+                    let is_instance = match interp.ordinary_has_instance(&ctor, _this) {
+                        Completion::Normal(v) => v.as_boolean().unwrap_or(false),
+                        Completion::Throw(e) => return Completion::Throw(e),
+                        _ => false,
+                    };
+                    if is_instance {
+                        let key = match interp.intl_fallback_symbol().as_symbol() {
+                            Some(s) => s.to_property_key(),
+                            None => unreachable!(),
                         };
-                        if is_instance {
-                            let key = match interp.intl_fallback_symbol() {
-                                JsValue::Symbol(s) => s.to_property_key(),
-                                _ => unreachable!(),
-                            };
-                            let desc = crate::interpreter::types::PropertyDescriptor::data(
-                                JsValue::Object(crate::types::JsObject { id: obj_id }),
-                                false,
-                                false,
-                                false,
-                            );
-                            // ? DefinePropertyOrThrow(this, [[FallbackSymbol]], desc):
-                            // route through the receiver's [[DefineOwnProperty]] so a
-                            // Proxy's defineProperty trap fires and a later [[Get]] in
-                            // Unwrap can observe the chained formatter.
-                            let is_proxy = interp
-                                .get_object_cell(recv_id)
-                                .map(|c| {
-                                    let b = c.borrow();
-                                    b.is_proxy() || b.is_proxy_revoked()
-                                })
-                                .unwrap_or(false);
-                            let defined = if is_proxy {
-                                let desc_val = interp.from_property_descriptor(&desc);
-                                match interp.proxy_define_own_property(recv_id, key, &desc_val) {
-                                    Ok(b) => b,
-                                    Err(e) => return Completion::Throw(e),
-                                }
-                            } else {
-                                interp
-                                    .get_object_cell_expect(recv_id)
-                                    .borrow_mut()
-                                    .define_own_property(key, desc)
-                            };
-                            if !defined {
-                                return Completion::Throw(interp.create_type_error(
-                                    "Cannot define [[FallbackSymbol]] property on receiver",
-                                ));
+                        let desc = crate::interpreter::types::PropertyDescriptor::data(
+                            JsValue::object(obj_id),
+                            false,
+                            false,
+                            false,
+                        );
+                        // ? DefinePropertyOrThrow(this, [[FallbackSymbol]], desc):
+                        // route through the receiver's [[DefineOwnProperty]] so a
+                        // Proxy's defineProperty trap fires and a later [[Get]] in
+                        // Unwrap can observe the chained formatter.
+                        let is_proxy = interp
+                            .get_object_cell(recv_id)
+                            .map(|c| {
+                                let b = c.borrow();
+                                b.is_proxy() || b.is_proxy_revoked()
+                            })
+                            .unwrap_or(false);
+                        let defined = if is_proxy {
+                            let desc_val = interp.from_property_descriptor(&desc);
+                            match interp.proxy_define_own_property(recv_id, key, &desc_val) {
+                                Ok(b) => b,
+                                Err(e) => return Completion::Throw(e),
                             }
-                            return Completion::Normal(_this.clone());
+                        } else {
+                            interp
+                                .get_object_cell_expect(recv_id)
+                                .borrow_mut()
+                                .define_own_property(key, desc)
+                        };
+                        if !defined {
+                            return Completion::Throw(interp.create_type_error(
+                                "Cannot define [[FallbackSymbol]] property on receiver",
+                            ));
                         }
+                        return Completion::Normal(_this.clone());
                     }
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set DateTimeFormat.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &dtf_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = dtf_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -6715,8 +6702,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/intl/displaynames.rs
+++ b/src/interpreter/builtins/intl/displaynames.rs
@@ -886,8 +886,8 @@ fn extract_display_names_data(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<DisplayNamesData, JsValue> {
-    if let JsValue::Object(o) = this
-        && let Some(cell) = interp.get_object_cell(o.id)
+    if let Some(o) = this.as_object_id()
+        && let Some(cell) = interp.get_object_cell(o)
     {
         let b = cell.borrow();
         if let Some(IntlData::DisplayNames {
@@ -1091,7 +1091,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let code_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let code_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let code = match interp.to_string_value(&code_arg) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
@@ -1105,10 +1105,8 @@ impl Interpreter {
                     &data.language_display,
                     &code,
                 ) {
-                    Ok(Some(name)) => {
-                        Completion::Normal(JsValue::String(JsString::from_str(&name)))
-                    }
-                    Ok(None) => Completion::Normal(JsValue::Undefined),
+                    Ok(Some(name)) => Completion::Normal(JsValue::from_str(&name)),
+                    Ok(None) => Completion::Normal(JsValue::UNDEFINED),
                     Err(_msg) => {
                         let err = interp.create_range_error(&format!("Invalid code: {}", code));
                         Completion::Throw(err)
@@ -1144,24 +1142,14 @@ impl Interpreter {
                     .borrow_mut()
                     .insert_property(
                         "locale".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(&data.locale)),
-                            true,
-                            true,
-                            true,
-                        ),
+                        PropertyDescriptor::data(JsValue::from_str(&data.locale), true, true, true),
                     );
                 interp
                     .get_object_cell_expect(result_id)
                     .borrow_mut()
                     .insert_property(
                         "style".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(&data.style)),
-                            true,
-                            true,
-                            true,
-                        ),
+                        PropertyDescriptor::data(JsValue::from_str(&data.style), true, true, true),
                     );
                 interp
                     .get_object_cell_expect(result_id)
@@ -1169,7 +1157,7 @@ impl Interpreter {
                     .insert_property(
                         "type".to_string(),
                         PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(&data.display_type)),
+                            JsValue::from_str(&data.display_type),
                             true,
                             true,
                             true,
@@ -1181,7 +1169,7 @@ impl Interpreter {
                     .insert_property(
                         "fallback".to_string(),
                         PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(&data.fallback)),
+                            JsValue::from_str(&data.fallback),
                             true,
                             true,
                             true,
@@ -1194,16 +1182,11 @@ impl Interpreter {
                         .borrow_mut()
                         .insert_property(
                             "languageDisplay".to_string(),
-                            PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(ld)),
-                                true,
-                                true,
-                                true,
-                            ),
+                            PropertyDescriptor::data(JsValue::from_str(ld), true, true, true),
                         );
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
+                Completion::Normal(JsValue::object(result_id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1213,7 +1196,7 @@ impl Interpreter {
         self.realm_mut().intl_display_names_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let display_names_ctor = self.create_function(JsFunction::constructor(
@@ -1226,8 +1209,8 @@ impl Interpreter {
                     );
                 }
 
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -1235,7 +1218,7 @@ impl Interpreter {
                 };
 
                 // DisplayNames requires options to be an object, not undefined
-                if matches!(options_arg, JsValue::Undefined) {
+                if options_arg.is_undefined() {
                     return Completion::Throw(
                         interp.create_type_error(
                             "Options argument is required for Intl.DisplayNames",
@@ -1344,15 +1327,14 @@ impl Interpreter {
                         language_display,
                     }));
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set DisplayNames.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &display_names_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = display_names_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -1365,8 +1347,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -575,21 +575,21 @@ fn to_duration_record(
     input: &JsValue,
 ) -> Result<DurationRecord, JsValue> {
     // Step 1-2: If input is a string, parse as ISO 8601 duration
-    if let JsValue::String(s) = input {
+    if let Some(s) = input.as_string() {
         let dur_str = s.to_rust_string();
         return parse_duration_string(interp, &dur_str);
     }
 
     // Not an object? TypeError
-    if matches!(input, JsValue::Undefined | JsValue::Null) {
+    if input.is_nullish() {
         return Err(interp.create_type_error("Duration must be an object or string"));
     }
-    if !matches!(input, JsValue::Object(_)) {
+    if !input.is_object() {
         return Err(interp.create_type_error("Duration must be an object or string"));
     }
 
-    let obj_id = if let JsValue::Object(o) = input {
-        o.id
+    let obj_id = if let Some(o) = input.as_object_id() {
+        o
     } else {
         unreachable!()
     };
@@ -635,10 +635,10 @@ fn to_duration_record(
             let val = match interp.get_object_property(obj_id, name, input) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
 
-            if matches!(val, JsValue::Undefined) {
+            if val.is_undefined() {
                 return Ok(0.0);
             }
 
@@ -894,8 +894,8 @@ fn extract_duration_format_data(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<DurationFormatData, JsValue> {
-    if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(o) = this.as_object_id()
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let b = obj.borrow();
         if let Some(IntlData::DurationFormat {
@@ -1160,14 +1160,14 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let dur_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let dur_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let dur = match to_duration_record(interp, &dur_arg) {
                     Ok(d) => d,
                     Err(e) => return Completion::Throw(e),
                 };
 
                 let result = format_duration(&data, &dur);
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1184,7 +1184,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let dur_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let dur_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let dur = match to_duration_record(interp, &dur_arg) {
                     Ok(d) => d,
                     Err(e) => return Completion::Throw(e),
@@ -1208,7 +1208,7 @@ impl Interpreter {
                             .insert_property(
                                 "type".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&ptype)),
+                                    JsValue::from_str(&ptype),
                                     true,
                                     true,
                                     true,
@@ -1220,7 +1220,7 @@ impl Interpreter {
                             .insert_property(
                                 "value".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&value)),
+                                    JsValue::from_str(&value),
                                     true,
                                     true,
                                     true,
@@ -1233,15 +1233,14 @@ impl Interpreter {
                                 .insert_property(
                                     "unit".to_string(),
                                     PropertyDescriptor::data(
-                                        JsValue::String(JsString::from_str(&unit)),
+                                        JsValue::from_str(&unit),
                                         true,
                                         true,
                                         true,
                                     ),
                                 );
                         }
-                        let id = part_obj_id;
-                        JsValue::Object(crate::types::JsObject { id })
+                        JsValue::object(part_obj_id)
                     })
                     .collect();
 
@@ -1271,81 +1270,42 @@ impl Interpreter {
                 }
 
                 let mut props: Vec<(&str, JsValue)> = vec![
-                    ("locale", JsValue::String(JsString::from_str(&data.locale))),
-                    (
-                        "numberingSystem",
-                        JsValue::String(JsString::from_str(&data.numbering_system)),
-                    ),
-                    ("style", JsValue::String(JsString::from_str(&data.style))),
-                    ("years", JsValue::String(JsString::from_str(&data.years))),
-                    (
-                        "yearsDisplay",
-                        JsValue::String(JsString::from_str(&data.years_display)),
-                    ),
-                    ("months", JsValue::String(JsString::from_str(&data.months))),
-                    (
-                        "monthsDisplay",
-                        JsValue::String(JsString::from_str(&data.months_display)),
-                    ),
-                    ("weeks", JsValue::String(JsString::from_str(&data.weeks))),
-                    (
-                        "weeksDisplay",
-                        JsValue::String(JsString::from_str(&data.weeks_display)),
-                    ),
-                    ("days", JsValue::String(JsString::from_str(&data.days))),
-                    (
-                        "daysDisplay",
-                        JsValue::String(JsString::from_str(&data.days_display)),
-                    ),
-                    ("hours", JsValue::String(JsString::from_str(&data.hours))),
-                    (
-                        "hoursDisplay",
-                        JsValue::String(JsString::from_str(&data.hours_display)),
-                    ),
-                    (
-                        "minutes",
-                        JsValue::String(JsString::from_str(&data.minutes)),
-                    ),
-                    (
-                        "minutesDisplay",
-                        JsValue::String(JsString::from_str(&data.minutes_display)),
-                    ),
-                    (
-                        "seconds",
-                        JsValue::String(JsString::from_str(&data.seconds)),
-                    ),
-                    (
-                        "secondsDisplay",
-                        JsValue::String(JsString::from_str(&data.seconds_display)),
-                    ),
-                    (
-                        "milliseconds",
-                        JsValue::String(JsString::from_str(&data.milliseconds)),
-                    ),
+                    ("locale", JsValue::from_str(&data.locale)),
+                    ("numberingSystem", JsValue::from_str(&data.numbering_system)),
+                    ("style", JsValue::from_str(&data.style)),
+                    ("years", JsValue::from_str(&data.years)),
+                    ("yearsDisplay", JsValue::from_str(&data.years_display)),
+                    ("months", JsValue::from_str(&data.months)),
+                    ("monthsDisplay", JsValue::from_str(&data.months_display)),
+                    ("weeks", JsValue::from_str(&data.weeks)),
+                    ("weeksDisplay", JsValue::from_str(&data.weeks_display)),
+                    ("days", JsValue::from_str(&data.days)),
+                    ("daysDisplay", JsValue::from_str(&data.days_display)),
+                    ("hours", JsValue::from_str(&data.hours)),
+                    ("hoursDisplay", JsValue::from_str(&data.hours_display)),
+                    ("minutes", JsValue::from_str(&data.minutes)),
+                    ("minutesDisplay", JsValue::from_str(&data.minutes_display)),
+                    ("seconds", JsValue::from_str(&data.seconds)),
+                    ("secondsDisplay", JsValue::from_str(&data.seconds_display)),
+                    ("milliseconds", JsValue::from_str(&data.milliseconds)),
                     (
                         "millisecondsDisplay",
-                        JsValue::String(JsString::from_str(&data.milliseconds_display)),
+                        JsValue::from_str(&data.milliseconds_display),
                     ),
-                    (
-                        "microseconds",
-                        JsValue::String(JsString::from_str(&data.microseconds)),
-                    ),
+                    ("microseconds", JsValue::from_str(&data.microseconds)),
                     (
                         "microsecondsDisplay",
-                        JsValue::String(JsString::from_str(&data.microseconds_display)),
+                        JsValue::from_str(&data.microseconds_display),
                     ),
-                    (
-                        "nanoseconds",
-                        JsValue::String(JsString::from_str(&data.nanoseconds)),
-                    ),
+                    ("nanoseconds", JsValue::from_str(&data.nanoseconds)),
                     (
                         "nanosecondsDisplay",
-                        JsValue::String(JsString::from_str(&data.nanoseconds_display)),
+                        JsValue::from_str(&data.nanoseconds_display),
                     ),
                 ];
 
                 if let Some(fd) = data.fractional_digits {
-                    props.push(("fractionalDigits", JsValue::Number(fd as f64)));
+                    props.push(("fractionalDigits", JsValue::number(fd as f64)));
                 }
 
                 for (key, val) in props {
@@ -1358,7 +1318,7 @@ impl Interpreter {
                         );
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
+                Completion::Normal(JsValue::object(result_id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1368,7 +1328,7 @@ impl Interpreter {
         self.realm_mut().intl_duration_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let duration_format_ctor = self.create_function(JsFunction::constructor(
@@ -1381,8 +1341,8 @@ impl Interpreter {
                     );
                 }
 
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -1733,15 +1693,14 @@ impl Interpreter {
                         },
                     ));
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set DurationFormat.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &duration_format_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = duration_format_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -1754,8 +1713,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/intl/listformat.rs
+++ b/src/interpreter/builtins/intl/listformat.rs
@@ -37,7 +37,7 @@ fn string_list_from_iterable(
     interp: &mut Interpreter,
     iterable: &JsValue,
 ) -> Result<Vec<String>, JsValue> {
-    if matches!(iterable, JsValue::Undefined) {
+    if iterable.is_undefined() {
         return Ok(Vec::new());
     }
 
@@ -49,7 +49,7 @@ fn string_list_from_iterable(
             None => break,
             Some(result) => {
                 let value = interp.iterator_value(&result)?;
-                if let JsValue::String(s) = &value {
+                if let Some(s) = value.as_string() {
                     list.push(s.to_rust_string());
                 } else {
                     let err = interp.create_type_error("Iterable yielded a non-string value");
@@ -125,19 +125,19 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let string_list = match string_list_from_iterable(interp, &iterable) {
                     Ok(list) => list,
                     Err(e) => return Completion::Throw(e),
                 };
 
                 if string_list.is_empty() {
-                    return Completion::Normal(JsValue::String(JsString::from_str("")));
+                    return Completion::Normal(JsValue::from_str(""));
                 }
 
                 let formatter = create_list_formatter(&locale, &list_type, &style);
                 let result = formatter.format_to_string(string_list.iter().map(|s| s.as_str()));
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -154,7 +154,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let iterable = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let iterable = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let string_list = match string_list_from_iterable(interp, &iterable) {
                     Ok(list) => list,
                     Err(e) => return Completion::Throw(e),
@@ -183,7 +183,7 @@ impl Interpreter {
                             .insert_property(
                                 "type".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&ptype)),
+                                    JsValue::from_str(&ptype),
                                     true,
                                     true,
                                     true,
@@ -195,14 +195,13 @@ impl Interpreter {
                             .insert_property(
                                 "value".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&value)),
+                                    JsValue::from_str(&value),
                                     true,
                                     true,
                                     true,
                                 ),
                             );
-                        let id = part_obj_id;
-                        JsValue::Object(crate::types::JsObject { id })
+                        JsValue::object(part_obj_id)
                     })
                     .collect();
 
@@ -232,9 +231,9 @@ impl Interpreter {
                 }
 
                 let props = vec![
-                    ("locale", JsValue::String(JsString::from_str(&locale))),
-                    ("type", JsValue::String(JsString::from_str(&list_type))),
-                    ("style", JsValue::String(JsString::from_str(&style))),
+                    ("locale", JsValue::from_str(&locale)),
+                    ("type", JsValue::from_str(&list_type)),
+                    ("style", JsValue::from_str(&style)),
                 ];
                 for (key, val) in props {
                     interp
@@ -246,7 +245,7 @@ impl Interpreter {
                         );
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
+                Completion::Normal(JsValue::object(result_id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -256,7 +255,7 @@ impl Interpreter {
         self.realm_mut().intl_list_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let list_format_ctor = self.create_function(JsFunction::constructor(
@@ -269,8 +268,8 @@ impl Interpreter {
                     );
                 }
 
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -338,15 +337,14 @@ impl Interpreter {
                         style,
                     }));
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set ListFormat.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &list_format_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = list_format_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -359,8 +357,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),
@@ -398,8 +396,8 @@ fn extract_list_format_data(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(String, String, String), JsValue> {
-    if let JsValue::Object(o) = this
-        && let Some(cell) = interp.get_object_cell(o.id)
+    if let Some(o) = this.as_object_id()
+        && let Some(cell) = interp.get_object_cell(o)
     {
         let b = cell.borrow();
         if let Some(IntlData::ListFormat {

--- a/src/interpreter/builtins/intl/locale.rs
+++ b/src/interpreter/builtins/intl/locale.rs
@@ -165,7 +165,7 @@ fn create_locale_object_from_icu(interp: &mut Interpreter, locale: &IcuLocale) -
         .class_name = "Intl.Locale".to_string();
     interp.get_object_cell_expect(obj_id).borrow_mut().kind =
         crate::interpreter::types::ObjectKind::Intl(Box::new(build_intl_data_from_locale(locale)));
-    JsValue::Object(crate::types::JsObject { id: obj_id })
+    JsValue::object(obj_id)
 }
 
 fn get_locale_intl_data_field<F>(
@@ -177,8 +177,8 @@ fn get_locale_intl_data_field<F>(
 where
     F: FnOnce(&IntlData) -> Completion,
 {
-    if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(o) = this.as_object_id()
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let b = obj.borrow();
         if let Some(data @ IntlData::Locale { .. }) = b.intl_data() {
@@ -235,7 +235,7 @@ impl Interpreter {
                             result.push('-');
                             result.push_str(v);
                         }
-                        Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                        Completion::Normal(JsValue::from_str(&result))
                     } else {
                         unreachable!()
                     }
@@ -257,8 +257,8 @@ impl Interpreter {
                 get_locale_intl_data_field(interp, this, "calendar", |data| {
                     if let IntlData::Locale { calendar, .. } = data {
                         Completion::Normal(match calendar {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -281,8 +281,8 @@ impl Interpreter {
                 get_locale_intl_data_field(interp, this, "caseFirst", |data| {
                     if let IntlData::Locale { case_first, .. } = data {
                         Completion::Normal(match case_first {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -305,8 +305,8 @@ impl Interpreter {
                 get_locale_intl_data_field(interp, this, "collation", |data| {
                     if let IntlData::Locale { collation, .. } = data {
                         Completion::Normal(match collation {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -329,8 +329,8 @@ impl Interpreter {
                 get_locale_intl_data_field(interp, this, "hourCycle", |data| {
                     if let IntlData::Locale { hour_cycle, .. } = data {
                         Completion::Normal(match hour_cycle {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -352,7 +352,7 @@ impl Interpreter {
             |interp, this, _args| {
                 get_locale_intl_data_field(interp, this, "language", |data| {
                     if let IntlData::Locale { language, .. } = data {
-                        Completion::Normal(JsValue::String(JsString::from_str(language)))
+                        Completion::Normal(JsValue::from_str(language))
                     } else {
                         unreachable!()
                     }
@@ -377,8 +377,8 @@ impl Interpreter {
                     } = data
                     {
                         Completion::Normal(match numbering_system {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -400,7 +400,7 @@ impl Interpreter {
             |interp, this, _args| {
                 get_locale_intl_data_field(interp, this, "numeric", |data| {
                     if let IntlData::Locale { numeric, .. } = data {
-                        Completion::Normal(JsValue::Boolean(numeric.unwrap_or(false)))
+                        Completion::Normal(JsValue::boolean(numeric.unwrap_or(false)))
                     } else {
                         unreachable!()
                     }
@@ -422,8 +422,8 @@ impl Interpreter {
                 get_locale_intl_data_field(interp, this, "region", |data| {
                     if let IntlData::Locale { region, .. } = data {
                         Completion::Normal(match region {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -446,8 +446,8 @@ impl Interpreter {
                 get_locale_intl_data_field(interp, this, "script", |data| {
                     if let IntlData::Locale { script, .. } = data {
                         Completion::Normal(match script {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -470,8 +470,8 @@ impl Interpreter {
                 get_locale_intl_data_field(interp, this, "variants", |data| {
                     if let IntlData::Locale { variants, .. } = data {
                         Completion::Normal(match variants {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -497,8 +497,8 @@ impl Interpreter {
                     } = data
                     {
                         Completion::Normal(match first_day_of_week {
-                            Some(s) => JsValue::String(JsString::from_str(s)),
-                            None => JsValue::Undefined,
+                            Some(s) => JsValue::from_str(s),
+                            None => JsValue::UNDEFINED,
                         })
                     } else {
                         unreachable!()
@@ -522,7 +522,7 @@ impl Interpreter {
             |interp, this, _args| {
                 get_locale_intl_data_field(interp, this, "toString", |data| {
                     if let IntlData::Locale { tag, .. } = data {
-                        Completion::Normal(JsValue::String(JsString::from_str(tag)))
+                        Completion::Normal(JsValue::from_str(tag))
                     } else {
                         unreachable!()
                     }
@@ -540,7 +540,7 @@ impl Interpreter {
             |interp, this, _args| {
                 get_locale_intl_data_field(interp, this, "toJSON", |data| {
                     if let IntlData::Locale { tag, .. } = data {
-                        Completion::Normal(JsValue::String(JsString::from_str(tag)))
+                        Completion::Normal(JsValue::from_str(tag))
                     } else {
                         unreachable!()
                     }
@@ -556,8 +556,8 @@ impl Interpreter {
             "maximize".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let tag_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let tag_opt = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale { tag, .. }) = b.intl_data() {
                             Some(tag.clone())
@@ -584,9 +584,7 @@ impl Interpreter {
                         Err(_) => {
                             // For tags ICU4X can't parse (like "posix"),
                             // maximize returns the same tag
-                            return Completion::Normal(JsValue::Object(crate::types::JsObject {
-                                id: o.id,
-                            }));
+                            return Completion::Normal(JsValue::object(o));
                         }
                     }
                 }
@@ -604,8 +602,8 @@ impl Interpreter {
             "minimize".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let tag_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let tag_opt = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale { tag, .. }) = b.intl_data() {
                             Some(tag.clone())
@@ -630,9 +628,7 @@ impl Interpreter {
                             ));
                         }
                         Err(_) => {
-                            return Completion::Normal(JsValue::Object(crate::types::JsObject {
-                                id: o.id,
-                            }));
+                            return Completion::Normal(JsValue::object(o));
                         }
                     }
                 }
@@ -652,8 +648,8 @@ impl Interpreter {
             "getCalendars".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let cal_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let cal_opt = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale { calendar, .. }) = b.intl_data() {
                             Some(calendar.clone())
@@ -669,9 +665,9 @@ impl Interpreter {
                             )),
                         };
                     let calendars = if let Some(ca) = cal {
-                        vec![JsValue::String(JsString::from_str(&ca))]
+                        vec![JsValue::from_str(&ca)]
                     } else {
-                        vec![JsValue::String(JsString::from_str("gregory"))]
+                        vec![JsValue::from_str("gregory")]
                     };
                     return Completion::Normal(interp.create_array(calendars));
                 }
@@ -689,8 +685,8 @@ impl Interpreter {
             "getCollations".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let col_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let col_opt = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale { collation, .. }) = b.intl_data() {
                             Some(collation.clone())
@@ -706,12 +702,12 @@ impl Interpreter {
                     };
                     let collations = if let Some(co) = col {
                         if co == "standard" || co == "search" {
-                            vec![JsValue::String(JsString::from_str("emoji"))]
+                            vec![JsValue::from_str("emoji")]
                         } else {
-                            vec![JsValue::String(JsString::from_str(&co))]
+                            vec![JsValue::from_str(&co)]
                         }
                     } else {
-                        vec![JsValue::String(JsString::from_str("emoji"))]
+                        vec![JsValue::from_str("emoji")]
                     };
                     return Completion::Normal(interp.create_array(collations));
                 }
@@ -729,8 +725,8 @@ impl Interpreter {
             "getHourCycles".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let snapshot = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let snapshot = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale {
                             hour_cycle,
@@ -752,7 +748,7 @@ impl Interpreter {
                         }
                     };
                     let cycles = if let Some(h) = hc {
-                        vec![JsValue::String(JsString::from_str(&h))]
+                        vec![JsValue::from_str(&h)]
                     } else {
                         let h12_regions = ["US", "CA", "AU", "NZ", "PH", "IN", "EG", "SA", "CO", "PK", "MY"];
                         let default = if let Some(ref r) = region {
@@ -760,7 +756,7 @@ impl Interpreter {
                         } else {
                             "h23"
                         };
-                        vec![JsValue::String(JsString::from_str(default))]
+                        vec![JsValue::from_str(default)]
                     };
                     return Completion::Normal(interp.create_array(cycles));
                 }
@@ -780,8 +776,8 @@ impl Interpreter {
             "getNumberingSystems".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let nu_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let nu_opt = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale {
                             numbering_system,
@@ -802,9 +798,9 @@ impl Interpreter {
                         }
                     };
                     let systems = if let Some(n) = nu {
-                        vec![JsValue::String(JsString::from_str(&n))]
+                        vec![JsValue::from_str(&n)]
                     } else {
-                        vec![JsValue::String(JsString::from_str("latn"))]
+                        vec![JsValue::from_str("latn")]
                     };
                     return Completion::Normal(interp.create_array(systems));
                 }
@@ -824,8 +820,8 @@ impl Interpreter {
             "getTextInfo".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let tag_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let tag_opt = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale { tag, .. }) = b.intl_data() {
                             Some(tag.clone())
@@ -864,16 +860,14 @@ impl Interpreter {
                         .insert_property(
                             "direction".to_string(),
                             PropertyDescriptor::data(
-                                JsValue::String(JsString::from_str(direction)),
+                                JsValue::from_str(direction),
                                 true,
                                 true,
                                 true,
                             ),
                         );
                     let info_id = info_obj_id;
-                    return Completion::Normal(JsValue::Object(crate::types::JsObject {
-                        id: info_id,
-                    }));
+                    return Completion::Normal(JsValue::object(info_id));
                 }
                 Completion::Throw(interp.create_type_error(
                     "Intl.Locale.prototype.getTextInfo requires an Intl.Locale object",
@@ -889,8 +883,8 @@ impl Interpreter {
             "getTimeZones".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let region_opt = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let region_opt = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale { region, .. }) = b.intl_data() {
                             Some(region.clone())
@@ -906,15 +900,12 @@ impl Interpreter {
                             )),
                         };
                     if region.is_none() {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
 
                     let region_str = region.unwrap();
                     let tzs = get_timezones_for_region(&region_str);
-                    let values: Vec<JsValue> = tzs
-                        .iter()
-                        .map(|tz| JsValue::String(JsString::from_str(tz)))
-                        .collect();
+                    let values: Vec<JsValue> = tzs.iter().map(|tz| JsValue::from_str(tz)).collect();
                     return Completion::Normal(interp.create_array(values));
                 }
                 Completion::Throw(interp.create_type_error(
@@ -931,8 +922,8 @@ impl Interpreter {
             "getWeekInfo".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this {
-                    let snapshot = interp.get_object_cell(o.id).and_then(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let snapshot = interp.get_object_cell(o).and_then(|cell| {
                         let b = cell.borrow();
                         if let Some(IntlData::Locale {
                             tag,
@@ -1010,7 +1001,7 @@ impl Interpreter {
                         .insert_property(
                             "firstDay".to_string(),
                             PropertyDescriptor::data(
-                                JsValue::Number(first_day as f64),
+                                JsValue::number(first_day as f64),
                                 true,
                                 true,
                                 true,
@@ -1018,7 +1009,7 @@ impl Interpreter {
                         );
                     let weekend_values: Vec<JsValue> = weekend_days
                         .iter()
-                        .map(|&d| JsValue::Number(d as f64))
+                        .map(|&d| JsValue::number(d as f64))
                         .collect();
                     let weekend_arr = interp.create_array(weekend_values);
                     interp
@@ -1029,9 +1020,7 @@ impl Interpreter {
                             PropertyDescriptor::data(weekend_arr, true, true, true),
                         );
                     let info_id = info_obj_id;
-                    return Completion::Normal(JsValue::Object(crate::types::JsObject {
-                        id: info_id,
-                    }));
+                    return Completion::Normal(JsValue::object(info_id));
                 }
                 Completion::Throw(interp.create_type_error(
                     "Intl.Locale.prototype.getWeekInfo requires an Intl.Locale object",
@@ -1046,7 +1035,7 @@ impl Interpreter {
         self.realm_mut().intl_locale_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let locale_ctor = self.create_function(JsFunction::constructor(
@@ -1059,21 +1048,18 @@ impl Interpreter {
                     );
                 }
 
-                let tag_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let tag_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // Step 7: If Type(tag) is not String or Object, throw a TypeError
-                match &tag_arg {
-                    JsValue::String(_) | JsValue::Object(_) => {}
-                    _ => {
-                        return Completion::Throw(interp.create_type_error(
-                            "First argument to Intl.Locale must be a string or object",
-                        ));
-                    }
+                if !tag_arg.is_string() && !tag_arg.is_object() {
+                    return Completion::Throw(interp.create_type_error(
+                        "First argument to Intl.Locale must be a string or object",
+                    ));
                 }
 
                 // If tag_arg is an Intl.Locale, get its tag string
-                let tag_string = if let JsValue::Object(o) = &tag_arg {
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                let tag_string = if let Some(o) = tag_arg.as_object_id() {
+                    if let Some(obj) = interp.get_object_cell(o) {
                         let b = obj.borrow();
                         if let Some(IntlData::Locale { tag, .. }) = b.intl_data() {
                             tag.clone()
@@ -1123,20 +1109,19 @@ impl Interpreter {
                 }
 
                 // Apply options if provided
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 if !options_arg.is_undefined() {
                     let options = match interp.intl_coerce_options_to_object(&options_arg) {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
 
-                    if let JsValue::Object(o) = &options {
+                    if let Some(o) = options.as_object_id() {
                         // language override
-                        let lang_val = match interp.get_object_property(o.id, "language", &options)
-                        {
+                        let lang_val = match interp.get_object_property(o, "language", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         if !lang_val.is_undefined() {
                             let lang_str = match interp.to_string_value(&lang_val) {
@@ -1154,11 +1139,10 @@ impl Interpreter {
                         }
 
                         // script override
-                        let script_val = match interp.get_object_property(o.id, "script", &options)
-                        {
+                        let script_val = match interp.get_object_property(o, "script", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         if !script_val.is_undefined() {
                             let script_str = match interp.to_string_value(&script_val) {
@@ -1176,11 +1160,10 @@ impl Interpreter {
                         }
 
                         // region override
-                        let region_val = match interp.get_object_property(o.id, "region", &options)
-                        {
+                        let region_val = match interp.get_object_property(o, "region", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         if !region_val.is_undefined() {
                             let region_str = match interp.to_string_value(&region_val) {
@@ -1198,12 +1181,12 @@ impl Interpreter {
                         }
 
                         // variants override
-                        let variants_val =
-                            match interp.get_object_property(o.id, "variants", &options) {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
-                            };
+                        let variants_val = match interp.get_object_property(o, "variants", &options)
+                        {
+                            Completion::Normal(v) => v,
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => JsValue::UNDEFINED,
+                        };
                         if !variants_val.is_undefined() {
                             let variants_str = match interp.to_string_value(&variants_val) {
                                 Ok(s) => s,
@@ -1249,10 +1232,10 @@ impl Interpreter {
                         }
 
                         // calendar (ca)
-                        let cal_val = match interp.get_object_property(o.id, "calendar", &options) {
+                        let cal_val = match interp.get_object_property(o, "calendar", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         if !cal_val.is_undefined() {
                             let s = match interp.to_string_value(&cal_val) {
@@ -1269,11 +1252,10 @@ impl Interpreter {
                         }
 
                         // collation (co)
-                        let col_val = match interp.get_object_property(o.id, "collation", &options)
-                        {
+                        let col_val = match interp.get_object_property(o, "collation", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         if !col_val.is_undefined() {
                             let s = match interp.to_string_value(&col_val) {
@@ -1290,12 +1272,12 @@ impl Interpreter {
                         }
 
                         // firstDayOfWeek (fw)
-                        let fw_val =
-                            match interp.get_object_property(o.id, "firstDayOfWeek", &options) {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
-                            };
+                        let fw_val = match interp.get_object_property(o, "firstDayOfWeek", &options)
+                        {
+                            Completion::Normal(v) => v,
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => JsValue::UNDEFINED,
+                        };
                         if !fw_val.is_undefined() {
                             let fw_string = match interp.to_string_value(&fw_val) {
                                 Ok(s) => s,
@@ -1320,10 +1302,10 @@ impl Interpreter {
                         }
 
                         // hourCycle (hc)
-                        let hc_val = match interp.get_object_property(o.id, "hourCycle", &options) {
+                        let hc_val = match interp.get_object_property(o, "hourCycle", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         if !hc_val.is_undefined() {
                             let s = match interp.to_string_value(&hc_val) {
@@ -1340,10 +1322,10 @@ impl Interpreter {
                         }
 
                         // caseFirst (kf)
-                        let kf_val = match interp.get_object_property(o.id, "caseFirst", &options) {
+                        let kf_val = match interp.get_object_property(o, "caseFirst", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                         if !kf_val.is_undefined() {
                             let s = match interp.to_string_value(&kf_val) {
@@ -1360,12 +1342,11 @@ impl Interpreter {
                         }
 
                         // numeric (kn)
-                        let numeric_val =
-                            match interp.get_object_property(o.id, "numeric", &options) {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
-                            };
+                        let numeric_val = match interp.get_object_property(o, "numeric", &options) {
+                            Completion::Normal(v) => v,
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => JsValue::UNDEFINED,
+                        };
                         if !numeric_val.is_undefined() {
                             let b = interp.to_boolean_val(&numeric_val);
                             let kn_val = if b { "true" } else { "false" };
@@ -1374,10 +1355,10 @@ impl Interpreter {
 
                         // numberingSystem (nu)
                         let nu_val =
-                            match interp.get_object_property(o.id, "numberingSystem", &options) {
+                            match interp.get_object_property(o, "numberingSystem", &options) {
                                 Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
                         if !nu_val.is_undefined() {
                             let s = match interp.to_string_value(&nu_val) {
@@ -1428,7 +1409,7 @@ impl Interpreter {
                             numbering_system: None,
                             first_day_of_week: None,
                         }));
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                    Completion::Normal(JsValue::object(obj_id))
                 } else {
                     // Canonicalize again after applying options
                     let canonicalizer = LocaleCanonicalizer::new_extended();
@@ -1448,16 +1429,15 @@ impl Interpreter {
                         crate::interpreter::types::ObjectKind::Intl(Box::new(
                             build_intl_data_from_locale(&locale),
                         ));
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                    Completion::Normal(JsValue::object(obj_id))
                 }
             },
         ));
 
         // Set Locale.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &locale_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = locale_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -1470,8 +1450,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/intl/mod.rs
+++ b/src/interpreter/builtins/intl/mod.rs
@@ -26,13 +26,11 @@ impl Interpreter {
             "getCanonicalLocales".to_string(),
             1,
             |interp: &mut Interpreter, _this: &JsValue, args: &[JsValue]| {
-                let locales = args.first().unwrap_or(&JsValue::Undefined);
+                let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
                 match interp.intl_canonicalize_locale_list(locales) {
                     Ok(list) => {
-                        let values: Vec<JsValue> = list
-                            .into_iter()
-                            .map(|s| JsValue::String(JsString::from_str(&s)))
-                            .collect();
+                        let values: Vec<JsValue> =
+                            list.into_iter().map(|s| JsValue::from_str(&s)).collect();
                         Completion::Normal(interp.create_array(values))
                     }
                     Err(e) => Completion::Throw(e),
@@ -260,10 +258,7 @@ impl Interpreter {
                     }
                 };
 
-                let js_values: Vec<JsValue> = values
-                    .into_iter()
-                    .map(|s| JsValue::String(JsString::from_str(s)))
-                    .collect();
+                let js_values: Vec<JsValue> = values.into_iter().map(JsValue::from_str).collect();
                 Completion::Normal(interp.create_array(js_values))
             },
         ));
@@ -301,7 +296,7 @@ impl Interpreter {
         // Intl.DurationFormat
         self.setup_intl_duration_format(intl_obj_id);
 
-        let intl_val = JsValue::Object(crate::types::JsObject { id: intl_id });
+        let intl_val = JsValue::object(intl_id);
         self.realm()
             .global_env
             .borrow_mut()
@@ -419,14 +414,14 @@ impl Interpreter {
         &mut self,
         locales: &JsValue,
     ) -> Result<Vec<String>, JsValue> {
-        if matches!(locales, JsValue::Undefined) {
+        if locales.is_undefined() {
             return Ok(Vec::new());
         }
 
         let mut seen = Vec::new();
 
         // Step 3: If Type(locales) is String or locales has [[InitializedLocale]]
-        if let JsValue::String(s) = locales {
+        if let Some(s) = locales.as_string() {
             let tag = s.to_rust_string();
             match tag.parse::<IcuLocale>() {
                 Ok(mut locale) => {
@@ -448,8 +443,8 @@ impl Interpreter {
         }
 
         // Check if locales is an Intl.Locale object itself (treat as single-element list)
-        if let JsValue::Object(o) = locales
-            && let Some(cell) = self.get_object_cell(o.id)
+        if let Some(o) = locales.as_object_id()
+            && let Some(cell) = self.get_object_cell(o)
         {
             let b = cell.borrow();
             if let Some(IntlData::Locale { tag, .. }) = b.intl_data() {
@@ -466,14 +461,14 @@ impl Interpreter {
             _ => return Ok(Vec::new()),
         };
 
-        let len_val = if let JsValue::Object(o) = &obj {
-            match self.get_object_property(o.id, "length", &obj) {
+        let len_val = if let Some(o) = obj.as_object_id() {
+            match self.get_object_property(o, "length", &obj) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             }
         } else {
-            JsValue::Undefined
+            JsValue::UNDEFINED
         };
 
         // Step 5: Let len be ? ToLength(? Get(O, "length")).
@@ -491,8 +486,8 @@ impl Interpreter {
             let key = i.to_string();
 
             // Step 7b: Let kPresent be ? HasProperty(O, Pk).
-            let k_present = if let JsValue::Object(o) = &obj {
-                self.proxy_has_property(o.id, &key)?
+            let k_present = if let Some(o) = obj.as_object_id() {
+                self.proxy_has_property(o, &key)?
             } else {
                 false
             };
@@ -503,27 +498,24 @@ impl Interpreter {
             }
 
             // Step 7c.i: Let kValue be ? Get(O, Pk).
-            let k_value = if let JsValue::Object(o) = &obj {
-                match self.get_object_property(o.id, &key, &obj) {
+            let k_value = if let Some(o) = obj.as_object_id() {
+                match self.get_object_property(o, &key, &obj) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 }
             } else {
-                JsValue::Undefined
+                JsValue::UNDEFINED
             };
 
             // Step 7c.ii: If Type(kValue) is not String or Object, throw TypeError.
-            match &k_value {
-                JsValue::String(_) | JsValue::Object(_) => {}
-                _ => {
-                    return Err(self.create_type_error("Language tag must be a string or object"));
-                }
+            if !k_value.is_string() && !k_value.is_object() {
+                return Err(self.create_type_error("Language tag must be a string or object"));
             }
 
             // Step 7c.iii-iv: If kValue has [[InitializedLocale]], use [[Locale]] directly
-            let tag = if let JsValue::Object(o) = &k_value {
-                let cached = self.get_object_cell(o.id).and_then(|cell| {
+            let tag = if let Some(o) = k_value.as_object_id() {
+                let cached = self.get_object_cell(o).and_then(|cell| {
                     if let Some(IntlData::Locale { tag, .. }) = cell.borrow().intl_data() {
                         Some(tag.clone())
                     } else {
@@ -535,7 +527,7 @@ impl Interpreter {
                 } else {
                     self.to_string_value(&k_value)?
                 }
-            } else if let JsValue::String(s) = &k_value {
+            } else if let Some(s) = k_value.as_string() {
                 s.to_rust_string()
             } else {
                 unreachable!()
@@ -571,13 +563,13 @@ impl Interpreter {
         &mut self,
         options: &JsValue,
     ) -> Result<JsValue, JsValue> {
-        if matches!(options, JsValue::Undefined) {
+        if options.is_undefined() {
             let obj_id = self.create_object_id();
             self.get_object_cell_expect(obj_id)
                 .borrow_mut()
                 .prototype_id = None; // ObjectCreate(null)
             let id = obj_id;
-            return Ok(JsValue::Object(crate::types::JsObject { id }));
+            return Ok(JsValue::object(id));
         }
         match self.to_object(options) {
             Completion::Normal(v) => Ok(v),
@@ -585,7 +577,7 @@ impl Interpreter {
             _ => {
                 let obj_id = self.create_object_id();
                 let id = obj_id;
-                Ok(JsValue::Object(crate::types::JsObject { id }))
+                Ok(JsValue::object(id))
             }
         }
     }
@@ -595,15 +587,15 @@ impl Interpreter {
         &mut self,
         options: &JsValue,
     ) -> Result<JsValue, JsValue> {
-        if matches!(options, JsValue::Undefined) {
+        if options.is_undefined() {
             let obj_id = self.create_object_id();
             self.get_object_cell_expect(obj_id)
                 .borrow_mut()
                 .prototype_id = None;
             let id = obj_id;
-            return Ok(JsValue::Object(crate::types::JsObject { id }));
+            return Ok(JsValue::object(id));
         }
-        if matches!(options, JsValue::Object(_)) {
+        if options.is_object() {
             return Ok(options.clone());
         }
         Err(self.create_type_error("Options argument must be an object or undefined"))
@@ -617,17 +609,17 @@ impl Interpreter {
         valid_values: &[&str],
         fallback: Option<&str>,
     ) -> Result<Option<String>, JsValue> {
-        let value = if let JsValue::Object(o) = options {
-            match self.get_object_property(o.id, property, options) {
+        let value = if let Some(o) = options.as_object_id() {
+            match self.get_object_property(o, property, options) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             }
         } else {
-            JsValue::Undefined
+            JsValue::UNDEFINED
         };
 
-        if matches!(value, JsValue::Undefined) {
+        if value.is_undefined() {
             return Ok(fallback.map(|s| s.to_string()));
         }
 
@@ -652,17 +644,17 @@ impl Interpreter {
         maximum: f64,
         fallback: Option<f64>,
     ) -> Result<Option<f64>, JsValue> {
-        let value = if let JsValue::Object(o) = options {
-            match self.get_object_property(o.id, property, options) {
+        let value = if let Some(o) = options.as_object_id() {
+            match self.get_object_property(o, property, options) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             }
         } else {
-            JsValue::Undefined
+            JsValue::UNDEFINED
         };
 
-        if matches!(value, JsValue::Undefined) {
+        if value.is_undefined() {
             return Ok(fallback);
         }
 
@@ -683,15 +675,15 @@ impl Interpreter {
         requested: &[String],
         options: &JsValue,
     ) -> Result<JsValue, JsValue> {
-        if !matches!(options, JsValue::Undefined) {
+        if !options.is_undefined() {
             // Step 1: If options is not undefined, let options be ToObject(options)
-            if matches!(options, JsValue::Null) {
+            if options.is_null() {
                 return Err(self.create_type_error("Cannot convert null to object"));
             }
             let opts = match self.to_object(options) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
             // Validate localeMatcher option
             let _matcher = self.intl_get_option(
@@ -708,7 +700,7 @@ impl Interpreter {
                 let locale: IcuLocale = tag.parse().ok()?;
                 let canonical = locale.to_string();
                 if Self::intl_best_available_locale(&canonical) {
-                    Some(JsValue::String(JsString::from_str(&canonical)))
+                    Some(JsValue::from_str(&canonical))
                 } else {
                     None
                 }
@@ -842,7 +834,7 @@ impl Interpreter {
         }
         let id = self.next_symbol_id;
         self.next_symbol_id += 1;
-        let sym = JsValue::Symbol(crate::types::JsSymbol::new(
+        let sym = JsValue::symbol(crate::types::JsSymbol::new(
             id,
             Some(crate::types::JsString::from_str(
                 "IntlLegacyConstructedSymbol",
@@ -866,7 +858,7 @@ impl Interpreter {
         self.new_target = Some(nf_ctor.clone());
         let result = self.call_function(
             &nf_ctor,
-            &JsValue::Undefined,
+            &JsValue::UNDEFINED,
             &[locales.clone(), options.clone()],
         );
         self.new_target = old_new_target;
@@ -882,13 +874,13 @@ impl Interpreter {
         nf: &JsValue,
         value: &JsValue,
     ) -> Completion {
-        if let JsValue::Object(nf_obj) = nf {
-            let format_fn = match self.get_object_property(nf_obj.id, "format", nf) {
+        if let Some(nf_obj) = nf.as_object_id() {
+            let format_fn = match self.get_object_property(nf_obj, "format", nf) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Completion::Throw(e),
                 _ => return Completion::Throw(self.create_type_error("format not found")),
             };
-            self.call_function(&format_fn, &JsValue::Undefined, std::slice::from_ref(value))
+            self.call_function(&format_fn, &JsValue::UNDEFINED, std::slice::from_ref(value))
         } else {
             Completion::Throw(self.create_type_error("NumberFormat is not an object"))
         }

--- a/src/interpreter/builtins/intl/numberformat.rs
+++ b/src/interpreter/builtins/intl/numberformat.rs
@@ -12,9 +12,9 @@ use icu::locale::Locale as IcuLocale;
 /// %Intl%.[[FallbackSymbol]] via the ordinary [[Get]] (so Proxy traps fire)
 /// and require the result to carry the slot; otherwise throw a TypeError.
 fn unwrap_nf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsValue> {
-    if let JsValue::Object(o) = this {
+    if let Some(o) = this.as_object_id() {
         let has_slot = interp
-            .get_object_cell(o.id)
+            .get_object_cell(o)
             .map(|c| matches!(c.borrow().intl_data(), Some(IntlData::NumberFormat { .. })))
             .unwrap_or(false);
         if has_slot {
@@ -23,23 +23,23 @@ fn unwrap_nf(interp: &mut Interpreter, this: &JsValue) -> Result<JsValue, JsValu
         if let Some(ctor) = interp.realm().intl_number_format_ctor.clone() {
             // ? OrdinaryHasInstance(%NumberFormat%, this) — propagate abrupt completions.
             let is_instance = match interp.ordinary_has_instance(&ctor, this) {
-                Completion::Normal(JsValue::Boolean(b)) => b,
+                Completion::Normal(v) => v.as_boolean().unwrap_or(false),
                 Completion::Throw(e) => return Err(e),
                 _ => false,
             };
             if is_instance {
-                let key = match interp.intl_fallback_symbol() {
-                    JsValue::Symbol(s) => s.to_property_key(),
-                    _ => unreachable!(),
+                let key = match interp.intl_fallback_symbol().as_symbol() {
+                    Some(s) => s.to_property_key(),
+                    None => unreachable!(),
                 };
-                let fb = match interp.get_object_property(o.id, &key, this) {
+                let fb = match interp.get_object_property(o, &key, this) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
-                    _ => JsValue::Undefined,
+                    _ => JsValue::UNDEFINED,
                 };
-                if let JsValue::Object(fo) = &fb {
+                if let Some(fo) = fb.as_object_id() {
                     let fb_has_slot = interp
-                        .get_object_cell(fo.id)
+                        .get_object_cell(fo)
                         .map(|c| {
                             matches!(c.borrow().intl_data(), Some(IntlData::NumberFormat { .. }))
                         })
@@ -1190,16 +1190,14 @@ fn wrap_style(
 }
 
 fn intl_to_number(interp: &mut Interpreter, val: &JsValue) -> Result<f64, JsValue> {
-    match val {
-        JsValue::BigInt(bi) => {
-            let s = bi.value.to_string();
-            Ok(s.parse::<f64>().unwrap_or(if s.starts_with('-') {
-                f64::NEG_INFINITY
-            } else {
-                f64::INFINITY
-            }))
-        }
-        _ => interp.to_number_value(val),
+    if let Some(s) = val.with_bigint(|b| b.to_string()) {
+        Ok(s.parse::<f64>().unwrap_or(if s.starts_with('-') {
+            f64::NEG_INFINITY
+        } else {
+            f64::INFINITY
+        }))
+    } else {
+        interp.to_number_value(val)
     }
 }
 
@@ -2976,14 +2974,14 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 let this = &recv;
-                if let JsValue::Object(o) = this {
+                if let Some(o) = this.as_object_id() {
                     enum Probe {
                         NotNf,
                         Cached(JsValue),
                         Uncached,
                     }
                     let probe = interp
-                        .get_object_cell(o.id)
+                        .get_object_cell(o)
                         .map(|cell| {
                             let b = cell.borrow();
                             if !matches!(b.intl_data(), Some(IntlData::NumberFormat { .. })) {
@@ -3010,7 +3008,7 @@ impl Interpreter {
                     }
 
                     let nf_data = {
-                        if let Some(obj) = interp.get_object_cell(o.id) {
+                        if let Some(obj) = interp.get_object_cell(o) {
                             let b = obj.borrow();
                             b.intl_data().cloned()
                         } else {
@@ -3046,22 +3044,24 @@ impl Interpreter {
                             "".to_string(),
                             1,
                             move |interp2, _this2, args2| {
-                                let val = args2.first().cloned().unwrap_or(JsValue::Undefined);
+                                let val = args2.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
-                                let use_string_decimal = if let JsValue::BigInt(bi) = &val {
-                                    let abs_str = bi.value.to_string().trim_start_matches('-').to_string();
+                                let use_string_decimal = if let Some(bi_str) = val.with_bigint(|b| b.to_string()) {
+                                    let abs_str = bi_str.trim_start_matches('-').to_string();
                                     abs_str.len() > 15
-                                } else if let JsValue::String(s) = &val {
+                                } else if let Some(s) = val.as_string() {
                                     string_needs_decimal_precision(&s.to_string())
                                 } else {
                                     false
                                 };
 
                                 let result = if use_string_decimal {
-                                    let s = match &val {
-                                        JsValue::BigInt(bi) => bi.value.to_string(),
-                                        JsValue::String(s) => s.to_string(),
-                                        _ => unreachable!(),
+                                    let s = if let Some(bi_str) = val.with_bigint(|b| b.to_string()) {
+                                        bi_str
+                                    } else if let Some(s) = val.as_string() {
+                                        s.to_string()
+                                    } else {
+                                        unreachable!()
                                     };
                                     format_number_from_string_decimal(
                                         &s, &locale, &style, &currency, &currency_display,
@@ -3085,11 +3085,11 @@ impl Interpreter {
                                     )
                                 };
 
-                                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                                Completion::Normal(JsValue::from_str(&result))
                             },
                         ));
 
-                        if let Some(obj) = interp.get_object_cell(o.id) {
+                        if let Some(obj) = interp.get_object_cell(o) {
                             obj.borrow_mut().properties.insert(
                                 crate::interpreter::key_intern::intern_key("[[BoundFormat]]"),
                                 PropertyDescriptor::data(format_fn.clone(), false, false, false),
@@ -3121,9 +3121,9 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 let this = &recv;
-                if let JsValue::Object(o) = this {
+                if let Some(o) = this.as_object_id() {
                     let nf_data = {
-                        if let Some(obj) = interp.get_object_cell(o.id) {
+                        if let Some(obj) = interp.get_object_cell(o) {
                             let b = obj.borrow();
                             b.intl_data().cloned()
                         } else {
@@ -3155,7 +3155,7 @@ impl Interpreter {
                         trailing_zero_display,
                     }) = nf_data
                     {
-                        let val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let num = match intl_to_number(interp, &val) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
@@ -3202,7 +3202,7 @@ impl Interpreter {
                                     .insert_property(
                                         "type".to_string(),
                                         PropertyDescriptor::data(
-                                            JsValue::String(JsString::from_str(&typ)),
+                                            JsValue::from_str(&typ),
                                             true,
                                             true,
                                             true,
@@ -3214,14 +3214,13 @@ impl Interpreter {
                                     .insert_property(
                                         "value".to_string(),
                                         PropertyDescriptor::data(
-                                            JsValue::String(JsString::from_str(&val)),
+                                            JsValue::from_str(&val),
                                             true,
                                             true,
                                             true,
                                         ),
                                     );
-                                let id = part_obj_id;
-                                JsValue::Object(crate::types::JsObject { id })
+                                JsValue::object(part_obj_id)
                             })
                             .collect();
 
@@ -3247,25 +3246,24 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 let this = &recv;
-                if let JsValue::Object(o) = this {
-                    let nf_present = interp.get_object_cell(o.id).is_some_and(|cell| {
+                if let Some(o) = this.as_object_id() {
+                    let nf_present = interp.get_object_cell(o).is_some_and(|cell| {
                         matches!(
                             cell.borrow().intl_data(),
                             Some(IntlData::NumberFormat { .. })
                         )
                     });
                     if nf_present {
-                        let start = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        let end = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                        let start = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                        let end = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
-                        if matches!(start, JsValue::Undefined) || matches!(end, JsValue::Undefined)
-                        {
+                        if start.is_undefined() || end.is_undefined() {
                             return Completion::Throw(
                                 interp.create_type_error("start and end must not be undefined"),
                             );
                         }
 
-                        let start_str = if let JsValue::String(s) = &start {
+                        let start_str = if let Some(s) = start.as_string() {
                             let sv = s.to_string();
                             if string_needs_decimal_precision(&sv) {
                                 Some(sv)
@@ -3275,7 +3273,7 @@ impl Interpreter {
                         } else {
                             None
                         };
-                        let end_str = if let JsValue::String(s) = &end {
+                        let end_str = if let Some(s) = end.as_string() {
                             let sv = s.to_string();
                             if string_needs_decimal_precision(&sv) {
                                 Some(sv)
@@ -3302,7 +3300,7 @@ impl Interpreter {
                         }
 
                         let nf_data = interp
-                            .get_object_cell(o.id)
+                            .get_object_cell(o)
                             .and_then(|cell| cell.borrow().intl_data().cloned());
 
                         if let Some(IntlData::NumberFormat {
@@ -3425,9 +3423,7 @@ impl Interpreter {
                                 &currency_display,
                                 &sign_display,
                             );
-                            return Completion::Normal(JsValue::String(JsString::from_str(
-                                &result,
-                            )));
+                            return Completion::Normal(JsValue::from_str(&result));
                         }
                     }
                 }
@@ -3450,15 +3446,15 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 let this = &recv;
-                if let JsValue::Object(o) = this {
+                if let Some(o) = this.as_object_id() {
                     let nf_present = interp
-                        .get_object_cell(o.id)
+                        .get_object_cell(o)
                         .is_some_and(|cell| matches!(cell.borrow().intl_data(), Some(IntlData::NumberFormat { .. })));
                     if nf_present {
-                        let start = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        let end = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                        let start = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                        let end = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
-                        if matches!(start, JsValue::Undefined) || matches!(end, JsValue::Undefined) {
+                        if start.is_undefined() || end.is_undefined() {
                             return Completion::Throw(interp.create_type_error(
                                 "start and end must not be undefined",
                             ));
@@ -3480,7 +3476,7 @@ impl Interpreter {
                         }
 
                         let nf_data = interp
-                            .get_object_cell(o.id)
+                            .get_object_cell(o)
                             .and_then(|cell| cell.borrow().intl_data().cloned());
 
                         if let Some(IntlData::NumberFormat {
@@ -3535,18 +3531,17 @@ impl Interpreter {
                                 }
                                 interp.get_object_cell_expect(part_id).borrow_mut().insert_property(
                                     "type".to_string(),
-                                    PropertyDescriptor::data(JsValue::String(JsString::from_str(typ)), true, true, true),
+                                    PropertyDescriptor::data(JsValue::from_str(typ), true, true, true),
                                 );
                                 interp.get_object_cell_expect(part_id).borrow_mut().insert_property(
                                     "value".to_string(),
-                                    PropertyDescriptor::data(JsValue::String(JsString::from_str(val)), true, true, true),
+                                    PropertyDescriptor::data(JsValue::from_str(val), true, true, true),
                                 );
                                 interp.get_object_cell_expect(part_id).borrow_mut().insert_property(
                                     "source".to_string(),
-                                    PropertyDescriptor::data(JsValue::String(JsString::from_str(source)), true, true, true),
+                                    PropertyDescriptor::data(JsValue::from_str(source), true, true, true),
                                 );
-                                let id = part_id;
-                                JsValue::Object(crate::types::JsObject { id })
+                                JsValue::object(part_id)
                             };
 
                             let mut result_parts = Vec::new();
@@ -3619,8 +3614,8 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
                 let this = &recv;
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = this.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -3659,103 +3654,82 @@ impl Interpreter {
                         }
 
                         let mut props: Vec<(&str, JsValue)> = vec![
-                            ("locale", JsValue::String(JsString::from_str(&locale))),
-                            (
-                                "numberingSystem",
-                                JsValue::String(JsString::from_str(&numbering_system)),
-                            ),
-                            ("style", JsValue::String(JsString::from_str(&style))),
+                            ("locale", JsValue::from_str(&locale)),
+                            ("numberingSystem", JsValue::from_str(&numbering_system)),
+                            ("style", JsValue::from_str(&style)),
                         ];
 
                         if style == "currency" {
                             if let Some(ref c) = currency {
-                                props.push(("currency", JsValue::String(JsString::from_str(c))));
+                                props.push(("currency", JsValue::from_str(c)));
                             }
                             if let Some(ref cd) = currency_display {
-                                props.push((
-                                    "currencyDisplay",
-                                    JsValue::String(JsString::from_str(cd)),
-                                ));
+                                props.push(("currencyDisplay", JsValue::from_str(cd)));
                             }
                             if let Some(ref cs) = currency_sign {
-                                props.push((
-                                    "currencySign",
-                                    JsValue::String(JsString::from_str(cs)),
-                                ));
+                                props.push(("currencySign", JsValue::from_str(cs)));
                             }
                         }
 
                         if style == "unit" {
                             if let Some(ref u) = unit {
-                                props.push(("unit", JsValue::String(JsString::from_str(u))));
+                                props.push(("unit", JsValue::from_str(u)));
                             }
                             if let Some(ref ud) = unit_display {
-                                props
-                                    .push(("unitDisplay", JsValue::String(JsString::from_str(ud))));
+                                props.push(("unitDisplay", JsValue::from_str(ud)));
                             }
                         }
 
                         props.push((
                             "minimumIntegerDigits",
-                            JsValue::Number(minimum_integer_digits as f64),
+                            JsValue::number(minimum_integer_digits as f64),
                         ));
                         props.push((
                             "minimumFractionDigits",
-                            JsValue::Number(minimum_fraction_digits as f64),
+                            JsValue::number(minimum_fraction_digits as f64),
                         ));
                         props.push((
                             "maximumFractionDigits",
-                            JsValue::Number(maximum_fraction_digits as f64),
+                            JsValue::number(maximum_fraction_digits as f64),
                         ));
 
                         if let Some(min_sd) = minimum_significant_digits {
                             props
-                                .push(("minimumSignificantDigits", JsValue::Number(min_sd as f64)));
+                                .push(("minimumSignificantDigits", JsValue::number(min_sd as f64)));
                         }
                         if let Some(max_sd) = maximum_significant_digits {
                             props
-                                .push(("maximumSignificantDigits", JsValue::Number(max_sd as f64)));
+                                .push(("maximumSignificantDigits", JsValue::number(max_sd as f64)));
                         }
 
                         // useGrouping: spec says return a string or boolean
                         let ug_val = match use_grouping.as_str() {
-                            "true" => JsValue::String(JsString::from_str("auto")),
-                            "false" => JsValue::Boolean(false),
-                            "auto" | "always" | "min2" => {
-                                JsValue::String(JsString::from_str(&use_grouping))
-                            }
-                            _ => JsValue::String(JsString::from_str(&use_grouping)),
+                            "true" => JsValue::from_str("auto"),
+                            "false" => JsValue::FALSE,
+                            "auto" | "always" | "min2" => JsValue::from_str(&use_grouping),
+                            _ => JsValue::from_str(&use_grouping),
                         };
                         props.push(("useGrouping", ug_val));
 
-                        props.push(("notation", JsValue::String(JsString::from_str(&notation))));
+                        props.push(("notation", JsValue::from_str(&notation)));
 
                         if notation == "compact"
                             && let Some(ref cd) = compact_display
                         {
-                            props.push(("compactDisplay", JsValue::String(JsString::from_str(cd))));
+                            props.push(("compactDisplay", JsValue::from_str(cd)));
                         }
 
-                        props.push((
-                            "signDisplay",
-                            JsValue::String(JsString::from_str(&sign_display)),
-                        ));
+                        props.push(("signDisplay", JsValue::from_str(&sign_display)));
 
                         props.push((
                             "roundingIncrement",
-                            JsValue::Number(rounding_increment as f64),
+                            JsValue::number(rounding_increment as f64),
                         ));
-                        props.push((
-                            "roundingMode",
-                            JsValue::String(JsString::from_str(&rounding_mode)),
-                        ));
-                        props.push((
-                            "roundingPriority",
-                            JsValue::String(JsString::from_str(&rounding_priority)),
-                        ));
+                        props.push(("roundingMode", JsValue::from_str(&rounding_mode)));
+                        props.push(("roundingPriority", JsValue::from_str(&rounding_priority)));
                         props.push((
                             "trailingZeroDisplay",
-                            JsValue::String(JsString::from_str(&trailing_zero_display)),
+                            JsValue::from_str(&trailing_zero_display),
                         ));
 
                         for (key, val) in props {
@@ -3768,9 +3742,7 @@ impl Interpreter {
                                 );
                         }
 
-                        return Completion::Normal(JsValue::Object(crate::types::JsObject {
-                            id: result_id,
-                        }));
+                        return Completion::Normal(JsValue::object(result_id));
                     }
                 }
                 Completion::Throw(interp.create_type_error(
@@ -3785,15 +3757,15 @@ impl Interpreter {
         self.realm_mut().intl_number_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let nf_ctor = self.create_function(JsFunction::constructor(
             "NumberFormat".to_string(),
             0,
             move |interp, _this, args| {
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -4023,10 +3995,10 @@ impl Interpreter {
                 };
 
                 // Read raw options to detect presence
-                let raw_min_fd = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "minimumFractionDigits", &options) {
+                let raw_min_fd = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "minimumFractionDigits", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -4039,10 +4011,10 @@ impl Interpreter {
                     None
                 };
 
-                let raw_max_fd = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "maximumFractionDigits", &options) {
+                let raw_max_fd = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "maximumFractionDigits", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -4055,10 +4027,10 @@ impl Interpreter {
                     None
                 };
 
-                let raw_min_sd = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "minimumSignificantDigits", &options) {
+                let raw_min_sd = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "minimumSignificantDigits", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -4071,10 +4043,10 @@ impl Interpreter {
                     None
                 };
 
-                let raw_max_sd = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "maximumSignificantDigits", &options) {
+                let raw_max_sd = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "maximumSignificantDigits", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -4091,10 +4063,10 @@ impl Interpreter {
                 let has_fd = raw_min_fd.is_some() || raw_max_fd.is_some();
 
                 // Read roundingIncrement raw value (read in spec order)
-                let raw_rounding_increment = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "roundingIncrement", &options) {
+                let raw_rounding_increment = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "roundingIncrement", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -4403,45 +4375,48 @@ impl Interpreter {
                 // useGrouping: GetStringOrBooleanOption per spec
                 let use_grouping_default = if notation == "compact" { "min2" } else { "auto" };
                 let use_grouping = {
-                    let ug_val = if let JsValue::Object(o) = &options {
-                        match interp.get_object_property(o.id, "useGrouping", &options) {
+                    let ug_val = if let Some(o) = options.as_object_id() {
+                        match interp.get_object_property(o, "useGrouping", &options) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         }
                     } else {
-                        JsValue::Undefined
+                        JsValue::UNDEFINED
                     };
 
-                    match &ug_val {
-                        JsValue::Undefined => use_grouping_default.to_string(),
-                        JsValue::Boolean(true) => "always".to_string(),
-                        _ => {
-                            // Step 4-5: ToBoolean(value) - if false, return false
-                            let val_bool = match &ug_val {
-                                JsValue::Boolean(false) | JsValue::Null => false,
-                                JsValue::Number(n) => *n != 0.0 && !n.is_nan(),
-                                JsValue::String(s) => !s.to_rust_string().is_empty(),
-                                _ => true,
+                    if ug_val.is_undefined() {
+                        use_grouping_default.to_string()
+                    } else if ug_val.as_boolean() == Some(true) {
+                        "always".to_string()
+                    } else {
+                        // Step 4-5: ToBoolean(value) - if false, return false
+                        let val_bool = if ug_val.as_boolean() == Some(false) || ug_val.is_null() {
+                            false
+                        } else if let Some(n) = ug_val.as_number() {
+                            n != 0.0 && !n.is_nan()
+                        } else if let Some(s) = ug_val.as_string() {
+                            !s.to_rust_string().is_empty()
+                        } else {
+                            true
+                        };
+                        if !val_bool {
+                            "false".to_string()
+                        } else {
+                            // Step 6: ToString(value)
+                            let sv = match interp.to_string_value(&ug_val) {
+                                Ok(s) => s,
+                                Err(e) => return Completion::Throw(e),
                             };
-                            if !val_bool {
-                                "false".to_string()
+                            // Step 7: "true"/"false" strings -> fallback
+                            if sv == "true" || sv == "false" {
+                                use_grouping_default.to_string()
+                            } else if sv == "auto" || sv == "always" || sv == "min2" {
+                                sv
                             } else {
-                                // Step 6: ToString(value)
-                                let sv = match interp.to_string_value(&ug_val) {
-                                    Ok(s) => s,
-                                    Err(e) => return Completion::Throw(e),
-                                };
-                                // Step 7: "true"/"false" strings -> fallback
-                                if sv == "true" || sv == "false" {
-                                    use_grouping_default.to_string()
-                                } else if sv == "auto" || sv == "always" || sv == "min2" {
-                                    sv
-                                } else {
-                                    return Completion::Throw(interp.create_range_error(
-                                        "Invalid useGrouping value",
-                                    ));
-                                }
+                                return Completion::Throw(interp.create_range_error(
+                                    "Invalid useGrouping value",
+                                ));
                             }
                         }
                     }
@@ -4516,71 +4491,68 @@ impl Interpreter {
                 // freshly-initialized formatter under %Intl%.[[FallbackSymbol]]
                 // and return the receiver instead of a fresh object.
                 if interp.new_target.is_none()
-                    && let JsValue::Object(recv) = _this
+                    && let Some(recv_id) = _this.as_object_id()
+                    && let Some(ctor) = interp.realm().intl_number_format_ctor.clone()
                 {
-                    let recv_id = recv.id;
-                    if let Some(ctor) = interp.realm().intl_number_format_ctor.clone() {
-                        // ? OrdinaryHasInstance(%NumberFormat%, this) — an abrupt
-                        // completion (e.g. revoked Proxy / throwing getPrototypeOf
-                        // trap) must propagate, not fall through to a fresh object.
-                        let is_instance = match interp.ordinary_has_instance(&ctor, _this) {
-                            Completion::Normal(JsValue::Boolean(b)) => b,
-                            Completion::Throw(e) => return Completion::Throw(e),
-                            _ => false,
+                    // ? OrdinaryHasInstance(%NumberFormat%, this) — an abrupt
+                    // completion (e.g. revoked Proxy / throwing getPrototypeOf
+                    // trap) must propagate, not fall through to a fresh object.
+                    let is_instance = match interp.ordinary_has_instance(&ctor, _this) {
+                        Completion::Normal(v) => v.as_boolean().unwrap_or(false),
+                        Completion::Throw(e) => return Completion::Throw(e),
+                        _ => false,
+                    };
+                    if is_instance {
+                        let key = match interp.intl_fallback_symbol().as_symbol() {
+                            Some(s) => s.to_property_key(),
+                            None => unreachable!(),
                         };
-                        if is_instance {
-                            let key = match interp.intl_fallback_symbol() {
-                                JsValue::Symbol(s) => s.to_property_key(),
-                                _ => unreachable!(),
-                            };
-                            let desc = crate::interpreter::types::PropertyDescriptor::data(
-                                JsValue::Object(crate::types::JsObject { id: obj_id }),
-                                false,
-                                false,
-                                false,
-                            );
-                            // ? DefinePropertyOrThrow(this, [[FallbackSymbol]], desc):
-                            // route through the receiver's [[DefineOwnProperty]] so a
-                            // Proxy's defineProperty trap fires and a later [[Get]] in
-                            // Unwrap can observe the chained formatter.
-                            let is_proxy = interp
-                                .get_object_cell(recv_id)
-                                .map(|c| {
-                                    let b = c.borrow();
-                                    b.is_proxy() || b.is_proxy_revoked()
-                                })
-                                .unwrap_or(false);
-                            let defined = if is_proxy {
-                                let desc_val = interp.from_property_descriptor(&desc);
-                                match interp.proxy_define_own_property(recv_id, key, &desc_val) {
-                                    Ok(b) => b,
-                                    Err(e) => return Completion::Throw(e),
-                                }
-                            } else {
-                                interp
-                                    .get_object_cell_expect(recv_id)
-                                    .borrow_mut()
-                                    .define_own_property(key, desc)
-                            };
-                            if !defined {
-                                return Completion::Throw(interp.create_type_error(
-                                    "Cannot define [[FallbackSymbol]] property on receiver",
-                                ));
+                        let desc = crate::interpreter::types::PropertyDescriptor::data(
+                            JsValue::object(obj_id),
+                            false,
+                            false,
+                            false,
+                        );
+                        // ? DefinePropertyOrThrow(this, [[FallbackSymbol]], desc):
+                        // route through the receiver's [[DefineOwnProperty]] so a
+                        // Proxy's defineProperty trap fires and a later [[Get]] in
+                        // Unwrap can observe the chained formatter.
+                        let is_proxy = interp
+                            .get_object_cell(recv_id)
+                            .map(|c| {
+                                let b = c.borrow();
+                                b.is_proxy() || b.is_proxy_revoked()
+                            })
+                            .unwrap_or(false);
+                        let defined = if is_proxy {
+                            let desc_val = interp.from_property_descriptor(&desc);
+                            match interp.proxy_define_own_property(recv_id, key, &desc_val) {
+                                Ok(b) => b,
+                                Err(e) => return Completion::Throw(e),
                             }
-                            return Completion::Normal(_this.clone());
+                        } else {
+                            interp
+                                .get_object_cell_expect(recv_id)
+                                .borrow_mut()
+                                .define_own_property(key, desc)
+                        };
+                        if !defined {
+                            return Completion::Throw(interp.create_type_error(
+                                "Cannot define [[FallbackSymbol]] property on receiver",
+                            ));
                         }
+                        return Completion::Normal(_this.clone());
                     }
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set NumberFormat.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &nf_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = nf_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -4593,8 +4565,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/intl/pluralrules.rs
+++ b/src/interpreter/builtins/intl/pluralrules.rs
@@ -183,8 +183,8 @@ impl Interpreter {
             "select".to_string(),
             1,
             |interp, this, args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = this.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -198,16 +198,14 @@ impl Interpreter {
                         ..
                     }) = data
                     {
-                        let n_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let n_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let n = match interp.to_number_value(&n_val) {
                             Ok(v) => v,
                             Err(e) => return Completion::Throw(e),
                         };
 
                         if n.is_nan() {
-                            return Completion::Normal(JsValue::String(JsString::from_str(
-                                "other",
-                            )));
+                            return Completion::Normal(JsValue::from_str("other"));
                         }
 
                         let base = base_locale(&locale);
@@ -224,9 +222,7 @@ impl Interpreter {
                         let rules = match IcuPluralRules::try_new(prefs, opts) {
                             Ok(r) => r,
                             Err(_) => {
-                                return Completion::Normal(JsValue::String(JsString::from_str(
-                                    "other",
-                                )));
+                                return Completion::Normal(JsValue::from_str("other"));
                             }
                         };
 
@@ -236,9 +232,7 @@ impl Interpreter {
                             compact_display.as_deref(),
                         );
                         let cat = rules.category_for(operands);
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            plural_category_to_str(cat),
-                        )));
+                        return Completion::Normal(JsValue::from_str(plural_category_to_str(cat)));
                     }
                 }
                 Completion::Throw(interp.create_type_error(
@@ -255,8 +249,8 @@ impl Interpreter {
             "selectRange".to_string(),
             2,
             |interp, this, args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = this.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -270,15 +264,15 @@ impl Interpreter {
                         ..
                     }) = data
                     {
-                        let start_val = args.first().cloned().unwrap_or(JsValue::Undefined);
-                        let end_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                        let start_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                        let end_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
-                        if matches!(start_val, JsValue::Undefined) {
+                        if start_val.is_undefined() {
                             return Completion::Throw(
                                 interp.create_type_error("start is undefined"),
                             );
                         }
-                        if matches!(end_val, JsValue::Undefined) {
+                        if end_val.is_undefined() {
                             return Completion::Throw(interp.create_type_error("end is undefined"));
                         }
 
@@ -311,9 +305,7 @@ impl Interpreter {
                         let range_rules = match PluralRulesWithRanges::try_new(prefs, opts) {
                             Ok(r) => r,
                             Err(_) => {
-                                return Completion::Normal(JsValue::String(JsString::from_str(
-                                    "other",
-                                )));
+                                return Completion::Normal(JsValue::from_str("other"));
                             }
                         };
 
@@ -328,9 +320,7 @@ impl Interpreter {
                             compact_display.as_deref(),
                         );
                         let cat = range_rules.category_for_range(start_ops, end_ops);
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            plural_category_to_str(cat),
-                        )));
+                        return Completion::Normal(JsValue::from_str(plural_category_to_str(cat)));
                     }
                 }
                 Completion::Throw(interp.create_type_error(
@@ -347,8 +337,8 @@ impl Interpreter {
             "resolvedOptions".to_string(),
             0,
             |interp, this, _args| {
-                if let JsValue::Object(o) = this
-                    && let Some(obj) = interp.get_object_cell(o.id)
+                if let Some(o) = this.as_object_id()
+                    && let Some(obj) = interp.get_object_cell(o)
                 {
                     let data = {
                         let b = obj.borrow();
@@ -389,7 +379,7 @@ impl Interpreter {
                             .insert_property(
                                 "locale".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&locale)),
+                                    JsValue::from_str(&locale),
                                     true,
                                     true,
                                     true,
@@ -401,7 +391,7 @@ impl Interpreter {
                             .insert_property(
                                 "type".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&plural_type)),
+                                    JsValue::from_str(&plural_type),
                                     true,
                                     true,
                                     true,
@@ -413,7 +403,7 @@ impl Interpreter {
                             .insert_property(
                                 "notation".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&notation)),
+                                    JsValue::from_str(&notation),
                                     true,
                                     true,
                                     true,
@@ -427,7 +417,7 @@ impl Interpreter {
                                 .insert_property(
                                     "compactDisplay".to_string(),
                                     PropertyDescriptor::data(
-                                        JsValue::String(JsString::from_str(cd)),
+                                        JsValue::from_str(cd),
                                         true,
                                         true,
                                         true,
@@ -440,7 +430,7 @@ impl Interpreter {
                             .insert_property(
                                 "minimumIntegerDigits".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::Number(minimum_integer_digits as f64),
+                                    JsValue::number(minimum_integer_digits as f64),
                                     true,
                                     true,
                                     true,
@@ -455,7 +445,7 @@ impl Interpreter {
                                 .insert_property(
                                     "minimumFractionDigits".to_string(),
                                     PropertyDescriptor::data(
-                                        JsValue::Number(minimum_fraction_digits as f64),
+                                        JsValue::number(minimum_fraction_digits as f64),
                                         true,
                                         true,
                                         true,
@@ -467,7 +457,7 @@ impl Interpreter {
                                 .insert_property(
                                     "maximumFractionDigits".to_string(),
                                     PropertyDescriptor::data(
-                                        JsValue::Number(maximum_fraction_digits as f64),
+                                        JsValue::number(maximum_fraction_digits as f64),
                                         true,
                                         true,
                                         true,
@@ -482,7 +472,7 @@ impl Interpreter {
                                     .insert_property(
                                         "minimumFractionDigits".to_string(),
                                         PropertyDescriptor::data(
-                                            JsValue::Number(minimum_fraction_digits as f64),
+                                            JsValue::number(minimum_fraction_digits as f64),
                                             true,
                                             true,
                                             true,
@@ -494,7 +484,7 @@ impl Interpreter {
                                     .insert_property(
                                         "maximumFractionDigits".to_string(),
                                         PropertyDescriptor::data(
-                                            JsValue::Number(maximum_fraction_digits as f64),
+                                            JsValue::number(maximum_fraction_digits as f64),
                                             true,
                                             true,
                                             true,
@@ -510,7 +500,7 @@ impl Interpreter {
                                 .insert_property(
                                     "minimumSignificantDigits".to_string(),
                                     PropertyDescriptor::data(
-                                        JsValue::Number(min_sd as f64),
+                                        JsValue::number(min_sd as f64),
                                         true,
                                         true,
                                         true,
@@ -524,7 +514,7 @@ impl Interpreter {
                                 .insert_property(
                                     "maximumSignificantDigits".to_string(),
                                     PropertyDescriptor::data(
-                                        JsValue::Number(max_sd as f64),
+                                        JsValue::number(max_sd as f64),
                                         true,
                                         true,
                                         true,
@@ -534,10 +524,8 @@ impl Interpreter {
 
                         // pluralCategories
                         let cats = get_plural_categories_sorted(&locale, &plural_type);
-                        let cat_values: Vec<JsValue> = cats
-                            .iter()
-                            .map(|c| JsValue::String(JsString::from_str(c)))
-                            .collect();
+                        let cat_values: Vec<JsValue> =
+                            cats.iter().map(|c| JsValue::from_str(c)).collect();
                         let cat_array = interp.create_array(cat_values);
                         interp
                             .get_object_cell_expect(result_id)
@@ -553,7 +541,7 @@ impl Interpreter {
                             .insert_property(
                                 "roundingIncrement".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::Number(rounding_increment as f64),
+                                    JsValue::number(rounding_increment as f64),
                                     true,
                                     true,
                                     true,
@@ -565,7 +553,7 @@ impl Interpreter {
                             .insert_property(
                                 "roundingMode".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&rounding_mode)),
+                                    JsValue::from_str(&rounding_mode),
                                     true,
                                     true,
                                     true,
@@ -577,7 +565,7 @@ impl Interpreter {
                             .insert_property(
                                 "roundingPriority".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&rounding_priority)),
+                                    JsValue::from_str(&rounding_priority),
                                     true,
                                     true,
                                     true,
@@ -589,16 +577,14 @@ impl Interpreter {
                             .insert_property(
                                 "trailingZeroDisplay".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&trailing_zero_display)),
+                                    JsValue::from_str(&trailing_zero_display),
                                     true,
                                     true,
                                     true,
                                 ),
                             );
 
-                        return Completion::Normal(JsValue::Object(crate::types::JsObject {
-                            id: result_id,
-                        }));
+                        return Completion::Normal(JsValue::object(result_id));
                     }
                 }
                 Completion::Throw(interp.create_type_error(
@@ -613,7 +599,7 @@ impl Interpreter {
         self.realm_mut().intl_plural_rules_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let ctor = self.create_function(JsFunction::constructor(
@@ -626,8 +612,8 @@ impl Interpreter {
                     ));
                 }
 
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -704,10 +690,10 @@ impl Interpreter {
                 };
 
                 // Read raw digit options to detect presence
-                let raw_min_fd = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "minimumFractionDigits", &options) {
+                let raw_min_fd = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "minimumFractionDigits", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -720,10 +706,10 @@ impl Interpreter {
                     None
                 };
 
-                let raw_max_fd = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "maximumFractionDigits", &options) {
+                let raw_max_fd = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "maximumFractionDigits", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -736,12 +722,10 @@ impl Interpreter {
                     None
                 };
 
-                let raw_min_sd = if let JsValue::Object(o) = &options {
-                    match interp
-                        .get_object_property(o.id, "minimumSignificantDigits", &options)
-                    {
+                let raw_min_sd = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "minimumSignificantDigits", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -754,12 +738,10 @@ impl Interpreter {
                     None
                 };
 
-                let raw_max_sd = if let JsValue::Object(o) = &options {
-                    match interp
-                        .get_object_property(o.id, "maximumSignificantDigits", &options)
-                    {
+                let raw_max_sd = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "maximumSignificantDigits", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -776,10 +758,10 @@ impl Interpreter {
                 let has_fd = raw_min_fd.is_some() || raw_max_fd.is_some();
 
                 // roundingIncrement
-                let raw_rounding_increment = if let JsValue::Object(o) = &options {
-                    match interp.get_object_property(o.id, "roundingIncrement", &options) {
+                let raw_rounding_increment = if let Some(o) = options.as_object_id() {
+                    match interp.get_object_property(o, "roundingIncrement", &options) {
                         Completion::Normal(v) => {
-                            if matches!(v, JsValue::Undefined) {
+                            if v.is_undefined() {
                                 None
                             } else {
                                 Some(v)
@@ -1072,15 +1054,14 @@ impl Interpreter {
                     trailing_zero_display,
                 }));
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set PluralRules.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -1093,8 +1074,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/intl/relativetimeformat.rs
+++ b/src/interpreter/builtins/intl/relativetimeformat.rs
@@ -439,8 +439,8 @@ fn extract_rtf_data(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(String, String, String, String), JsValue> {
-    if let JsValue::Object(o) = this
-        && let Some(cell) = interp.get_object_cell(o.id)
+    if let Some(o) = this.as_object_id()
+        && let Some(cell) = interp.get_object_cell(o)
     {
         let b = cell.borrow();
         if let Some(IntlData::RelativeTimeFormat {
@@ -487,7 +487,7 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
 
-                    let value_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let value_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let value = match interp.to_number_value(&value_arg) {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
@@ -499,7 +499,7 @@ impl Interpreter {
                         ));
                     }
 
-                    let unit_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let unit_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let unit_str = match interp.to_string_value(&unit_arg) {
                         Ok(s) => s,
                         Err(e) => return Completion::Throw(e),
@@ -517,7 +517,7 @@ impl Interpreter {
 
                     let result =
                         replace_number_in_rtf_output(&locale, &ns, &style, unit, &numeric, value);
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::from_str(&result))
                 },
             ));
         self.get_object_cell_expect(proto_id)
@@ -534,7 +534,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let value_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let value_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let value = match interp.to_number_value(&value_arg) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
@@ -546,7 +546,7 @@ impl Interpreter {
                     ));
                 }
 
-                let unit_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let unit_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let unit_str = match interp.to_string_value(&unit_arg) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
@@ -584,7 +584,7 @@ impl Interpreter {
                             .insert_property(
                                 "type".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&ptype)),
+                                    JsValue::from_str(&ptype),
                                     true,
                                     true,
                                     true,
@@ -596,7 +596,7 @@ impl Interpreter {
                             .insert_property(
                                 "value".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&pvalue)),
+                                    JsValue::from_str(&pvalue),
                                     true,
                                     true,
                                     true,
@@ -609,15 +609,14 @@ impl Interpreter {
                                 .insert_property(
                                     "unit".to_string(),
                                     PropertyDescriptor::data(
-                                        JsValue::String(JsString::from_str(&u)),
+                                        JsValue::from_str(&u),
                                         true,
                                         true,
                                         true,
                                     ),
                                 );
                         }
-                        let id = part_obj_id;
-                        JsValue::Object(crate::types::JsObject { id })
+                        JsValue::object(part_obj_id)
                     })
                     .collect();
 
@@ -648,13 +647,10 @@ impl Interpreter {
                 }
 
                 let props = vec![
-                    ("locale", JsValue::String(JsString::from_str(&locale))),
-                    ("style", JsValue::String(JsString::from_str(&style))),
-                    ("numeric", JsValue::String(JsString::from_str(&numeric))),
-                    (
-                        "numberingSystem",
-                        JsValue::String(JsString::from_str(&numbering_system)),
-                    ),
+                    ("locale", JsValue::from_str(&locale)),
+                    ("style", JsValue::from_str(&style)),
+                    ("numeric", JsValue::from_str(&numeric)),
+                    ("numberingSystem", JsValue::from_str(&numbering_system)),
                 ];
                 for (key, val) in props {
                     interp
@@ -666,7 +662,7 @@ impl Interpreter {
                         );
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
+                Completion::Normal(JsValue::object(result_id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -676,7 +672,7 @@ impl Interpreter {
         self.realm_mut().intl_relative_time_format_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let rtf_ctor = self.create_function(JsFunction::constructor(
@@ -691,8 +687,8 @@ impl Interpreter {
                     );
                 }
 
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -855,15 +851,14 @@ impl Interpreter {
                         },
                     ));
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set RelativeTimeFormat.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &rtf_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = rtf_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -876,8 +871,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/intl/segmenter.rs
+++ b/src/interpreter/builtins/intl/segmenter.rs
@@ -104,7 +104,7 @@ fn create_segment_object(
         .insert_property(
             "segment".to_string(),
             PropertyDescriptor::data(
-                JsValue::String(JsString::from_vec(segment.to_vec())),
+                JsValue::string(JsString::from_vec(segment.to_vec())),
                 true,
                 true,
                 true,
@@ -115,7 +115,7 @@ fn create_segment_object(
         .borrow_mut()
         .insert_property(
             "index".to_string(),
-            PropertyDescriptor::data(JsValue::Number(index as f64), true, true, true),
+            PropertyDescriptor::data(JsValue::number(index as f64), true, true, true),
         );
     interp
         .get_object_cell_expect(obj_id)
@@ -123,7 +123,7 @@ fn create_segment_object(
         .insert_property(
             "input".to_string(),
             PropertyDescriptor::data(
-                JsValue::String(JsString::from_vec(input.to_vec())),
+                JsValue::string(JsString::from_vec(input.to_vec())),
                 true,
                 true,
                 true,
@@ -135,19 +135,18 @@ fn create_segment_object(
             .borrow_mut()
             .insert_property(
                 "isWordLike".to_string(),
-                PropertyDescriptor::data(JsValue::Boolean(wl), true, true, true),
+                PropertyDescriptor::data(JsValue::boolean(wl), true, true, true),
             );
     }
-    let id = obj_id;
-    JsValue::Object(crate::types::JsObject { id })
+    JsValue::object(obj_id)
 }
 
 fn extract_segmenter_data(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(String, String), JsValue> {
-    if let JsValue::Object(o) = this
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(o) = this.as_object_id()
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let b = obj.borrow();
         if let Some(IntlData::Segmenter {
@@ -186,7 +185,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let str_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let str_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let input_js = match interp.to_js_string(&str_arg) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
@@ -212,7 +211,7 @@ impl Interpreter {
                     .borrow_mut()
                     .insert_property(
                         "[[SegmenterInput]]".to_string(),
-                        PropertyDescriptor::data(JsValue::String(input_js), false, false, false),
+                        PropertyDescriptor::data(JsValue::string(input_js), false, false, false),
                     );
                 interp
                     .get_object_cell_expect(segments_obj_id)
@@ -220,7 +219,7 @@ impl Interpreter {
                     .insert_property(
                         "[[SegmenterGranularity]]".to_string(),
                         PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(&granularity)),
+                            JsValue::from_str(&granularity),
                             false,
                             false,
                             false,
@@ -231,16 +230,11 @@ impl Interpreter {
                     .borrow_mut()
                     .insert_property(
                         "[[SegmenterLocale]]".to_string(),
-                        PropertyDescriptor::data(
-                            JsValue::String(JsString::from_str(&locale)),
-                            false,
-                            false,
-                            false,
-                        ),
+                        PropertyDescriptor::data(JsValue::from_str(&locale), false, false, false),
                     );
 
                 let breaks_vals: Vec<JsValue> =
-                    breaks.iter().map(|&b| JsValue::Number(b as f64)).collect();
+                    breaks.iter().map(|&b| JsValue::number(b as f64)).collect();
                 let breaks_arr = interp.create_array(breaks_vals);
                 interp
                     .get_object_cell_expect(segments_obj_id)
@@ -256,8 +250,8 @@ impl Interpreter {
                     1,
                     |interp, this, args| {
                         // RequireInternalSlot(segments, [[SegmentsSegmenter]])
-                        let is_segments = if let JsValue::Object(o) = this {
-                            if let Some(obj) = interp.get_object_cell(o.id) {
+                        let is_segments = if let Some(o) = this.as_object_id() {
+                            if let Some(obj) = interp.get_object_cell(o) {
                                 let b = obj.borrow();
                                 b.class_name == "Segmenter Segments"
                                     && b.properties.contains_key("[[SegmenterInput]]")
@@ -273,7 +267,7 @@ impl Interpreter {
                             ));
                         }
 
-                        let idx_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                        let idx_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                         let idx = match interp.to_number_value(&idx_arg) {
                             Ok(n) => n,
                             Err(e) => return Completion::Throw(e),
@@ -287,35 +281,24 @@ impl Interpreter {
                         };
 
                         if idx < 0.0 {
-                            return Completion::Normal(JsValue::Undefined);
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
                         let idx = idx as usize;
 
-                        let (input_u16, granularity, breaks) = if let JsValue::Object(o) = this {
-                            if let Some(obj) = interp.get_object_cell(o.id) {
+                        let (input_u16, granularity, breaks) = if let Some(o) = this.as_object_id()
+                        {
+                            if let Some(obj) = interp.get_object_cell(o) {
                                 let b = obj.borrow();
                                 let input_u16 = b
                                     .properties
                                     .get("[[SegmenterInput]]")
                                     .and_then(|pd| pd.value.as_ref())
-                                    .and_then(|v| {
-                                        if let JsValue::String(s) = v {
-                                            Some(s.code_units.clone())
-                                        } else {
-                                            None
-                                        }
-                                    });
+                                    .and_then(|v| v.as_string().map(|s| s.code_units));
                                 let granularity = b
                                     .properties
                                     .get("[[SegmenterGranularity]]")
                                     .and_then(|pd| pd.value.as_ref())
-                                    .and_then(|v| {
-                                        if let JsValue::String(s) = v {
-                                            Some(s.to_rust_string())
-                                        } else {
-                                            None
-                                        }
-                                    });
+                                    .and_then(|v| v.as_string().map(|s| s.to_rust_string()));
                                 let breaks_val = b
                                     .properties
                                     .get("[[SegmenterBreaks]]")
@@ -323,14 +306,14 @@ impl Interpreter {
                                 drop(b);
 
                                 let mut break_points = Vec::new();
-                                if let Some(JsValue::Object(arr_obj)) = breaks_val
-                                    && let Some(arr) = interp.get_object_cell(arr_obj.id)
+                                if let Some(arr_obj) = breaks_val.and_then(|v| v.as_object_id())
+                                    && let Some(arr) = interp.get_object_cell(arr_obj)
                                 {
                                     let ab = arr.borrow();
                                     if let Some(elems) = ab.array_elements() {
                                         for elem in elems {
-                                            if let JsValue::Number(n) = elem {
-                                                break_points.push(*n as usize);
+                                            if let Some(n) = elem.as_number() {
+                                                break_points.push(n as usize);
                                             }
                                         }
                                     }
@@ -346,12 +329,12 @@ impl Interpreter {
 
                         let input_u16 = match input_u16 {
                             Some(s) => s,
-                            None => return Completion::Normal(JsValue::Undefined),
+                            None => return Completion::Normal(JsValue::UNDEFINED),
                         };
                         let granularity = granularity.unwrap_or_else(|| "grapheme".to_string());
 
                         if idx >= input_u16.len() {
-                            return Completion::Normal(JsValue::Undefined);
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
 
                         // Find the segment containing idx (UTF-16 index)
@@ -429,7 +412,7 @@ impl Interpreter {
                             .insert_property(
                                 "[[HasWordLike]]".to_string(),
                                 PropertyDescriptor::data(
-                                    JsValue::Boolean(has_word_like),
+                                    JsValue::boolean(has_word_like),
                                     false,
                                     false,
                                     false,
@@ -440,10 +423,10 @@ impl Interpreter {
                             "next".to_string(),
                             0,
                             |interp, this, _args| {
-                                if let JsValue::Object(o) = this
-                                    && interp.get_object_cell(o.id).is_some()
+                                if let Some(o) = this.as_object_id()
+                                    && interp.get_object_cell(o).is_some()
                                 {
-                                    let iter_id = o.id;
+                                    let iter_id = o;
                                     enum Step {
                                         Done,
                                         Yield {
@@ -462,7 +445,7 @@ impl Interpreter {
                                             .properties
                                             .get("[[HasWordLike]]")
                                             .and_then(|pd| pd.value.as_ref())
-                                            .map(|v| matches!(v, JsValue::Boolean(true)))
+                                            .map(|v| v.as_boolean() == Some(true))
                                             .unwrap_or(false);
                                         let mut b = cell.borrow_mut();
                                         if let Some(IteratorState::SegmentIterator {
@@ -494,7 +477,7 @@ impl Interpreter {
                                         Step::Done => {
                                             return Completion::Normal(
                                                 interp.create_iter_result_object(
-                                                    JsValue::Undefined,
+                                                    JsValue::UNDEFINED,
                                                     true,
                                                 ),
                                             );
@@ -523,7 +506,7 @@ impl Interpreter {
                                     }
                                 }
                                 Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::Undefined, true),
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 )
                             },
                         ));
@@ -532,8 +515,7 @@ impl Interpreter {
                             .borrow_mut()
                             .insert_builtin("next".to_string(), next_fn);
 
-                        let iter_id = iter_obj_id;
-                        Completion::Normal(JsValue::Object(crate::types::JsObject { id: iter_id }))
+                        Completion::Normal(JsValue::object(iter_obj_id))
                     },
                 ));
 
@@ -545,8 +527,7 @@ impl Interpreter {
                         PropertyDescriptor::data(iter_fn, true, false, true),
                     );
 
-                let segments_id = segments_obj_id;
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: segments_id }))
+                Completion::Normal(JsValue::object(segments_obj_id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -572,11 +553,8 @@ impl Interpreter {
                 }
 
                 let props = vec![
-                    ("locale", JsValue::String(JsString::from_str(&locale))),
-                    (
-                        "granularity",
-                        JsValue::String(JsString::from_str(&granularity)),
-                    ),
+                    ("locale", JsValue::from_str(&locale)),
+                    ("granularity", JsValue::from_str(&granularity)),
                 ];
                 for (key, val) in props {
                     interp
@@ -588,7 +566,7 @@ impl Interpreter {
                         );
                 }
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: result_id }))
+                Completion::Normal(JsValue::object(result_id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -598,7 +576,7 @@ impl Interpreter {
         self.realm_mut().intl_segmenter_prototype = Some(proto_id);
 
         // --- Constructor ---
-        let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+        let proto_val = JsValue::object(proto_id);
         let proto_clone_id = proto_id;
 
         let segmenter_ctor = self.create_function(JsFunction::constructor(
@@ -611,8 +589,8 @@ impl Interpreter {
                     );
                 }
 
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
 
                 let requested = match interp.intl_canonicalize_locale_list(&locales_arg) {
                     Ok(list) => list,
@@ -668,15 +646,14 @@ impl Interpreter {
                         granularity,
                     }));
 
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id: obj_id }))
+                Completion::Normal(JsValue::object(obj_id))
             },
         ));
 
         // Set Segmenter.prototype on constructor
-        if let JsValue::Object(ctor_ref) = &segmenter_ctor
-            && self.get_object_cell(ctor_ref.id).is_some()
+        if let Some(ctor_id) = segmenter_ctor.as_object_id()
+            && self.get_object_cell(ctor_id).is_some()
         {
-            let ctor_id = ctor_ref.id;
             self.get_object_cell_expect(ctor_id)
                 .borrow_mut()
                 .insert_property(
@@ -689,8 +666,8 @@ impl Interpreter {
                 "supportedLocalesOf".to_string(),
                 1,
                 |interp, _this, args| {
-                    let locales = args.first().unwrap_or(&JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales = args.first().unwrap_or(&JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let requested = match interp.intl_canonicalize_locale_list(locales) {
                         Ok(list) => list,
                         Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -54,11 +54,11 @@ impl Interpreter {
             "__host_write".to_string(),
             2,
             |interp, _this, args| {
-                let fd = match interp.to_number_value(args.first().unwrap_or(&JsValue::Undefined)) {
+                let fd = match interp.to_number_value(args.first().unwrap_or(&JsValue::UNDEFINED)) {
                     Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 };
-                let s = match interp.to_string_value(args.get(1).unwrap_or(&JsValue::Undefined)) {
+                let s = match interp.to_string_value(args.get(1).unwrap_or(&JsValue::UNDEFINED)) {
                     Ok(s) => s,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -73,7 +73,7 @@ impl Interpreter {
                     let _ = out.write_all(bytes);
                     let _ = out.flush();
                 }
-                Completion::Normal(JsValue::Number(written as f64))
+                Completion::Normal(JsValue::number(written as f64))
             },
         ));
         self.install_host_global("__host_write", write_fn);
@@ -94,7 +94,8 @@ impl Interpreter {
             1,
             |interp, _this, args| {
                 let code = match args.first() {
-                    None | Some(JsValue::Undefined) => 0,
+                    None => 0,
+                    Some(v) if v.is_undefined() => 0,
                     Some(v) => match interp.to_number_value(v) {
                         Ok(n) if n.is_finite() => n.trunc() as i64 as i32,
                         Ok(_) => 0,
@@ -119,7 +120,7 @@ impl Interpreter {
                     .host_clock_start
                     .map(|start| start.elapsed().as_nanos())
                     .unwrap_or(0);
-                Completion::Normal(JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(ns))))
+                Completion::Normal(JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(ns))))
             },
         ));
         self.install_host_global("__host_hrtime", hrtime_fn);
@@ -134,7 +135,7 @@ impl Interpreter {
             1,
             |interp, _this, args| {
                 let n_f = match interp
-                    .to_integer_or_infinity_value(args.first().unwrap_or(&JsValue::Undefined))
+                    .to_integer_or_infinity_value(args.first().unwrap_or(&JsValue::UNDEFINED))
                 {
                     Ok(n) => n,
                     Err(e) => return Completion::Throw(e),

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -70,7 +70,7 @@ fn to_relative_to_date(
         return Ok(None);
     }
     // For strings, handle ZonedDateTime-like strings specially
-    if let JsValue::String(s) = val {
+    if let Some(s) = val.as_string() {
         let raw = s.to_rust_string();
         // Reject year zero (-000000)
         if raw.starts_with("-000000") {
@@ -217,8 +217,8 @@ fn to_relative_to_date(
         }
     }
     // If the value is a Temporal object, handle directly (no property bag reading)
-    if let JsValue::Object(obj_ref) = val
-        && let Some(obj) = interp.get_object_cell(obj_ref.id)
+    if let Some(obj_ref) = val.as_object_id()
+        && let Some(obj) = interp.get_object_cell(obj_ref)
     {
         let td = obj.borrow().temporal_data().cloned();
         if let Some(super::TemporalData::ZonedDateTime {
@@ -253,7 +253,7 @@ fn to_relative_to_date(
     }
 
     // Property bag: read ALL fields in alphabetical order per spec PrepareTemporalFields.
-    if let JsValue::Object(_) = val {
+    if val.is_object() {
         // 1. calendar
         let cal_val = match get_prop(interp, val, "calendar") {
             Completion::Normal(v) => v,
@@ -1661,11 +1661,11 @@ impl Interpreter {
                 format!("get {name}"),
                 0,
                 move |interp, this, _args| {
-                    let snapshot = match &this {
-                        JsValue::Object(o) => interp
-                            .get_object_cell(o.id)
+                    let snapshot = match this.as_object_id() {
+                        Some(o) => interp
+                            .get_object_cell(o)
                             .map(|cell| cell.borrow().temporal_data().cloned()),
-                        _ => None,
+                        None => None,
                     };
                     match snapshot {
                         Some(Some(TemporalData::Duration {
@@ -1681,17 +1681,17 @@ impl Interpreter {
                             nanoseconds,
                         })) => {
                             let val = match name {
-                                "years" => JsValue::Number(years),
-                                "months" => JsValue::Number(months),
-                                "weeks" => JsValue::Number(weeks),
-                                "days" => JsValue::Number(days),
-                                "hours" => JsValue::Number(hours),
-                                "minutes" => JsValue::Number(minutes),
-                                "seconds" => JsValue::Number(seconds),
-                                "milliseconds" => JsValue::Number(milliseconds),
-                                "microseconds" => JsValue::Number(microseconds),
-                                "nanoseconds" => JsValue::Number(nanoseconds),
-                                "sign" => JsValue::Number(duration_sign(
+                                "years" => JsValue::number(years),
+                                "months" => JsValue::number(months),
+                                "weeks" => JsValue::number(weeks),
+                                "days" => JsValue::number(days),
+                                "hours" => JsValue::number(hours),
+                                "minutes" => JsValue::number(minutes),
+                                "seconds" => JsValue::number(seconds),
+                                "milliseconds" => JsValue::number(milliseconds),
+                                "microseconds" => JsValue::number(microseconds),
+                                "nanoseconds" => JsValue::number(nanoseconds),
+                                "sign" => JsValue::number(duration_sign(
                                     years,
                                     months,
                                     weeks,
@@ -1703,7 +1703,7 @@ impl Interpreter {
                                     microseconds,
                                     nanoseconds,
                                 ) as f64),
-                                "blank" => JsValue::Boolean(
+                                "blank" => JsValue::boolean(
                                     duration_sign(
                                         years,
                                         months,
@@ -1717,7 +1717,7 @@ impl Interpreter {
                                         nanoseconds,
                                     ) == 0,
                                 ),
-                                _ => JsValue::Undefined,
+                                _ => JsValue::UNDEFINED,
                             };
                             Completion::Normal(val)
                         }
@@ -1796,8 +1796,8 @@ impl Interpreter {
                     Err(c) => return c,
                 };
                 let (y, mo, w, d, h, mi, s, ms, us, ns) = fields;
-                let like = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(like, JsValue::Object(_)) {
+                let like = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !like.is_object() {
                     return Completion::Throw(
                         interp.create_type_error("Duration.with requires an object argument"),
                     );
@@ -1856,7 +1856,7 @@ impl Interpreter {
                 let (y, mo, w, d, h, mi, s, ms, us, ns) = fields;
                 let other = match to_temporal_duration_record(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(f) => f,
                     Err(c) => return c,
@@ -1901,7 +1901,7 @@ impl Interpreter {
                 let (y, mo, w, d, h, mi, s, ms, us, ns) = fields;
                 let other = match to_temporal_duration_record(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(f) => f,
                     Err(c) => return c,
@@ -1944,7 +1944,7 @@ impl Interpreter {
                     Err(c) => return c,
                 };
                 let (y, mo, w, d, h, mi, s, ms, us, ns) = fields;
-                let round_to = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let round_to = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if is_undefined(&round_to) {
                     return Completion::Throw(
                         interp.create_type_error("round requires options argument"),
@@ -2243,14 +2243,14 @@ impl Interpreter {
                     Err(c) => return c,
                 };
                 let (y, mo, w, d, h, mi, s, ms, us, ns) = fields;
-                let total_of = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let total_of = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if is_undefined(&total_of) {
                     return Completion::Throw(
                         interp.create_type_error("total requires options argument"),
                     );
                 }
 
-                let (unit, relative_to) = if let JsValue::String(ref su) = total_of {
+                let (unit, relative_to) = if let Some(su) = total_of.as_string() {
                     let su_str = su.to_rust_string();
                     let u = match temporal_unit_singular(&su_str) {
                         Some(u) => u,
@@ -2261,7 +2261,7 @@ impl Interpreter {
                         }
                     };
                     (u, None)
-                } else if matches!(total_of, JsValue::Object(_)) {
+                } else if total_of.is_object() {
                     // Per spec: get + process relativeTo first, then get + coerce unit
                     let rt = match get_prop(interp, &total_of, "relativeTo") {
                         Completion::Normal(v) => v,
@@ -2307,7 +2307,7 @@ impl Interpreter {
                     match total_relative_duration_zdt(
                         y, mo, w, d, h, mi, s, ms, us, ns, unit, by, bm, bd, ens, tz,
                     ) {
-                        Ok(result) => Completion::Normal(JsValue::Number(result)),
+                        Ok(result) => Completion::Normal(JsValue::number(result)),
                         Err(()) => Completion::Throw(interp.create_range_error(
                             "duration out of range when applied to relativeTo",
                         )),
@@ -2326,7 +2326,7 @@ impl Interpreter {
                         && us == 0.0
                         && ns == 0.0;
                     if is_zero {
-                        return Completion::Normal(JsValue::Number(0.0));
+                        return Completion::Normal(JsValue::number(0.0));
                     }
                     // Spec step 2: ISODateTimeWithinLimits on base at midnight
                     if !super::iso_date_time_within_limits(by, bm, bd, 0, 0, 0, 0, 0, 0) {
@@ -2337,7 +2337,7 @@ impl Interpreter {
                     match total_relative_duration(
                         y, mo, w, d, h, mi, s, ms, us, ns, unit, by, bm, bd,
                     ) {
-                        Ok(result) => Completion::Normal(JsValue::Number(result)),
+                        Ok(result) => Completion::Normal(JsValue::number(result)),
                         Err(()) => Completion::Throw(interp.create_range_error(
                             "duration out of range when applied to relativeTo",
                         )),
@@ -2352,7 +2352,7 @@ impl Interpreter {
                         + ns as i128;
                     let unit_ns = temporal_unit_length_ns(unit) as i128;
                     let result = divide_i128_to_f64(total_ns, unit_ns);
-                    Completion::Normal(JsValue::Number(result))
+                    Completion::Normal(JsValue::number(result))
                 }
             },
         ));
@@ -2394,7 +2394,7 @@ impl Interpreter {
                     Ok(s) => s,
                     Err(msg) => return Completion::Throw(interp.create_range_error(&msg)),
                 };
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2416,7 +2416,7 @@ impl Interpreter {
                         Ok(s) => s,
                         Err(msg) => return Completion::Throw(interp.create_range_error(&msg)),
                     };
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2442,22 +2442,22 @@ impl Interpreter {
                             Ok(s) => s,
                             Err(msg) => return Completion::Throw(interp.create_range_error(&msg)),
                         };
-                        return Completion::Normal(JsValue::String(JsString::from_str(&result)));
+                        return Completion::Normal(JsValue::from_str(&result));
                     }
                 };
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let df_instance = match interp.construct(&df_val, &[locales_arg, options_arg]) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
-                if let JsValue::Object(df_obj) = &df_instance {
+                if let Some(df_obj) = df_instance.as_object_id() {
                     let format_val =
-                        match interp.get_object_property(df_obj.id, "format", &df_instance) {
+                        match interp.get_object_property(df_obj, "format", &df_instance) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => JsValue::Undefined,
+                            _ => JsValue::UNDEFINED,
                         };
                     match interp.call_function(
                         &format_val,
@@ -2466,7 +2466,7 @@ impl Interpreter {
                     ) {
                         Completion::Normal(v) => Completion::Normal(v),
                         Completion::Throw(e) => Completion::Throw(e),
-                        _ => Completion::Normal(JsValue::Undefined),
+                        _ => Completion::Normal(JsValue::UNDEFINED),
                     }
                 } else {
                     let (y, mo, w, d, h, mi, s, ms, us, ns) = fields;
@@ -2476,7 +2476,7 @@ impl Interpreter {
                             Ok(s) => s,
                             Err(msg) => return Completion::Throw(interp.create_range_error(&msg)),
                         };
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::from_str(&result))
                 }
             },
         ));
@@ -2513,7 +2513,7 @@ impl Interpreter {
                 }
 
                 let get_field = |interp: &mut Interpreter, idx: usize| -> Result<f64, Completion> {
-                    let v = args.get(idx).cloned().unwrap_or(JsValue::Undefined);
+                    let v = args.get(idx).cloned().unwrap_or(JsValue::UNDEFINED);
                     if is_undefined(&v) {
                         return Ok(0.0);
                     }
@@ -2596,19 +2596,21 @@ impl Interpreter {
                     microseconds,
                     nanoseconds,
                 );
-                if let Completion::Normal(JsValue::Object(ref o)) = result {
+                if let Completion::Normal(ref v) = result
+                    && let Some(o) = v.as_object_id()
+                {
                     let dp = interp.realm().temporal_duration_prototype;
-                    interp.apply_new_target_prototype(o.id, dp, |r| r.temporal_duration_prototype);
+                    interp.apply_new_target_prototype(o, dp, |r| r.temporal_duration_prototype);
                 }
                 result
             },
         ));
 
         // Constructor.prototype_id
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -2628,7 +2630,7 @@ impl Interpreter {
             "from".to_string(),
             1,
             |interp, _this, args| {
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let record = match to_temporal_duration_record(interp, item) {
                     Ok(r) => r,
                     Err(c) => return c,
@@ -2637,8 +2639,8 @@ impl Interpreter {
                 create_duration_result(interp, y, mo, w, d, h, mi, s, ms, us, ns)
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -2650,23 +2652,23 @@ impl Interpreter {
             |interp, _this, args| {
                 let one = match to_temporal_duration_record(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(r) => r,
                     Err(c) => return c,
                 };
                 let two = match to_temporal_duration_record(
                     interp,
-                    args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                    args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(r) => r,
                     Err(c) => return c,
                 };
                 // Parse options (3rd argument)
-                let options = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let options = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 let relative_to = if is_undefined(&options) {
                     None
-                } else if matches!(options, JsValue::Object(_)) {
+                } else if options.is_object() {
                     let rt = match get_prop(interp, &options, "relativeTo") {
                         Completion::Normal(v) => v,
                         other => return other,
@@ -2693,7 +2695,7 @@ impl Interpreter {
                     && one.8 == two.8
                     && one.9 == two.9
                 {
-                    return Completion::Normal(JsValue::Number(0.0));
+                    return Completion::Normal(JsValue::number(0.0));
                 }
 
                 let has_calendar_units = one.0 != 0.0
@@ -2788,11 +2790,11 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -2812,11 +2814,11 @@ fn get_duration_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(f64, f64, f64, f64, f64, f64, f64, f64, f64, f64), Completion> {
-    let snapshot = match this {
-        JsValue::Object(o) => interp
-            .get_object_cell(o.id)
+    let snapshot = match this.as_object_id() {
+        Some(o) => interp
+            .get_object_cell(o)
             .map(|cell| cell.borrow().temporal_data().cloned()),
-        _ => None,
+        None => None,
     };
     match snapshot {
         Some(Some(TemporalData::Duration {
@@ -2913,7 +2915,7 @@ pub(crate) fn create_duration_result(
             nanoseconds,
         });
     let id = obj_id;
-    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }
 
 pub(crate) fn to_temporal_duration_record(
@@ -2921,7 +2923,7 @@ pub(crate) fn to_temporal_duration_record(
     item: JsValue,
 ) -> Result<(f64, f64, f64, f64, f64, f64, f64, f64, f64, f64), Completion> {
     // String path first
-    if let JsValue::String(s) = &item {
+    if let Some(s) = item.as_string() {
         let parsed = parse_temporal_duration_string(&s.to_rust_string()).ok_or_else(|| {
             Completion::Throw(interp.create_range_error(&format!("Invalid duration string: {s}")))
         })?;
@@ -2946,14 +2948,14 @@ pub(crate) fn to_temporal_duration_record(
         return Ok((y, mo, w, d, h, mi, sec, ms, us, ns));
     }
     // Must be an object (reject null, booleans, numbers, etc.)
-    if !matches!(&item, JsValue::Object(_)) {
+    if !item.is_object() {
         return Err(Completion::Throw(
             interp.create_type_error("Invalid duration: expected string or object"),
         ));
     }
     // Check for existing Duration instance
-    if let JsValue::Object(o) = &item
-        && let Some(obj) = interp.get_object_cell(o.id)
+    if let Some(o) = item.as_object_id()
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let data = obj.borrow();
         if let Some(TemporalData::Duration {
@@ -3073,7 +3075,7 @@ fn parse_round_options(
     ),
     Completion,
 > {
-    if let JsValue::String(su) = round_to {
+    if let Some(su) = round_to.as_string() {
         let su_str = su.to_rust_string();
         let unit = temporal_unit_singular(&su_str).ok_or_else(|| {
             Completion::Throw(interp.create_range_error(&format!("Invalid unit: {su_str}")))
@@ -3086,7 +3088,7 @@ fn parse_round_options(
         };
         return Ok((unit, "halfExpand", 1.0, largest, None));
     }
-    if !matches!(round_to, JsValue::Object(_)) {
+    if !round_to.is_object() {
         return Err(Completion::Throw(
             interp.create_type_error("round requires a string or options object"),
         ));
@@ -3229,7 +3231,7 @@ fn parse_to_string_options(
     interp: &mut Interpreter,
     options: Option<&JsValue>,
 ) -> Result<(Option<u8>, &'static str), Completion> {
-    let opt_val = options.cloned().unwrap_or(JsValue::Undefined);
+    let opt_val = options.cloned().unwrap_or(JsValue::UNDEFINED);
     let has_opts = super::get_options_object(interp, &opt_val)?;
     if !has_opts {
         return Ok((None, "trunc"));
@@ -3246,7 +3248,7 @@ fn parse_to_string_options(
     };
     let fsd_result: Option<Option<u8>> = if is_undefined(&fp) {
         None // will use default
-    } else if matches!(fp, JsValue::Number(_)) {
+    } else if fp.is_number() {
         let n = interp.to_number_value(&fp).map_err(Completion::Throw)?;
         if n.is_nan() || !n.is_finite() {
             return Err(Completion::Throw(interp.create_range_error(

--- a/src/interpreter/builtins/temporal/instant.rs
+++ b/src/interpreter/builtins/temporal/instant.rs
@@ -34,7 +34,7 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let ms = floor_div_bigint(&ns, NS_PER_MS);
-                    Completion::Normal(JsValue::Number(bigint_to_f64(&ms)))
+                    Completion::Normal(JsValue::number(bigint_to_f64(&ms)))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -62,7 +62,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::BigInt(crate::types::JsBigInt::new(ns)))
+                    Completion::Normal(JsValue::bigint(crate::types::JsBigInt::new(ns)))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -91,12 +91,12 @@ impl Interpreter {
                 };
                 let other = match to_temporal_instant(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                Completion::Normal(JsValue::Boolean(ns == other))
+                Completion::Normal(JsValue::boolean(ns == other))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -114,7 +114,7 @@ impl Interpreter {
                 };
                 let dur = match super::duration::to_temporal_duration_record(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -152,7 +152,7 @@ impl Interpreter {
                 };
                 let dur = match super::duration::to_temporal_duration_record(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -191,7 +191,7 @@ impl Interpreter {
                     };
                     let ns2 = match to_temporal_instant(
                         interp,
-                        args.first().cloned().unwrap_or(JsValue::Undefined),
+                        args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -203,7 +203,7 @@ impl Interpreter {
                     };
 
                     // Parse options
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let time_units: &[&str] = &[
                         "hour",
                         "minute",
@@ -284,11 +284,11 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let round_to = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let round_to = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if is_undefined(&round_to) {
                     return Completion::Throw(interp.create_type_error("round requires options"));
                 }
-                let (unit, rounding_mode, increment) = if let JsValue::String(ref su) = round_to {
+                let (unit, rounding_mode, increment) = if let Some(su) = round_to.as_string() {
                     let su_str = su.to_rust_string();
                     match temporal_unit_singular(&su_str) {
                         Some(u) if is_valid_instant_round_unit(u) => (u, "halfExpand", 1.0),
@@ -303,7 +303,7 @@ impl Interpreter {
                             );
                         }
                     }
-                } else if matches!(round_to, JsValue::Object(_)) {
+                } else if round_to.is_object() {
                     // Read all options in alphabetical order first, then validate
                     // 1. roundingIncrement
                     let inc_val = match get_prop(interp, &round_to, "roundingIncrement") {
@@ -420,7 +420,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let options = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let options = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (tz_id, tz_offset_ns, tz_explicit, frac_digits, smallest_unit, rounding_mode) =
                     match parse_to_string_options(interp, &options) {
                         Ok(v) => v,
@@ -463,7 +463,7 @@ impl Interpreter {
                     precision,
                     tz_explicit,
                 );
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -480,7 +480,7 @@ impl Interpreter {
                     Err(c) => return c,
                 };
                 let result = instant_to_string_with_tz(&ns, "UTC", 0, None, false);
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -500,15 +500,15 @@ impl Interpreter {
                     Some(v) => v,
                     None => {
                         let result = instant_to_string_with_tz(&_ns, "UTC", 0, None, false);
-                        return Completion::Normal(JsValue::String(JsString::from_str(&result)));
+                        return Completion::Normal(JsValue::from_str(&result));
                     }
                 };
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let dtf_instance = match interp.construct(&dtf_val, &[locales_arg, options_arg]) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
                 super::temporal_format_with_dtf(interp, &dtf_instance, this)
             },
@@ -541,7 +541,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let tz_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let tz_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if super::is_undefined(&tz_arg) {
                     return Completion::Throw(
                         interp.create_type_error("timeZone argument is required"),
@@ -570,7 +570,7 @@ impl Interpreter {
                         interp.create_type_error("Temporal.Instant must be called with new"),
                     );
                 }
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let epoch_ns = match to_bigint_arg(interp, &arg) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -579,19 +579,21 @@ impl Interpreter {
                     return Completion::Throw(interp.create_range_error("Instant out of range"));
                 }
                 let result = create_instant_result(interp, epoch_ns);
-                if let Completion::Normal(JsValue::Object(ref o)) = result {
+                if let Completion::Normal(ref v) = result
+                    && let Some(o) = v.as_object_id()
+                {
                     let dp = interp.realm().temporal_instant_prototype;
-                    interp.apply_new_target_prototype(o.id, dp, |r| r.temporal_instant_prototype);
+                    interp.apply_new_target_prototype(o, dp, |r| r.temporal_instant_prototype);
                 }
                 result
             },
         ));
 
         // Constructor.prototype_id
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -609,7 +611,7 @@ impl Interpreter {
             "from".to_string(),
             1,
             |interp, _this, args| {
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let ns = match to_temporal_instant(interp, item) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -617,8 +619,8 @@ impl Interpreter {
                 create_instant_result(interp, ns)
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -628,7 +630,7 @@ impl Interpreter {
             "fromEpochMilliseconds".to_string(),
             1,
             |interp, _this, args| {
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let ms = match interp.to_number_value(&arg) {
                     Ok(v) => v,
                     Err(e) => return Completion::Throw(e),
@@ -645,8 +647,8 @@ impl Interpreter {
                 create_instant_result(interp, ns)
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("fromEpochMilliseconds".to_string(), from_ms_fn);
@@ -657,7 +659,7 @@ impl Interpreter {
             "fromEpochNanoseconds".to_string(),
             1,
             |interp, _this, args| {
-                let arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let ns = match to_bigint_arg(interp, &arg) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -668,8 +670,8 @@ impl Interpreter {
                 create_instant_result(interp, ns)
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("fromEpochNanoseconds".to_string(), from_ns_fn);
@@ -682,14 +684,14 @@ impl Interpreter {
             |interp, _this, args| {
                 let one = match to_temporal_instant(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
                 let two = match to_temporal_instant(
                     interp,
-                    args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                    args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -701,11 +703,11 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -797,11 +799,12 @@ fn is_valid_instant_round_unit(unit: &str) -> bool {
 }
 
 fn get_instant_ns(interp: &mut Interpreter, this: &JsValue) -> Result<BigInt, Completion> {
-    let snapshot = match this {
-        JsValue::Object(o) => interp
-            .get_object_cell(o.id)
-            .map(|cell| cell.borrow().temporal_data().cloned()),
-        _ => None,
+    let snapshot = if let Some(o) = this.as_object_id() {
+        interp
+            .get_object_cell(o)
+            .map(|cell| cell.borrow().temporal_data().cloned())
+    } else {
+        None
     };
     match snapshot {
         Some(Some(TemporalData::Instant { epoch_nanoseconds })) => Ok(epoch_nanoseconds),
@@ -828,16 +831,17 @@ fn create_instant_result(interp: &mut Interpreter, epoch_ns: BigInt) -> Completi
             epoch_nanoseconds: epoch_ns,
         });
     let id = obj_id;
-    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }
 
 pub(super) fn to_temporal_instant(
     interp: &mut Interpreter,
     item: JsValue,
 ) -> Result<BigInt, Completion> {
-    match &item {
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id) {
+    match item.kind() {
+        ValueKind::Object => {
+            let oid = item.as_object_id().expect("checked Object kind");
+            if let Some(obj) = interp.get_object_cell(oid) {
                 let data = obj.borrow();
                 if let Some(TemporalData::Instant { epoch_nanoseconds }) = data.temporal_data() {
                     return Ok(epoch_nanoseconds.clone());
@@ -856,15 +860,18 @@ pub(super) fn to_temporal_instant(
             };
             parse_instant_string(interp, &s)
         }
-        JsValue::String(s) => parse_instant_string(interp, &s.to_rust_string()),
-        JsValue::Undefined
-        | JsValue::Null
-        | JsValue::Boolean(_)
-        | JsValue::Number(_)
-        | JsValue::BigInt(_) => Err(Completion::Throw(
+        ValueKind::String => {
+            let s = item.as_string().expect("checked String kind");
+            parse_instant_string(interp, &s.to_rust_string())
+        }
+        ValueKind::Undefined
+        | ValueKind::Null
+        | ValueKind::Boolean
+        | ValueKind::Number
+        | ValueKind::BigInt => Err(Completion::Throw(
             interp.create_type_error("Cannot convert to Temporal.Instant"),
         )),
-        JsValue::Symbol(_) => Err(Completion::Throw(
+        ValueKind::Symbol => Err(Completion::Throw(
             interp.create_type_error("Cannot convert a Symbol to a string"),
         )),
     }
@@ -904,36 +911,38 @@ fn parse_instant_string(interp: &mut Interpreter, s: &str) -> Result<BigInt, Com
 }
 
 pub(super) fn to_bigint_arg(interp: &mut Interpreter, val: &JsValue) -> Result<BigInt, Completion> {
-    match val {
-        JsValue::BigInt(n) => Ok((*n.value).clone()),
-        JsValue::String(s) => {
-            let s_str = s.to_rust_string();
-            match s_str.parse::<BigInt>() {
-                Ok(v) => Ok(v),
-                Err(_) => Err(Completion::Throw(interp.create_error(
-                    "SyntaxError",
-                    &format!("Cannot convert {s_str} to a BigInt"),
-                ))),
-            }
+    if let Some(n) = val.as_bigint() {
+        Ok((*n.value).clone())
+    } else if let Some(s) = val.as_string() {
+        let s_str = s.to_rust_string();
+        match s_str.parse::<BigInt>() {
+            Ok(v) => Ok(v),
+            Err(_) => Err(Completion::Throw(interp.create_error(
+                "SyntaxError",
+                &format!("Cannot convert {s_str} to a BigInt"),
+            ))),
         }
-        JsValue::Boolean(b) => Ok(BigInt::from(if *b { 1 } else { 0 })),
-        JsValue::Number(_) => Err(Completion::Throw(
+    } else if let Some(b) = val.as_boolean() {
+        Ok(BigInt::from(if b { 1 } else { 0 }))
+    } else if val.is_number() {
+        Err(Completion::Throw(
             interp.create_type_error("Cannot convert a Number to a BigInt"),
-        )),
-        JsValue::Undefined | JsValue::Null => Err(Completion::Throw(
+        ))
+    } else if val.is_nullish() {
+        Err(Completion::Throw(
             interp.create_type_error("Cannot convert to BigInt"),
-        )),
-        JsValue::Symbol(_) => Err(Completion::Throw(
-            interp.create_type_error("Cannot convert a Symbol value to a BigInt"),
-        )),
-        _ => {
-            // ToBigInt via ToPrimitive
-            let prim = match interp.to_primitive(val, "number") {
-                Ok(v) => v,
-                Err(e) => return Err(Completion::Throw(e)),
-            };
-            to_bigint_arg(interp, &prim)
-        }
+        ))
+    } else if val.is_symbol() {
+        Err(Completion::Throw(interp.create_type_error(
+            "Cannot convert a Symbol value to a BigInt",
+        )))
+    } else {
+        // ToBigInt via ToPrimitive
+        let prim = match interp.to_primitive(val, "number") {
+            Ok(v) => v,
+            Err(e) => return Err(Completion::Throw(e)),
+        };
+        to_bigint_arg(interp, &prim)
     }
 }
 
@@ -1172,7 +1181,7 @@ fn parse_to_string_options(
     if is_undefined(options) {
         return Ok(("UTC".to_string(), 0, false, None, None, "trunc"));
     }
-    if !matches!(options, JsValue::Object(_)) {
+    if !options.is_object() {
         return Err(Completion::Throw(
             interp.create_type_error("options must be an object"),
         ));
@@ -1188,7 +1197,7 @@ fn parse_to_string_options(
     };
     let frac_digits = if is_undefined(&fsd_val) {
         None
-    } else if matches!(fsd_val, JsValue::Number(_)) {
+    } else if fsd_val.is_number() {
         let n = match interp.to_number_value(&fsd_val) {
             Ok(v) => v,
             Err(e) => return Err(Completion::Throw(e)),
@@ -1273,9 +1282,9 @@ fn parse_to_string_options(
         ("UTC".to_string(), 0i64, false)
     } else {
         // Per spec, must be a string (not coerced from other types)
-        let tz_str = match &tz_val {
-            JsValue::String(s) => s.to_string(),
-            _ => {
+        let tz_str = match tz_val.as_string() {
+            Some(s) => s.to_string(),
+            None => {
                 return Err(Completion::Throw(
                     interp.create_type_error("timeZone must be a string"),
                 ));

--- a/src/interpreter/builtins/temporal/mod.rs
+++ b/src/interpreter/builtins/temporal/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod plain_year_month;
 pub(crate) mod zoned_date_time;
 
 use super::*;
+use crate::types::ValueKind;
 
 /// Check if options object has a style that conflicts with the temporal type.
 /// In toLocaleString, each style must overlap with the type's data model:
@@ -22,19 +23,19 @@ pub(crate) fn check_locale_string_style_conflict(
     has_date: bool,
     has_time: bool,
 ) -> Result<(), JsValue> {
-    if let JsValue::Object(o) = options {
-        let ds = match interp.get_object_property(o.id, "dateStyle", options) {
+    if let Some(o) = options.as_object_id() {
+        let ds = match interp.get_object_property(o, "dateStyle", options) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(e),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
-        let ts = match interp.get_object_property(o.id, "timeStyle", options) {
+        let ts = match interp.get_object_property(o, "timeStyle", options) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(e),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
-        let has_ds = !matches!(ds, JsValue::Undefined);
-        let has_ts = !matches!(ts, JsValue::Undefined);
+        let has_ds = !ds.is_undefined();
+        let has_ts = !ts.is_undefined();
         if has_ds && !has_date {
             return Err(
                 interp.create_type_error("dateStyle does not overlap with this Temporal type")
@@ -60,32 +61,31 @@ pub(crate) fn check_calendar_mismatch(
     if allow_iso && temporal_calendar == "iso8601" {
         return Ok(());
     }
-    if let JsValue::Object(dtf_obj) = dtf_instance {
-        let resolved_fn =
-            match interp.get_object_property(dtf_obj.id, "resolvedOptions", dtf_instance) {
-                Completion::Normal(v) => v,
-                Completion::Throw(e) => return Err(e),
-                _ => return Ok(()),
-            };
+    if let Some(dtf_obj) = dtf_instance.as_object_id() {
+        let resolved_fn = match interp.get_object_property(dtf_obj, "resolvedOptions", dtf_instance)
+        {
+            Completion::Normal(v) => v,
+            Completion::Throw(e) => return Err(e),
+            _ => return Ok(()),
+        };
         let resolved = match interp.call_function(&resolved_fn, dtf_instance, &[]) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(e),
             _ => return Ok(()),
         };
-        if let JsValue::Object(ro) = &resolved {
-            let dtf_cal = match interp.get_object_property(ro.id, "calendar", &resolved) {
+        if let Some(ro) = resolved.as_object_id() {
+            let dtf_cal = match interp.get_object_property(ro, "calendar", &resolved) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => JsValue::Undefined,
+                _ => JsValue::UNDEFINED,
             };
-            if let JsValue::String(ref s) = dtf_cal {
-                let dtf_cal_str = s.to_string();
-                if dtf_cal_str != temporal_calendar {
-                    return Err(interp.create_range_error(&format!(
-                        "calendar mismatch: Temporal object uses '{}' but locale uses '{}'",
-                        temporal_calendar, dtf_cal_str
-                    )));
-                }
+            if let Some(dtf_cal_str) = dtf_cal.as_string().map(|s| s.to_string())
+                && dtf_cal_str != temporal_calendar
+            {
+                return Err(interp.create_range_error(&format!(
+                    "calendar mismatch: Temporal object uses '{}' but locale uses '{}'",
+                    temporal_calendar, dtf_cal_str
+                )));
             }
         }
     }
@@ -98,11 +98,11 @@ pub(crate) fn temporal_format_with_dtf(
     dtf_instance: &JsValue,
     temporal_this: &JsValue,
 ) -> Completion {
-    if let JsValue::Object(dtf_obj) = dtf_instance {
-        let format_val = match interp.get_object_property(dtf_obj.id, "format", dtf_instance) {
+    if let Some(dtf_obj) = dtf_instance.as_object_id() {
+        let format_val = match interp.get_object_property(dtf_obj, "format", dtf_instance) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Completion::Throw(e),
-            _ => JsValue::Undefined,
+            _ => JsValue::UNDEFINED,
         };
         match interp.call_function(
             &format_val,
@@ -111,10 +111,10 @@ pub(crate) fn temporal_format_with_dtf(
         ) {
             Completion::Normal(v) => Completion::Normal(v),
             Completion::Throw(e) => Completion::Throw(e),
-            _ => Completion::Normal(JsValue::Undefined),
+            _ => Completion::Normal(JsValue::UNDEFINED),
         }
     } else {
-        Completion::Normal(JsValue::Undefined)
+        Completion::Normal(JsValue::UNDEFINED)
     }
 }
 
@@ -1290,52 +1290,52 @@ pub(crate) fn to_temporal_calendar_slot_value(
     interp: &mut Interpreter,
     val: &JsValue,
 ) -> Result<String, Completion> {
-    match val {
-        JsValue::Undefined => Ok("iso8601".to_string()),
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id) {
-                let data = obj.borrow();
-                match data.temporal_data() {
-                    Some(TemporalData::PlainDate { calendar, .. })
-                    | Some(TemporalData::PlainDateTime { calendar, .. })
-                    | Some(TemporalData::PlainYearMonth { calendar, .. })
-                    | Some(TemporalData::PlainMonthDay { calendar, .. })
-                    | Some(TemporalData::ZonedDateTime { calendar, .. }) => {
-                        return Ok(calendar.clone());
-                    }
-                    _ => {}
-                }
-            }
-            Err(Completion::Throw(interp.create_type_error(
-                "Invalid calendar value: expected a string or Temporal object",
-            )))
-        }
-        JsValue::String(s) => {
-            let raw = s.to_rust_string();
-            match validate_calendar(&raw) {
-                Some(c) => Ok(c),
-                None => Err(Completion::Throw(
-                    interp.create_range_error(&format!("Invalid calendar: {raw}")),
-                )),
-            }
-        }
-        _ => Err(Completion::Throw(interp.create_type_error(
-            "Invalid calendar value: expected a string or Temporal object",
-        ))),
+    if val.is_undefined() {
+        return Ok("iso8601".to_string());
     }
+    if let Some(o) = val.as_object_id() {
+        if let Some(obj) = interp.get_object_cell(o) {
+            let data = obj.borrow();
+            match data.temporal_data() {
+                Some(TemporalData::PlainDate { calendar, .. })
+                | Some(TemporalData::PlainDateTime { calendar, .. })
+                | Some(TemporalData::PlainYearMonth { calendar, .. })
+                | Some(TemporalData::PlainMonthDay { calendar, .. })
+                | Some(TemporalData::ZonedDateTime { calendar, .. }) => {
+                    return Ok(calendar.clone());
+                }
+                _ => {}
+            }
+        }
+        return Err(Completion::Throw(interp.create_type_error(
+            "Invalid calendar value: expected a string or Temporal object",
+        )));
+    }
+    if let Some(s) = val.as_string() {
+        let raw = s.to_rust_string();
+        return match validate_calendar(&raw) {
+            Some(c) => Ok(c),
+            None => Err(Completion::Throw(
+                interp.create_range_error(&format!("Invalid calendar: {raw}")),
+            )),
+        };
+    }
+    Err(Completion::Throw(interp.create_type_error(
+        "Invalid calendar value: expected a string or Temporal object",
+    )))
 }
 
-// Helper: get a property from a JsValue::Object, returning Completion
+// Helper: get a property from a JsValue-Object, returning Completion
 pub(crate) fn get_prop(interp: &mut Interpreter, obj: &JsValue, key: &str) -> Completion {
-    match obj {
-        JsValue::Object(o) => interp.get_object_property(o.id, key, obj),
-        _ => Completion::Normal(JsValue::Undefined),
+    match obj.as_object_id() {
+        Some(o) => interp.get_object_property(o, key, obj),
+        None => Completion::Normal(JsValue::UNDEFINED),
     }
 }
 
 // Helper: check if JsValue is undefined
 pub(crate) fn is_undefined(v: &JsValue) -> bool {
-    matches!(v, JsValue::Undefined)
+    v.is_undefined()
 }
 /// Check if monthCode string has valid syntax: /^M\d{2}L?$/
 /// Returns true if syntax is valid (even if the value is not valid for ISO 8601).
@@ -1363,16 +1363,16 @@ pub(crate) fn is_partial_temporal_object(
     interp: &mut Interpreter,
     value: &JsValue,
 ) -> Result<(), Completion> {
-    let obj_ref = match value {
-        JsValue::Object(o) => o,
-        _ => {
+    let obj_ref = match value.as_object_id() {
+        Some(o) => o,
+        None => {
             return Err(Completion::Throw(
                 interp.create_type_error("with requires an object argument"),
             ));
         }
     };
 
-    if let Some(obj) = interp.get_object_cell(obj_ref.id) {
+    if let Some(obj) = interp.get_object_cell(obj_ref) {
         let td = obj.borrow().temporal_data().cloned();
         if let Some(
             TemporalData::PlainDate { .. }
@@ -1501,10 +1501,10 @@ pub(crate) fn get_options_object(
     interp: &mut Interpreter,
     options: &JsValue,
 ) -> Result<bool, Completion> {
-    if matches!(options, JsValue::Undefined) {
+    if options.is_undefined() {
         return Ok(false);
     }
-    if matches!(options, JsValue::Object(_)) {
+    if options.is_object() {
         return Ok(true);
     }
     Err(Completion::Throw(interp.create_type_error(
@@ -1630,7 +1630,7 @@ impl Interpreter {
         self.setup_temporal_now(temporal_obj_id);
 
         // Register Temporal as global (writable, not enumerable, configurable)
-        let temporal_val = JsValue::Object(crate::types::JsObject { id: temporal_id });
+        let temporal_val = JsValue::object(temporal_id);
         self.realm()
             .global_env
             .borrow_mut()
@@ -2769,21 +2769,20 @@ pub(super) fn validate_timezone_identifier_strict(
     interp: &mut Interpreter,
     arg: &JsValue,
 ) -> Result<String, Completion> {
-    match arg {
-        JsValue::String(s) => {
-            let s_str = s.to_string();
-            if let Some(offset) = parse_utc_offset_timezone(&s_str) {
-                Ok(offset)
-            } else if is_iana_timezone(&s_str) {
-                Ok(normalize_iana_timezone(&s_str))
-            } else {
-                Err(Completion::Throw(interp.create_range_error(&format!(
-                    "Invalid time zone: {}",
-                    s_str
-                ))))
-            }
+    if let Some(s) = arg.as_string() {
+        let s_str = s.to_string();
+        if let Some(offset) = parse_utc_offset_timezone(&s_str) {
+            Ok(offset)
+        } else if is_iana_timezone(&s_str) {
+            Ok(normalize_iana_timezone(&s_str))
+        } else {
+            Err(Completion::Throw(interp.create_range_error(&format!(
+                "Invalid time zone: {}",
+                s_str
+            ))))
         }
-        _ => to_temporal_time_zone_identifier(interp, arg),
+    } else {
+        to_temporal_time_zone_identifier(interp, arg)
     }
 }
 
@@ -2792,31 +2791,31 @@ pub(super) fn validate_calendar_strict(
     interp: &mut Interpreter,
     val: &JsValue,
 ) -> Result<String, Completion> {
-    match val {
-        JsValue::Undefined => Ok("iso8601".to_string()),
-        JsValue::String(s) => {
-            let raw = s.to_rust_string();
-            if raw.is_empty() {
-                return Err(Completion::Throw(
-                    interp.create_range_error("Invalid calendar: empty string"),
-                ));
-            }
-            if !raw.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-') {
-                return Err(Completion::Throw(
-                    interp.create_range_error(&format!("Invalid calendar: {raw}")),
-                ));
-            }
-            let normalized = canonicalize_temporal_calendar(&raw);
-            if is_supported_temporal_calendar(&normalized) {
-                Ok(normalized)
-            } else {
-                Err(Completion::Throw(
-                    interp.create_range_error(&format!("Invalid calendar: {raw}")),
-                ))
-            }
-        }
-        _ => to_temporal_calendar_slot_value(interp, val),
+    if val.is_undefined() {
+        return Ok("iso8601".to_string());
     }
+    if let Some(s) = val.as_string() {
+        let raw = s.to_rust_string();
+        if raw.is_empty() {
+            return Err(Completion::Throw(
+                interp.create_range_error("Invalid calendar: empty string"),
+            ));
+        }
+        if !raw.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-') {
+            return Err(Completion::Throw(
+                interp.create_range_error(&format!("Invalid calendar: {raw}")),
+            ));
+        }
+        let normalized = canonicalize_temporal_calendar(&raw);
+        return if is_supported_temporal_calendar(&normalized) {
+            Ok(normalized)
+        } else {
+            Err(Completion::Throw(
+                interp.create_range_error(&format!("Invalid calendar: {raw}")),
+            ))
+        };
+    }
+    to_temporal_calendar_slot_value(interp, val)
 }
 
 /// ToTemporalTimeZoneIdentifier — validates and returns a timezone string, or throws
@@ -2824,10 +2823,10 @@ pub(super) fn to_temporal_time_zone_identifier(
     interp: &mut Interpreter,
     arg: &JsValue,
 ) -> Result<String, Completion> {
-    match arg {
-        JsValue::Undefined => Ok(canonicalize_iana_tz(&system_time_zone_identifier())),
-        JsValue::String(s) => {
-            let s_str = s.to_string();
+    match arg.kind() {
+        ValueKind::Undefined => Ok(canonicalize_iana_tz(&system_time_zone_identifier())),
+        ValueKind::String => {
+            let s_str = arg.as_string().expect("checked String kind").to_string();
             match parse_temporal_time_zone_string(&s_str) {
                 Some(tz) => Ok(tz),
                 None => Err(Completion::Throw(
@@ -2835,9 +2834,10 @@ pub(super) fn to_temporal_time_zone_identifier(
                 )),
             }
         }
-        JsValue::Object(o) => {
+        ValueKind::Object => {
             // If it's a Temporal.ZonedDateTime, extract timeZoneId
-            if let Some(obj) = interp.get_object_cell(o.id) {
+            let o = arg.as_object_id().expect("checked Object kind");
+            if let Some(obj) = interp.get_object_cell(o) {
                 let td = obj.borrow().temporal_data().cloned();
                 if let Some(TemporalData::ZonedDateTime { time_zone, .. }) = td {
                     return Ok(time_zone);
@@ -2847,13 +2847,13 @@ pub(super) fn to_temporal_time_zone_identifier(
                 interp.create_type_error("Expected a string for time zone"),
             ))
         }
-        JsValue::Null | JsValue::Boolean(_) | JsValue::Number(_) => Err(Completion::Throw(
+        ValueKind::Null | ValueKind::Boolean | ValueKind::Number => Err(Completion::Throw(
             interp.create_type_error("Expected a string for time zone"),
         )),
-        JsValue::Symbol(_) => Err(Completion::Throw(
+        ValueKind::Symbol => Err(Completion::Throw(
             interp.create_type_error("Cannot convert a Symbol value to a string"),
         )),
-        JsValue::BigInt(_) => Err(Completion::Throw(
+        ValueKind::BigInt => Err(Completion::Throw(
             interp.create_type_error("Cannot convert a BigInt value to a string"),
         )),
     }
@@ -3996,9 +3996,9 @@ pub(crate) fn to_primitive_and_require_string(
     let primitive = interp
         .to_primitive(val, "string")
         .map_err(Completion::Throw)?;
-    match primitive {
-        JsValue::String(s) => Ok(s.to_rust_string()),
-        _ => Err(Completion::Throw(
+    match primitive.as_string() {
+        Some(s) => Ok(s.to_rust_string()),
+        None => Err(Completion::Throw(
             interp.create_type_error(&format!("{field_name} must be a string")),
         )),
     }

--- a/src/interpreter/builtins/temporal/now.rs
+++ b/src/interpreter/builtins/temporal/now.rs
@@ -16,7 +16,7 @@ impl Interpreter {
             0,
             |_interp, _this, _args| {
                 let tz = super::canonicalize_iana_tz(&system_time_zone_identifier());
-                Completion::Normal(JsValue::String(JsString::from_str(&tz)))
+                Completion::Normal(JsValue::from_str(&tz))
             },
         ));
         self.get_object_cell_expect(now_obj_id)
@@ -45,7 +45,7 @@ impl Interpreter {
                         epoch_nanoseconds: ns,
                     });
                 let id = obj_id;
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
         self.get_object_cell_expect(now_obj_id)
@@ -57,7 +57,7 @@ impl Interpreter {
             "plainDateTimeISO".to_string(),
             0,
             |interp, _this, args| {
-                let tz_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let tz_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // Validate timezone argument (but still use local time)
                 match super::to_temporal_time_zone_identifier(interp, &tz_arg) {
                     Ok(_tz) => {}
@@ -79,7 +79,7 @@ impl Interpreter {
             "plainDateISO".to_string(),
             0,
             |interp, _this, args| {
-                let tz_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let tz_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 match super::to_temporal_time_zone_identifier(interp, &tz_arg) {
                     Ok(_tz) => {}
                     Err(c) => return c,
@@ -98,7 +98,7 @@ impl Interpreter {
             "plainTimeISO".to_string(),
             0,
             |interp, _this, args| {
-                let tz_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let tz_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 match super::to_temporal_time_zone_identifier(interp, &tz_arg) {
                     Ok(_tz) => {}
                     Err(c) => return c,
@@ -117,7 +117,7 @@ impl Interpreter {
             "zonedDateTimeISO".to_string(),
             0,
             |interp, _this, args| {
-                let tz_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let tz_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let tz = match super::to_temporal_time_zone_identifier(interp, &tz_arg) {
                     Ok(tz) => tz,
                     Err(c) => return c,
@@ -141,14 +141,14 @@ impl Interpreter {
                         calendar: "iso8601".to_string(),
                     });
                 let id = obj_id;
-                Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                Completion::Normal(JsValue::object(id))
             },
         ));
         self.get_object_cell_expect(now_obj_id)
             .borrow_mut()
             .insert_builtin("zonedDateTimeISO".to_string(), zdt_fn);
 
-        let now_val = JsValue::Object(crate::types::JsObject { id: now_id });
+        let now_val = JsValue::object(now_id);
         self.get_object_cell_expect(temporal_obj_id)
             .borrow_mut()
             .insert_property(

--- a/src/interpreter/builtins/temporal/plain_date.rs
+++ b/src/interpreter/builtins/temporal/plain_date.rs
@@ -25,7 +25,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&cal)))
+                    Completion::Normal(JsValue::from_str(&cal))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -61,14 +61,14 @@ impl Interpreter {
                             1 => cf.month_ordinal as f64,
                             _ => cf.day as f64,
                         };
-                        return Completion::Normal(JsValue::Number(val));
+                        return Completion::Normal(JsValue::number(val));
                     }
                     let val = match idx {
                         0 => y as f64,
                         1 => m as f64,
                         _ => d as f64,
                     };
-                    Completion::Normal(JsValue::Number(val))
+                    Completion::Normal(JsValue::number(val))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -99,11 +99,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            &cf.month_code,
-                        )));
+                        return Completion::Normal(JsValue::from_str(&cf.month_code));
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&iso_month_code(m))))
+                    Completion::Normal(JsValue::from_str(&iso_month_code(m)))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -131,7 +129,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::Number(iso_day_of_week(y, m, d) as f64))
+                    Completion::Normal(JsValue::number(iso_day_of_week(y, m, d) as f64))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -162,9 +160,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::Number(cf.day_of_year as f64));
+                        return Completion::Normal(JsValue::number(cf.day_of_year as f64));
                     }
-                    Completion::Normal(JsValue::Number(iso_day_of_year(y, m, d) as f64))
+                    Completion::Normal(JsValue::number(iso_day_of_year(y, m, d) as f64))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -193,10 +191,10 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     if cal != "iso8601" {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     let (week, _) = iso_week_of_year(y, m, d);
-                    Completion::Normal(JsValue::Number(week as f64))
+                    Completion::Normal(JsValue::number(week as f64))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -225,10 +223,10 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     if cal != "iso8601" {
-                        return Completion::Normal(JsValue::Undefined);
+                        return Completion::Normal(JsValue::UNDEFINED);
                     }
                     let (_, year_of_week) = iso_week_of_year(y, m, d);
-                    Completion::Normal(JsValue::Number(year_of_week as f64))
+                    Completion::Normal(JsValue::number(year_of_week as f64))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -256,7 +254,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::Number(7.0))
+                    Completion::Normal(JsValue::number(7.0))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -287,9 +285,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::Number(cf.days_in_month as f64));
+                        return Completion::Normal(JsValue::number(cf.days_in_month as f64));
                     }
-                    Completion::Normal(JsValue::Number(iso_days_in_month(y, m) as f64))
+                    Completion::Normal(JsValue::number(iso_days_in_month(y, m) as f64))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -320,9 +318,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::Number(cf.days_in_year as f64));
+                        return Completion::Normal(JsValue::number(cf.days_in_year as f64));
                     }
-                    Completion::Normal(JsValue::Number(iso_days_in_year(y) as f64))
+                    Completion::Normal(JsValue::number(iso_days_in_year(y) as f64))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -353,9 +351,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::Number(cf.months_in_year as f64));
+                        return Completion::Normal(JsValue::number(cf.months_in_year as f64));
                     }
-                    Completion::Normal(JsValue::Number(12.0))
+                    Completion::Normal(JsValue::number(12.0))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -386,9 +384,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::Boolean(cf.in_leap_year));
+                        return Completion::Normal(JsValue::boolean(cf.in_leap_year));
                     }
-                    Completion::Normal(JsValue::Boolean(iso_is_leap_year(y)))
+                    Completion::Normal(JsValue::boolean(iso_is_leap_year(y)))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -420,9 +418,9 @@ impl Interpreter {
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                         && let Some(era) = cf.era
                     {
-                        return Completion::Normal(JsValue::String(JsString::from_str(&era)));
+                        return Completion::Normal(JsValue::from_str(&era));
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -454,9 +452,9 @@ impl Interpreter {
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                         && let Some(ey) = cf.era_year
                     {
-                        return Completion::Normal(JsValue::Number(ey as f64));
+                        return Completion::Normal(JsValue::number(ey as f64));
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -483,7 +481,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if let Err(c) = is_partial_temporal_object(interp, &item) {
                     return c;
                 }
@@ -587,7 +585,7 @@ impl Interpreter {
 
                     let overflow = match parse_overflow_option(
                         interp,
-                        &args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                        &args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -650,7 +648,7 @@ impl Interpreter {
                 // GetTemporalOverflowOption (after fields, before algorithmic validation)
                 let overflow = match parse_overflow_option(
                     interp,
-                    &args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                    &args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -690,14 +688,14 @@ impl Interpreter {
                     };
                     let dur = match super::duration::to_temporal_duration_record(
                         interp,
-                        args.first().cloned().unwrap_or(JsValue::Undefined),
+                        args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
                     let overflow = match parse_overflow_option(
                         interp,
-                        &args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                        &args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -770,7 +768,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let (y2, mut m2, mut d2, cal2) = match to_temporal_plain_date(interp, other) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -782,7 +780,7 @@ impl Interpreter {
                     }
                     m2 = m2.clamp(1, 12);
                     d2 = d2.clamp(1, iso_days_in_month(y2, m2));
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let date_units: &[&str] = &["year", "month", "week", "day"];
                     let (largest_unit, smallest_unit, rounding_mode, rounding_increment) =
                         match parse_difference_options(interp, &options, "day", date_units) {
@@ -917,7 +915,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (y2, mut m2, mut d2, c2) = match to_temporal_plain_date(interp, other) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -925,7 +923,7 @@ impl Interpreter {
                 m2 = m2.clamp(1, 12);
                 d2 = d2.max(1).min(iso_days_in_month(y2, m2));
                 let eq = y1 == y2 && m1 == m2 && d1 == d2 && c1 == c2;
-                Completion::Normal(JsValue::Boolean(eq))
+                Completion::Normal(JsValue::boolean(eq))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -941,7 +939,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let options = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let options = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let has_opts = match super::get_options_object(interp, &options) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -976,7 +974,7 @@ impl Interpreter {
                 };
 
                 let result = format_plain_date(y, m, d, &cal, show_calendar);
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -993,7 +991,7 @@ impl Interpreter {
                     Err(c) => return c,
                 };
                 let result = format_plain_date(y, m, d, &cal, "auto");
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1013,11 +1011,11 @@ impl Interpreter {
                     Some(v) => v,
                     None => {
                         let result = format_plain_date(y, m, d, &cal, "auto");
-                        return Completion::Normal(JsValue::String(JsString::from_str(&result)));
+                        return Completion::Normal(JsValue::from_str(&result));
                     }
                 };
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // PlainDate has date but not time
                 if let Err(e) =
                     super::check_locale_string_style_conflict(interp, &options_arg, true, false)
@@ -1027,7 +1025,7 @@ impl Interpreter {
                 let dtf_instance = match interp.construct(&dtf_val, &[locales_arg, options_arg]) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
                 if let Err(e) = super::check_calendar_mismatch(interp, &dtf_instance, &cal, true) {
                     return Completion::Throw(e);
@@ -1063,7 +1061,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let time = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let time = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (h, mi, s, ms, us, ns) = if is_undefined(&time) {
                     (0u8, 0u8, 0u8, 0u16, 0u16, 0u16)
                 } else {
@@ -1165,8 +1163,8 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let cal_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if matches!(cal_arg, JsValue::Undefined) {
+                let cal_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if cal_arg.is_undefined() {
                     return Completion::Throw(
                         interp.create_type_error("withCalendar requires a calendar argument"),
                     );
@@ -1191,16 +1189,16 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
                 // has_plain_time = true when the caller explicitly provides a plainTime
-                let (tz, has_plain_time, h, mi, s, ms, us, ns) = if let JsValue::String(_) = &item {
+                let (tz, has_plain_time, h, mi, s, ms, us, ns) = if item.is_string() {
                     let tz = match super::to_temporal_time_zone_identifier(interp, &item) {
                         Ok(t) => t,
                         Err(c) => return c,
                     };
                     (tz, false, 0u8, 0u8, 0u8, 0u16, 0u16, 0u16)
-                } else if let JsValue::Object(_) = &item {
+                } else if item.is_object() {
                     let tz_val = match super::get_prop(interp, &item, "timeZone") {
                         Completion::Normal(v) => v,
                         c => return c,
@@ -1277,7 +1275,7 @@ impl Interpreter {
                         interp.create_type_error("Temporal.PlainDate must be called with new"),
                     );
                 }
-                let y_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let y_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let y = match interp.to_number_value(&y_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -1287,7 +1285,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let m_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let m_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let m = match interp.to_number_value(&m_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -1301,7 +1299,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let d_val = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let d_val = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 let d = match interp.to_number_value(&d_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -1315,7 +1313,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let cal_arg = args.get(3).cloned().unwrap_or(JsValue::Undefined);
+                let cal_arg = args.get(3).cloned().unwrap_or(JsValue::UNDEFINED);
                 let cal = match super::validate_calendar_strict(interp, &cal_arg) {
                     Ok(c) => c,
                     Err(c) => return c,
@@ -1329,20 +1327,21 @@ impl Interpreter {
                     );
                 }
                 let result = create_plain_date_result(interp, y, m, d, &cal);
-                if let Completion::Normal(JsValue::Object(ref o)) = result {
+                if let Completion::Normal(ref v) = result
+                    && let Some(o) = v.as_object_id()
+                {
                     let dp = interp.realm().temporal_plain_date_prototype;
-                    interp
-                        .apply_new_target_prototype(o.id, dp, |r| r.temporal_plain_date_prototype);
+                    interp.apply_new_target_prototype(o, dp, |r| r.temporal_plain_date_prototype);
                 }
                 result
             },
         ));
 
         // Constructor.prototype_id
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -1360,10 +1359,10 @@ impl Interpreter {
             "from".to_string(),
             1,
             |interp, _this, args| {
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // Per spec: if item is a string, parse first, then validate overflow (but don't use it)
-                if matches!(&item, JsValue::String(_)) {
+                if item.is_string() {
                     let (y, m, d, cal) = match to_temporal_plain_date(interp, item) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -1380,8 +1379,8 @@ impl Interpreter {
                     return create_plain_date_result(interp, y, m, d, &cal);
                 }
                 // Check if it's a Temporal object (read overflow first, return copy)
-                let is_temporal = if let JsValue::Object(ref o) = item {
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                let is_temporal = if let Some(o) = item.as_object_id() {
+                    if let Some(obj) = interp.get_object_cell(o) {
                         let data = obj.borrow();
                         matches!(
                             data.temporal_data(),
@@ -1481,8 +1480,8 @@ impl Interpreter {
                 }
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -1494,7 +1493,7 @@ impl Interpreter {
             |interp, _this, args| {
                 let (y1, mut m1, mut d1, _) = match to_temporal_plain_date(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -1503,7 +1502,7 @@ impl Interpreter {
                 d1 = d1.max(1).min(iso_days_in_month(y1, m1));
                 let (y2, mut m2, mut d2, _) = match to_temporal_plain_date(
                     interp,
-                    args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                    args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -1519,11 +1518,11 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -1542,11 +1541,12 @@ fn get_plain_date_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(i32, u8, u8, String), Completion> {
-    let snapshot = match this {
-        JsValue::Object(o) => interp
-            .get_object_cell(o.id)
-            .map(|cell| cell.borrow().temporal_data().cloned()),
-        _ => None,
+    let snapshot = if let Some(o) = this.as_object_id() {
+        interp
+            .get_object_cell(o)
+            .map(|cell| cell.borrow().temporal_data().cloned())
+    } else {
+        None
     };
     match snapshot {
         Some(Some(TemporalData::PlainDate {
@@ -1587,7 +1587,7 @@ pub(super) fn create_plain_date_result(
             calendar: cal.to_string(),
         });
     let id = obj_id;
-    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }
 
 /// Read PlainDate property bag fields without validating monthCode.
@@ -1761,232 +1761,229 @@ pub(super) fn to_temporal_plain_date(
     interp: &mut Interpreter,
     item: JsValue,
 ) -> Result<(i32, u8, u8, String), Completion> {
-    match &item {
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id) {
-                let data = obj.borrow();
-                if let Some(TemporalData::PlainDate {
-                    iso_year,
-                    iso_month,
-                    iso_day,
-                    calendar,
-                }) = data.temporal_data()
-                {
-                    return Ok((*iso_year, *iso_month, *iso_day, calendar.clone()));
-                }
-                if let Some(TemporalData::PlainDateTime {
-                    iso_year,
-                    iso_month,
-                    iso_day,
-                    calendar,
-                    ..
-                }) = data.temporal_data()
-                {
-                    return Ok((*iso_year, *iso_month, *iso_day, calendar.clone()));
-                }
-                if let Some(TemporalData::ZonedDateTime {
-                    epoch_nanoseconds,
-                    time_zone,
-                    calendar,
-                }) = data.temporal_data()
-                {
-                    let (y, m, d, _, _, _, _, _, _) =
-                        super::zoned_date_time::epoch_ns_to_components(
-                            epoch_nanoseconds,
-                            time_zone,
-                        );
-                    return Ok((y, m, d, calendar.clone()));
-                }
+    if let Some(o) = item.as_object_id() {
+        if let Some(obj) = interp.get_object_cell(o) {
+            let data = obj.borrow();
+            if let Some(TemporalData::PlainDate {
+                iso_year,
+                iso_month,
+                iso_day,
+                calendar,
+            }) = data.temporal_data()
+            {
+                return Ok((*iso_year, *iso_month, *iso_day, calendar.clone()));
             }
-            // Property bag: read fields in alphabetical order with interleaved coercion.
-            // Per spec PrepareCalendarFields: calendar, day, era, eraYear, month, monthCode, year
+            if let Some(TemporalData::PlainDateTime {
+                iso_year,
+                iso_month,
+                iso_day,
+                calendar,
+                ..
+            }) = data.temporal_data()
+            {
+                return Ok((*iso_year, *iso_month, *iso_day, calendar.clone()));
+            }
+            if let Some(TemporalData::ZonedDateTime {
+                epoch_nanoseconds,
+                time_zone,
+                calendar,
+            }) = data.temporal_data()
+            {
+                let (y, m, d, _, _, _, _, _, _) =
+                    super::zoned_date_time::epoch_ns_to_components(epoch_nanoseconds, time_zone);
+                return Ok((y, m, d, calendar.clone()));
+            }
+        }
+        // Property bag: read fields in alphabetical order with interleaved coercion.
+        // Per spec PrepareCalendarFields: calendar, day, era, eraYear, month, monthCode, year
 
-            // 1. calendar: get + coerce
-            let cal_val = match get_prop(interp, &item, "calendar") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let cal = to_temporal_calendar_slot_value(interp, &cal_val)?;
+        // 1. calendar: get + coerce
+        let cal_val = match get_prop(interp, &item, "calendar") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let cal = to_temporal_calendar_slot_value(interp, &cal_val)?;
 
-            // 2. day: get + coerce (required, positive integer)
-            let d_val = match get_prop(interp, &item, "day") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let d = if is_undefined(&d_val) {
+        // 2. day: get + coerce (required, positive integer)
+        let d_val = match get_prop(interp, &item, "day") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let d = if is_undefined(&d_val) {
+            return Err(Completion::Throw(
+                interp.create_type_error("day is required"),
+            ));
+        } else {
+            let d_f = to_integer_with_truncation(interp, &d_val)?;
+            if d_f < 1.0 {
                 return Err(Completion::Throw(
-                    interp.create_type_error("day is required"),
+                    interp.create_range_error("day must be a positive integer"),
                 ));
-            } else {
-                let d_f = to_integer_with_truncation(interp, &d_val)?;
-                if d_f < 1.0 {
-                    return Err(Completion::Throw(
-                        interp.create_range_error("day must be a positive integer"),
-                    ));
-                }
-                d_f as u8
-            };
+            }
+            d_f as u8
+        };
 
-            // 2b-2c. era/eraYear: only for non-ISO calendars (§12.5.1 CalendarFields)
-            let (era_str, era_year) = if cal != "iso8601" && super::calendar_has_eras(&cal) {
-                let era_val = match get_prop(interp, &item, "era") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let era_s = if !is_undefined(&era_val) {
-                    Some(super::to_primitive_and_require_string(
-                        interp, &era_val, "era",
-                    )?)
-                } else {
-                    None
-                };
-                let era_year_val = match get_prop(interp, &item, "eraYear") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let era_y = if !is_undefined(&era_year_val) {
-                    Some(to_integer_with_truncation(interp, &era_year_val)? as i32)
-                } else {
-                    None
-                };
-                (era_s, era_y)
-            } else {
-                (None, None)
-            };
-
-            // 3. month: get + coerce
-            let m_val = match get_prop(interp, &item, "month") {
+        // 2b-2c. era/eraYear: only for non-ISO calendars (§12.5.1 CalendarFields)
+        let (era_str, era_year) = if cal != "iso8601" && super::calendar_has_eras(&cal) {
+            let era_val = match get_prop(interp, &item, "era") {
                 Completion::Normal(v) => v,
                 other => return Err(other),
             };
-            let has_month = !is_undefined(&m_val);
-            let month_num = if has_month {
-                let m_f = to_integer_with_truncation(interp, &m_val)?;
-                if m_f < 1.0 {
-                    return Err(Completion::Throw(
-                        interp.create_range_error("month must be a positive integer"),
-                    ));
-                }
-                Some(m_f as u8)
+            let era_s = if !is_undefined(&era_val) {
+                Some(super::to_primitive_and_require_string(
+                    interp, &era_val, "era",
+                )?)
             } else {
                 None
             };
-
-            // 4. monthCode: get + coerce + SYNTAX check (before year)
-            let mc_val = match get_prop(interp, &item, "monthCode") {
+            let era_year_val = match get_prop(interp, &item, "eraYear") {
                 Completion::Normal(v) => v,
                 other => return Err(other),
             };
-            let has_month_code = !is_undefined(&mc_val);
-            let mc_str = if has_month_code {
-                let mc = super::to_primitive_and_require_string(interp, &mc_val, "monthCode")?;
-                if !super::is_month_code_syntax_valid(&mc) {
+            let era_y = if !is_undefined(&era_year_val) {
+                Some(to_integer_with_truncation(interp, &era_year_val)? as i32)
+            } else {
+                None
+            };
+            (era_s, era_y)
+        } else {
+            (None, None)
+        };
+
+        // 3. month: get + coerce
+        let m_val = match get_prop(interp, &item, "month") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let has_month = !is_undefined(&m_val);
+        let month_num = if has_month {
+            let m_f = to_integer_with_truncation(interp, &m_val)?;
+            if m_f < 1.0 {
+                return Err(Completion::Throw(
+                    interp.create_range_error("month must be a positive integer"),
+                ));
+            }
+            Some(m_f as u8)
+        } else {
+            None
+        };
+
+        // 4. monthCode: get + coerce + SYNTAX check (before year)
+        let mc_val = match get_prop(interp, &item, "monthCode") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let has_month_code = !is_undefined(&mc_val);
+        let mc_str = if has_month_code {
+            let mc = super::to_primitive_and_require_string(interp, &mc_val, "monthCode")?;
+            if !super::is_month_code_syntax_valid(&mc) {
+                return Err(Completion::Throw(
+                    interp.create_range_error(&format!("Invalid monthCode: {mc}")),
+                ));
+            }
+            Some(mc)
+        } else {
+            None
+        };
+
+        // 5. year: get + coerce
+        let y_val = match get_prop(interp, &item, "year") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let has_year = !is_undefined(&y_val);
+        let year_num = if has_year {
+            Some(to_integer_with_truncation(interp, &y_val)? as i32)
+        } else {
+            None
+        };
+
+        // Non-ISO calendar path: use ICU4X to convert calendar fields → ISO
+        if cal != "iso8601" {
+            // Determine the month code
+            if mc_str.is_none() && month_num.is_none() {
+                return Err(Completion::Throw(
+                    interp.create_type_error("month or monthCode is required"),
+                ));
+            }
+
+            // Determine era and year for ICU
+            let (icu_era, icu_year) = if let (Some(e), Some(ey)) = (&era_str, era_year) {
+                (Some(e.as_str()), ey)
+            } else if let Some(y) = year_num {
+                (None, y)
+            } else {
+                return Err(Completion::Throw(
+                    interp.create_type_error("year or era+eraYear is required"),
+                ));
+            };
+
+            match super::calendar_fields_to_iso(
+                icu_era,
+                icu_year,
+                mc_str.as_deref(),
+                month_num,
+                d,
+                &cal,
+            ) {
+                Some((iso_y, iso_m, iso_d)) => return Ok((iso_y, iso_m, iso_d, cal)),
+                None => {
+                    return Err(Completion::Throw(
+                        interp.create_range_error("Invalid calendar date"),
+                    ));
+                }
+            }
+        }
+
+        // ISO path
+        let y = match year_num {
+            Some(y) => y,
+            None => {
+                return Err(Completion::Throw(
+                    interp.create_type_error("year is required"),
+                ));
+            }
+        };
+
+        // Validate monthCode VALUE (after year coercion)
+        let month_code_num = if let Some(ref mc) = mc_str {
+            match month_code_to_number(mc) {
+                Some(n) => Some(n),
+                None => {
                     return Err(Completion::Throw(
                         interp.create_range_error(&format!("Invalid monthCode: {mc}")),
                     ));
                 }
-                Some(mc)
-            } else {
-                None
-            };
-
-            // 5. year: get + coerce
-            let y_val = match get_prop(interp, &item, "year") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let has_year = !is_undefined(&y_val);
-            let year_num = if has_year {
-                Some(to_integer_with_truncation(interp, &y_val)? as i32)
-            } else {
-                None
-            };
-
-            // Non-ISO calendar path: use ICU4X to convert calendar fields → ISO
-            if cal != "iso8601" {
-                // Determine the month code
-                if mc_str.is_none() && month_num.is_none() {
-                    return Err(Completion::Throw(
-                        interp.create_type_error("month or monthCode is required"),
-                    ));
-                }
-
-                // Determine era and year for ICU
-                let (icu_era, icu_year) = if let (Some(e), Some(ey)) = (&era_str, era_year) {
-                    (Some(e.as_str()), ey)
-                } else if let Some(y) = year_num {
-                    (None, y)
-                } else {
-                    return Err(Completion::Throw(
-                        interp.create_type_error("year or era+eraYear is required"),
-                    ));
-                };
-
-                match super::calendar_fields_to_iso(
-                    icu_era,
-                    icu_year,
-                    mc_str.as_deref(),
-                    month_num,
-                    d,
-                    &cal,
-                ) {
-                    Some((iso_y, iso_m, iso_d)) => return Ok((iso_y, iso_m, iso_d, cal)),
-                    None => {
-                        return Err(Completion::Throw(
-                            interp.create_range_error("Invalid calendar date"),
-                        ));
-                    }
-                }
             }
+        } else {
+            None
+        };
 
-            // ISO path
-            let y = match year_num {
-                Some(y) => y,
-                None => {
-                    return Err(Completion::Throw(
-                        interp.create_type_error("year is required"),
-                    ));
-                }
-            };
-
-            // Validate monthCode VALUE (after year coercion)
-            let month_code_num = if let Some(ref mc) = mc_str {
-                match month_code_to_number(mc) {
-                    Some(n) => Some(n),
-                    None => {
-                        return Err(Completion::Throw(
-                            interp.create_range_error(&format!("Invalid monthCode: {mc}")),
-                        ));
-                    }
-                }
-            } else {
-                None
-            };
-
-            // Resolve month
-            let m = if let Some(mc_n) = month_code_num {
-                if let Some(explicit_m) = month_num
-                    && explicit_m != mc_n
-                {
-                    return Err(Completion::Throw(
-                        interp.create_range_error("month and monthCode conflict"),
-                    ));
-                }
-                mc_n
-            } else if let Some(mn) = month_num {
-                mn
-            } else {
+        // Resolve month
+        let m = if let Some(mc_n) = month_code_num {
+            if let Some(explicit_m) = month_num
+                && explicit_m != mc_n
+            {
                 return Err(Completion::Throw(
-                    interp.create_type_error("month or monthCode is required"),
+                    interp.create_range_error("month and monthCode conflict"),
                 ));
-            };
+            }
+            mc_n
+        } else if let Some(mn) = month_num {
+            mn
+        } else {
+            return Err(Completion::Throw(
+                interp.create_type_error("month or monthCode is required"),
+            ));
+        };
 
-            Ok((y, m, d, cal))
-        }
-        JsValue::String(s) => parse_date_string(interp, &s.to_rust_string()),
-        _ => Err(Completion::Throw(
+        Ok((y, m, d, cal))
+    } else if let Some(s) = item.as_string() {
+        parse_date_string(interp, &s.to_rust_string())
+    } else {
+        Err(Completion::Throw(
             interp.create_type_error("Cannot convert to Temporal.PlainDate"),
-        )),
+        ))
     }
 }
 

--- a/src/interpreter/builtins/temporal/plain_date_time.rs
+++ b/src/interpreter/builtins/temporal/plain_date_time.rs
@@ -46,7 +46,7 @@ pub(super) fn create_plain_date_time_result(
             calendar: cal.to_string(),
         });
     let id = obj_id;
-    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }
 
 pub(super) fn to_temporal_plain_date_time(
@@ -61,125 +61,120 @@ pub(super) fn to_temporal_plain_date_time_with_overflow(
     item: JsValue,
     overflow: &str,
 ) -> Result<(i32, u8, u8, u8, u8, u8, u16, u16, u16, String), Completion> {
-    match &item {
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id) {
-                let data = obj.borrow();
-                if let Some(TemporalData::PlainDateTime {
-                    iso_year,
-                    iso_month,
-                    iso_day,
-                    hour,
-                    minute,
-                    second,
-                    millisecond,
-                    microsecond,
-                    nanosecond,
-                    calendar,
-                }) = data.temporal_data()
-                {
-                    return Ok((
-                        *iso_year,
-                        *iso_month,
-                        *iso_day,
-                        *hour,
-                        *minute,
-                        *second,
-                        *millisecond,
-                        *microsecond,
-                        *nanosecond,
-                        calendar.clone(),
-                    ));
-                }
-                if let Some(TemporalData::PlainDate {
-                    iso_year,
-                    iso_month,
-                    iso_day,
-                    calendar,
-                }) = data.temporal_data()
-                {
-                    return Ok((
-                        *iso_year,
-                        *iso_month,
-                        *iso_day,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        calendar.clone(),
-                    ));
-                }
-                if let Some(TemporalData::ZonedDateTime {
-                    epoch_nanoseconds,
-                    time_zone,
-                    calendar,
-                }) = data.temporal_data()
-                {
-                    let (y, mo, d, h, mi, s, ms, us, ns) =
-                        super::zoned_date_time::epoch_ns_to_components(
-                            epoch_nanoseconds,
-                            time_zone,
-                        );
-                    return Ok((y, mo, d, h, mi, s, ms, us, ns, calendar.clone()));
-                }
+    if let Some(o) = item.as_object_id() {
+        if let Some(obj) = interp.get_object_cell(o) {
+            let data = obj.borrow();
+            if let Some(TemporalData::PlainDateTime {
+                iso_year,
+                iso_month,
+                iso_day,
+                hour,
+                minute,
+                second,
+                millisecond,
+                microsecond,
+                nanosecond,
+                calendar,
+            }) = data.temporal_data()
+            {
+                return Ok((
+                    *iso_year,
+                    *iso_month,
+                    *iso_day,
+                    *hour,
+                    *minute,
+                    *second,
+                    *millisecond,
+                    *microsecond,
+                    *nanosecond,
+                    calendar.clone(),
+                ));
             }
-            let (y_f, month_num, mc_str, d_f, h, mi, s, ms, us, ns, cal) =
-                read_pdt_property_bag(interp, &item)?;
-
-            // Non-ISO calendar: convert calendar fields to ISO
-            if cal != "iso8601" {
-                let era_val = match super::get_prop(interp, &item, "era") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let era_year_val = match super::get_prop(interp, &item, "eraYear") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let has_era = !super::is_undefined(&era_val);
-                let has_era_year = !super::is_undefined(&era_year_val);
-
-                let (icu_era, icu_year) =
-                    if super::calendar_has_eras(&cal) && has_era && has_era_year {
-                        let era_str =
-                            super::to_primitive_and_require_string(interp, &era_val, "era")?;
-                        let ey = super::to_integer_with_truncation(interp, &era_year_val)? as i32;
-                        (Some(era_str), ey)
-                    } else if super::calendar_has_eras(&cal) && (has_era != has_era_year) {
-                        return Err(Completion::Throw(interp.create_type_error(
-                            "era and eraYear must both be present or both be absent",
-                        )));
-                    } else {
-                        (None, y_f as i32)
-                    };
-
-                if let Some((iso_y, iso_m, iso_d)) = super::calendar_fields_to_iso(
-                    icu_era.as_deref(),
-                    icu_year,
-                    mc_str.as_deref(),
-                    month_num.map(|v| v as u8),
-                    d_f as u8,
-                    &cal,
-                ) {
-                    return Ok((iso_y, iso_m, iso_d, h, mi, s, ms, us, ns, cal));
-                }
-                if icu_era.is_some() || overflow == "reject" {
-                    return Err(Completion::Throw(
-                        interp.create_range_error("Invalid calendar date"),
-                    ));
-                }
+            if let Some(TemporalData::PlainDate {
+                iso_year,
+                iso_month,
+                iso_day,
+                calendar,
+            }) = data.temporal_data()
+            {
+                return Ok((
+                    *iso_year,
+                    *iso_month,
+                    *iso_day,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    calendar.clone(),
+                ));
             }
-
-            apply_pdt_overflow(
-                interp, y_f, month_num, mc_str, d_f, h, mi, s, ms, us, ns, cal, overflow,
-            )
+            if let Some(TemporalData::ZonedDateTime {
+                epoch_nanoseconds,
+                time_zone,
+                calendar,
+            }) = data.temporal_data()
+            {
+                let (y, mo, d, h, mi, s, ms, us, ns) =
+                    super::zoned_date_time::epoch_ns_to_components(epoch_nanoseconds, time_zone);
+                return Ok((y, mo, d, h, mi, s, ms, us, ns, calendar.clone()));
+            }
         }
-        JsValue::String(s) => parse_date_time_string(interp, &s.to_rust_string()),
-        _ => Err(Completion::Throw(
-            interp.create_type_error("Cannot convert to Temporal.PlainDateTime"),
-        )),
+        let (y_f, month_num, mc_str, d_f, h, mi, s, ms, us, ns, cal) =
+            read_pdt_property_bag(interp, &item)?;
+
+        // Non-ISO calendar: convert calendar fields to ISO
+        if cal != "iso8601" {
+            let era_val = match super::get_prop(interp, &item, "era") {
+                Completion::Normal(v) => v,
+                other => return Err(other),
+            };
+            let era_year_val = match super::get_prop(interp, &item, "eraYear") {
+                Completion::Normal(v) => v,
+                other => return Err(other),
+            };
+            let has_era = !super::is_undefined(&era_val);
+            let has_era_year = !super::is_undefined(&era_year_val);
+
+            let (icu_era, icu_year) = if super::calendar_has_eras(&cal) && has_era && has_era_year {
+                let era_str = super::to_primitive_and_require_string(interp, &era_val, "era")?;
+                let ey = super::to_integer_with_truncation(interp, &era_year_val)? as i32;
+                (Some(era_str), ey)
+            } else if super::calendar_has_eras(&cal) && (has_era != has_era_year) {
+                return Err(Completion::Throw(interp.create_type_error(
+                    "era and eraYear must both be present or both be absent",
+                )));
+            } else {
+                (None, y_f as i32)
+            };
+
+            if let Some((iso_y, iso_m, iso_d)) = super::calendar_fields_to_iso(
+                icu_era.as_deref(),
+                icu_year,
+                mc_str.as_deref(),
+                month_num.map(|v| v as u8),
+                d_f as u8,
+                &cal,
+            ) {
+                return Ok((iso_y, iso_m, iso_d, h, mi, s, ms, us, ns, cal));
+            }
+            if icu_era.is_some() || overflow == "reject" {
+                return Err(Completion::Throw(
+                    interp.create_range_error("Invalid calendar date"),
+                ));
+            }
+        }
+
+        apply_pdt_overflow(
+            interp, y_f, month_num, mc_str, d_f, h, mi, s, ms, us, ns, cal, overflow,
+        )
+    } else if let Some(s) = item.as_string() {
+        parse_date_time_string(interp, &s.to_rust_string())
+    } else {
+        Err(Completion::Throw(interp.create_type_error(
+            "Cannot convert to Temporal.PlainDateTime",
+        )))
     }
 }
 
@@ -468,11 +463,12 @@ fn get_pdt_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(i32, u8, u8, u8, u8, u8, u16, u16, u16, String), Completion> {
-    let snapshot = match this {
-        JsValue::Object(o) => interp
-            .get_object_cell(o.id)
-            .map(|cell| cell.borrow().temporal_data().cloned()),
-        _ => None,
+    let snapshot = if let Some(o) = this.as_object_id() {
+        interp
+            .get_object_cell(o)
+            .map(|cell| cell.borrow().temporal_data().cloned())
+    } else {
+        None
     };
     match snapshot {
         Some(Some(TemporalData::PlainDateTime {
@@ -554,7 +550,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&cal)))
+                    Completion::Normal(JsValue::from_str(&cal))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -590,14 +586,14 @@ impl Interpreter {
                             1 => cf.month_ordinal as f64,
                             _ => cf.day as f64,
                         };
-                        return Completion::Normal(JsValue::Number(val));
+                        return Completion::Normal(JsValue::number(val));
                     }
                     let val = match idx {
                         0 => y as f64,
                         1 => m as f64,
                         _ => d as f64,
                     };
-                    Completion::Normal(JsValue::Number(val))
+                    Completion::Normal(JsValue::number(val))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -640,7 +636,7 @@ impl Interpreter {
                         4 => us as f64,
                         _ => ns as f64,
                     };
-                    Completion::Normal(JsValue::Number(val))
+                    Completion::Normal(JsValue::number(val))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -671,11 +667,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            &cf.month_code,
-                        )));
+                        return Completion::Normal(JsValue::from_str(&cf.month_code));
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&iso_month_code(m))))
+                    Completion::Normal(JsValue::from_str(&iso_month_code(m)))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -716,37 +710,37 @@ impl Interpreter {
                     if cal != "iso8601" {
                         // weekOfYear and yearOfWeek are undefined for non-ISO calendars
                         if which == 2 || which == 3 {
-                            return Completion::Normal(JsValue::Undefined);
+                            return Completion::Normal(JsValue::UNDEFINED);
                         }
                         if let Some(cf) = super::iso_to_calendar_fields(y, m, d, &cal) {
                             let val = match which {
-                                0 => JsValue::Number(iso_day_of_week(y, m, d) as f64),
-                                1 => JsValue::Number(cf.day_of_year as f64),
-                                4 => JsValue::Number(7.0),
-                                5 => JsValue::Number(cf.days_in_month as f64),
-                                6 => JsValue::Number(cf.days_in_year as f64),
-                                7 => JsValue::Number(cf.months_in_year as f64),
-                                _ => JsValue::Boolean(cf.in_leap_year),
+                                0 => JsValue::number(iso_day_of_week(y, m, d) as f64),
+                                1 => JsValue::number(cf.day_of_year as f64),
+                                4 => JsValue::number(7.0),
+                                5 => JsValue::number(cf.days_in_month as f64),
+                                6 => JsValue::number(cf.days_in_year as f64),
+                                7 => JsValue::number(cf.months_in_year as f64),
+                                _ => JsValue::boolean(cf.in_leap_year),
                             };
                             return Completion::Normal(val);
                         }
                     }
                     let val = match which {
-                        0 => JsValue::Number(iso_day_of_week(y, m, d) as f64),
-                        1 => JsValue::Number(iso_day_of_year(y, m, d) as f64),
+                        0 => JsValue::number(iso_day_of_week(y, m, d) as f64),
+                        1 => JsValue::number(iso_day_of_year(y, m, d) as f64),
                         2 => {
                             let (w, _) = iso_week_of_year(y, m, d);
-                            JsValue::Number(w as f64)
+                            JsValue::number(w as f64)
                         }
                         3 => {
                             let (_, yw) = iso_week_of_year(y, m, d);
-                            JsValue::Number(yw as f64)
+                            JsValue::number(yw as f64)
                         }
-                        4 => JsValue::Number(7.0),
-                        5 => JsValue::Number(iso_days_in_month(y, m) as f64),
-                        6 => JsValue::Number(iso_days_in_year(y) as f64),
-                        7 => JsValue::Number(12.0),
-                        _ => JsValue::Boolean(iso_is_leap_year(y)),
+                        4 => JsValue::number(7.0),
+                        5 => JsValue::number(iso_days_in_month(y, m) as f64),
+                        6 => JsValue::number(iso_days_in_year(y) as f64),
+                        7 => JsValue::number(12.0),
+                        _ => JsValue::boolean(iso_is_leap_year(y)),
                     };
                     Completion::Normal(val)
                 },
@@ -781,17 +775,17 @@ impl Interpreter {
                     {
                         if is_era {
                             return Completion::Normal(match cf.era {
-                                Some(e) => JsValue::String(JsString::from_str(&e)),
-                                None => JsValue::Undefined,
+                                Some(e) => JsValue::from_str(&e),
+                                None => JsValue::UNDEFINED,
                             });
                         } else {
                             return Completion::Normal(match cf.era_year {
-                                Some(ey) => JsValue::Number(ey as f64),
-                                None => JsValue::Undefined,
+                                Some(ey) => JsValue::number(ey as f64),
+                                None => JsValue::UNDEFINED,
                             });
                         }
                     }
-                    Completion::Normal(JsValue::Undefined)
+                    Completion::Normal(JsValue::UNDEFINED)
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -818,7 +812,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // IsPartialTemporalObject
                 if let Err(c) = is_partial_temporal_object(interp, &item) {
                     return c;
@@ -955,7 +949,7 @@ impl Interpreter {
 
                     let overflow = match parse_overflow_option(
                         interp,
-                        &args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                        &args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -1067,7 +1061,7 @@ impl Interpreter {
                     );
                 }
                 // GetTemporalOverflowOption
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let overflow = match parse_overflow_option(interp, &options) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -1134,7 +1128,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let time_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let time_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (h, mi, s, ms, us, ns) = if is_undefined(&time_arg) {
                     (0, 0, 0, 0, 0, 0)
                 } else {
@@ -1164,8 +1158,8 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let cal_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if matches!(cal_arg, JsValue::Undefined) {
+                let cal_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if cal_arg.is_undefined() {
                     return Completion::Throw(
                         interp.create_type_error("withCalendar requires a calendar argument"),
                     );
@@ -1193,12 +1187,12 @@ impl Interpreter {
                     };
                     let dur = match super::duration::to_temporal_duration_record(
                         interp,
-                        args.first().cloned().unwrap_or(JsValue::Undefined),
+                        args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let overflow = match parse_overflow_option(interp, &options) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -1274,7 +1268,7 @@ impl Interpreter {
                             Ok(v) => v,
                             Err(c) => return c,
                         };
-                    let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let (y2, m2, d2, h2, mi2, s2, ms2, us2, ns2, cal2) =
                         match to_temporal_plain_date_time(interp, other) {
                             Ok(v) => v,
@@ -1285,7 +1279,7 @@ impl Interpreter {
                             &format!("cannot compute difference between dates of different calendars: {} and {}", cal, cal2),
                         ));
                     }
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let all_units: &[&str] = &[
                         "year",
                         "month",
@@ -1578,8 +1572,8 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let options = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let (unit, mode_str, increment) = if let JsValue::String(ref s) = options {
+                let options = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let (unit, mode_str, increment) = if let Some(s) = options.as_string() {
                     let u = match temporal_unit_singular(&s.to_rust_string()) {
                         Some(u) => u,
                         None => {
@@ -1587,7 +1581,7 @@ impl Interpreter {
                         }
                     };
                     (u, "halfExpand".to_string(), 1i128)
-                } else if matches!(options, JsValue::Object(_)) {
+                } else if options.is_object() {
                     // Read all options in alphabetical order first, then validate
                     // 1. roundingIncrement
                     let ri = match get_prop(interp, &options, "roundingIncrement") {
@@ -1718,7 +1712,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let b = match to_temporal_plain_date_time(interp, other) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -1733,7 +1727,7 @@ impl Interpreter {
                     && a.7 == b.7
                     && a.8 == b.8
                     && a.9 == b.9;
-                Completion::Normal(JsValue::Boolean(eq))
+                Completion::Normal(JsValue::boolean(eq))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1749,7 +1743,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let options = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let options = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let has_opts = match super::get_options_object(interp, &options) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -1786,7 +1780,7 @@ impl Interpreter {
                         };
                         let mut prec: Option<i32> = if is_undefined(&fsd) {
                             None
-                        } else if matches!(fsd, JsValue::Number(_)) {
+                        } else if fsd.is_number() {
                             let n = match interp.to_number_value(&fsd) {
                                 Ok(v) => v,
                                 Err(e) => return Completion::Throw(e),
@@ -1922,7 +1916,7 @@ impl Interpreter {
                     show_calendar,
                     precision,
                 );
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1940,7 +1934,7 @@ impl Interpreter {
                 };
                 let result =
                     format_plain_date_time(y, m, d, h, mi, s, ms, us, ns, &cal, "auto", None);
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1963,15 +1957,15 @@ impl Interpreter {
                         let result = format_plain_date_time(
                             _y, _m, _d, _h, _mi, _s, _ms, _us, _ns, &_cal, "auto", None,
                         );
-                        return Completion::Normal(JsValue::String(JsString::from_str(&result)));
+                        return Completion::Normal(JsValue::from_str(&result));
                     }
                 };
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let dtf_instance = match interp.construct(&dtf_val, &[locales_arg, options_arg]) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
                 if let Err(e) = super::check_calendar_mismatch(interp, &dtf_instance, &_cal, true) {
                     return Completion::Throw(e);
@@ -2038,20 +2032,20 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let tz_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let tz_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let tz = match super::to_temporal_time_zone_identifier(interp, &tz_arg) {
                     Ok(t) => t,
                     Err(c) => return c,
                 };
                 // Validate options: read disambiguation per spec
-                let opts = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                if !super::is_undefined(&opts) && !matches!(opts, JsValue::Object(_)) {
+                let opts = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                if !super::is_undefined(&opts) && !opts.is_object() {
                     return Completion::Throw(
                         interp.create_type_error("options must be an object"),
                     );
                 }
                 let mut disambiguation = "compatible".to_string();
-                if matches!(opts, JsValue::Object(_)) {
+                if opts.is_object() {
                     let dis_val = match super::get_prop(interp, &opts, "disambiguation") {
                         Completion::Normal(v) => v,
                         c => return c,
@@ -2110,7 +2104,7 @@ impl Interpreter {
                         interp.create_type_error("Temporal.PlainDateTime must be called with new"),
                     );
                 }
-                let y_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let y_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let y = match interp.to_number_value(&y_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -2120,7 +2114,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let m_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let m_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let m = match interp.to_number_value(&m_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -2134,7 +2128,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let d_val = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let d_val = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 let d = match interp.to_number_value(&d_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -2172,7 +2166,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let cal_arg = args.get(9).cloned().unwrap_or(JsValue::Undefined);
+                let cal_arg = args.get(9).cloned().unwrap_or(JsValue::UNDEFINED);
                 let cal = match super::validate_calendar_strict(interp, &cal_arg) {
                     Ok(c) => c,
                     Err(c) => return c,
@@ -2187,9 +2181,11 @@ impl Interpreter {
                 }
                 let result =
                     create_plain_date_time_result(interp, y, m, d, h, mi, s, ms, us, ns, &cal);
-                if let Completion::Normal(JsValue::Object(ref o)) = result {
+                if let Completion::Normal(ref v) = result
+                    && let Some(o) = v.as_object_id()
+                {
                     let dp = interp.realm().temporal_plain_date_time_prototype;
-                    interp.apply_new_target_prototype(o.id, dp, |r| {
+                    interp.apply_new_target_prototype(o, dp, |r| {
                         r.temporal_plain_date_time_prototype
                     });
                 }
@@ -2198,10 +2194,10 @@ impl Interpreter {
         ));
 
         // Constructor.prototype_id
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -2219,10 +2215,10 @@ impl Interpreter {
             "from".to_string(),
             1,
             |interp, _this, args| {
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // Per spec: if item is a string, parse first, then validate overflow (but don't use it)
-                if matches!(&item, JsValue::String(_)) {
+                if item.is_string() {
                     let (y, m, d, h, mi, s, ms, us, ns, cal) =
                         match to_temporal_plain_date_time_with_overflow(interp, item, "constrain") {
                             Ok(v) => v,
@@ -2242,8 +2238,8 @@ impl Interpreter {
                     );
                 }
                 // Check if it's a Temporal object (read overflow first, then return copy)
-                let is_temporal = if let JsValue::Object(ref o) = item {
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                let is_temporal = if let Some(o) = item.as_object_id() {
+                    if let Some(obj) = interp.get_object_cell(o) {
                         let data = obj.borrow();
                         matches!(
                             data.temporal_data(),
@@ -2373,8 +2369,8 @@ impl Interpreter {
                 }
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -2386,14 +2382,14 @@ impl Interpreter {
             |interp, _this, args| {
                 let a = match to_temporal_plain_date_time(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
                 let b = match to_temporal_plain_date_time(
                     interp,
-                    args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                    args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -2405,11 +2401,11 @@ impl Interpreter {
                     std::cmp::Ordering::Equal => 0.0,
                     std::cmp::Ordering::Greater => 1.0,
                 };
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -2430,7 +2426,7 @@ fn get_constructor_field(
     min: u8,
     max: u8,
 ) -> Result<u8, Completion> {
-    let val = arg.cloned().unwrap_or(JsValue::Undefined);
+    let val = arg.cloned().unwrap_or(JsValue::UNDEFINED);
     if is_undefined(&val) {
         return Ok(0);
     }
@@ -2460,7 +2456,7 @@ fn get_constructor_field_u16(
     min: u16,
     max: u16,
 ) -> Result<u16, Completion> {
-    let val = arg.cloned().unwrap_or(JsValue::Undefined);
+    let val = arg.cloned().unwrap_or(JsValue::UNDEFINED);
     if is_undefined(&val) {
         return Ok(0);
     }

--- a/src/interpreter/builtins/temporal/plain_month_day.rs
+++ b/src/interpreter/builtins/temporal/plain_month_day.rs
@@ -30,19 +30,19 @@ pub(super) fn create_plain_month_day_result(
             reference_iso_year: ref_year,
             calendar: cal.to_string(),
         });
-    let id = obj_id;
-    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+    Completion::Normal(JsValue::object(obj_id))
 }
 
 fn get_md_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(u8, u8, i32, String), Completion> {
-    let snapshot = match this {
-        JsValue::Object(o) => interp
-            .get_object_cell(o.id)
-            .map(|cell| cell.borrow().temporal_data().cloned()),
-        _ => None,
+    let snapshot = if let Some(oid) = this.as_object_id() {
+        interp
+            .get_object_cell(oid)
+            .map(|cell| cell.borrow().temporal_data().cloned())
+    } else {
+        None
     };
     match snapshot {
         Some(Some(TemporalData::PlainMonthDay {
@@ -153,136 +153,52 @@ fn to_temporal_plain_month_day(
     interp: &mut Interpreter,
     item: JsValue,
 ) -> Result<(u8, u8, i32, String), Completion> {
-    match &item {
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id) {
-                let data = obj.borrow();
-                if let Some(TemporalData::PlainMonthDay {
-                    iso_month,
-                    iso_day,
-                    reference_iso_year,
-                    calendar,
-                }) = data.temporal_data()
-                {
-                    return Ok((*iso_month, *iso_day, *reference_iso_year, calendar.clone()));
-                }
+    if let Some(oid) = item.as_object_id() {
+        if let Some(obj) = interp.get_object_cell(oid) {
+            let data = obj.borrow();
+            if let Some(TemporalData::PlainMonthDay {
+                iso_month,
+                iso_day,
+                reference_iso_year,
+                calendar,
+            }) = data.temporal_data()
+            {
+                return Ok((*iso_month, *iso_day, *reference_iso_year, calendar.clone()));
             }
-            // Alphabetical order: calendar, day, era, eraYear, month, monthCode, year
-            let cal_val = match get_prop(interp, &item, "calendar") {
+        }
+        // Alphabetical order: calendar, day, era, eraYear, month, monthCode, year
+        let cal_val = match get_prop(interp, &item, "calendar") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let cal = to_temporal_calendar_slot_value(interp, &cal_val)?;
+        let d_val = match get_prop(interp, &item, "day") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let d_f = if is_undefined(&d_val) {
+            return Err(Completion::Throw(
+                interp.create_type_error("day is required"),
+            ));
+        } else {
+            to_integer_with_truncation(interp, &d_val)?
+        };
+        if d_f < 1.0 {
+            return Err(Completion::Throw(
+                interp.create_range_error("day must be a positive integer"),
+            ));
+        }
+
+        if cal != "iso8601" {
+            // Non-ISO calendar path: read era, eraYear too
+            let era_val = match super::get_prop(interp, &item, "era") {
                 Completion::Normal(v) => v,
                 other => return Err(other),
             };
-            let cal = to_temporal_calendar_slot_value(interp, &cal_val)?;
-            let d_val = match get_prop(interp, &item, "day") {
+            let era_year_val = match super::get_prop(interp, &item, "eraYear") {
                 Completion::Normal(v) => v,
                 other => return Err(other),
             };
-            let d_f = if is_undefined(&d_val) {
-                return Err(Completion::Throw(
-                    interp.create_type_error("day is required"),
-                ));
-            } else {
-                to_integer_with_truncation(interp, &d_val)?
-            };
-            if d_f < 1.0 {
-                return Err(Completion::Throw(
-                    interp.create_range_error("day must be a positive integer"),
-                ));
-            }
-
-            if cal != "iso8601" {
-                // Non-ISO calendar path: read era, eraYear too
-                let era_val = match super::get_prop(interp, &item, "era") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let era_year_val = match super::get_prop(interp, &item, "eraYear") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let m_val = match get_prop(interp, &item, "month") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let month_num = if !is_undefined(&m_val) {
-                    Some(to_integer_with_truncation(interp, &m_val)?)
-                } else {
-                    None
-                };
-                let mc_val = match get_prop(interp, &item, "monthCode") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let mc_str = if !is_undefined(&mc_val) {
-                    let mc = super::to_primitive_and_require_string(interp, &mc_val, "monthCode")?;
-                    if !super::is_month_code_syntax_valid(&mc) {
-                        return Err(Completion::Throw(
-                            interp.create_range_error(&format!("Invalid monthCode: {mc}")),
-                        ));
-                    }
-                    Some(mc)
-                } else {
-                    None
-                };
-                let y_val = match get_prop(interp, &item, "year") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let year_opt = if !is_undefined(&y_val) {
-                    Some(to_integer_with_truncation(interp, &y_val)? as i32)
-                } else {
-                    None
-                };
-
-                // Determine the calendar month code
-                let mc = if let Some(mc) = mc_str {
-                    mc
-                } else if let Some(mn) = month_num {
-                    if let Some(yr) = year_opt {
-                        super::ordinal_month_to_month_code(yr, mn as u8, &cal)
-                            .unwrap_or_else(|| format!("M{:02}", mn as u8))
-                    } else {
-                        format!("M{:02}", mn as u8)
-                    }
-                } else {
-                    return Err(Completion::Throw(
-                        interp.create_type_error("month or monthCode is required"),
-                    ));
-                };
-
-                // Determine year: from era+eraYear, year, or use reference
-                let icu_year = if !is_undefined(&era_val) && !is_undefined(&era_year_val) {
-                    let ey = to_integer_with_truncation(interp, &era_year_val)? as i32;
-                    let era_str = super::to_primitive_and_require_string(interp, &era_val, "era")?;
-                    // Convert era+eraYear to extended year via ICU
-                    if let Some((iso_y, iso_m, iso_d)) = super::calendar_fields_to_iso(
-                        Some(&era_str),
-                        ey,
-                        Some(&mc),
-                        month_num.map(|v| v as u8),
-                        d_f as u8,
-                        &cal,
-                    ) {
-                        return Ok((iso_m, iso_d, iso_y, cal));
-                    }
-                    return Err(Completion::Throw(
-                        interp.create_range_error("Invalid calendar fields for PlainMonthDay"),
-                    ));
-                } else {
-                    year_opt
-                };
-
-                if let Some((iso_y, iso_m, iso_d)) =
-                    super::calendar_month_day_to_iso(&mc, d_f as u8, icu_year, &cal, "constrain")
-                {
-                    return Ok((iso_m, iso_d, iso_y, cal));
-                }
-                return Err(Completion::Throw(
-                    interp.create_range_error("Invalid calendar fields for PlainMonthDay"),
-                ));
-            }
-
-            // ISO path
             let m_val = match get_prop(interp, &item, "month") {
                 Completion::Normal(v) => v,
                 other => return Err(other),
@@ -311,91 +227,172 @@ fn to_temporal_plain_month_day(
                 Completion::Normal(v) => v,
                 other => return Err(other),
             };
-            let _y = if !is_undefined(&y_val) {
+            let year_opt = if !is_undefined(&y_val) {
                 Some(to_integer_with_truncation(interp, &y_val)? as i32)
             } else {
                 None
             };
-            let m = if let Some(ref mc) = mc_str {
-                match super::plain_date::month_code_to_number_pub(mc) {
-                    Some(n) => {
-                        if let Some(mn) = month_num
-                            && mn as u8 != n
-                        {
-                            return Err(Completion::Throw(
-                                interp.create_range_error("month and monthCode conflict"),
-                            ));
-                        }
-                        n
-                    }
-                    None => {
-                        return Err(Completion::Throw(
-                            interp.create_range_error(&format!("Invalid monthCode: {mc}")),
-                        ));
-                    }
-                }
+
+            // Determine the calendar month code
+            let mc = if let Some(mc) = mc_str {
+                mc
             } else if let Some(mn) = month_num {
-                mn as u8
+                if let Some(yr) = year_opt {
+                    super::ordinal_month_to_month_code(yr, mn as u8, &cal)
+                        .unwrap_or_else(|| format!("M{:02}", mn as u8))
+                } else {
+                    format!("M{:02}", mn as u8)
+                }
             } else {
                 return Err(Completion::Throw(
                     interp.create_type_error("month or monthCode is required"),
                 ));
             };
-            let d = d_f as u8;
-            Ok((m, d, 1972, cal))
-        }
-        JsValue::String(s) => {
-            let parsed = match parse_temporal_month_day_string(&s.to_rust_string()) {
-                Some(v) => v,
-                None => {
-                    return Err(Completion::Throw(interp.create_range_error(&format!(
-                        "Invalid month-day string: {}",
-                        s.to_rust_string()
-                    ))));
-                }
-            };
-            // PlainMonthDay does not accept UTC designator
-            if parsed.4 {
-                return Err(Completion::Throw(interp.create_range_error(
-                    "UTC designator Z is not allowed in a PlainMonthDay string",
-                )));
-            }
-            let cal = parsed.3.unwrap_or_else(|| "iso8601".to_string());
-            let cal = match validate_calendar_name(&cal) {
-                Some(c) => c,
-                None => {
-                    return Err(Completion::Throw(
-                        interp.create_range_error(&format!("Invalid calendar: {cal}")),
-                    ));
-                }
-            };
-            if cal != "iso8601" {
-                // Non-ISO calendar: convert the parsed ISO date to calendar fields
-                let iso_year = parsed.2.unwrap_or(1972);
-                if !(-271821..=275760).contains(&iso_year) {
-                    return Err(Completion::Throw(
-                        interp.create_range_error("ISO year out of range for non-ISO calendar"),
-                    ));
-                }
-                if let Some(fields) =
-                    super::iso_to_calendar_fields(iso_year, parsed.0, parsed.1, &cal)
-                {
-                    let mc = &fields.month_code;
-                    if let Some((ref_y, ref_m, ref_d)) =
-                        super::calendar_month_day_to_iso(mc, fields.day, None, &cal, "constrain")
-                    {
-                        return Ok((ref_m, ref_d, ref_y, cal));
-                    }
+
+            // Determine year: from era+eraYear, year, or use reference
+            let icu_year = if !is_undefined(&era_val) && !is_undefined(&era_year_val) {
+                let ey = to_integer_with_truncation(interp, &era_year_val)? as i32;
+                let era_str = super::to_primitive_and_require_string(interp, &era_val, "era")?;
+                // Convert era+eraYear to extended year via ICU
+                if let Some((iso_y, iso_m, iso_d)) = super::calendar_fields_to_iso(
+                    Some(&era_str),
+                    ey,
+                    Some(&mc),
+                    month_num.map(|v| v as u8),
+                    d_f as u8,
+                    &cal,
+                ) {
+                    return Ok((iso_m, iso_d, iso_y, cal));
                 }
                 return Err(Completion::Throw(
                     interp.create_range_error("Invalid calendar fields for PlainMonthDay"),
                 ));
+            } else {
+                year_opt
+            };
+
+            if let Some((iso_y, iso_m, iso_d)) =
+                super::calendar_month_day_to_iso(&mc, d_f as u8, icu_year, &cal, "constrain")
+            {
+                return Ok((iso_m, iso_d, iso_y, cal));
             }
-            Ok((parsed.0, parsed.1, 1972, cal))
+            return Err(Completion::Throw(
+                interp.create_range_error("Invalid calendar fields for PlainMonthDay"),
+            ));
         }
-        _ => Err(Completion::Throw(
-            interp.create_type_error("Cannot convert to Temporal.PlainMonthDay"),
-        )),
+
+        // ISO path
+        let m_val = match get_prop(interp, &item, "month") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let month_num = if !is_undefined(&m_val) {
+            Some(to_integer_with_truncation(interp, &m_val)?)
+        } else {
+            None
+        };
+        let mc_val = match get_prop(interp, &item, "monthCode") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let mc_str = if !is_undefined(&mc_val) {
+            let mc = super::to_primitive_and_require_string(interp, &mc_val, "monthCode")?;
+            if !super::is_month_code_syntax_valid(&mc) {
+                return Err(Completion::Throw(
+                    interp.create_range_error(&format!("Invalid monthCode: {mc}")),
+                ));
+            }
+            Some(mc)
+        } else {
+            None
+        };
+        let y_val = match get_prop(interp, &item, "year") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let _y = if !is_undefined(&y_val) {
+            Some(to_integer_with_truncation(interp, &y_val)? as i32)
+        } else {
+            None
+        };
+        let m = if let Some(ref mc) = mc_str {
+            match super::plain_date::month_code_to_number_pub(mc) {
+                Some(n) => {
+                    if let Some(mn) = month_num
+                        && mn as u8 != n
+                    {
+                        return Err(Completion::Throw(
+                            interp.create_range_error("month and monthCode conflict"),
+                        ));
+                    }
+                    n
+                }
+                None => {
+                    return Err(Completion::Throw(
+                        interp.create_range_error(&format!("Invalid monthCode: {mc}")),
+                    ));
+                }
+            }
+        } else if let Some(mn) = month_num {
+            mn as u8
+        } else {
+            return Err(Completion::Throw(
+                interp.create_type_error("month or monthCode is required"),
+            ));
+        };
+        let d = d_f as u8;
+        Ok((m, d, 1972, cal))
+    } else if let Some(s) = item.as_string() {
+        let parsed = match parse_temporal_month_day_string(&s.to_rust_string()) {
+            Some(v) => v,
+            None => {
+                return Err(Completion::Throw(interp.create_range_error(&format!(
+                    "Invalid month-day string: {}",
+                    s.to_rust_string()
+                ))));
+            }
+        };
+        // PlainMonthDay does not accept UTC designator
+        if parsed.4 {
+            return Err(Completion::Throw(interp.create_range_error(
+                "UTC designator Z is not allowed in a PlainMonthDay string",
+            )));
+        }
+        let cal = parsed.3.unwrap_or_else(|| "iso8601".to_string());
+        let cal = match validate_calendar_name(&cal) {
+            Some(c) => c,
+            None => {
+                return Err(Completion::Throw(
+                    interp.create_range_error(&format!("Invalid calendar: {cal}")),
+                ));
+            }
+        };
+        if cal != "iso8601" {
+            // Non-ISO calendar: convert the parsed ISO date to calendar fields
+            let iso_year = parsed.2.unwrap_or(1972);
+            if !(-271821..=275760).contains(&iso_year) {
+                return Err(Completion::Throw(
+                    interp.create_range_error("ISO year out of range for non-ISO calendar"),
+                ));
+            }
+            if let Some(fields) = super::iso_to_calendar_fields(iso_year, parsed.0, parsed.1, &cal)
+            {
+                let mc = &fields.month_code;
+                if let Some((ref_y, ref_m, ref_d)) =
+                    super::calendar_month_day_to_iso(mc, fields.day, None, &cal, "constrain")
+                {
+                    return Ok((ref_m, ref_d, ref_y, cal));
+                }
+            }
+            return Err(Completion::Throw(
+                interp.create_range_error("Invalid calendar fields for PlainMonthDay"),
+            ));
+        }
+        Ok((parsed.0, parsed.1, 1972, cal))
+    } else {
+        Err(Completion::Throw(interp.create_type_error(
+            "Cannot convert to Temporal.PlainMonthDay",
+        )))
     }
 }
 
@@ -417,7 +414,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&cal)))
+                    Completion::Normal(JsValue::from_str(&cal))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -446,11 +443,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(ry, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            &cf.month_code,
-                        )));
+                        return Completion::Normal(JsValue::from_str(&cf.month_code));
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&iso_month_code(m))))
+                    Completion::Normal(JsValue::from_str(&iso_month_code(m)))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -479,9 +474,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(ry, m, d, &cal)
                     {
-                        return Completion::Normal(JsValue::Number(cf.day as f64));
+                        return Completion::Normal(JsValue::number(cf.day as f64));
                     }
-                    Completion::Normal(JsValue::Number(d as f64))
+                    Completion::Normal(JsValue::number(d as f64))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -508,7 +503,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // IsPartialTemporalObject
                 if let Err(c) = is_partial_temporal_object(interp, &item) {
                     return c;
@@ -548,7 +543,7 @@ impl Interpreter {
                         "month requires monthCode for non-ISO calendars in PlainMonthDay.with()",
                     ));
                 }
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let overflow = match parse_overflow_option(interp, &options) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -616,12 +611,12 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (m2, d2, ry2, c2) = match to_temporal_plain_month_day(interp, other) {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                Completion::Normal(JsValue::Boolean(
+                Completion::Normal(JsValue::boolean(
                     m1 == m2 && d1 == d2 && ry1 == ry2 && c1 == c2,
                 ))
             },
@@ -639,7 +634,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let options = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let options = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let has_opts = match super::get_options_object(interp, &options) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -668,13 +663,13 @@ impl Interpreter {
                 } else {
                     "auto".to_string()
                 };
-                Completion::Normal(JsValue::String(JsString::from_str(&format_month_day(
+                Completion::Normal(JsValue::from_str(&format_month_day(
                     m,
                     d,
                     ref_year,
                     &cal,
                     &show_cal_owned,
-                ))))
+                )))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -689,9 +684,9 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                Completion::Normal(JsValue::String(JsString::from_str(&format_month_day(
+                Completion::Normal(JsValue::from_str(&format_month_day(
                     m, d, ref_year, &cal, "auto",
-                ))))
+                )))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -709,13 +704,13 @@ impl Interpreter {
                 let dtf_val = match interp.realm().intl_date_time_format_ctor.clone() {
                     Some(v) => v,
                     None => {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            &format_month_day(m, d, ref_year, &cal, "auto"),
+                        return Completion::Normal(JsValue::from_str(&format_month_day(
+                            m, d, ref_year, &cal, "auto",
                         )));
                     }
                 };
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 if let Err(e) =
                     super::check_locale_string_style_conflict(interp, &options_arg, true, false)
                 {
@@ -724,7 +719,7 @@ impl Interpreter {
                 let dtf_instance = match interp.construct(&dtf_val, &[locales_arg, options_arg]) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
                 if let Err(e) = super::check_calendar_mismatch(interp, &dtf_instance, &cal, false) {
                     return Completion::Throw(e);
@@ -759,8 +754,8 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(item, JsValue::Object(_)) {
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !item.is_object() {
                     return Completion::Throw(
                         interp.create_type_error("argument must be an object with a year property"),
                     );
@@ -874,7 +869,7 @@ impl Interpreter {
                         interp.create_type_error("Temporal.PlainMonthDay must be called with new"),
                     );
                 }
-                let m_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let m_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let m = match interp.to_number_value(&m_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -888,7 +883,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let d_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let d_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let d = match interp.to_number_value(&d_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -902,7 +897,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let cal_arg = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let cal_arg = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 let cal = match super::validate_calendar_strict(interp, &cal_arg) {
                     Ok(c) => c,
                     Err(c) => return c,
@@ -935,9 +930,11 @@ impl Interpreter {
                     );
                 }
                 let result = create_plain_month_day_result(interp, m, d, ry, &cal);
-                if let Completion::Normal(JsValue::Object(ref o)) = result {
+                if let Completion::Normal(ref v) = result
+                    && let Some(oid) = v.as_object_id()
+                {
                     let dp = interp.realm().temporal_plain_month_day_prototype;
-                    interp.apply_new_target_prototype(o.id, dp, |r| {
+                    interp.apply_new_target_prototype(oid, dp, |r| {
                         r.temporal_plain_month_day_prototype
                     });
                 }
@@ -945,10 +942,10 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(oid) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(oid)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -966,10 +963,10 @@ impl Interpreter {
             "from".to_string(),
             1,
             |interp, _, args| {
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // Per spec: if item is a string, parse first, then validate overflow (but don't use it)
-                if matches!(&item, JsValue::String(_)) {
+                if item.is_string() {
                     let (m, d, ry, cal) = match to_temporal_plain_month_day(interp, item) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -981,8 +978,8 @@ impl Interpreter {
                     return create_plain_month_day_result(interp, m, d, ry, &cal);
                 }
                 // Check if it's a Temporal PlainMonthDay (read overflow first, return copy)
-                let is_temporal = if let JsValue::Object(ref o) = item {
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                let is_temporal = if let Some(oid) = item.as_object_id() {
+                    if let Some(obj) = interp.get_object_cell(oid) {
                         let data = obj.borrow();
                         matches!(
                             data.temporal_data(),
@@ -1201,8 +1198,8 @@ impl Interpreter {
                 }
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(oid) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(oid)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }

--- a/src/interpreter/builtins/temporal/plain_time.rs
+++ b/src/interpreter/builtins/temporal/plain_time.rs
@@ -40,7 +40,7 @@ impl Interpreter {
                         5 => fields.5 as f64,
                         _ => 0.0,
                     };
-                    Completion::Normal(JsValue::Number(val))
+                    Completion::Normal(JsValue::number(val))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -67,7 +67,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // IsPartialTemporalObject
                 if let Err(c) = is_partial_temporal_object(interp, &item) {
                     return c;
@@ -114,7 +114,7 @@ impl Interpreter {
                             .create_type_error("with() requires at least one recognized property"),
                     );
                 }
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let overflow = match parse_overflow_option(interp, &options) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -159,7 +159,7 @@ impl Interpreter {
                     };
                     let dur = match super::duration::to_temporal_duration_record(
                         interp,
-                        args.first().cloned().unwrap_or(JsValue::Undefined),
+                        args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -194,7 +194,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let (h2, m2, s2, ms2, us2, ns2) = match to_temporal_plain_time(interp, other) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -207,7 +207,7 @@ impl Interpreter {
                         ns_this - ns_other
                     };
 
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let (largest_unit, smallest_unit, rounding_mode, rounding_increment) =
                         match parse_time_diff_options(interp, &options, "hour") {
                             Ok(v) => v,
@@ -262,11 +262,11 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let round_to = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let round_to = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 if is_undefined(&round_to) {
                     return Completion::Throw(interp.create_type_error("round requires options"));
                 }
-                let (unit, rounding_mode, increment) = if let JsValue::String(ref su) = round_to {
+                let (unit, rounding_mode, increment) = if let Some(su) = round_to.as_string() {
                     let su_str = su.to_rust_string();
                     match temporal_unit_singular(&su_str) {
                         Some(u) if is_valid_time_round_unit(u) => (u, "halfExpand", 1.0),
@@ -281,7 +281,7 @@ impl Interpreter {
                             );
                         }
                     }
-                } else if matches!(round_to, JsValue::Object(_)) {
+                } else if round_to.is_object() {
                     // Read all options in alphabetical order first, then validate
                     // 1. roundingIncrement: get + coerce
                     let inc_val = match get_prop(interp, &round_to, "roundingIncrement") {
@@ -395,13 +395,13 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (h2, m2, s2, ms2, us2, ns2) = match to_temporal_plain_time(interp, other) {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
                 let eq = h1 == h2 && m1 == m2 && s1 == s2 && ms1 == ms2 && us1 == us2 && ns1 == ns2;
-                Completion::Normal(JsValue::Boolean(eq))
+                Completion::Normal(JsValue::boolean(eq))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -417,7 +417,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let options = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let options = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (precision, rounding_mode) =
                     match parse_time_to_string_options(interp, &options) {
                         Ok(v) => v,
@@ -449,7 +449,7 @@ impl Interpreter {
                 };
 
                 let result = format_plain_time(rh, rm, rs, rms, rus, rns, precision);
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -466,7 +466,7 @@ impl Interpreter {
                     Err(c) => return c,
                 };
                 let result = format_plain_time(h, m, s, ms, us, ns, None);
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -486,11 +486,11 @@ impl Interpreter {
                     Some(v) => v,
                     None => {
                         let result = format_plain_time(h, m, s, ms, us, ns, None);
-                        return Completion::Normal(JsValue::String(JsString::from_str(&result)));
+                        return Completion::Normal(JsValue::from_str(&result));
                     }
                 };
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // PlainTime has time but not date
                 if let Err(e) =
                     super::check_locale_string_style_conflict(interp, &options_arg, false, true)
@@ -500,7 +500,7 @@ impl Interpreter {
                 let dtf_instance = match interp.construct(&dtf_val, &[locales_arg, options_arg]) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
                 super::temporal_format_with_dtf(interp, &dtf_instance, this)
             },
@@ -695,20 +695,21 @@ impl Interpreter {
                     microsecond,
                     nanosecond,
                 );
-                if let Completion::Normal(JsValue::Object(ref o)) = result {
+                if let Completion::Normal(ref v) = result
+                    && let Some(o) = v.as_object_id()
+                {
                     let dp = interp.realm().temporal_plain_time_prototype;
-                    interp
-                        .apply_new_target_prototype(o.id, dp, |r| r.temporal_plain_time_prototype);
+                    interp.apply_new_target_prototype(o, dp, |r| r.temporal_plain_time_prototype);
                 }
                 result
             },
         ));
 
         // Constructor.prototype_id
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -726,10 +727,10 @@ impl Interpreter {
             "from".to_string(),
             1,
             |interp, _this, args| {
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // Per spec: if item is a string, parse first, then validate overflow (but don't use it)
-                if matches!(&item, JsValue::String(_)) {
+                if item.is_string() {
                     let (h, m, s, ms, us, ns) =
                         match to_temporal_plain_time_with_overflow(interp, item, "constrain") {
                             Ok(v) => v,
@@ -768,8 +769,8 @@ impl Interpreter {
                 }
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -781,14 +782,14 @@ impl Interpreter {
             |interp, _this, args| {
                 let one = match to_temporal_plain_time(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
                 let two = match to_temporal_plain_time(
                     interp,
-                    args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                    args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -802,11 +803,11 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                Completion::Normal(JsValue::Number(result))
+                Completion::Normal(JsValue::number(result))
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);
@@ -825,12 +826,11 @@ fn get_plain_time_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(u8, u8, u8, u16, u16, u16), Completion> {
-    let snapshot = match this {
-        JsValue::Object(o) => interp
-            .get_object_cell(o.id)
-            .map(|cell| cell.borrow().temporal_data().cloned()),
-        _ => None,
-    };
+    let snapshot = this.as_object_id().and_then(|o| {
+        interp
+            .get_object_cell(o)
+            .map(|cell| cell.borrow().temporal_data().cloned())
+    });
     match snapshot {
         Some(Some(TemporalData::PlainTime {
             hour,
@@ -876,7 +876,7 @@ pub(super) fn create_plain_time_result(
             nanosecond: ns,
         });
     let id = obj_id;
-    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }
 
 pub(super) fn to_temporal_plain_time_with_overflow(
@@ -926,129 +926,126 @@ fn to_temporal_plain_time_raw(
     interp: &mut Interpreter,
     item: JsValue,
 ) -> Result<(u8, u8, u8, u16, u16, u16), Completion> {
-    match &item {
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id) {
-                let data = obj.borrow();
-                if let Some(TemporalData::PlainTime {
-                    hour,
-                    minute,
-                    second,
-                    millisecond,
-                    microsecond,
-                    nanosecond,
-                }) = data.temporal_data()
-                {
-                    return Ok((
-                        *hour,
-                        *minute,
-                        *second,
-                        *millisecond,
-                        *microsecond,
-                        *nanosecond,
-                    ));
-                }
-                if let Some(TemporalData::PlainDateTime {
-                    hour,
-                    minute,
-                    second,
-                    millisecond,
-                    microsecond,
-                    nanosecond,
-                    ..
-                }) = data.temporal_data()
-                {
-                    return Ok((
-                        *hour,
-                        *minute,
-                        *second,
-                        *millisecond,
-                        *microsecond,
-                        *nanosecond,
-                    ));
-                }
-                if let Some(TemporalData::ZonedDateTime {
-                    epoch_nanoseconds,
-                    time_zone,
-                    ..
-                }) = data.temporal_data()
-                {
-                    let (_, _, _, h, mi, s, ms, us, ns) =
-                        super::zoned_date_time::epoch_ns_to_components(
-                            epoch_nanoseconds,
-                            time_zone,
-                        );
-                    return Ok((h, mi, s, ms, us, ns));
-                }
-            }
-            // Property bag: read and coerce each field in alphabetical order per spec:
-            // hour, microsecond, millisecond, minute, nanosecond, second
-            let h_val = match get_prop(interp, &item, "hour") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let (h, h_present) = if is_undefined(&h_val) {
-                (0u8, false)
-            } else {
-                (to_integer_with_truncation(interp, &h_val)? as u8, true)
-            };
-            let us_val = match get_prop(interp, &item, "microsecond") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let (us, us_present) = if is_undefined(&us_val) {
-                (0u16, false)
-            } else {
-                (to_integer_with_truncation(interp, &us_val)? as u16, true)
-            };
-            let ms_val = match get_prop(interp, &item, "millisecond") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let (ms, ms_present) = if is_undefined(&ms_val) {
-                (0u16, false)
-            } else {
-                (to_integer_with_truncation(interp, &ms_val)? as u16, true)
-            };
-            let m_val = match get_prop(interp, &item, "minute") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let (m, m_present) = if is_undefined(&m_val) {
-                (0u8, false)
-            } else {
-                (to_integer_with_truncation(interp, &m_val)? as u8, true)
-            };
-            let ns_val = match get_prop(interp, &item, "nanosecond") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let (ns, ns_present) = if is_undefined(&ns_val) {
-                (0u16, false)
-            } else {
-                (to_integer_with_truncation(interp, &ns_val)? as u16, true)
-            };
-            let s_val = match get_prop(interp, &item, "second") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let (s, s_present) = if is_undefined(&s_val) {
-                (0u8, false)
-            } else {
-                (to_integer_with_truncation(interp, &s_val)? as u8, true)
-            };
-            // Per spec: if no time properties exist, throw TypeError
-            if !h_present && !m_present && !s_present && !ms_present && !us_present && !ns_present {
-                return Err(Completion::Throw(
-                    interp.create_type_error("Property bag has no time fields"),
+    if let Some(o) = item.as_object_id() {
+        if let Some(obj) = interp.get_object_cell(o) {
+            let data = obj.borrow();
+            if let Some(TemporalData::PlainTime {
+                hour,
+                minute,
+                second,
+                millisecond,
+                microsecond,
+                nanosecond,
+            }) = data.temporal_data()
+            {
+                return Ok((
+                    *hour,
+                    *minute,
+                    *second,
+                    *millisecond,
+                    *microsecond,
+                    *nanosecond,
                 ));
             }
-            Ok((h, m, s, ms, us, ns))
+            if let Some(TemporalData::PlainDateTime {
+                hour,
+                minute,
+                second,
+                millisecond,
+                microsecond,
+                nanosecond,
+                ..
+            }) = data.temporal_data()
+            {
+                return Ok((
+                    *hour,
+                    *minute,
+                    *second,
+                    *millisecond,
+                    *microsecond,
+                    *nanosecond,
+                ));
+            }
+            if let Some(TemporalData::ZonedDateTime {
+                epoch_nanoseconds,
+                time_zone,
+                ..
+            }) = data.temporal_data()
+            {
+                let (_, _, _, h, mi, s, ms, us, ns) =
+                    super::zoned_date_time::epoch_ns_to_components(epoch_nanoseconds, time_zone);
+                return Ok((h, mi, s, ms, us, ns));
+            }
         }
-        JsValue::String(s) => parse_time_string(interp, &s.to_rust_string()),
-        _ => Err(Completion::Throw(
+        // Property bag: read and coerce each field in alphabetical order per spec:
+        // hour, microsecond, millisecond, minute, nanosecond, second
+        let h_val = match get_prop(interp, &item, "hour") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let (h, h_present) = if is_undefined(&h_val) {
+            (0u8, false)
+        } else {
+            (to_integer_with_truncation(interp, &h_val)? as u8, true)
+        };
+        let us_val = match get_prop(interp, &item, "microsecond") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let (us, us_present) = if is_undefined(&us_val) {
+            (0u16, false)
+        } else {
+            (to_integer_with_truncation(interp, &us_val)? as u16, true)
+        };
+        let ms_val = match get_prop(interp, &item, "millisecond") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let (ms, ms_present) = if is_undefined(&ms_val) {
+            (0u16, false)
+        } else {
+            (to_integer_with_truncation(interp, &ms_val)? as u16, true)
+        };
+        let m_val = match get_prop(interp, &item, "minute") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let (m, m_present) = if is_undefined(&m_val) {
+            (0u8, false)
+        } else {
+            (to_integer_with_truncation(interp, &m_val)? as u8, true)
+        };
+        let ns_val = match get_prop(interp, &item, "nanosecond") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let (ns, ns_present) = if is_undefined(&ns_val) {
+            (0u16, false)
+        } else {
+            (to_integer_with_truncation(interp, &ns_val)? as u16, true)
+        };
+        let s_val = match get_prop(interp, &item, "second") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let (s, s_present) = if is_undefined(&s_val) {
+            (0u8, false)
+        } else {
+            (to_integer_with_truncation(interp, &s_val)? as u8, true)
+        };
+        // Per spec: if no time properties exist, throw TypeError
+        if !h_present && !m_present && !s_present && !ms_present && !us_present && !ns_present {
+            return Err(Completion::Throw(
+                interp.create_type_error("Property bag has no time fields"),
+            ));
+        }
+        Ok((h, m, s, ms, us, ns))
+    } else if let Some(s) = item.as_string() {
+        parse_time_string(interp, &s.to_rust_string())
+    } else {
+        Err(Completion::Throw(
             interp.create_type_error("Cannot convert to Temporal.PlainTime"),
-        )),
+        ))
     }
 }
 
@@ -1292,7 +1289,7 @@ fn parse_time_to_string_options(
     if is_undefined(options) {
         return Ok((None, "trunc"));
     }
-    if !matches!(options, JsValue::Object(_)) {
+    if !options.is_object() {
         return Err(Completion::Throw(
             interp.create_type_error("options must be an object"),
         ));
@@ -1304,7 +1301,7 @@ fn parse_time_to_string_options(
     };
     let mut precision = None;
     if !is_undefined(&fsd_val) {
-        if matches!(fsd_val, JsValue::Number(_)) {
+        if fsd_val.is_number() {
             // GetStringOrNumberOption: value is Number → floor then range check
             let n = match interp.to_number_value(&fsd_val) {
                 Ok(v) => v,

--- a/src/interpreter/builtins/temporal/plain_year_month.rs
+++ b/src/interpreter/builtins/temporal/plain_year_month.rs
@@ -37,18 +37,18 @@ pub(super) fn create_plain_year_month_result(
             calendar: cal.to_string(),
         });
     let id = obj_id;
-    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }
 
 fn get_ym_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(i32, u8, u8, String), Completion> {
-    let snapshot = match this {
-        JsValue::Object(o) => interp
-            .get_object_cell(o.id)
+    let snapshot = match this.as_object_id() {
+        Some(o) => interp
+            .get_object_cell(o)
             .map(|cell| cell.borrow().temporal_data().cloned()),
-        _ => None,
+        None => None,
     };
     match snapshot {
         Some(Some(TemporalData::PlainYearMonth {
@@ -181,209 +181,204 @@ fn to_temporal_plain_year_month(
     interp: &mut Interpreter,
     item: JsValue,
 ) -> Result<(i32, u8, u8, String), Completion> {
-    match &item {
-        JsValue::Object(o) => {
-            if let Some(obj) = interp.get_object_cell(o.id) {
-                let data = obj.borrow();
-                if let Some(TemporalData::PlainYearMonth {
-                    iso_year,
-                    iso_month,
-                    reference_iso_day,
-                    calendar,
-                }) = data.temporal_data()
-                {
-                    return Ok((*iso_year, *iso_month, *reference_iso_day, calendar.clone()));
-                }
+    if let Some(o) = item.as_object_id() {
+        if let Some(obj) = interp.get_object_cell(o) {
+            let data = obj.borrow();
+            if let Some(TemporalData::PlainYearMonth {
+                iso_year,
+                iso_month,
+                reference_iso_day,
+                calendar,
+            }) = data.temporal_data()
+            {
+                return Ok((*iso_year, *iso_month, *reference_iso_day, calendar.clone()));
             }
-            // Alphabetical order: calendar, month, monthCode, year
-            let cal_val = match get_prop(interp, &item, "calendar") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let cal = to_temporal_calendar_slot_value(interp, &cal_val)?;
-            let m_val = match get_prop(interp, &item, "month") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let month_num = if !is_undefined(&m_val) {
-                Some(to_integer_with_truncation(interp, &m_val)?)
-            } else {
-                None
-            };
-            let mc_val = match get_prop(interp, &item, "monthCode") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let mc_str = if !is_undefined(&mc_val) {
-                let mc = super::to_primitive_and_require_string(interp, &mc_val, "monthCode")?;
-                if !super::is_month_code_syntax_valid(&mc) {
-                    return Err(Completion::Throw(
-                        interp.create_range_error(&format!("Invalid monthCode: {mc}")),
-                    ));
-                }
-                Some(mc)
-            } else {
-                None
-            };
-            let y_val = match get_prop(interp, &item, "year") {
-                Completion::Normal(v) => v,
-                other => return Err(other),
-            };
-            let has_year = !is_undefined(&y_val);
-
-            // Non-ISO calendar: convert via ICU
-            if cal != "iso8601" {
-                let era_val = match get_prop(interp, &item, "era") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let era_year_val = match get_prop(interp, &item, "eraYear") {
-                    Completion::Normal(v) => v,
-                    other => return Err(other),
-                };
-                let has_era = !is_undefined(&era_val);
-                let has_era_year = !is_undefined(&era_year_val);
-
-                if super::calendar_has_eras(&cal) && (has_era != has_era_year) {
-                    return Err(Completion::Throw(interp.create_type_error(
-                        "era and eraYear must both be present or both be absent",
-                    )));
-                }
-
-                let y = if has_year {
-                    to_integer_with_truncation(interp, &y_val)? as i32
-                } else if super::calendar_has_eras(&cal) && has_era && has_era_year {
-                    0 // placeholder — overridden by era+eraYear
-                } else {
-                    return Err(Completion::Throw(
-                        interp.create_type_error("year is required"),
-                    ));
-                };
-
-                let (icu_era, icu_year) =
-                    if super::calendar_has_eras(&cal) && has_era && has_era_year {
-                        let era_str =
-                            super::to_primitive_and_require_string(interp, &era_val, "era")?;
-                        let ey = super::to_integer_with_truncation(interp, &era_year_val)? as i32;
-                        (Some(era_str), ey)
-                    } else {
-                        (None, y)
-                    };
-
-                if let Some((iso_y, iso_m, iso_d)) = super::calendar_fields_to_iso(
-                    icu_era.as_deref(),
-                    icu_year,
-                    mc_str.as_deref(),
-                    month_num.map(|v| v as u8),
-                    1,
-                    &cal,
-                ) {
-                    return Ok((iso_y, iso_m, iso_d, cal));
-                }
+        }
+        // Alphabetical order: calendar, month, monthCode, year
+        let cal_val = match get_prop(interp, &item, "calendar") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let cal = to_temporal_calendar_slot_value(interp, &cal_val)?;
+        let m_val = match get_prop(interp, &item, "month") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let month_num = if !is_undefined(&m_val) {
+            Some(to_integer_with_truncation(interp, &m_val)?)
+        } else {
+            None
+        };
+        let mc_val = match get_prop(interp, &item, "monthCode") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let mc_str = if !is_undefined(&mc_val) {
+            let mc = super::to_primitive_and_require_string(interp, &mc_val, "monthCode")?;
+            if !super::is_month_code_syntax_valid(&mc) {
+                return Err(Completion::Throw(
+                    interp.create_range_error(&format!("Invalid monthCode: {mc}")),
+                ));
             }
-            // ISO path: year is required
+            Some(mc)
+        } else {
+            None
+        };
+        let y_val = match get_prop(interp, &item, "year") {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        let has_year = !is_undefined(&y_val);
+
+        // Non-ISO calendar: convert via ICU
+        if cal != "iso8601" {
+            let era_val = match get_prop(interp, &item, "era") {
+                Completion::Normal(v) => v,
+                other => return Err(other),
+            };
+            let era_year_val = match get_prop(interp, &item, "eraYear") {
+                Completion::Normal(v) => v,
+                other => return Err(other),
+            };
+            let has_era = !is_undefined(&era_val);
+            let has_era_year = !is_undefined(&era_year_val);
+
+            if super::calendar_has_eras(&cal) && (has_era != has_era_year) {
+                return Err(Completion::Throw(interp.create_type_error(
+                    "era and eraYear must both be present or both be absent",
+                )));
+            }
+
             let y = if has_year {
                 to_integer_with_truncation(interp, &y_val)? as i32
+            } else if super::calendar_has_eras(&cal) && has_era && has_era_year {
+                0 // placeholder — overridden by era+eraYear
             } else {
                 return Err(Completion::Throw(
                     interp.create_type_error("year is required"),
                 ));
             };
 
-            // ISO: resolve month from month/monthCode
-            let m = if let Some(ref mc) = mc_str {
-                match super::plain_date::month_code_to_number_pub(mc) {
-                    Some(n) => {
-                        if let Some(mn) = month_num
-                            && mn as u8 != n
-                        {
-                            return Err(Completion::Throw(
-                                interp.create_range_error("month and monthCode conflict"),
-                            ));
-                        }
-                        n
-                    }
-                    None => {
+            let (icu_era, icu_year) = if super::calendar_has_eras(&cal) && has_era && has_era_year {
+                let era_str = super::to_primitive_and_require_string(interp, &era_val, "era")?;
+                let ey = super::to_integer_with_truncation(interp, &era_year_val)? as i32;
+                (Some(era_str), ey)
+            } else {
+                (None, y)
+            };
+
+            if let Some((iso_y, iso_m, iso_d)) = super::calendar_fields_to_iso(
+                icu_era.as_deref(),
+                icu_year,
+                mc_str.as_deref(),
+                month_num.map(|v| v as u8),
+                1,
+                &cal,
+            ) {
+                return Ok((iso_y, iso_m, iso_d, cal));
+            }
+        }
+        // ISO path: year is required
+        let y = if has_year {
+            to_integer_with_truncation(interp, &y_val)? as i32
+        } else {
+            return Err(Completion::Throw(
+                interp.create_type_error("year is required"),
+            ));
+        };
+
+        // ISO: resolve month from month/monthCode
+        let m = if let Some(ref mc) = mc_str {
+            match super::plain_date::month_code_to_number_pub(mc) {
+                Some(n) => {
+                    if let Some(mn) = month_num
+                        && mn as u8 != n
+                    {
                         return Err(Completion::Throw(
-                            interp.create_range_error(&format!("Invalid monthCode: {mc}")),
+                            interp.create_range_error("month and monthCode conflict"),
                         ));
                     }
+                    n
                 }
-            } else if let Some(mn) = month_num {
-                mn as u8
-            } else {
-                return Err(Completion::Throw(
-                    interp.create_type_error("month or monthCode is required"),
-                ));
-            };
-            Ok((y, m, 1, cal))
-        }
-        JsValue::String(s) => {
-            let parsed = match parse_temporal_year_month_string(&s.to_rust_string()) {
-                Some(v) => v,
-                None => {
-                    return Err(Completion::Throw(interp.create_range_error(&format!(
-                        "Invalid year-month string: {}",
-                        s.to_rust_string()
-                    ))));
-                }
-            };
-            // PlainYearMonth does not accept UTC designator
-            if parsed.4 {
-                return Err(Completion::Throw(interp.create_range_error(
-                    "UTC designator Z is not allowed in a PlainYearMonth string",
-                )));
-            }
-            // Date-only string with UTC offset is not valid
-            if parsed.5 {
-                return Err(Completion::Throw(interp.create_range_error(
-                    "UTC offset without time is not valid for PlainYearMonth",
-                )));
-            }
-            let cal = parsed.3.unwrap_or_else(|| "iso8601".to_string());
-            let cal = match validate_calendar_name(&cal) {
-                Some(c) => c,
                 None => {
                     return Err(Completion::Throw(
-                        interp.create_range_error(&format!("Invalid calendar: {cal}")),
+                        interp.create_range_error(&format!("Invalid monthCode: {mc}")),
                     ));
                 }
-            };
-            if cal != "iso8601" {
-                // Non-ISO calendar: parse ISO date, convert to calendar year/month
-                let iso_year = parsed.0;
-                let iso_month = parsed.1;
-                let iso_day = parsed.2.unwrap_or(1);
-                if let Some(fields) =
-                    super::iso_to_calendar_fields(iso_year, iso_month, iso_day, &cal)
-                {
-                    // Convert calendar year+month back to ISO for storage
-                    if let Some((ref_y, ref_m, ref_d)) = super::calendar_fields_to_iso(
-                        fields.era.as_deref(),
-                        fields.year,
-                        Some(&fields.month_code),
-                        Some(fields.month_ordinal),
-                        1,
-                        &cal,
-                    ) {
-                        return Ok((ref_y, ref_m, ref_d, cal));
-                    }
-                }
-                return Err(Completion::Throw(
-                    interp.create_range_error("Invalid calendar fields for PlainYearMonth"),
-                ));
             }
-            if !super::iso_year_month_within_limits(parsed.0, parsed.1) {
-                return Err(Completion::Throw(
-                    interp.create_range_error("Date outside representable range"),
-                ));
+        } else if let Some(mn) = month_num {
+            mn as u8
+        } else {
+            return Err(Completion::Throw(
+                interp.create_type_error("month or monthCode is required"),
+            ));
+        };
+        Ok((y, m, 1, cal))
+    } else if let Some(s) = item.as_string() {
+        let parsed = match parse_temporal_year_month_string(&s.to_rust_string()) {
+            Some(v) => v,
+            None => {
+                return Err(Completion::Throw(interp.create_range_error(&format!(
+                    "Invalid year-month string: {}",
+                    s.to_rust_string()
+                ))));
             }
-            // referenceISODay is always 1 when parsing from string
-            Ok((parsed.0, parsed.1, 1, cal))
+        };
+        // PlainYearMonth does not accept UTC designator
+        if parsed.4 {
+            return Err(Completion::Throw(interp.create_range_error(
+                "UTC designator Z is not allowed in a PlainYearMonth string",
+            )));
         }
-        _ => Err(Completion::Throw(
-            interp.create_type_error("Cannot convert to Temporal.PlainYearMonth"),
-        )),
+        // Date-only string with UTC offset is not valid
+        if parsed.5 {
+            return Err(Completion::Throw(interp.create_range_error(
+                "UTC offset without time is not valid for PlainYearMonth",
+            )));
+        }
+        let cal = parsed.3.unwrap_or_else(|| "iso8601".to_string());
+        let cal = match validate_calendar_name(&cal) {
+            Some(c) => c,
+            None => {
+                return Err(Completion::Throw(
+                    interp.create_range_error(&format!("Invalid calendar: {cal}")),
+                ));
+            }
+        };
+        if cal != "iso8601" {
+            // Non-ISO calendar: parse ISO date, convert to calendar year/month
+            let iso_year = parsed.0;
+            let iso_month = parsed.1;
+            let iso_day = parsed.2.unwrap_or(1);
+            if let Some(fields) = super::iso_to_calendar_fields(iso_year, iso_month, iso_day, &cal)
+            {
+                // Convert calendar year+month back to ISO for storage
+                if let Some((ref_y, ref_m, ref_d)) = super::calendar_fields_to_iso(
+                    fields.era.as_deref(),
+                    fields.year,
+                    Some(&fields.month_code),
+                    Some(fields.month_ordinal),
+                    1,
+                    &cal,
+                ) {
+                    return Ok((ref_y, ref_m, ref_d, cal));
+                }
+            }
+            return Err(Completion::Throw(
+                interp.create_range_error("Invalid calendar fields for PlainYearMonth"),
+            ));
+        }
+        if !super::iso_year_month_within_limits(parsed.0, parsed.1) {
+            return Err(Completion::Throw(
+                interp.create_range_error("Date outside representable range"),
+            ));
+        }
+        // referenceISODay is always 1 when parsing from string
+        Ok((parsed.0, parsed.1, 1, cal))
+    } else {
+        Err(Completion::Throw(interp.create_type_error(
+            "Cannot convert to Temporal.PlainYearMonth",
+        )))
     }
 }
 
@@ -405,7 +400,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    Completion::Normal(JsValue::String(JsString::from_str(&cal)))
+                    Completion::Normal(JsValue::from_str(&cal))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -434,13 +429,13 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, rd, &cal)
                     {
-                        return Completion::Normal(JsValue::Number(if idx == 0 {
+                        return Completion::Normal(JsValue::number(if idx == 0 {
                             cf.year as f64
                         } else {
                             cf.month_ordinal as f64
                         }));
                     }
-                    Completion::Normal(JsValue::Number(if idx == 0 { y as f64 } else { m as f64 }))
+                    Completion::Normal(JsValue::number(if idx == 0 { y as f64 } else { m as f64 }))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -469,11 +464,9 @@ impl Interpreter {
                     if cal != "iso8601"
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, rd, &cal)
                     {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            &cf.month_code,
-                        )));
+                        return Completion::Normal(JsValue::from_str(&cf.month_code));
                     }
-                    Completion::Normal(JsValue::String(JsString::from_str(&iso_month_code(m))))
+                    Completion::Normal(JsValue::from_str(&iso_month_code(m)))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -512,27 +505,27 @@ impl Interpreter {
                         && let Some(cf) = super::iso_to_calendar_fields(y, m, rd, &cal)
                     {
                         return match which {
-                            0 => Completion::Normal(JsValue::Number(cf.days_in_month as f64)),
-                            1 => Completion::Normal(JsValue::Number(cf.days_in_year as f64)),
-                            2 => Completion::Normal(JsValue::Number(cf.months_in_year as f64)),
-                            3 => Completion::Normal(JsValue::Boolean(cf.in_leap_year)),
+                            0 => Completion::Normal(JsValue::number(cf.days_in_month as f64)),
+                            1 => Completion::Normal(JsValue::number(cf.days_in_year as f64)),
+                            2 => Completion::Normal(JsValue::number(cf.months_in_year as f64)),
+                            3 => Completion::Normal(JsValue::boolean(cf.in_leap_year)),
                             4 => Completion::Normal(match cf.era {
-                                Some(e) => JsValue::String(JsString::from_str(&e)),
-                                None => JsValue::Undefined,
+                                Some(e) => JsValue::from_str(&e),
+                                None => JsValue::UNDEFINED,
                             }),
                             _ => Completion::Normal(match cf.era_year {
-                                Some(ey) => JsValue::Number(ey as f64),
-                                None => JsValue::Undefined,
+                                Some(ey) => JsValue::number(ey as f64),
+                                None => JsValue::UNDEFINED,
                             }),
                         };
                     }
                     match which {
-                        0 => Completion::Normal(JsValue::Number(iso_days_in_month(y, m) as f64)),
-                        1 => Completion::Normal(JsValue::Number(iso_days_in_year(y) as f64)),
-                        2 => Completion::Normal(JsValue::Number(12.0)),
-                        3 => Completion::Normal(JsValue::Boolean(iso_is_leap_year(y))),
-                        4 => Completion::Normal(JsValue::Undefined),
-                        _ => Completion::Normal(JsValue::Undefined),
+                        0 => Completion::Normal(JsValue::number(iso_days_in_month(y, m) as f64)),
+                        1 => Completion::Normal(JsValue::number(iso_days_in_year(y) as f64)),
+                        2 => Completion::Normal(JsValue::number(12.0)),
+                        3 => Completion::Normal(JsValue::boolean(iso_is_leap_year(y))),
+                        4 => Completion::Normal(JsValue::UNDEFINED),
+                        _ => Completion::Normal(JsValue::UNDEFINED),
                     }
                 },
             ));
@@ -560,7 +553,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 // IsPartialTemporalObject
                 if let Err(c) = is_partial_temporal_object(interp, &item) {
                     return c;
@@ -655,7 +648,7 @@ impl Interpreter {
 
                     let overflow = match parse_overflow_option(
                         interp,
-                        &args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                        &args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -707,7 +700,7 @@ impl Interpreter {
                             .create_type_error("with() requires at least one recognized property"),
                     );
                 }
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let overflow = match parse_overflow_option(interp, &options) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -743,12 +736,12 @@ impl Interpreter {
                     };
                     let dur = match super::duration::to_temporal_duration_record(
                         interp,
-                        args.first().cloned().unwrap_or(JsValue::Undefined),
+                        args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                     ) {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let overflow = match parse_overflow_option(interp, &options) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -823,7 +816,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let (y2, m2, rd2, cal2) = match to_temporal_plain_year_month(interp, other) {
                         Ok(v) => v,
                         Err(c) => return c,
@@ -847,7 +840,7 @@ impl Interpreter {
                             "PlainYearMonth outside representable range for since/until",
                         ));
                     }
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let ym_units: &[&str] = &["year", "month"];
                     let (largest_unit, smallest_unit, rounding_mode, rounding_increment) =
                         match parse_difference_options(interp, &options, "year", ym_units) {
@@ -960,12 +953,12 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let other = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let other = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let (y2, m2, rd2, c2) = match to_temporal_plain_year_month(interp, other) {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                Completion::Normal(JsValue::Boolean(
+                Completion::Normal(JsValue::boolean(
                     y1 == y2 && m1 == m2 && rd1 == rd2 && c1 == c2,
                 ))
             },
@@ -983,7 +976,7 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let options = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let options = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let has_opts = match super::get_options_object(interp, &options) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -1013,7 +1006,7 @@ impl Interpreter {
                     "auto".to_string()
                 };
                 let result = format_year_month(y, m, ref_day, &cal, &show_cal_owned);
-                Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                Completion::Normal(JsValue::from_str(&result))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1028,9 +1021,9 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                Completion::Normal(JsValue::String(JsString::from_str(&format_year_month(
+                Completion::Normal(JsValue::from_str(&format_year_month(
                     y, m, ref_day, &cal, "auto",
-                ))))
+                )))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1048,13 +1041,13 @@ impl Interpreter {
                 let dtf_val = match interp.realm().intl_date_time_format_ctor.clone() {
                     Some(v) => v,
                     None => {
-                        return Completion::Normal(JsValue::String(JsString::from_str(
-                            &format_year_month(y, m, ref_day, &cal, "auto"),
+                        return Completion::Normal(JsValue::from_str(&format_year_month(
+                            y, m, ref_day, &cal, "auto",
                         )));
                     }
                 };
-                let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // PlainYearMonth has date but not time
                 if let Err(e) =
                     super::check_locale_string_style_conflict(interp, &options_arg, true, false)
@@ -1064,7 +1057,7 @@ impl Interpreter {
                 let dtf_instance = match interp.construct(&dtf_val, &[locales_arg, options_arg]) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::Undefined),
+                    _ => return Completion::Normal(JsValue::UNDEFINED),
                 };
                 if let Err(e) = super::check_calendar_mismatch(interp, &dtf_instance, &cal, false) {
                     return Completion::Throw(e);
@@ -1099,8 +1092,8 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
-                if !matches!(item, JsValue::Object(_)) {
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                if !item.is_object() {
                     return Completion::Throw(
                         interp.create_type_error("argument must be an object with a day property"),
                     );
@@ -1176,7 +1169,7 @@ impl Interpreter {
                         interp.create_type_error("Temporal.PlainYearMonth must be called with new"),
                     );
                 }
-                let y_val = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let y_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let y = match interp.to_number_value(&y_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -1186,7 +1179,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let m_val = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let m_val = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let m = match interp.to_number_value(&m_val) {
                     Ok(n) => {
                         if !n.is_finite() {
@@ -1200,7 +1193,7 @@ impl Interpreter {
                     }
                     Err(e) => return Completion::Throw(e),
                 };
-                let cal_arg = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let cal_arg = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 let cal = match super::validate_calendar_strict(interp, &cal_arg) {
                     Ok(c) => c,
                     Err(c) => return c,
@@ -1241,9 +1234,11 @@ impl Interpreter {
                     );
                 }
                 let result = create_plain_year_month_result(interp, y, m, rd, &cal);
-                if let Completion::Normal(JsValue::Object(ref o)) = result {
+                if let Completion::Normal(ref v) = result
+                    && let Some(oid) = v.as_object_id()
+                {
                     let dp = interp.realm().temporal_plain_year_month_prototype;
-                    interp.apply_new_target_prototype(o.id, dp, |r| {
+                    interp.apply_new_target_prototype(oid, dp, |r| {
                         r.temporal_plain_year_month_prototype
                     });
                 }
@@ -1251,10 +1246,10 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(oid) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(oid)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -1272,10 +1267,10 @@ impl Interpreter {
             "from".to_string(),
             1,
             |interp, _, args| {
-                let item = args.first().cloned().unwrap_or(JsValue::Undefined);
-                let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 // Per spec: if item is a string, parse first, then validate overflow (but don't use it)
-                if matches!(&item, JsValue::String(_)) {
+                if item.is_string() {
                     let (y, m, rd, cal) =
                         match to_temporal_plain_year_month_with_overflow(interp, item, "constrain")
                         {
@@ -1289,8 +1284,8 @@ impl Interpreter {
                     return create_plain_year_month_result(interp, y, m, rd, &cal);
                 }
                 // Check if it's a Temporal PlainYearMonth (read overflow first, return copy)
-                let is_temporal = if let JsValue::Object(ref o) = item {
-                    if let Some(obj) = interp.get_object_cell(o.id) {
+                let is_temporal = if let Some(oid) = item.as_object_id() {
+                    if let Some(obj) = interp.get_object_cell(oid) {
                         let data = obj.borrow();
                         matches!(
                             data.temporal_data(),
@@ -1402,8 +1397,8 @@ impl Interpreter {
                 }
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(oid) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(oid)
         {
             obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
         }
@@ -1415,14 +1410,14 @@ impl Interpreter {
             |interp, _, args| {
                 let (y1, m1, rd1, _) = match to_temporal_plain_year_month(
                     interp,
-                    args.first().cloned().unwrap_or(JsValue::Undefined),
+                    args.first().cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
                 };
                 let (y2, m2, rd2, _) = match to_temporal_plain_year_month(
                     interp,
-                    args.get(1).cloned().unwrap_or(JsValue::Undefined),
+                    args.get(1).cloned().unwrap_or(JsValue::UNDEFINED),
                 ) {
                     Ok(v) => v,
                     Err(c) => return c,
@@ -1436,11 +1431,11 @@ impl Interpreter {
                 } else {
                     0.0
                 };
-                Completion::Normal(JsValue::Number(r))
+                Completion::Normal(JsValue::number(r))
             },
         ));
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(oid) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(oid)
         {
             obj.borrow_mut()
                 .insert_builtin("compare".to_string(), compare_fn);

--- a/src/interpreter/builtins/temporal/zoned_date_time.rs
+++ b/src/interpreter/builtins/temporal/zoned_date_time.rs
@@ -152,10 +152,11 @@ fn get_zdt_fields(
     interp: &mut Interpreter,
     this: &JsValue,
 ) -> Result<(BigInt, String, String), Completion> {
-    match this {
-        JsValue::Object(o) => {
+    match this.kind() {
+        ValueKind::Object => {
+            let o = this.as_object_id().expect("checked Object kind");
             let snapshot = interp
-                .get_object_cell(o.id)
+                .get_object_cell(o)
                 .map(|cell| cell.borrow().temporal_data().cloned());
             match snapshot {
                 Some(Some(TemporalData::ZonedDateTime {
@@ -707,7 +708,7 @@ fn create_zdt(interp: &mut Interpreter, ns: BigInt, tz: String, cal: String) -> 
             calendar: cal,
         });
     let id = obj_id;
-    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+    Completion::Normal(JsValue::object(id))
 }
 
 pub(super) fn get_tz_offset_ns_pub(tz: &str, epoch_ns: &BigInt) -> i64 {
@@ -745,9 +746,10 @@ fn to_temporal_zoned_date_time_with_options(
     offset_option: &str,
     deferred_options: Option<(&JsValue, &str)>,
 ) -> Completion {
-    match item {
-        JsValue::Object(o) => {
-            let obj = match interp.get_object_cell(o.id) {
+    match item.kind() {
+        ValueKind::Object => {
+            let o = item.as_object_id().expect("checked Object kind");
+            let obj = match interp.get_object_cell(o) {
                 Some(o) => o,
                 None => return Completion::Throw(interp.create_type_error("invalid object")),
             };
@@ -1291,7 +1293,8 @@ fn to_temporal_zoned_date_time_with_options(
             };
             create_zdt(interp, epoch_ns, tz, calendar)
         }
-        JsValue::String(s) => {
+        ValueKind::String => {
+            let s = item.as_string().expect("checked String kind");
             let s_str = s.to_string();
             match super::parse_temporal_date_time_string(&s_str) {
                 Some(parsed) => {
@@ -1451,9 +1454,9 @@ fn from_string_with_options(
     item: &JsValue,
     options: &JsValue,
 ) -> Completion {
-    let s_str = match item {
-        JsValue::String(s) => s.to_string(),
-        _ => unreachable!(),
+    let s_str = match item.as_string() {
+        Some(s) => s.to_string(),
+        None => unreachable!(),
     };
     let parsed = match super::parse_temporal_date_time_string(&s_str) {
         Some(p) => p,
@@ -1838,20 +1841,20 @@ impl Interpreter {
         }
 
         zdt_getter!("calendarId", |_ns, _tz, cal| {
-            Completion::Normal(JsValue::String(JsString::from_str(cal)))
+            Completion::Normal(JsValue::from_str(cal))
         });
 
         zdt_getter!("timeZoneId", |_ns, tz, _cal| {
-            Completion::Normal(JsValue::String(JsString::from_str(tz)))
+            Completion::Normal(JsValue::from_str(tz))
         });
 
         zdt_getter!("epochMilliseconds", |ns, _tz, _cal| {
             let ms = floor_div_bigint(ns, NS_PER_MS);
-            Completion::Normal(JsValue::Number(bigint_to_f64(&ms)))
+            Completion::Normal(JsValue::number(bigint_to_f64(&ms)))
         });
 
         zdt_getter!("epochNanoseconds", |ns, _tz, _cal| {
-            Completion::Normal(JsValue::BigInt(crate::types::JsBigInt::new(ns.clone())))
+            Completion::Normal(JsValue::bigint(crate::types::JsBigInt::new(ns.clone())))
         });
 
         zdt_getter!("year", |ns, tz, cal| {
@@ -1859,9 +1862,9 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::Number(cf.year as f64));
+                return Completion::Normal(JsValue::number(cf.year as f64));
             }
-            Completion::Normal(JsValue::Number(y as f64))
+            Completion::Normal(JsValue::number(y as f64))
         });
 
         zdt_getter!("month", |ns, tz, cal| {
@@ -1869,9 +1872,9 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::Number(cf.month_ordinal as f64));
+                return Completion::Normal(JsValue::number(cf.month_ordinal as f64));
             }
-            Completion::Normal(JsValue::Number(m as f64))
+            Completion::Normal(JsValue::number(m as f64))
         });
 
         zdt_getter!("monthCode", |ns, tz, cal| {
@@ -1879,9 +1882,9 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::String(JsString::from_str(&cf.month_code)));
+                return Completion::Normal(JsValue::from_str(&cf.month_code));
             }
-            Completion::Normal(JsValue::String(JsString::from_str(&format!("M{m:02}"))))
+            Completion::Normal(JsValue::from_str(&format!("M{m:02}")))
         });
 
         zdt_getter!("day", |ns, tz, cal| {
@@ -1889,44 +1892,44 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::Number(cf.day as f64));
+                return Completion::Normal(JsValue::number(cf.day as f64));
             }
-            Completion::Normal(JsValue::Number(d as f64))
+            Completion::Normal(JsValue::number(d as f64))
         });
 
         zdt_getter!("hour", |ns, tz, _cal| {
             let (_, _, _, h, _, _, _, _, _) = epoch_ns_to_components(ns, tz);
-            Completion::Normal(JsValue::Number(h as f64))
+            Completion::Normal(JsValue::number(h as f64))
         });
 
         zdt_getter!("minute", |ns, tz, _cal| {
             let (_, _, _, _, mi, _, _, _, _) = epoch_ns_to_components(ns, tz);
-            Completion::Normal(JsValue::Number(mi as f64))
+            Completion::Normal(JsValue::number(mi as f64))
         });
 
         zdt_getter!("second", |ns, tz, _cal| {
             let (_, _, _, _, _, s, _, _, _) = epoch_ns_to_components(ns, tz);
-            Completion::Normal(JsValue::Number(s as f64))
+            Completion::Normal(JsValue::number(s as f64))
         });
 
         zdt_getter!("millisecond", |ns, tz, _cal| {
             let (_, _, _, _, _, _, ms, _, _) = epoch_ns_to_components(ns, tz);
-            Completion::Normal(JsValue::Number(ms as f64))
+            Completion::Normal(JsValue::number(ms as f64))
         });
 
         zdt_getter!("microsecond", |ns, tz, _cal| {
             let (_, _, _, _, _, _, _, us, _) = epoch_ns_to_components(ns, tz);
-            Completion::Normal(JsValue::Number(us as f64))
+            Completion::Normal(JsValue::number(us as f64))
         });
 
         zdt_getter!("nanosecond", |ns, tz, _cal| {
             let (_, _, _, _, _, _, _, _, nanos) = epoch_ns_to_components(ns, tz);
-            Completion::Normal(JsValue::Number(nanos as f64))
+            Completion::Normal(JsValue::number(nanos as f64))
         });
 
         zdt_getter!("dayOfWeek", |ns, tz, _cal| {
             let (y, m, d, _, _, _, _, _, _) = epoch_ns_to_components(ns, tz);
-            Completion::Normal(JsValue::Number(super::iso_day_of_week(y, m, d) as f64))
+            Completion::Normal(JsValue::number(super::iso_day_of_week(y, m, d) as f64))
         });
 
         zdt_getter!("dayOfYear", |ns, tz, cal| {
@@ -1934,31 +1937,31 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::Number(cf.day_of_year as f64));
+                return Completion::Normal(JsValue::number(cf.day_of_year as f64));
             }
-            Completion::Normal(JsValue::Number(super::iso_day_of_year(y, m, d) as f64))
+            Completion::Normal(JsValue::number(super::iso_day_of_year(y, m, d) as f64))
         });
 
         zdt_getter!("weekOfYear", |ns, tz, cal| {
             if cal != "iso8601" {
-                return Completion::Normal(JsValue::Undefined);
+                return Completion::Normal(JsValue::UNDEFINED);
             }
             let (y, m, d, _, _, _, _, _, _) = epoch_ns_to_components(ns, tz);
             let (woy, _) = super::iso_week_of_year(y, m, d);
-            Completion::Normal(JsValue::Number(woy as f64))
+            Completion::Normal(JsValue::number(woy as f64))
         });
 
         zdt_getter!("yearOfWeek", |ns, tz, cal| {
             if cal != "iso8601" {
-                return Completion::Normal(JsValue::Undefined);
+                return Completion::Normal(JsValue::UNDEFINED);
             }
             let (y, m, d, _, _, _, _, _, _) = epoch_ns_to_components(ns, tz);
             let (_, yow) = super::iso_week_of_year(y, m, d);
-            Completion::Normal(JsValue::Number(yow as f64))
+            Completion::Normal(JsValue::number(yow as f64))
         });
 
         zdt_getter!("daysInWeek", |_ns, _tz, _cal| {
-            Completion::Normal(JsValue::Number(7.0))
+            Completion::Normal(JsValue::number(7.0))
         });
 
         zdt_getter!("daysInMonth", |ns, tz, cal| {
@@ -1966,9 +1969,9 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::Number(cf.days_in_month as f64));
+                return Completion::Normal(JsValue::number(cf.days_in_month as f64));
             }
-            Completion::Normal(JsValue::Number(super::iso_days_in_month(y, m) as f64))
+            Completion::Normal(JsValue::number(super::iso_days_in_month(y, m) as f64))
         });
 
         zdt_getter!("daysInYear", |ns, tz, cal| {
@@ -1976,10 +1979,10 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::Number(cf.days_in_year as f64));
+                return Completion::Normal(JsValue::number(cf.days_in_year as f64));
             }
             let days = if super::iso_is_leap_year(y) { 366 } else { 365 };
-            Completion::Normal(JsValue::Number(days as f64))
+            Completion::Normal(JsValue::number(days as f64))
         });
 
         zdt_getter!("monthsInYear", |ns, tz, cal| {
@@ -1987,9 +1990,9 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::Number(cf.months_in_year as f64));
+                return Completion::Normal(JsValue::number(cf.months_in_year as f64));
             }
-            Completion::Normal(JsValue::Number(12.0))
+            Completion::Normal(JsValue::number(12.0))
         });
 
         zdt_getter!("inLeapYear", |ns, tz, cal| {
@@ -1997,21 +2000,19 @@ impl Interpreter {
             if cal != "iso8601"
                 && let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal)
             {
-                return Completion::Normal(JsValue::Boolean(cf.in_leap_year));
+                return Completion::Normal(JsValue::boolean(cf.in_leap_year));
             }
-            Completion::Normal(JsValue::Boolean(super::iso_is_leap_year(y)))
+            Completion::Normal(JsValue::boolean(super::iso_is_leap_year(y)))
         });
 
         zdt_getter!("offset", |ns, tz, _cal| {
             let offset_ns = get_tz_offset_ns(tz, ns);
-            Completion::Normal(JsValue::String(JsString::from_str(&format_offset_string(
-                offset_ns,
-            ))))
+            Completion::Normal(JsValue::from_str(&format_offset_string(offset_ns)))
         });
 
         zdt_getter!("offsetNanoseconds", |ns, tz, _cal| {
             let offset_ns = get_tz_offset_ns(tz, ns);
-            Completion::Normal(JsValue::Number(offset_ns as f64))
+            Completion::Normal(JsValue::number(offset_ns as f64))
         });
 
         {
@@ -2057,7 +2058,7 @@ impl Interpreter {
 
                     let diff_ns = next_utc - start_utc;
                     let hours = diff_ns as f64 / NS_PER_HOUR as f64;
-                    Completion::Normal(JsValue::Number(hours))
+                    Completion::Normal(JsValue::number(hours))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -2080,12 +2081,12 @@ impl Interpreter {
                 let (y, m, d, _, _, _, _, _, _) = epoch_ns_to_components(ns, tz);
                 if let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal) {
                     return Completion::Normal(match cf.era {
-                        Some(e) => JsValue::String(JsString::from_str(&e)),
-                        None => JsValue::Undefined,
+                        Some(e) => JsValue::from_str(&e),
+                        None => JsValue::UNDEFINED,
                     });
                 }
             }
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         zdt_getter!("eraYear", |ns, tz, cal| {
@@ -2093,12 +2094,12 @@ impl Interpreter {
                 let (y, m, d, _, _, _, _, _, _) = epoch_ns_to_components(ns, tz);
                 if let Some(cf) = super::iso_to_calendar_fields(y, m, d, cal) {
                     return Completion::Normal(match cf.era_year {
-                        Some(ey) => JsValue::Number(ey as f64),
-                        None => JsValue::Undefined,
+                        Some(ey) => JsValue::number(ey as f64),
+                        None => JsValue::UNDEFINED,
                     });
                 }
             }
-            Completion::Normal(JsValue::Undefined)
+            Completion::Normal(JsValue::UNDEFINED)
         });
 
         self.realm_mut().temporal_zoned_date_time_prototype = Some(proto_id);
@@ -2115,7 +2116,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let options = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let options = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let (precision, rounding_mode, offset_display, tz_display, cal_display) =
                         match parse_zdt_to_string_options(interp, &options) {
                             Ok(v) => v,
@@ -2131,7 +2132,7 @@ impl Interpreter {
                         precision,
                         &rounding_mode,
                     );
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::from_str(&result))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -2151,7 +2152,7 @@ impl Interpreter {
                     };
                     let result =
                         zdt_to_string(&ns, &tz, &cal, "auto", "auto", "auto", None, "trunc");
-                    Completion::Normal(JsValue::String(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::from_str(&result))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -2175,22 +2176,19 @@ impl Interpreter {
                             let result = zdt_to_string(
                                 &ns, &tz, &_cal, "auto", "auto", "auto", None, "trunc",
                             );
-                            return Completion::Normal(JsValue::String(JsString::from_str(
-                                &result,
-                            )));
+                            return Completion::Normal(JsValue::from_str(&result));
                         }
                     };
-                    let locales_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let options_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let options_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     // Reject user-provided timeZone option
-                    if let JsValue::Object(ref o) = options_arg {
-                        let tz_val =
-                            match interp.get_object_property(o.id, "timeZone", &options_arg) {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => return Completion::Throw(e),
-                                _ => JsValue::Undefined,
-                            };
-                        if !matches!(tz_val, JsValue::Undefined) {
+                    if let Some(o) = options_arg.as_object_id() {
+                        let tz_val = match interp.get_object_property(o, "timeZone", &options_arg) {
+                            Completion::Normal(v) => v,
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => JsValue::UNDEFINED,
+                        };
+                        if !tz_val.is_undefined() {
                             return Completion::Throw(interp.create_type_error(
                                 "ZonedDateTime toLocaleString does not accept a timeZone option",
                             ));
@@ -2206,17 +2204,16 @@ impl Interpreter {
                                 .prototype_id = Some(op_id);
                         }
                         // Copy properties from user options if present
-                        if let JsValue::Object(ref o) = options_arg {
+                        if let Some(o) = options_arg.as_object_id() {
                             let keys: Vec<JsPropertyKey> = interp
-                                .get_object_cell(o.id)
+                                .get_object_cell(o)
                                 .map(|rc| rc.borrow().properties.keys().cloned().collect())
                                 .unwrap_or_default();
                             for key in keys {
-                                let val = match interp.get_object_property(o.id, &key, &options_arg)
-                                {
+                                let val = match interp.get_object_property(o, &key, &options_arg) {
                                     Completion::Normal(v) => v,
                                     Completion::Throw(e) => return Completion::Throw(e),
-                                    _ => JsValue::Undefined,
+                                    _ => JsValue::UNDEFINED,
                                 };
                                 interp
                                     .get_object_cell_expect(opts_obj_id)
@@ -2236,7 +2233,7 @@ impl Interpreter {
                             .insert_property(
                                 "timeZone".to_string(),
                                 crate::interpreter::types::PropertyDescriptor::data(
-                                    JsValue::String(JsString::from_str(&tz)),
+                                    JsValue::from_str(&tz),
                                     true,
                                     true,
                                     true,
@@ -2262,7 +2259,7 @@ impl Interpreter {
                             .iter()
                             .any(|k| {
                                 b.properties.get(k).is_some_and(|pd| {
-                                    !matches!(pd.value, Some(JsValue::Undefined) | None)
+                                    pd.value.as_ref().is_some_and(|v| !v.is_undefined())
                                 })
                             })
                         };
@@ -2270,7 +2267,7 @@ impl Interpreter {
                             let has_tz_name = {
                                 let b = interp.get_object_cell_expect(opts_obj_id).borrow();
                                 b.properties.get("timeZoneName").is_some_and(|pd| {
-                                    !matches!(pd.value, Some(JsValue::Undefined) | None)
+                                    pd.value.as_ref().is_some_and(|v| !v.is_undefined())
                                 })
                             };
                             for (k, v) in [
@@ -2287,7 +2284,7 @@ impl Interpreter {
                                     .insert_property(
                                         k.to_string(),
                                         crate::interpreter::types::PropertyDescriptor::data(
-                                            JsValue::String(JsString::from_str(v)),
+                                            JsValue::from_str(v),
                                             true,
                                             true,
                                             true,
@@ -2301,7 +2298,7 @@ impl Interpreter {
                                     .insert_property(
                                         "timeZoneName".to_string(),
                                         crate::interpreter::types::PropertyDescriptor::data(
-                                            JsValue::String(JsString::from_str("short")),
+                                            JsValue::from_str("short"),
                                             true,
                                             true,
                                             true,
@@ -2310,13 +2307,13 @@ impl Interpreter {
                             }
                         }
                         let oid = opts_obj_id;
-                        JsValue::Object(crate::types::JsObject { id: oid })
+                        JsValue::object(oid)
                     };
                     let dtf_instance =
                         match interp.construct(&dtf_val, &[locales_arg, effective_opts]) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => return Completion::Throw(e),
-                            _ => return Completion::Normal(JsValue::Undefined),
+                            _ => return Completion::Normal(JsValue::UNDEFINED),
                         };
                     if let Err(e) =
                         super::check_calendar_mismatch(interp, &dtf_instance, &_cal, true)
@@ -2329,7 +2326,7 @@ impl Interpreter {
                         let ms_bigint = &ns / BigInt::from(1_000_000i64);
                         ms_bigint.to_string().parse::<f64>().unwrap_or(f64::NAN)
                     };
-                    let ms_val = JsValue::Number(epoch_ms);
+                    let ms_val = JsValue::number(epoch_ms);
                     super::temporal_format_with_dtf(interp, &dtf_instance, &ms_val)
                 },
             ));
@@ -2364,7 +2361,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let other_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let other_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let other_val = match to_temporal_zoned_date_time(interp, &other_arg) {
                         Completion::Normal(v) => v,
                         c => return c,
@@ -2375,7 +2372,7 @@ impl Interpreter {
                     };
                     let tz_equal = tz.eq_ignore_ascii_case(&otz)
                         || super::canonicalize_iana_tz(&tz) == super::canonicalize_iana_tz(&otz);
-                    Completion::Normal(JsValue::Boolean(ns == ons && tz_equal && cal == ocal))
+                    Completion::Normal(JsValue::boolean(ns == ons && tz_equal && cal == ocal))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -2409,7 +2406,7 @@ impl Interpreter {
                             epoch_nanoseconds: ns,
                         });
                     let id = obj_id;
-                    Completion::Normal(JsValue::Object(crate::types::JsObject { id }))
+                    Completion::Normal(JsValue::object(id))
                 },
             ));
             self.get_object_cell_expect(proto_id)
@@ -2507,8 +2504,8 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let cal_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    if matches!(&cal_arg, JsValue::Undefined) {
+                    let cal_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    if cal_arg.is_undefined() {
                         return Completion::Throw(
                             interp.create_type_error("withCalendar requires a calendar argument"),
                         );
@@ -2535,7 +2532,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let tz_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let tz_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let new_tz = match to_temporal_time_zone_identifier(interp, &tz_arg) {
                         Ok(t) => t,
                         Err(c) => return c,
@@ -2559,7 +2556,7 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let (y, m, d, _, _, _, _, _, _) = epoch_ns_to_components(&ns, &tz);
-                    let time_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let time_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let epoch_days = super::iso_date_to_epoch_days(y, m, d) as i128;
                     if is_undefined(&time_arg) {
                         // Per spec: use GetStartOfDay
@@ -2600,7 +2597,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let bag = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let bag = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if let Err(c) = is_partial_temporal_object(interp, &bag) {
                         return c;
                     }
@@ -2680,8 +2677,9 @@ impl Interpreter {
                         let mut cached_offset_str_cal: Option<String> = None;
                         if !is_undefined(&offset_prop) {
                             has_any = true;
-                            match &offset_prop {
-                                JsValue::String(sv) => {
+                            match offset_prop.kind() {
+                                ValueKind::String => {
+                                    let sv = offset_prop.as_string().expect("checked String kind");
                                     let s_str = sv.to_rust_string();
                                     if super::parse_utc_offset_timezone(&s_str).is_none() {
                                         return Completion::Throw(interp.create_range_error(
@@ -2690,7 +2688,7 @@ impl Interpreter {
                                     }
                                     cached_offset_str_cal = Some(s_str);
                                 }
-                                JsValue::Object(_) => {
+                                ValueKind::Object => {
                                     let s_str = match interp.to_string_value(&offset_prop) {
                                         Ok(sv) => sv,
                                         Err(c) => return Completion::Throw(c),
@@ -2789,7 +2787,7 @@ impl Interpreter {
                         };
 
                         // Read options
-                        let opts = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                        let opts = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                         let (disambiguation_cal, offset_opt, overflow) =
                             match parse_zdt_options(interp, &opts, "prefer") {
                                 Ok(v) => v,
@@ -2985,8 +2983,9 @@ impl Interpreter {
                     let mut cached_offset_str: Option<String> = None;
                     if !is_undefined(&offset_prop) {
                         has_any = true;
-                        match &offset_prop {
-                            JsValue::String(s) => {
+                        match offset_prop.kind() {
+                            ValueKind::String => {
+                                let s = offset_prop.as_string().expect("checked String kind");
                                 let s_str = s.to_rust_string();
                                 if super::parse_utc_offset_timezone(&s_str).is_none() {
                                     return Completion::Throw(interp.create_range_error(&format!(
@@ -2995,7 +2994,7 @@ impl Interpreter {
                                 }
                                 cached_offset_str = Some(s_str);
                             }
-                            JsValue::Object(_) => {
+                            ValueKind::Object => {
                                 let s_str = match interp.to_string_value(&offset_prop) {
                                     Ok(s) => s,
                                     Err(c) => return Completion::Throw(c),
@@ -3029,7 +3028,7 @@ impl Interpreter {
                     }
 
                     // Read options: disambiguation (default "compatible"), offset (default "prefer"), overflow (default "constrain")
-                    let opts = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let opts = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let (disambiguation, offset_opt, overflow) =
                         match parse_zdt_options(interp, &opts, "prefer") {
                             Ok(v) => v,
@@ -3237,7 +3236,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let options_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let options_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if is_undefined(&options_arg) {
                         return Completion::Throw(
                             interp.create_type_error("round requires options"),
@@ -3253,8 +3252,8 @@ impl Interpreter {
                         "microsecond",
                         "nanosecond",
                     ];
-                    let (smallest_unit, rounding_mode, increment) = if let JsValue::String(s) =
-                        &options_arg
+                    let (smallest_unit, rounding_mode, increment) = if let Some(s) =
+                        options_arg.as_string()
                     {
                         let su = s.to_rust_string();
                         let unit = match temporal_unit_singular(&su) {
@@ -3271,7 +3270,7 @@ impl Interpreter {
                             }
                         };
                         (unit, "halfExpand".to_string(), 1.0)
-                    } else if matches!(options_arg, JsValue::Object(_)) {
+                    } else if options_arg.is_object() {
                         // Per spec: read roundingIncrement first, then roundingMode, then smallestUnit
                         let ri_val = match get_prop(interp, &options_arg, "roundingIncrement") {
                             Completion::Normal(v) => v,
@@ -3437,16 +3436,16 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let options_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                    let options_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     if is_undefined(&options_arg) {
                         return Completion::Throw(
                             interp.create_type_error("getTimeZoneTransition requires an argument"),
                         );
                     }
                     // Accept string shorthand or options object
-                    let direction = if let JsValue::String(s) = &options_arg {
+                    let direction = if let Some(s) = options_arg.as_string() {
                         s.to_rust_string()
-                    } else if matches!(options_arg, JsValue::Object(_)) {
+                    } else if options_arg.is_object() {
                         let dir_val = match get_prop(interp, &options_arg, "direction") {
                             Completion::Normal(v) => v,
                             c => return c,
@@ -3476,7 +3475,7 @@ impl Interpreter {
                     let epoch_ns_i128: i128 = ns.try_into().unwrap_or(0);
                     // Offset time zones have no transitions
                     if tz.starts_with('+') || tz.starts_with('-') || tz == "UTC" {
-                        return Completion::Normal(JsValue::Null);
+                        return Completion::Normal(JsValue::NULL);
                     }
                     let transition = if direction == "next" {
                         get_next_transition(&tz, epoch_ns_i128)
@@ -3487,12 +3486,12 @@ impl Interpreter {
                         Some(t) => {
                             let t_bi = BigInt::from(t);
                             if !is_valid_epoch_ns(&t_bi) {
-                                Completion::Normal(JsValue::Null)
+                                Completion::Normal(JsValue::NULL)
                             } else {
                                 create_zdt(interp, t_bi, tz, cal)
                             }
                         }
-                        None => Completion::Normal(JsValue::Null),
+                        None => Completion::Normal(JsValue::NULL),
                     }
                 },
             ));
@@ -3511,28 +3510,30 @@ impl Interpreter {
                         interp.create_type_error("Temporal.ZonedDateTime must be called with new"),
                     );
                 }
-                let ns_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+                let ns_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                 let ns_bigint = match to_bigint_arg(interp, &ns_arg) {
                     Ok(n) => n,
                     Err(c) => return c,
                 };
 
-                let tz_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                let tz_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                 let tz = match validate_timezone_identifier_strict(interp, &tz_arg) {
                     Ok(t) => t,
                     Err(c) => return c,
                 };
 
-                let cal_arg = args.get(2).cloned().unwrap_or(JsValue::Undefined);
+                let cal_arg = args.get(2).cloned().unwrap_or(JsValue::UNDEFINED);
                 let cal = match validate_calendar_strict(interp, &cal_arg) {
                     Ok(c) => c,
                     Err(c) => return c,
                 };
 
                 let result = create_zdt(interp, ns_bigint, tz, cal);
-                if let Completion::Normal(JsValue::Object(ref o)) = result {
+                if let Completion::Normal(ref v) = result
+                    && let Some(o) = v.as_object_id()
+                {
                     let dp = interp.realm().temporal_zoned_date_time_prototype;
-                    interp.apply_new_target_prototype(o.id, dp, |r| {
+                    interp.apply_new_target_prototype(o, dp, |r| {
                         r.temporal_zoned_date_time_prototype
                     });
                 }
@@ -3540,10 +3541,10 @@ impl Interpreter {
             },
         ));
 
-        if let JsValue::Object(ref o) = constructor
-            && let Some(obj) = self.get_object_cell(o.id)
+        if let Some(o) = constructor.as_object_id()
+            && let Some(obj) = self.get_object_cell(o)
         {
-            let proto_val = JsValue::Object(crate::types::JsObject { id: proto_id });
+            let proto_val = JsValue::object(proto_id);
             obj.borrow_mut().insert_property(
                 "prototype".to_string(),
                 PropertyDescriptor::data(proto_val, false, false, false),
@@ -3564,20 +3565,20 @@ impl Interpreter {
                 "from".to_string(),
                 1,
                 |interp, _this, args| {
-                    let item = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
-                    if matches!(&item, JsValue::String(_)) {
+                    let item = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                    if item.is_string() {
                         return from_string_with_options(interp, &item, &options);
                     }
-                    if !matches!(&item, JsValue::Object(_)) {
+                    if !item.is_object() {
                         return Completion::Throw(
                             interp.create_type_error("invalid type for ZonedDateTime.from"),
                         );
                     }
                     // Check if item is already a ZDT — read options then clone
-                    let is_zdt = if let JsValue::Object(o) = &item {
+                    let is_zdt = if let Some(o) = item.as_object_id() {
                         interp
-                            .get_object_cell(o.id)
+                            .get_object_cell(o)
                             .map(|obj| {
                                 matches!(
                                     obj.borrow().temporal_data(),
@@ -3614,8 +3615,8 @@ impl Interpreter {
                     )
                 },
             ));
-            if let JsValue::Object(ref o) = constructor
-                && let Some(obj) = self.get_object_cell(o.id)
+            if let Some(o) = constructor.as_object_id()
+                && let Some(obj) = self.get_object_cell(o)
             {
                 obj.borrow_mut().insert_builtin("from".to_string(), from_fn);
             }
@@ -3627,8 +3628,8 @@ impl Interpreter {
                 "compare".to_string(),
                 2,
                 |interp, _this, args| {
-                    let one_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
-                    let two_arg = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+                    let one_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                    let two_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
                     let one_val = match to_temporal_zoned_date_time(interp, &one_arg) {
                         Completion::Normal(v) => v,
                         c => return c,
@@ -3652,11 +3653,11 @@ impl Interpreter {
                     } else {
                         0.0
                     };
-                    Completion::Normal(JsValue::Number(result))
+                    Completion::Normal(JsValue::number(result))
                 },
             ));
-            if let JsValue::Object(ref o) = constructor
-                && let Some(obj) = self.get_object_cell(o.id)
+            if let Some(o) = constructor.as_object_id()
+                && let Some(obj) = self.get_object_cell(o)
             {
                 obj.borrow_mut()
                     .insert_builtin("compare".to_string(), compare_fn);
@@ -3682,12 +3683,12 @@ fn zdt_add_subtract(
         Ok(v) => v,
         Err(c) => return c,
     };
-    let dur_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+    let dur_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
     let dur = match super::duration::to_temporal_duration_record(interp, dur_arg) {
         Ok(d) => d,
         Err(c) => return c,
     };
-    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
     let overflow = match parse_overflow_option(interp, &options) {
         Ok(v) => v,
         Err(c) => return c,
@@ -3779,7 +3780,7 @@ fn zdt_until_since(
         Ok(v) => v,
         Err(c) => return c,
     };
-    let other_arg = args.first().cloned().unwrap_or(JsValue::Undefined);
+    let other_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
     let other_val = match to_temporal_zoned_date_time(interp, &other_arg) {
         Completion::Normal(v) => v,
         c => return c,
@@ -3795,7 +3796,7 @@ fn zdt_until_since(
         )));
     }
 
-    let options = args.get(1).cloned().unwrap_or(JsValue::Undefined);
+    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
     let all_units: &[&str] = &[
         "year",
         "month",
@@ -4185,7 +4186,7 @@ fn parse_zdt_to_string_options(
             "auto".to_string(),
         ));
     }
-    if !matches!(options, JsValue::Object(_)) {
+    if !options.is_object() {
         return Err(Completion::Throw(
             interp.create_type_error("options must be an object"),
         ));
@@ -4220,7 +4221,7 @@ fn parse_zdt_to_string_options(
     };
     let fsd_precision = if is_undefined(&fsd_val) {
         None
-    } else if matches!(&fsd_val, JsValue::Number(_)) {
+    } else if fsd_val.is_number() {
         let n = match interp.to_number_value(&fsd_val) {
             Ok(n) => n,
             Err(c) => return Err(Completion::Throw(c)),


### PR DESCRIPTION
## Summary

- Mechanical, zero-behavior-change call-site conversion for the NaN-boxing migration (epic #69, design in #402): converts direct `JsValue::` construction/matching to PR #154's accessor API.
- Covers the Temporal builtins (`temporal/mod.rs` + 9 leaf files: `zoned_date_time.rs`, `plain_date_time.rs`, `plain_date.rs`, `plain_time.rs`, `plain_year_month.rs`, `plain_month_day.rs`, `duration.rs`, `instant.rs`, `now.rs`), the Intl builtins (`intl/mod.rs` + 10 leaf files: `numberformat.rs`, `locale.rs`, `datetimeformat.rs`, `pluralrules.rs`, `durationformat.rs`, `segmenter.rs`, `collator.rs`, `relativetimeformat.rs`, `listformat.rs`, `displaynames.rs`), and `node_host.rs` (22 files total).
- The two shared-header files (`temporal/mod.rs`, `intl/mod.rs`) were converted first/solo to avoid a merge race across the parallel leaf-file conversions, mirroring the precedent set by #407/#410.
- Exhaustive 8-arm matches with no wildcard were converted to `match val.kind()` on `ValueKind` to preserve compile-time exhaustiveness; non-exhaustive matches (with a `_` fallback) were converted to if-let/if-else chains using the accessor API.

Fixes #411

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo clippy --release -- -D warnings` — clean
- [x] test262 full suite: 99,568/99,568 (100%), 0 regressions
- [x] test262-extra: 118/118 (includes the bit-exact NaN round-trip tests, which would catch a botched `JsValue::Number` → `JsValue::number` conversion)
- [x] custom tests (`scripts/run-custom-tests.py`): 11/11
- [x] `cargo test --release`: 457/457 (453 unit + 3 host-time-zone + 1 test262-smoke-oracle)
- [x] Residual-pattern audit: grepped every converted file for `JsValue::(Number|Boolean|String|Symbol|BigInt|Object)(` and `JsValue::(Undefined|Null)` tuple/bare construction — zero survivors, so no site silently bypasses Phase 3's future NaN canonicalization