### PR TITLE
refactor(nan-box): migrate test modules to JsValue accessors

### DIFF
--- a/src/interpreter/bytecode/tests.rs
+++ b/src/interpreter/bytecode/tests.rs
@@ -10,7 +10,7 @@ use crate::types::JsValue;
 fn run(chunk: Chunk) -> Completion {
     let mut interp = Interpreter::new();
     let env = interp.realm().global_env.clone();
-    run_chunk(&mut interp, &chunk, &env, JsValue::Undefined)
+    run_chunk(&mut interp, &chunk, &env, JsValue::UNDEFINED)
 }
 
 #[test]
@@ -35,7 +35,7 @@ fn eval_with_mode(source: &str, bytecode: bool) -> (JsValue, usize) {
     let _ = interp.run(&program);
     let v = interp
         .get_global_var_ref("__r")
-        .unwrap_or(JsValue::Undefined);
+        .unwrap_or(JsValue::UNDEFINED);
     (v, interp.bytecode_chunks_executed)
 }
 
@@ -49,8 +49,8 @@ fn end_to_end_literal_return_takes_bytecode_path() {
         bc_count >= 1,
         "bytecode mode must execute at least one chunk"
     );
-    assert!(matches!(ast_v, JsValue::Number(n) if n == 42.0));
-    assert!(matches!(bc_v, JsValue::Number(n) if n == 42.0));
+    assert_eq!(ast_v.as_number(), Some(42.0));
+    assert_eq!(bc_v.as_number(), Some(42.0));
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn end_to_end_addition_return_takes_bytecode_path() {
     let source = "var __r = (function(){ return 1 + 2; })();";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode mode must execute at least one chunk");
-    assert!(matches!(v, JsValue::Number(n) if n == 3.0));
+    assert_eq!(v.as_number(), Some(3.0));
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn end_to_end_var_declaration_takes_bytecode_path() {
     let source = "var __r = (function(){ var x = 7; return x; })();";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode mode must execute the var body");
-    assert!(matches!(v, JsValue::Number(n) if n == 7.0));
+    assert_eq!(v.as_number(), Some(7.0));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn end_to_end_bytecode_off_unchanged() {
     let source = "var __r = (function(){ return 42; })();";
     let (v, count) = eval_with_mode(source, false);
     assert_eq!(count, 0);
-    assert!(matches!(v, JsValue::Number(n) if n == 42.0));
+    assert_eq!(v.as_number(), Some(42.0));
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn end_to_end_constructor_with_empty_body_returns_this() {
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode path must execute the empty body");
     assert!(
-        matches!(v, JsValue::Object(_)),
+        v.is_object(),
         "expected new f() to return the instance, got {v:?}"
     );
 }
@@ -108,7 +108,7 @@ fn end_to_end_member_assignment_in_loop_takes_bytecode_path() {
         count >= 1,
         "member access inside the loop should now compile to bytecode"
     );
-    assert!(matches!(v, JsValue::Number(n) if n == 9.0));
+    assert_eq!(v.as_number(), Some(9.0));
 }
 
 #[test]
@@ -145,7 +145,7 @@ fn property_access_loop_releases_consumed_operand_roots() {
     let hot = interp.get_global_var_ref("hot").expect("hot binding");
     let chunks_before = interp.bytecode_chunks_executed;
     assert!(matches!(
-        interp.call_function(&hot, &JsValue::Undefined, &[JsValue::Number(64.0)]),
+        interp.call_function(&hot, &JsValue::UNDEFINED, &[JsValue::number(64.0)]),
         Completion::Normal(_)
     ));
     assert!(
@@ -164,7 +164,7 @@ fn end_to_end_dot_read_takes_bytecode_path() {
     let source = "var __r = (function(o){ return o.x; })({x: 5});";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "dot read should compile to bytecode");
-    assert!(matches!(v, JsValue::Number(n) if n == 5.0));
+    assert_eq!(v.as_number(), Some(5.0));
 }
 
 #[test]
@@ -172,7 +172,7 @@ fn end_to_end_computed_read_on_plain_array_takes_bytecode_path() {
     let source = "var __r = (function(a,i){ return a[i]; })([10,20,30], 1);";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "computed array read should compile to bytecode");
-    assert!(matches!(v, JsValue::Number(n) if n == 20.0));
+    assert_eq!(v.as_number(), Some(20.0));
 }
 
 #[test]
@@ -183,7 +183,7 @@ fn end_to_end_computed_read_on_typed_array_takes_bytecode_path() {
         count >= 1,
         "computed typed-array read should compile to bytecode"
     );
-    assert!(matches!(v, JsValue::Number(n) if n == 3.0));
+    assert_eq!(v.as_number(), Some(3.0));
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn end_to_end_dot_write_takes_bytecode_path() {
     let source = "var __r = (function(o){ o.x = 9; return o.x; })({});";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "dot write should compile to bytecode");
-    assert!(matches!(v, JsValue::Number(n) if n == 9.0));
+    assert_eq!(v.as_number(), Some(9.0));
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn end_to_end_computed_write_on_plain_array_takes_bytecode_path() {
         count >= 1,
         "computed array write should compile to bytecode"
     );
-    assert!(matches!(v, JsValue::Number(n) if n == 42.0));
+    assert_eq!(v.as_number(), Some(42.0));
 }
 
 #[test]
@@ -214,7 +214,7 @@ fn end_to_end_computed_write_on_typed_array_takes_bytecode_path() {
         count >= 1,
         "computed typed-array write should compile to bytecode"
     );
-    assert!(matches!(v, JsValue::Number(n) if n == 42.0));
+    assert_eq!(v.as_number(), Some(42.0));
 }
 
 fn assert_message_parity(source: &str) {
@@ -290,8 +290,9 @@ fn end_to_end_member_chain_base_survives_gc_during_rhs_evaluation() {
         count >= 1,
         "the containing function should compile to bytecode"
     );
-    assert!(
-        matches!(v, JsValue::Number(n) if n == 42.0),
+    assert_eq!(
+        v.as_number(),
+        Some(42.0),
         "the `a.base` result must survive the nested GC triggered while evaluating `a.rhs`, got {v:?}"
     );
 }
@@ -325,7 +326,7 @@ fn end_to_end_getprop_call_argument_survives_gc_during_sibling_arg_evaluation() 
         "the containing function should compile to bytecode"
     );
     assert!(
-        matches!(&v, JsValue::String(s) if s.to_string() == "ok"),
+        v.as_string().is_some_and(|s| s.to_string() == "ok"),
         "GetProp's call-argument result must survive the GC forced while evaluating a sibling call argument, got {v:?}"
     );
 }
@@ -341,7 +342,7 @@ fn load_const_and_return_yields_number_completion() {
         max_refs: 0,
     };
     match run(chunk) {
-        Completion::Return(JsValue::Number(n)) => assert_eq!(n, 42.0),
+        Completion::Return(value) => assert_eq!(value.as_number(), Some(42.0)),
         other => panic!("expected Return(Number(42.0)), got {other:?}"),
     }
 }
@@ -357,7 +358,7 @@ fn return_undefined_completes_with_undefined() {
         max_refs: 0,
     };
     match run(chunk) {
-        Completion::Return(JsValue::Undefined) => {}
+        Completion::Return(value) if value.is_undefined() => {}
         other => panic!("expected Return(Undefined), got {other:?}"),
     }
 }
@@ -383,7 +384,7 @@ fn add_two_numbers_via_eval_binary() {
         max_refs: 0,
     };
     match run(chunk) {
-        Completion::Return(JsValue::Number(n)) => assert_eq!(n, 5.0),
+        Completion::Return(value) => assert_eq!(value.as_number(), Some(5.0)),
         other => panic!("expected Return(Number(5.0)), got {other:?}"),
     }
 }
@@ -395,7 +396,7 @@ fn compile_body_return_number_literal() {
     )))];
     let chunk = compile_body(&body).expect("compile");
     match run(chunk) {
-        Completion::Return(JsValue::Number(n)) => assert_eq!(n, 42.0),
+        Completion::Return(value) => assert_eq!(value.as_number(), Some(42.0)),
         other => panic!("expected Return(Number(42.0)), got {other:?}"),
     }
 }
@@ -404,7 +405,7 @@ fn compile_body_return_number_literal() {
 fn compile_body_empty_returns_undefined() {
     let chunk = compile_body(&[]).expect("compile");
     match run(chunk) {
-        Completion::Return(JsValue::Undefined) => {}
+        Completion::Return(value) if value.is_undefined() => {}
         other => panic!("expected Return(Undefined), got {other:?}"),
     }
 }
@@ -414,7 +415,7 @@ fn compile_body_bare_return_yields_undefined() {
     let body = vec![Statement::Return(None)];
     let chunk = compile_body(&body).expect("compile");
     match run(chunk) {
-        Completion::Return(JsValue::Undefined) => {}
+        Completion::Return(value) if value.is_undefined() => {}
         other => panic!("expected Return(Undefined), got {other:?}"),
     }
 }
@@ -429,7 +430,7 @@ fn compile_body_return_addition_of_literals() {
     )))];
     let chunk = compile_body(&body).expect("compile");
     match run(chunk) {
-        Completion::Return(JsValue::Number(n)) => assert_eq!(n, 5.0),
+        Completion::Return(value) => assert_eq!(value.as_number(), Some(5.0)),
         other => panic!("expected Return(Number(5.0)), got {other:?}"),
     }
 }
@@ -447,10 +448,7 @@ fn end_to_end_sub_mul_div_mod_pow_via_bytecode() {
         let source = format!("var __r = {expr};");
         let (v, count) = eval_with_mode(&source, true);
         assert!(count >= 1, "{expr}: bytecode path must run");
-        match v {
-            JsValue::Number(n) => assert_eq!(n, expected, "{expr}"),
-            other => panic!("{expr}: expected Number({expected}), got {other:?}"),
-        }
+        assert_eq!(v.as_number(), Some(expected), "{expr}");
     }
 }
 
@@ -473,10 +471,7 @@ fn end_to_end_comparison_and_equality_ops_via_bytecode() {
         let source = format!("var __r = {expr};");
         let (v, count) = eval_with_mode(&source, true);
         assert!(count >= 1, "{expr}: bytecode path must run");
-        match v {
-            JsValue::Boolean(b) => assert_eq!(b, expected, "{expr}"),
-            other => panic!("{expr}: expected Boolean({expected}), got {other:?}"),
-        }
+        assert_eq!(v.as_boolean(), Some(expected), "{expr}");
     }
 }
 
@@ -494,36 +489,39 @@ fn end_to_end_bitwise_ops_via_bytecode() {
         let source = format!("var __r = {expr};");
         let (v, count) = eval_with_mode(&source, true);
         assert!(count >= 1, "{expr}: bytecode path must run");
-        match v {
-            JsValue::Number(n) => assert_eq!(n as i64, expected as i64, "{expr}"),
-            other => panic!("{expr}: expected Number, got {other:?}"),
-        }
+        let number = v
+            .as_number()
+            .unwrap_or_else(|| panic!("{expr}: expected Number, got {v:?}"));
+        assert_eq!(number as i64, expected as i64, "{expr}");
     }
 }
 
 #[test]
 fn end_to_end_unary_ops_via_bytecode() {
     let cases: &[(&str, JsValue)] = &[
-        ("(function(){ return -5; })()", JsValue::Number(-5.0)),
-        ("(function(){ return +'3'; })()", JsValue::Number(3.0)),
-        ("(function(){ return !true; })()", JsValue::Boolean(false)),
-        ("(function(){ return !0; })()", JsValue::Boolean(true)),
-        ("(function(){ return ~5; })()", JsValue::Number(-6.0)),
-        ("(function(){ return void 0; })()", JsValue::Undefined),
+        ("(function(){ return -5; })()", JsValue::number(-5.0)),
+        ("(function(){ return +'3'; })()", JsValue::number(3.0)),
+        ("(function(){ return !true; })()", JsValue::FALSE),
+        ("(function(){ return !0; })()", JsValue::TRUE),
+        ("(function(){ return ~5; })()", JsValue::number(-6.0)),
+        ("(function(){ return void 0; })()", JsValue::UNDEFINED),
         (
             "(function(){ return void 'anything'; })()",
-            JsValue::Undefined,
+            JsValue::UNDEFINED,
         ),
     ];
     for (expr, expected) in cases {
         let source = format!("var __r = {expr};");
         let (v, count) = eval_with_mode(&source, true);
         assert!(count >= 1, "{expr}: bytecode path must run");
-        match (&v, expected) {
-            (JsValue::Number(n), JsValue::Number(e)) => assert_eq!(n, e, "{expr}"),
-            (JsValue::Boolean(b), JsValue::Boolean(e)) => assert_eq!(b, e, "{expr}"),
-            (JsValue::Undefined, JsValue::Undefined) => {}
-            _ => panic!("{expr}: expected {expected:?}, got {v:?}"),
+        if let Some(expected_number) = expected.as_number() {
+            assert_eq!(v.as_number(), Some(expected_number), "{expr}");
+        } else if let Some(expected_boolean) = expected.as_boolean() {
+            assert_eq!(v.as_boolean(), Some(expected_boolean), "{expr}");
+        } else if expected.is_undefined() {
+            assert!(v.is_undefined(), "{expr}: expected undefined, got {v:?}");
+        } else {
+            panic!("{expr}: unsupported expected value {expected:?}");
         }
     }
 }
@@ -533,20 +531,20 @@ fn end_to_end_ternary_conditional_via_bytecode() {
     let cases: &[(&str, JsValue)] = &[
         (
             "(function(){ return true ? 1 : 2; })()",
-            JsValue::Number(1.0),
+            JsValue::number(1.0),
         ),
         (
             "(function(){ return false ? 1 : 2; })()",
-            JsValue::Number(2.0),
+            JsValue::number(2.0),
         ),
-        ("(function(){ return 0 ? 1 : 2; })()", JsValue::Number(2.0)),
+        ("(function(){ return 0 ? 1 : 2; })()", JsValue::number(2.0)),
         (
             "(function(){ return 1 ? 'yes' : 'no'; })()",
-            JsValue::Number(0.0), /* placeholder */
+            JsValue::number(0.0), /* placeholder */
         ),
         (
             "(function(){ return null ? 1 : 2; })()",
-            JsValue::Number(2.0),
+            JsValue::number(2.0),
         ),
     ];
     for (i, (expr, expected)) in cases.iter().enumerate() {
@@ -555,16 +553,13 @@ fn end_to_end_ternary_conditional_via_bytecode() {
         assert!(count >= 1, "{expr}: bytecode path must run");
         if i == 3 {
             // String case — check separately
-            match v {
-                JsValue::String(ref s) => assert_eq!(s.to_rust_string(), "yes", "{expr}"),
-                _ => panic!("{expr}: expected String 'yes', got {v:?}"),
-            }
+            let string = v
+                .as_string()
+                .unwrap_or_else(|| panic!("{expr}: expected String 'yes', got {v:?}"));
+            assert_eq!(string.to_rust_string(), "yes", "{expr}");
             continue;
         }
-        match (&v, expected) {
-            (JsValue::Number(n), JsValue::Number(e)) => assert_eq!(n, e, "{expr}"),
-            _ => panic!("{expr}: expected {expected:?}, got {v:?}"),
-        }
+        assert_eq!(v.as_number(), expected.as_number(), "{expr}");
     }
 }
 
@@ -574,21 +569,18 @@ fn end_to_end_logical_short_circuit_via_bytecode() {
     // || returns lhs if truthy, else rhs
     // ?? returns lhs if non-nullish, else rhs
     let cases: &[(&str, JsValue)] = &[
-        ("(function(){ return true && 5; })()", JsValue::Number(5.0)),
-        (
-            "(function(){ return false && 5; })()",
-            JsValue::Boolean(false),
-        ),
-        ("(function(){ return 0 && 5; })()", JsValue::Number(0.0)),
-        ("(function(){ return 1 && 2; })()", JsValue::Number(2.0)),
-        ("(function(){ return false || 5; })()", JsValue::Number(5.0)),
-        ("(function(){ return 7 || 5; })()", JsValue::Number(7.0)),
-        ("(function(){ return 0 || 5; })()", JsValue::Number(5.0)),
-        ("(function(){ return null ?? 5; })()", JsValue::Number(5.0)),
-        ("(function(){ return 0 ?? 5; })()", JsValue::Number(0.0)),
+        ("(function(){ return true && 5; })()", JsValue::number(5.0)),
+        ("(function(){ return false && 5; })()", JsValue::FALSE),
+        ("(function(){ return 0 && 5; })()", JsValue::number(0.0)),
+        ("(function(){ return 1 && 2; })()", JsValue::number(2.0)),
+        ("(function(){ return false || 5; })()", JsValue::number(5.0)),
+        ("(function(){ return 7 || 5; })()", JsValue::number(7.0)),
+        ("(function(){ return 0 || 5; })()", JsValue::number(5.0)),
+        ("(function(){ return null ?? 5; })()", JsValue::number(5.0)),
+        ("(function(){ return 0 ?? 5; })()", JsValue::number(0.0)),
         (
             "(function(){ return 'x' ?? 5; })()",
-            JsValue::Number(0.0), /* placeholder */
+            JsValue::number(0.0), /* placeholder */
         ),
     ];
     for (i, (expr, expected)) in cases.iter().enumerate() {
@@ -597,16 +589,18 @@ fn end_to_end_logical_short_circuit_via_bytecode() {
         assert!(count >= 1, "{expr}: bytecode path must run");
         if i == 9 {
             // 'x' ?? 5 → 'x'
-            match v {
-                JsValue::String(ref s) => assert_eq!(s.to_rust_string(), "x", "{expr}"),
-                _ => panic!("{expr}: expected String 'x', got {v:?}"),
-            }
+            let string = v
+                .as_string()
+                .unwrap_or_else(|| panic!("{expr}: expected String 'x', got {v:?}"));
+            assert_eq!(string.to_rust_string(), "x", "{expr}");
             continue;
         }
-        match (&v, expected) {
-            (JsValue::Number(n), JsValue::Number(e)) => assert_eq!(n, e, "{expr}"),
-            (JsValue::Boolean(b), JsValue::Boolean(e)) => assert_eq!(b, e, "{expr}"),
-            _ => panic!("{expr}: expected {expected:?}, got {v:?}"),
+        if let Some(expected_number) = expected.as_number() {
+            assert_eq!(v.as_number(), Some(expected_number), "{expr}");
+        } else if let Some(expected_boolean) = expected.as_boolean() {
+            assert_eq!(v.as_boolean(), Some(expected_boolean), "{expr}");
+        } else {
+            panic!("{expr}: unsupported expected value {expected:?}");
         }
     }
 }
@@ -617,7 +611,7 @@ fn end_to_end_param_read_via_bytecode() {
     let source = "var __r = (function(x){ return x; })(42);";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode path must run");
-    assert!(matches!(v, JsValue::Number(n) if n == 42.0), "got {v:?}");
+    assert_eq!(v.as_number(), Some(42.0), "got {v:?}");
 }
 
 #[test]
@@ -625,7 +619,7 @@ fn end_to_end_param_arithmetic_via_bytecode() {
     let source = "var __r = (function(x, y){ return x + y * 2; })(3, 5);";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode path must run");
-    assert!(matches!(v, JsValue::Number(n) if n == 13.0), "got {v:?}");
+    assert_eq!(v.as_number(), Some(13.0), "got {v:?}");
 }
 
 #[test]
@@ -633,7 +627,7 @@ fn end_to_end_param_compare_returns_boolean() {
     let source = "var __r = (function(n){ return n > 10; })(5);";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode path must run");
-    assert!(matches!(v, JsValue::Boolean(false)), "got {v:?}");
+    assert_eq!(v.as_boolean(), Some(false), "got {v:?}");
 }
 
 #[test]
@@ -641,7 +635,7 @@ fn end_to_end_undeclared_identifier_throws_reference_error() {
     // Should throw ReferenceError, not just falsely succeed via the bytecode path
     let source = "var __r = false; try { (function(){ return undeclaredX; })(); } catch (e) { __r = e instanceof ReferenceError; }";
     let (v, _count) = eval_with_mode(source, true);
-    assert!(matches!(v, JsValue::Boolean(true)), "got {v:?}");
+    assert_eq!(v.as_boolean(), Some(true), "got {v:?}");
 }
 
 #[test]
@@ -649,7 +643,7 @@ fn end_to_end_param_mutation_via_bytecode() {
     let source = "var __r = (function(x){ x = x + 1; return x; })(5);";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode path must run");
-    assert!(matches!(v, JsValue::Number(n) if n == 6.0), "got {v:?}");
+    assert_eq!(v.as_number(), Some(6.0), "got {v:?}");
 }
 
 #[test]
@@ -657,7 +651,7 @@ fn end_to_end_multiple_statements_via_bytecode() {
     let source = "var __r = (function(x){ x = x + 1; x = x * 2; return x; })(3);";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode path must run");
-    assert!(matches!(v, JsValue::Number(n) if n == 8.0), "got {v:?}");
+    assert_eq!(v.as_number(), Some(8.0), "got {v:?}");
 }
 
 #[test]
@@ -666,7 +660,7 @@ fn end_to_end_assignment_returns_assigned_value() {
     let source = "var __r = (function(x){ return (x = 99); })(0);";
     let (v, count) = eval_with_mode(source, true);
     assert!(count >= 1, "bytecode path must run");
-    assert!(matches!(v, JsValue::Number(n) if n == 99.0), "got {v:?}");
+    assert_eq!(v.as_number(), Some(99.0), "got {v:?}");
 }
 
 #[test]
@@ -690,7 +684,13 @@ fn add_string_and_number_falls_through_to_string_concat() {
         max_refs: 0,
     };
     match run(chunk) {
-        Completion::Return(JsValue::String(s)) => assert_eq!(s.to_string(), "x1"),
+        Completion::Return(value) => assert_eq!(
+            value
+                .as_string()
+                .expect("expected Return(String(\"x1\"))")
+                .to_string(),
+            "x1"
+        ),
         other => panic!("expected Return(String(\"x1\")), got {other:?}"),
     }
 }
@@ -704,13 +704,8 @@ fn assert_parity_number(source: &str, expected: f64) {
     let (bc_v, bc_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0, "{source}: AST mode must not run chunks");
     assert!(bc_count >= 1, "{source}: bytecode path must run a chunk");
-    match (&ast_v, &bc_v) {
-        (JsValue::Number(a), JsValue::Number(b)) => {
-            assert_eq!(*a, expected, "{source}: AST value");
-            assert_eq!(*b, expected, "{source}: bytecode value");
-        }
-        _ => panic!("{source}: expected Number({expected}), got ast={ast_v:?} bc={bc_v:?}"),
-    }
+    assert_eq!(ast_v.as_number(), Some(expected), "{source}: AST value");
+    assert_eq!(bc_v.as_number(), Some(expected), "{source}: bytecode value");
 }
 
 // NOTE: lexical declarations are not yet compilable, so a body containing one
@@ -790,14 +785,8 @@ fn if_truthiness_coercion_matches_tree_walker() {
     let (ast_v, _) = eval_with_mode(src, false);
     let (bc_v, bc_count) = eval_with_mode(src, true);
     assert_eq!(bc_count, 0, "object-literal test must bail to AST");
-    assert!(
-        matches!(ast_v, JsValue::Number(n) if n == 1.0),
-        "ast {ast_v:?}"
-    );
-    assert!(
-        matches!(bc_v, JsValue::Number(n) if n == 1.0),
-        "bc {bc_v:?}"
-    );
+    assert_eq!(ast_v.as_number(), Some(1.0), "ast {ast_v:?}");
+    assert_eq!(bc_v.as_number(), Some(1.0), "bc {bc_v:?}");
 }
 
 #[test]
@@ -819,7 +808,7 @@ fn compile_body_if_lowers_via_vm_directly() {
     })];
     let chunk = compile_body(&body).expect("compile if/else");
     match run(chunk) {
-        Completion::Return(JsValue::Number(n)) => assert_eq!(n, 10.0),
+        Completion::Return(value) => assert_eq!(value.as_number(), Some(10.0)),
         other => panic!("expected Return(Number(10.0)), got {other:?}"),
     }
 }
@@ -868,7 +857,7 @@ fn compound_assign_on_member_bails_to_unsupported() {
         count, 0,
         "compound assignment on a member target must bail to the tree-walker"
     );
-    assert!(matches!(v, JsValue::Number(n) if n == 2.0));
+    assert_eq!(v.as_number(), Some(2.0));
 }
 
 #[test]
@@ -879,7 +868,7 @@ fn update_on_member_bails_to_unsupported() {
         count, 0,
         "update expression on a member target must bail to the tree-walker"
     );
-    assert!(matches!(v, JsValue::Number(n) if n == 2.0));
+    assert_eq!(v.as_number(), Some(2.0));
 }
 
 #[test]
@@ -890,7 +879,7 @@ fn optional_member_access_bails_to_unsupported() {
         count, 0,
         "optional member access must bail to the tree-walker"
     );
-    assert!(matches!(v, JsValue::Number(n) if n == 3.0));
+    assert_eq!(v.as_number(), Some(3.0));
 }
 
 #[test]
@@ -929,7 +918,7 @@ fn compile_body_one_armed_if_returning_consequent_false_path_is_safe() {
     })];
     let chunk = compile_body(&body).expect("compile one-armed if");
     match run(chunk) {
-        Completion::Return(JsValue::Undefined) => {}
+        Completion::Return(value) if value.is_undefined() => {}
         other => panic!("expected Return(Undefined) on false path, got {other:?}"),
     }
 }
@@ -944,22 +933,16 @@ fn end_to_end_one_armed_if_last_statement_both_paths() {
     let (bv, bc) = eval_with_mode(true_src, true);
     assert_eq!(ac, 0, "AST mode must not run chunks");
     assert!(bc >= 1, "bytecode path must run (true)");
-    assert!(
-        matches!(av, JsValue::Number(n) if n == 1.0),
-        "ast true {av:?}"
-    );
-    assert!(
-        matches!(bv, JsValue::Number(n) if n == 1.0),
-        "bc true {bv:?}"
-    );
+    assert_eq!(av.as_number(), Some(1.0), "ast true {av:?}");
+    assert_eq!(bv.as_number(), Some(1.0), "bc true {bv:?}");
 
     let false_src = "var __r = (function(x){ if (x) return 1; })(false);";
     let (av2, ac2) = eval_with_mode(false_src, false);
     let (bv2, bc2) = eval_with_mode(false_src, true);
     assert_eq!(ac2, 0, "AST mode must not run chunks");
     assert!(bc2 >= 1, "bytecode path must run (false)");
-    assert!(matches!(av2, JsValue::Undefined), "ast false {av2:?}");
-    assert!(matches!(bv2, JsValue::Undefined), "bc false {bv2:?}");
+    assert!(av2.is_undefined(), "ast false {av2:?}");
+    assert!(bv2.is_undefined(), "bc false {bv2:?}");
 }
 
 #[test]
@@ -973,7 +956,7 @@ fn load_undefined_then_return_completes_with_undefined() {
         max_refs: 0,
     };
     match run(chunk) {
-        Completion::Return(JsValue::Undefined) => {}
+        Completion::Return(value) if value.is_undefined() => {}
         other => panic!("expected Return(Undefined), got {other:?}"),
     }
 }
@@ -987,8 +970,8 @@ fn var_bindings_are_hoisted_before_initializers() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert!(bytecode_count >= 1, "bytecode path must run");
-    assert!(matches!(ast, JsValue::Undefined));
-    assert!(matches!(bytecode, JsValue::Undefined));
+    assert!(ast.is_undefined());
+    assert!(bytecode.is_undefined());
 }
 
 #[test]
@@ -1018,13 +1001,14 @@ fn identifier_update_preserves_bigint_semantics() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert!(bytecode_count >= 1, "bytecode path must run");
-    match (ast, bytecode) {
-        (JsValue::BigInt(a), JsValue::BigInt(b)) => {
-            assert_eq!(a.value.to_string(), "2");
-            assert_eq!(b.value.to_string(), "2");
-        }
-        other => panic!("expected matching BigInt results, got {other:?}"),
-    }
+    let ast_bigint = ast
+        .as_bigint()
+        .unwrap_or_else(|| panic!("expected BigInt AST result, got {ast:?}"));
+    let bytecode_bigint = bytecode
+        .as_bigint()
+        .unwrap_or_else(|| panic!("expected BigInt bytecode result, got {bytecode:?}"));
+    assert_eq!(ast_bigint.value.to_string(), "2");
+    assert_eq!(bytecode_bigint.value.to_string(), "2");
 }
 
 #[test]
@@ -1039,8 +1023,8 @@ fn compound_assignment_preserves_captured_identifier_reference() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert!(bytecode_count >= 1, "nested function must use bytecode");
-    assert!(matches!(ast, JsValue::Number(n) if n == 5.0));
-    assert!(matches!(bytecode, JsValue::Number(n) if n == 5.0));
+    assert_eq!(ast.as_number(), Some(5.0));
+    assert_eq!(bytecode.as_number(), Some(5.0));
 }
 
 #[test]
@@ -1104,7 +1088,7 @@ fn lexical_for_loop_falls_back_to_tree_walker() {
     let source = "var __r = (function(){ var sum = 0; for (let i = 0; i < 3; i++) sum += i; return sum; })();";
     let (value, count) = eval_with_mode(source, true);
     assert_eq!(count, 0, "lexical loop must remain ineligible");
-    assert!(matches!(value, JsValue::Number(n) if n == 3.0));
+    assert_eq!(value.as_number(), Some(3.0));
 }
 
 #[test]
@@ -1112,7 +1096,7 @@ fn loop_with_break_falls_back_to_tree_walker() {
     let source = "var __r = (function(){ var i = 0; while (true) { i++; break; } return i; })();";
     let (value, count) = eval_with_mode(source, true);
     assert_eq!(count, 0, "break lowering is not part of this slice");
-    assert!(matches!(value, JsValue::Number(n) if n == 1.0));
+    assert_eq!(value.as_number(), Some(1.0));
 }
 
 // ----- direct identifier calls -----
@@ -1129,8 +1113,8 @@ fn direct_call_compiles_caller_and_compilable_callee() {
         bytecode_count >= 2,
         "caller and callee must both execute bytecode"
     );
-    assert!(matches!(ast, JsValue::Number(n) if n == 42.0));
-    assert!(matches!(bytecode, JsValue::Number(n) if n == 42.0));
+    assert_eq!(ast.as_number(), Some(42.0));
+    assert_eq!(bytecode.as_number(), Some(42.0));
 }
 
 #[test]
@@ -1145,8 +1129,8 @@ fn direct_call_bridges_to_ineligible_callee() {
         bytecode_count, 1,
         "only the caller should compile; the object/member callee must fall back"
     );
-    assert!(matches!(ast, JsValue::Number(n) if n == 37.0));
-    assert!(matches!(bytecode, JsValue::Number(n) if n == 37.0));
+    assert_eq!(ast.as_number(), Some(37.0));
+    assert_eq!(bytecode.as_number(), Some(37.0));
 }
 
 #[test]
@@ -1156,8 +1140,8 @@ fn direct_native_call_takes_bytecode_path() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert_eq!(bytecode_count, 1, "native callee has no bytecode Body");
-    assert!(matches!(ast, JsValue::Number(n) if n == 42.0));
-    assert!(matches!(bytecode, JsValue::Number(n) if n == 42.0));
+    assert_eq!(ast.as_number(), Some(42.0));
+    assert_eq!(bytecode.as_number(), Some(42.0));
 }
 
 #[test]
@@ -1179,18 +1163,18 @@ fn direct_native_call_preserves_persistent_callback_root() {
     let make_callback = interp
         .get_global_var_ref("makeCallback")
         .expect("makeCallback binding");
-    let callback = match interp.call_function(&make_callback, &JsValue::Undefined, &[]) {
+    let callback = match interp.call_function(&make_callback, &JsValue::UNDEFINED, &[]) {
         Completion::Normal(value) => value,
         other => panic!("makeCallback failed: {other:?}"),
     };
-    let JsValue::Object(callback_object) = callback.clone() else {
-        panic!("makeCallback must return a function object");
-    };
+    let callback_id = callback
+        .as_object_id()
+        .expect("makeCallback must return a function object");
     let schedule = interp
         .get_global_var_ref("schedule")
         .expect("schedule binding");
     assert!(matches!(
-        interp.call_function(&schedule, &JsValue::Undefined, &[callback]),
+        interp.call_function(&schedule, &JsValue::UNDEFINED, &[callback]),
         Completion::Normal(_)
     ));
     assert!(
@@ -1205,7 +1189,7 @@ fn direct_native_call_preserves_persistent_callback_root() {
     interp.gc.request();
     interp.gc_safepoint();
     assert!(
-        interp.get_object_cell(callback_object.id).is_some(),
+        interp.get_object_cell(callback_id).is_some(),
         "setTimeout's persistent callback root must survive the bytecode frame"
     );
 }
@@ -1238,8 +1222,8 @@ fn direct_call_preserves_with_base_as_this_value() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert!(bytecode_count >= 1, "runner must execute through bytecode");
-    assert!(matches!(ast, JsValue::Number(n) if n == 42.0));
-    assert!(matches!(bytecode, JsValue::Number(n) if n == 42.0));
+    assert_eq!(ast.as_number(), Some(42.0));
+    assert_eq!(bytecode.as_number(), Some(42.0));
 }
 
 #[test]
@@ -1264,9 +1248,10 @@ fn direct_call_clears_stale_with_base_before_global_resolution() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert!(bytecode_count >= 1, "runner must execute through bytecode");
-    assert!(matches!(ast, JsValue::Number(n) if n == 1.0));
-    assert!(
-        matches!(bytecode, JsValue::Number(n) if n == 1.0),
+    assert_eq!(ast.as_number(), Some(1.0));
+    assert_eq!(
+        bytecode.as_number(),
+        Some(1.0),
         "a global call must not inherit a with base from an earlier identifier read"
     );
 }
@@ -1303,9 +1288,10 @@ fn direct_call_checks_global_proxy_binding_once() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert!(bytecode_count >= 1, "run must execute through bytecode");
-    assert!(matches!(ast, JsValue::Number(n) if n == 111.0));
-    assert!(
-        matches!(bytecode, JsValue::Number(n) if n == 111.0),
+    assert_eq!(ast.as_number(), Some(111.0));
+    assert_eq!(
+        bytecode.as_number(),
+        Some(111.0),
         "bytecode must invoke the stateful global proxy has trap exactly once, got {bytecode:?}"
     );
 }
@@ -1335,8 +1321,8 @@ fn direct_call_hits_call_site_ic_in_bytecode() {
     let _ = interp.run(&program);
     let v = interp
         .get_global_var_ref("__r")
-        .unwrap_or(JsValue::Undefined);
-    assert!(matches!(v, JsValue::Number(n) if n == 700.0));
+        .unwrap_or(JsValue::UNDEFINED);
+    assert_eq!(v.as_number(), Some(700.0));
     assert!(
         interp.bytecode_chunks_executed >= 1,
         "loop must execute through bytecode"
@@ -1368,8 +1354,8 @@ fn pending_argument_survives_gc_during_later_call_argument() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert!(bytecode_count >= 1, "run must execute through bytecode");
-    assert!(matches!(ast, JsValue::Number(n) if n == 42.0));
-    assert!(matches!(bytecode, JsValue::Number(n) if n == 42.0));
+    assert_eq!(ast.as_number(), Some(42.0));
+    assert_eq!(bytecode.as_number(), Some(42.0));
 }
 
 #[test]
@@ -1391,8 +1377,8 @@ fn pending_with_getter_callee_survives_gc_during_argument() {
     let (bytecode, bytecode_count) = eval_with_mode(source, true);
     assert_eq!(ast_count, 0);
     assert!(bytecode_count >= 1, "runner must execute through bytecode");
-    assert!(matches!(ast, JsValue::Number(n) if n == 17.0));
-    assert!(matches!(bytecode, JsValue::Number(n) if n == 17.0));
+    assert_eq!(ast.as_number(), Some(17.0));
+    assert_eq!(bytecode.as_number(), Some(17.0));
 }
 
 #[test]
@@ -1409,7 +1395,7 @@ fn strict_direct_return_call_preserves_tail_calls() {
         bytecode_count >= 2001,
         "every recursive dispatch must execute bytecode"
     );
-    assert!(matches!(value, JsValue::Number(n) if n == 42.0));
+    assert_eq!(value.as_number(), Some(42.0));
 }
 
 #[test]
@@ -1421,7 +1407,7 @@ fn non_callable_direct_call_throws_via_bytecode() {
         try { run(); } catch (error) { __r = error instanceof TypeError; }";
     let (value, bytecode_count) = eval_with_mode(source, true);
     assert!(bytecode_count >= 1, "run must execute through bytecode");
-    assert!(matches!(value, JsValue::Boolean(true)));
+    assert_eq!(value.as_boolean(), Some(true));
 }
 
 #[test]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -62,33 +62,31 @@ fn run_module_with_path(source: &str, path: &Path) -> Interpreter {
 }
 
 fn global_string(interp: &Interpreter, name: &str) -> String {
-    match interp
+    let value = interp
         .get_global_var_ref(name)
-        .unwrap_or(JsValue::Undefined)
-    {
-        JsValue::String(s) => s.to_string(),
-        other => panic!("expected global string for {name}, got {other:?}"),
-    }
+        .unwrap_or(JsValue::UNDEFINED);
+    value
+        .as_string()
+        .unwrap_or_else(|| panic!("expected global string for {name}, got {value:?}"))
+        .to_string()
 }
 
 fn global_number(interp: &Interpreter, name: &str) -> f64 {
-    match interp
+    let value = interp
         .get_global_var_ref(name)
-        .unwrap_or(JsValue::Undefined)
-    {
-        JsValue::Number(n) => n,
-        other => panic!("expected global number for {name}, got {other:?}"),
-    }
+        .unwrap_or(JsValue::UNDEFINED);
+    value
+        .as_number()
+        .unwrap_or_else(|| panic!("expected global number for {name}, got {value:?}"))
 }
 
 fn global_object_id(interp: &Interpreter, name: &str) -> u64 {
-    match interp
+    let value = interp
         .get_global_var_ref(name)
-        .unwrap_or(JsValue::Undefined)
-    {
-        JsValue::Object(o) => o.id,
-        other => panic!("expected global object for {name}, got {other:?}"),
-    }
+        .unwrap_or(JsValue::UNDEFINED);
+    value
+        .as_object_id()
+        .unwrap_or_else(|| panic!("expected global object for {name}, got {value:?}"))
 }
 
 fn temp_case_dir(label: &str) -> PathBuf {
@@ -171,13 +169,12 @@ fn define_method_installs_a_correctly_shaped_builtin() {
     let target_id = interp.create_object_id();
 
     interp.define_method(target_id, "greet", 1, |_interp, _this, args| {
-        let name = match args.first() {
-            Some(JsValue::String(s)) => s.to_rust_string(),
-            _ => "world".to_string(),
-        };
-        Completion::Normal(JsValue::String(JsString::from_str(&format!(
-            "hello {name}"
-        ))))
+        let name = args
+            .first()
+            .and_then(JsValue::as_string)
+            .map(|s| s.to_rust_string())
+            .unwrap_or_else(|| "world".to_string());
+        Completion::Normal(JsValue::from_str(&format!("hello {name}")))
     });
 
     let desc = interp
@@ -200,27 +197,37 @@ fn define_method_installs_a_correctly_shaped_builtin() {
 
     // define_method must still route through create_function, so name/length bookkeeping
     // (used by Function.prototype.toString, .length, etc.) isn't lost.
-    let JsValue::Object(fn_obj) = &greet_fn else {
-        panic!("expected greet to be a function object")
-    };
-    let fn_cell = interp.get_object_cell_expect(fn_obj.id);
-    match fn_cell.borrow().get_own_property("name").unwrap().value {
-        Some(JsValue::String(ref s)) => assert_eq!(s.to_rust_string(), "greet"),
-        ref other => panic!("expected name string, got {other:?}"),
-    }
-    match fn_cell.borrow().get_own_property("length").unwrap().value {
-        Some(JsValue::Number(n)) => assert_eq!(n, 1.0),
-        ref other => panic!("expected length number, got {other:?}"),
-    }
+    let fn_id = greet_fn
+        .as_object_id()
+        .expect("expected greet to be a function object");
+    let fn_cell = interp.get_object_cell_expect(fn_id);
+    let name = fn_cell
+        .borrow()
+        .get_own_property("name")
+        .unwrap()
+        .value
+        .and_then(|value| value.as_string())
+        .expect("expected name string");
+    assert_eq!(name.to_rust_string(), "greet");
+    let length = fn_cell
+        .borrow()
+        .get_own_property("length")
+        .unwrap()
+        .value
+        .and_then(|value| value.as_number())
+        .expect("expected length number");
+    assert_eq!(length, 1.0);
 
-    let target_val = JsValue::Object(crate::types::JsObject { id: target_id });
-    let result = interp.call_function(
-        &greet_fn,
-        &target_val,
-        &[JsValue::String(JsString::from_str("jsse"))],
-    );
+    let target_val = JsValue::object(target_id);
+    let result = interp.call_function(&greet_fn, &target_val, &[JsValue::from_str("jsse")]);
     match result {
-        Completion::Normal(JsValue::String(s)) => assert_eq!(s.to_rust_string(), "hello jsse"),
+        Completion::Normal(value) => assert_eq!(
+            value
+                .as_string()
+                .expect("expected string completion")
+                .to_rust_string(),
+            "hello jsse"
+        ),
         other => panic!("unexpected completion: {other:?}"),
     }
 }
@@ -231,7 +238,7 @@ fn define_getter_installs_a_correctly_shaped_accessor() {
     let target_id = interp.create_object_id();
 
     let getter = interp.define_getter(target_id, "answer", |_interp, _this, _args| {
-        Completion::Normal(JsValue::Number(42.0))
+        Completion::Normal(JsValue::number(42.0))
     });
 
     // Raw stored descriptor (get_own_property would complete an absent setter
@@ -260,29 +267,38 @@ fn define_getter_installs_a_correctly_shaped_accessor() {
 
     // define_getter must return the same function it installed as the getter.
     let installed_getter = desc.get.expect("getter value present");
-    assert!(
-        matches!((&installed_getter, &getter), (JsValue::Object(a), JsValue::Object(b)) if a.id == b.id),
+    let getter_id = getter
+        .as_object_id()
+        .expect("expected getter to be a function object");
+    assert_eq!(
+        installed_getter.as_object_id(),
+        Some(getter_id),
         "returned getter must be the one installed on the accessor"
     );
 
     // Getter bookkeeping: name is prefixed with "get ", length is 0 (per spec).
-    let JsValue::Object(fn_obj) = &getter else {
-        panic!("expected getter to be a function object")
-    };
-    let fn_cell = interp.get_object_cell_expect(fn_obj.id);
-    match fn_cell.borrow().get_own_property("name").unwrap().value {
-        Some(JsValue::String(ref s)) => assert_eq!(s.to_rust_string(), "get answer"),
-        ref other => panic!("expected name string, got {other:?}"),
-    }
-    match fn_cell.borrow().get_own_property("length").unwrap().value {
-        Some(JsValue::Number(n)) => assert_eq!(n, 0.0),
-        ref other => panic!("expected length number, got {other:?}"),
-    }
+    let fn_cell = interp.get_object_cell_expect(getter_id);
+    let name = fn_cell
+        .borrow()
+        .get_own_property("name")
+        .unwrap()
+        .value
+        .and_then(|value| value.as_string())
+        .expect("expected name string");
+    assert_eq!(name.to_rust_string(), "get answer");
+    let length = fn_cell
+        .borrow()
+        .get_own_property("length")
+        .unwrap()
+        .value
+        .and_then(|value| value.as_number())
+        .expect("expected length number");
+    assert_eq!(length, 0.0);
 
     // The getter is callable and returns its computed value.
-    let target_val = JsValue::Object(crate::types::JsObject { id: target_id });
+    let target_val = JsValue::object(target_id);
     match interp.call_function(&getter, &target_val, &[]) {
-        Completion::Normal(JsValue::Number(n)) => assert_eq!(n, 42.0),
+        Completion::Normal(value) => assert_eq!(value.as_number(), Some(42.0)),
         other => panic!("unexpected completion: {other:?}"),
     }
 }
@@ -306,10 +322,12 @@ fn define_to_string_tag_installs_a_correctly_shaped_data_property() {
 
     // Per spec, @@toStringTag on builtin prototypes is a data property:
     // { [[Value]]: tag, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
-    match desc.value {
-        Some(JsValue::String(ref s)) => assert_eq!(s.to_rust_string(), "CorrectlyShaped"),
-        ref other => panic!("expected string tag value, got {other:?}"),
-    }
+    let tag = desc
+        .value
+        .as_ref()
+        .and_then(JsValue::as_string)
+        .expect("expected string tag value");
+    assert_eq!(tag.to_rust_string(), "CorrectlyShaped");
     assert_eq!(desc.writable, Some(false), "@@toStringTag is non-writable");
     assert_eq!(
         desc.enumerable,
@@ -339,15 +357,19 @@ fn define_to_string_tag_installs_a_correctly_shaped_data_property() {
     );
 
     // Observable: Object.prototype.toString sees the installed tag.
-    let target_val = JsValue::Object(crate::types::JsObject { id: target_id });
+    let target_val = JsValue::object(target_id);
     let to_string = match interp.run(&parse_program("Object.prototype.toString;")) {
         Completion::Normal(v) => v,
         other => panic!("expected Object.prototype.toString value, got {other:?}"),
     };
     match interp.call_function(&to_string, &target_val, &[]) {
-        Completion::Normal(JsValue::String(s)) => {
-            assert_eq!(s.to_rust_string(), "[object CorrectlyShaped]")
-        }
+        Completion::Normal(value) => assert_eq!(
+            value
+                .as_string()
+                .expect("expected string completion")
+                .to_rust_string(),
+            "[object CorrectlyShaped]"
+        ),
         other => panic!("unexpected completion: {other:?}"),
     }
 }
@@ -788,11 +810,11 @@ fn missing_named_module_import_throws_syntax_error() {
 fn gc_keeps_microtask_roots_alive_until_queue_is_cleared() {
     let mut interp = Interpreter::new();
     let id = interp.create_object_id();
-    let obj_val = JsValue::Object(crate::types::JsObject { id });
+    let obj_val = JsValue::object(id);
 
     interp.scheduler.enqueue_microtask((
         vec![obj_val.clone()],
-        Box::new(|_| Completion::Normal(JsValue::Undefined)),
+        Box::new(|_| Completion::Normal(JsValue::UNDEFINED)),
     ));
     interp.gc.request();
     interp.gc_safepoint();
@@ -830,18 +852,16 @@ fn gc_keeps_module_exports_alive_until_registry_entry_is_removed() {
         .get("obj")
         .expect("module export")
         .clone();
-    let JsValue::Object(obj_ref) = export_val else {
-        panic!("expected exported object");
-    };
+    let object_id = export_val.as_object_id().expect("expected exported object");
 
     interp.gc.request();
     interp.gc_safepoint();
-    assert!(interp.get_object_cell(obj_ref.id).is_some());
+    assert!(interp.get_object_cell(object_id).is_some());
 
     interp.module_registry.remove(&key);
     interp.gc.request();
     interp.gc_safepoint();
-    assert!(interp.get_object_cell(obj_ref.id).is_none());
+    assert!(interp.get_object_cell(object_id).is_none());
 
     let _ = fs::remove_dir_all(&dir);
 }
@@ -1228,7 +1248,7 @@ fn set_property_value_add_bumps_shape() {
         .get_object(id)
         .unwrap()
         .borrow_mut()
-        .set_property_value("x", JsValue::Number(1.0));
+        .set_property_value("x", JsValue::number(1.0));
     assert!(
         ok,
         "set_property_value should succeed on extensible empty obj"
@@ -1249,13 +1269,13 @@ fn set_property_value_update_existing_does_not_bump_shape() {
         .get_object(id)
         .unwrap()
         .borrow_mut()
-        .set_property_value("x", JsValue::Number(1.0));
+        .set_property_value("x", JsValue::number(1.0));
     let before = interp.get_object(id).unwrap().borrow().shape_id;
     interp
         .get_object(id)
         .unwrap()
         .borrow_mut()
-        .set_property_value("x", JsValue::Number(2.0));
+        .set_property_value("x", JsValue::number(2.0));
     let after = interp.get_object(id).unwrap().borrow().shape_id;
     assert_eq!(
         after, before,
@@ -1273,7 +1293,7 @@ fn define_own_property_bumps_shape_on_attribute_change() {
         .get_object(id)
         .unwrap()
         .borrow_mut()
-        .set_property_value("x", JsValue::Number(1.0));
+        .set_property_value("x", JsValue::number(1.0));
     let before = interp.get_object(id).unwrap().borrow().shape_id;
     let ok = interp
         .get_object(id)
@@ -1282,7 +1302,7 @@ fn define_own_property_bumps_shape_on_attribute_change() {
         .define_own_property(
             "x".to_string(),
             PropertyDescriptor {
-                value: Some(JsValue::Number(1.0)),
+                value: Some(JsValue::number(1.0)),
                 writable: Some(false),
                 enumerable: Some(true),
                 configurable: Some(true),
@@ -1867,7 +1887,7 @@ fn define_own_property_bumps_shape_on_data_to_accessor_swap() {
         .get_object(id)
         .unwrap()
         .borrow_mut()
-        .set_property_value("x", JsValue::Number(1.0));
+        .set_property_value("x", JsValue::number(1.0));
     let before = interp.get_object(id).unwrap().borrow().shape_id;
     // Swap data → accessor by defining a getter.
     let ok = interp
@@ -1879,7 +1899,7 @@ fn define_own_property_bumps_shape_on_data_to_accessor_swap() {
             PropertyDescriptor {
                 value: None,
                 writable: None,
-                get: Some(JsValue::Undefined), // sentinel — real getter not needed for this test
+                get: Some(JsValue::UNDEFINED), // sentinel — real getter not needed for this test
                 set: None,
                 enumerable: Some(true),
                 configurable: Some(true),
@@ -1967,18 +1987,28 @@ fn array_prototype_methods_have_correctly_shaped_builtins() {
             Some(true),
             "Array.prototype.{name} must stay configurable"
         );
-        let JsValue::Object(fn_obj) = desc.value.expect("method has a function value") else {
-            panic!("Array.prototype.{name} is not a function object")
-        };
-        let fn_cell = interp.get_object_cell_expect(fn_obj.id);
-        match fn_cell.borrow().get_own_property("name").unwrap().value {
-            Some(JsValue::String(ref s)) => assert_eq!(s.to_rust_string(), *name),
-            ref other => panic!("Array.prototype.{name}: expected name string, got {other:?}"),
-        }
-        match fn_cell.borrow().get_own_property("length").unwrap().value {
-            Some(JsValue::Number(n)) => assert_eq!(n, *len, "Array.prototype.{name}.length"),
-            ref other => panic!("Array.prototype.{name}: expected length number, got {other:?}"),
-        }
+        let fn_id = desc
+            .value
+            .expect("method has a function value")
+            .as_object_id()
+            .unwrap_or_else(|| panic!("Array.prototype.{name} is not a function object"));
+        let fn_cell = interp.get_object_cell_expect(fn_id);
+        let actual_name = fn_cell
+            .borrow()
+            .get_own_property("name")
+            .unwrap()
+            .value
+            .and_then(|value| value.as_string())
+            .unwrap_or_else(|| panic!("Array.prototype.{name}: expected name string"));
+        assert_eq!(actual_name.to_rust_string(), *name);
+        let actual_length = fn_cell
+            .borrow()
+            .get_own_property("length")
+            .unwrap()
+            .value
+            .and_then(|value| value.as_number())
+            .unwrap_or_else(|| panic!("Array.prototype.{name}: expected length number"));
+        assert_eq!(actual_length, *len, "Array.prototype.{name}.length");
     }
 
     // Array.prototype[@@iterator] must be the very same function object as .values (§23.1.3.35).
@@ -1993,16 +2023,18 @@ fn array_prototype_methods_have_correctly_shaped_builtins() {
         .borrow()
         .get_own_property(&iterator_key)
         .expect("@@iterator installed");
-    let (JsValue::Object(values_obj), JsValue::Object(iterator_obj)) = (
-        values_desc.value.expect("values has a function value"),
-        iterator_desc
-            .value
-            .expect("@@iterator has a function value"),
-    ) else {
-        panic!("expected both values and @@iterator to be function objects")
-    };
+    let values_id = values_desc
+        .value
+        .expect("values has a function value")
+        .as_object_id()
+        .expect("values must be a function object");
+    let iterator_id = iterator_desc
+        .value
+        .expect("@@iterator has a function value")
+        .as_object_id()
+        .expect("@@iterator must be a function object");
     assert_eq!(
-        values_obj.id, iterator_obj.id,
+        values_id, iterator_id,
         "Array.prototype[@@iterator] must be identical to Array.prototype.values"
     );
 }
@@ -2195,10 +2227,12 @@ mod loop_completion_value_tests {
     }
 
     fn assert_number(source: &str, expected: f64) {
-        match completion_value(source) {
-            JsValue::Number(n) => assert_eq!(n, expected, "completion value of `{source}`"),
-            other => panic!("expected number completion for `{source}`, got {other:?}"),
-        }
+        let value = completion_value(source);
+        assert_eq!(
+            value.as_number(),
+            Some(expected),
+            "completion value of `{source}`"
+        );
     }
 
     #[test]
@@ -2307,43 +2341,40 @@ mod to_integer_or_infinity_value_tests {
 
     #[test]
     fn truncates_toward_zero() {
-        assert_eq!(conv(JsValue::Number(3.7)), 3.0);
-        assert_eq!(conv(JsValue::Number(-3.7)), -3.0);
-        assert_eq!(conv(JsValue::Number(5.0)), 5.0);
-        assert_eq!(conv(JsValue::Number(-0.9)), 0.0);
+        assert_eq!(conv(JsValue::number(3.7)), 3.0);
+        assert_eq!(conv(JsValue::number(-3.7)), -3.0);
+        assert_eq!(conv(JsValue::number(5.0)), 5.0);
+        assert_eq!(conv(JsValue::number(-0.9)), 0.0);
     }
 
     #[test]
     fn nan_becomes_positive_zero() {
-        let r = conv(JsValue::Number(f64::NAN));
+        let r = conv(JsValue::number(f64::NAN));
         assert_eq!(r, 0.0);
         assert!(r.is_sign_positive(), "ToIntegerOrInfinity(NaN) is +0");
     }
 
     #[test]
     fn infinities_pass_through() {
-        assert_eq!(conv(JsValue::Number(f64::INFINITY)), f64::INFINITY);
-        assert_eq!(conv(JsValue::Number(f64::NEG_INFINITY)), f64::NEG_INFINITY);
+        assert_eq!(conv(JsValue::number(f64::INFINITY)), f64::INFINITY);
+        assert_eq!(conv(JsValue::number(f64::NEG_INFINITY)), f64::NEG_INFINITY);
     }
 
     #[test]
     fn coerces_booleans_null_and_undefined() {
-        assert_eq!(conv(JsValue::Boolean(true)), 1.0); // ToNumber(true) = 1
-        assert_eq!(conv(JsValue::Boolean(false)), 0.0);
-        assert_eq!(conv(JsValue::Null), 0.0); // ToNumber(null) = 0
-        assert_eq!(conv(JsValue::Undefined), 0.0); // ToNumber(undefined) = NaN -> 0
+        assert_eq!(conv(JsValue::TRUE), 1.0); // ToNumber(true) = 1
+        assert_eq!(conv(JsValue::FALSE), 0.0);
+        assert_eq!(conv(JsValue::NULL), 0.0); // ToNumber(null) = 0
+        assert_eq!(conv(JsValue::UNDEFINED), 0.0); // ToNumber(undefined) = NaN -> 0
     }
 
     #[test]
     fn coerces_strings() {
-        assert_eq!(conv(JsValue::String(JsString::from_str("42"))), 42.0);
-        assert_eq!(conv(JsValue::String(JsString::from_str("42.9"))), 42.0);
-        assert_eq!(conv(JsValue::String(JsString::from_str("  -7.5 "))), -7.0);
-        assert_eq!(conv(JsValue::String(JsString::from_str("abc"))), 0.0); // NaN -> 0
-        assert_eq!(
-            conv(JsValue::String(JsString::from_str("Infinity"))),
-            f64::INFINITY
-        );
+        assert_eq!(conv(JsValue::from_str("42")), 42.0);
+        assert_eq!(conv(JsValue::from_str("42.9")), 42.0);
+        assert_eq!(conv(JsValue::from_str("  -7.5 ")), -7.0);
+        assert_eq!(conv(JsValue::from_str("abc")), 0.0); // NaN -> 0
+        assert_eq!(conv(JsValue::from_str("Infinity")), f64::INFINITY);
     }
 
     #[test]

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -3889,7 +3889,7 @@ mod kind_accessor_tests {
 
     #[test]
     fn array_elements_some_for_array_kind() {
-        let obj = obj_with_kind(ObjectKind::Array(vec![JsValue::Undefined]));
+        let obj = obj_with_kind(ObjectKind::Array(vec![JsValue::UNDEFINED]));
         assert!(obj.array_elements().is_some());
         assert_eq!(obj.array_elements().unwrap().len(), 1);
     }
@@ -3903,9 +3903,7 @@ mod kind_accessor_tests {
     #[test]
     fn array_elements_mut_allows_push() {
         let mut obj = obj_with_kind(ObjectKind::Array(Vec::new()));
-        obj.array_elements_mut()
-            .unwrap()
-            .push(JsValue::Boolean(true));
+        obj.array_elements_mut().unwrap().push(JsValue::TRUE);
         assert_eq!(obj.array_elements().unwrap().len(), 1);
     }
 
@@ -3913,7 +3911,7 @@ mod kind_accessor_tests {
 
     #[test]
     fn set_data_some_for_set_kind() {
-        let obj = obj_with_kind(ObjectKind::Set(vec![Some(JsValue::Number(1.0))]));
+        let obj = obj_with_kind(ObjectKind::Set(vec![Some(JsValue::number(1.0))]));
         assert!(obj.set_data().is_some());
         assert_eq!(obj.set_data().unwrap().len(), 1);
     }
@@ -3935,7 +3933,7 @@ mod kind_accessor_tests {
 
     #[test]
     fn map_data_some_for_map_kind() {
-        let entry = Some((JsValue::Number(1.0), JsValue::Boolean(false)));
+        let entry = Some((JsValue::number(1.0), JsValue::FALSE));
         let obj = obj_with_kind(ObjectKind::Map(vec![entry]));
         assert!(obj.map_data().is_some());
         assert_eq!(obj.map_data().unwrap().len(), 1);
@@ -3952,7 +3950,7 @@ mod kind_accessor_tests {
         let mut obj = obj_with_kind(ObjectKind::Map(Vec::new()));
         obj.map_data_mut()
             .unwrap()
-            .push(Some((JsValue::Number(0.0), JsValue::Undefined)));
+            .push(Some((JsValue::number(0.0), JsValue::UNDEFINED)));
         assert_eq!(obj.map_data().unwrap().len(), 1);
     }
 
@@ -3961,8 +3959,8 @@ mod kind_accessor_tests {
     #[test]
     fn bound_some_for_bound_function_kind() {
         let data = BoundFunctionData {
-            target: JsValue::Undefined,
-            this: JsValue::Undefined,
+            target: JsValue::UNDEFINED,
+            this: JsValue::UNDEFINED,
             args: vec![],
         };
         let obj = obj_with_kind(ObjectKind::BoundFunction(data));
@@ -4035,8 +4033,8 @@ mod property_bag_tests {
     #[test]
     fn remove_property_clears_both_map_and_order() {
         let mut obj = JsObjectData::new();
-        obj.insert_property("a", PropertyDescriptor::data_default(JsValue::Number(1.0)));
-        obj.insert_property("b", PropertyDescriptor::data_default(JsValue::Number(2.0)));
+        obj.insert_property("a", PropertyDescriptor::data_default(JsValue::number(1.0)));
+        obj.insert_property("b", PropertyDescriptor::data_default(JsValue::number(2.0)));
 
         let removed = obj.remove_property("a");
 
@@ -4049,7 +4047,7 @@ mod property_bag_tests {
     fn remove_property_preserves_order_of_survivors() {
         let mut obj = JsObjectData::new();
         for k in ["a", "b", "c", "d"] {
-            obj.insert_property(k, PropertyDescriptor::data_default(JsValue::Undefined));
+            obj.insert_property(k, PropertyDescriptor::data_default(JsValue::UNDEFINED));
         }
 
         obj.remove_property("b");
@@ -4064,12 +4062,15 @@ mod property_bag_tests {
         let mut obj = JsObjectData::new();
         obj.insert_property(
             "x",
-            PropertyDescriptor::data(JsValue::Number(42.0), false, true, false),
+            PropertyDescriptor::data(JsValue::number(42.0), false, true, false),
         );
 
         let removed = obj.remove_property("x").expect("descriptor returned");
 
-        assert!(matches!(removed.value, Some(JsValue::Number(n)) if n == 42.0));
+        assert_eq!(
+            removed.value.and_then(|value| value.as_number()),
+            Some(42.0)
+        );
         assert_eq!(removed.writable, Some(false));
         assert_eq!(removed.enumerable, Some(true));
         assert_eq!(removed.configurable, Some(false));
@@ -4078,7 +4079,7 @@ mod property_bag_tests {
     #[test]
     fn remove_absent_key_is_a_noop() {
         let mut obj = JsObjectData::new();
-        obj.insert_property("a", PropertyDescriptor::data_default(JsValue::Undefined));
+        obj.insert_property("a", PropertyDescriptor::data_default(JsValue::UNDEFINED));
 
         assert!(obj.remove_property("missing").is_none());
         assert_eq!(keys(&obj), vec!["a"], "order untouched");
@@ -4088,7 +4089,7 @@ mod property_bag_tests {
     #[test]
     fn second_remove_returns_none() {
         let mut obj = JsObjectData::new();
-        obj.insert_property("a", PropertyDescriptor::data_default(JsValue::Undefined));
+        obj.insert_property("a", PropertyDescriptor::data_default(JsValue::UNDEFINED));
 
         assert!(obj.remove_property("a").is_some());
         assert!(obj.remove_property("a").is_none());

--- a/src/types.rs
+++ b/src/types.rs
@@ -1008,12 +1008,12 @@ mod tests {
 
     #[test]
     fn display_values() {
-        assert_eq!(format!("{}", JsValue::Undefined), "undefined");
-        assert_eq!(format!("{}", JsValue::Null), "null");
-        assert_eq!(format!("{}", JsValue::Boolean(true)), "true");
-        assert_eq!(format!("{}", JsValue::Number(42.0)), "42");
+        assert_eq!(format!("{}", JsValue::UNDEFINED), "undefined");
+        assert_eq!(format!("{}", JsValue::NULL), "null");
+        assert_eq!(format!("{}", JsValue::TRUE), "true");
+        assert_eq!(format!("{}", JsValue::number(42.0)), "42");
         assert_eq!(
-            format!("{}", JsValue::String(JsString::from_str("hi"))),
+            format!("{}", JsValue::string(JsString::from_str("hi"))),
             "hi"
         );
     }
@@ -1092,10 +1092,10 @@ mod tests {
 
     #[test]
     fn value_constructors() {
-        assert!(matches!(JsValue::UNDEFINED, JsValue::Undefined));
-        assert!(matches!(JsValue::NULL, JsValue::Null));
-        assert!(matches!(JsValue::TRUE, JsValue::Boolean(true)));
-        assert!(matches!(JsValue::FALSE, JsValue::Boolean(false)));
+        assert!(JsValue::UNDEFINED.is_undefined());
+        assert!(JsValue::NULL.is_null());
+        assert_eq!(JsValue::TRUE.as_boolean(), Some(true));
+        assert_eq!(JsValue::FALSE.as_boolean(), Some(false));
         assert_eq!(JsValue::boolean(true).as_boolean(), Some(true));
         assert_eq!(JsValue::number(3.5).as_number(), Some(3.5));
         assert_eq!(JsValue::object(7).as_object_id(), Some(7));
@@ -1124,58 +1124,58 @@ mod tests {
 
     #[test]
     fn typed_accessors_return_none_on_mismatch() {
-        let n = JsValue::Number(1.0);
+        let n = JsValue::number(1.0);
         assert_eq!(n.as_boolean(), None);
         assert_eq!(n.as_object_id(), None);
         assert!(n.as_string().is_none());
         assert!(n.as_symbol().is_none());
         assert!(n.as_bigint().is_none());
-        assert_eq!(JsValue::Boolean(true).as_number(), None);
+        assert_eq!(JsValue::TRUE.as_number(), None);
     }
 
     #[test]
     fn with_accessors() {
         let s = JsValue::from_str("abc");
         assert_eq!(s.with_string(|cu| cu.len()), Some(3));
-        assert_eq!(JsValue::Null.with_string(|cu| cu.len()), None);
+        assert_eq!(JsValue::NULL.with_string(|cu| cu.len()), None);
 
-        let sym = JsValue::Symbol(JsSymbol::new(9, None));
+        let sym = JsValue::symbol(JsSymbol::new(9, None));
         assert_eq!(sym.with_symbol(JsSymbol::id), Some(9));
-        assert_eq!(JsValue::Null.with_symbol(JsSymbol::id), None);
+        assert_eq!(JsValue::NULL.with_symbol(JsSymbol::id), None);
 
-        let big = JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(5)));
+        let big = JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(5)));
         assert_eq!(
             big.with_bigint(|b| b.clone()),
             Some(num_bigint::BigInt::from(5))
         );
-        assert_eq!(JsValue::Null.with_bigint(|b| b.clone()), None);
+        assert_eq!(JsValue::NULL.with_bigint(|b| b.clone()), None);
     }
 
     #[test]
     fn into_accessors() {
         let s = JsValue::from_str("x");
         assert_eq!(s.into_string().unwrap().to_rust_string(), "x");
-        assert!(JsValue::Null.into_string().is_none());
+        assert!(JsValue::NULL.into_string().is_none());
 
-        let big = JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(11)));
+        let big = JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(11)));
         assert_eq!(
             *big.into_bigint().unwrap().value,
             num_bigint::BigInt::from(11)
         );
-        assert!(JsValue::Number(1.0).into_bigint().is_none());
+        assert!(JsValue::number(1.0).into_bigint().is_none());
     }
 
     #[test]
     fn discriminant_and_kind() {
         let cases = [
-            (JsValue::Undefined, ValueKind::Undefined),
-            (JsValue::Null, ValueKind::Null),
-            (JsValue::Boolean(true), ValueKind::Boolean),
-            (JsValue::Number(1.0), ValueKind::Number),
+            (JsValue::UNDEFINED, ValueKind::Undefined),
+            (JsValue::NULL, ValueKind::Null),
+            (JsValue::TRUE, ValueKind::Boolean),
+            (JsValue::number(1.0), ValueKind::Number),
             (JsValue::from_str("s"), ValueKind::String),
-            (JsValue::Symbol(JsSymbol::new(0, None)), ValueKind::Symbol),
+            (JsValue::symbol(JsSymbol::new(0, None)), ValueKind::Symbol),
             (
-                JsValue::BigInt(JsBigInt::new(num_bigint::BigInt::from(0))),
+                JsValue::bigint(JsBigInt::new(num_bigint::BigInt::from(0))),
                 ValueKind::BigInt,
             ),
             (JsValue::object(1), ValueKind::Object),
@@ -1189,7 +1189,7 @@ mod tests {
     #[test]
     fn is_object_predicate() {
         assert!(JsValue::object(3).is_object());
-        assert!(!JsValue::Null.is_object());
-        assert!(!JsValue::Number(0.0).is_object());
+        assert!(!JsValue::NULL.is_object());
+        assert!(!JsValue::number(0.0).is_object());
     }
 }


### PR DESCRIPTION
## Summary

- replace direct `JsValue` enum construction in test modules with representation-neutral constructors and constants
- replace direct variant matching with typed accessors and predicates while preserving existing assertions

Fixes #413

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `./scripts/lint.sh` — clean
- [x] `cargo test` — 454 unit tests, 3 integration tests, and smoke oracle passing
- [x] `cargo build --release` — clean
- [x] `uv run python scripts/run-test262.py` — 99,568/99,568 (100.00%), 0 regressions
- [x] Direct enum-form grep across the four scoped test areas — no matches