### PR TITLE
chore(nan-box): remove leftover dead-code shims from the nan-box swap

### DIFF
--- a/docs/adr/0003-nan-boxed-jsvalue.md
+++ b/docs/adr/0003-nan-boxed-jsvalue.md
@@ -67,7 +67,12 @@ artifacts; the phantom comment carries no design authority and is superseded.
 ## Consequences
 
 - `JsValue` shrinks from ~32 bytes (tag plus largest inline variant,
-  `JsBigInt { num_bigint::BigInt }`) to 8 bytes everywhere it is stored.
+  `JsBigInt { num_bigint::BigInt }`) to 8 bytes everywhere it is stored. That
+  ~32-byte figure was accurate when this ADR was written, before #403/#404
+  wrapped `JsBigInt`/`JsSymbol` in `Arc`; by the time the swap (#414) actually
+  landed, the pre-swap enum measured 16 bytes — see the design doc's
+  [As Landed](../specs/2026-07-26-nan-boxed-js-value-design.md#as-landed-phase-4-issue-415)
+  section for the reconciled numbers.
 - `NanBoxedValue` is `Clone`, not `Copy`: every existing `.clone()` call site
   keeps working unchanged, but a stray `let y = x;` that implicitly relied on
   `Copy` now fails to compile instead of silently corrupting a refcount —

--- a/docs/specs/2026-07-26-nan-boxed-js-value-design.md
+++ b/docs/specs/2026-07-26-nan-boxed-js-value-design.md
@@ -333,21 +333,28 @@ got only approximately right, discovered while doing the Phase 4 cleanup pass:
 - **No feature flag was used**, per the Rollout mechanism section above — this
   held as planned; there was nothing to remove in Phase 4.
 - **Performance**: PR #439 measured a focused clone/read micro-benchmark
-  (10M Number/Object clone-read cycles) improving from 248.9ms to 96.0ms
-  (~2.6x) — a clean, repeatable, engine-internal measurement not sensitive to
-  host load, and the strongest evidence this migration delivers on its
-  memory/throughput goal for the operation it targets directly. The same
-  PR's one-off full test262 wall-clock timing went from 394.30s to 497.07s
-  (+26%), but both are single runs, on a shared host this project's own
+  (`nan_box_clone_benchmark`, `src/types.rs`: an `#[ignore]`d single-threaded
+  loop of 10M Number/Object clone-read cycles, timed with
+  `Instant::elapsed()`) improving from 248.9ms to 96.0ms (~2.6x). That number
+  is *not* immune to host load — a wall-clock loop timed with
+  `Instant::elapsed()` still reflects whatever the OS scheduler and CPU
+  frequency state were doing during that particular run — it was a single
+  measurement each side, same as the test262 timing below, with no repeated
+  trials or statistical treatment. What it does avoid is the specific
+  confounder that dominates the test262 comparison: it doesn't fork/exec
+  thousands of subprocesses, so it's less exposed to scheduler noise over a
+  multi-minute window. That's a difference of degree, not of kind, and it
+  isn't enough on its own to call the number validated.
+  The same PR's one-off full test262 wall-clock timing went from 394.30s to
+  497.07s (+26%); both are single runs on a shared host — this project's own
   development machine, not a dedicated benchmark box. Phase 4 attempted a
   clean re-measurement and confirmed the host is unsuitable for this
   comparison: the run coincided with unrelated load from other users
   (`uptime` load average ~190 against 61 cores, i.e. roughly 3x
   oversubscribed) and produced 8:26 — slower than both prior numbers, which a
   behaviorally-identical diff (attribute removals only, no codegen change)
-  cannot explain except as host noise. **The full-suite wall-clock
-  aggregate is therefore unresolved and not reliably measurable on this
-  host**; the 10M-cycle micro-benchmark result stands as the validated
-  performance claim for this migration, and the test262 aggregate should not
-  be cited as either a win or a regression until measured on an isolated,
-  unshared machine.
+  cannot explain except as host noise. **Both the micro-benchmark and the
+  full-suite wall-clock aggregate are therefore single, unrepeated
+  measurements on a contended host, and neither should be cited as a
+  validated performance result — win or regression — until re-measured with
+  repeated trials on an isolated, unshared machine.**

--- a/docs/specs/2026-07-26-nan-boxed-js-value-design.md
+++ b/docs/specs/2026-07-26-nan-boxed-js-value-design.md
@@ -307,3 +307,47 @@ Undefined, Null, Object, String, Symbol, or BigInt semantics.
   dependency on #403–#413 completing first: an unconverted file with a direct
   enum pattern fails to compile once the type stops being a plain enum. Phase
   4 (#415) removes any compatibility shims left over from the swap.
+
+## As Landed (Phase 4, issue #415)
+
+Phase 3 merged as PR #439, implementing the design above with no deviation to
+the tag layout, canonicalization, or ownership model. Two things are worth
+recording that the original framing (here and in [ADR 0003](../adr/0003-nan-boxed-jsvalue.md))
+got only approximately right, discovered while doing the Phase 4 cleanup pass:
+
+- **The actual shrink was 16 bytes → 8 bytes, not ~32 → 8.** This design doc
+  and ADR 0003 both cite "~32 bytes" as `JsValue`'s pre-migration size — that
+  was correct when issue #69 was opened, when `JsBigInt` inlined a
+  `num_bigint::BigInt` by value and `JsSymbol` inlined its description with no
+  wrapper. By the time Phase 3 actually ran, Phase 1 (#403 Arc-wrapping
+  `JsBigInt`, #404 Arc-wrapping `JsSymbol`) had already shrunk every heap
+  variant to a single pointer, so the pre-swap enum (`Undefined`, `Null`,
+  `Boolean(bool)`, `Number(f64)`, `String`/`Symbol`/`BigInt` each one `Arc`
+  pointer, `Object(u64)`) measured 16 bytes, confirmed by checking out the
+  commit immediately before the swap (`de832a4`) and by PR #439's own
+  before/after table. Phase 1 had therefore already captured half of the
+  total memory-footprint win before Phase 3 landed; the swap itself delivered
+  a further 2x (16→8), not the 4x (32→8) the epic's original framing implied.
+  This doesn't change the design's soundness, only the size of the win
+  attributable to Phase 3 specifically.
+- **No feature flag was used**, per the Rollout mechanism section above — this
+  held as planned; there was nothing to remove in Phase 4.
+- **Performance**: PR #439 measured a focused clone/read micro-benchmark
+  (10M Number/Object clone-read cycles) improving from 248.9ms to 96.0ms
+  (~2.6x) — a clean, repeatable, engine-internal measurement not sensitive to
+  host load, and the strongest evidence this migration delivers on its
+  memory/throughput goal for the operation it targets directly. The same
+  PR's one-off full test262 wall-clock timing went from 394.30s to 497.07s
+  (+26%), but both are single runs, on a shared host this project's own
+  development machine, not a dedicated benchmark box. Phase 4 attempted a
+  clean re-measurement and confirmed the host is unsuitable for this
+  comparison: the run coincided with unrelated load from other users
+  (`uptime` load average ~190 against 61 cores, i.e. roughly 3x
+  oversubscribed) and produced 8:26 — slower than both prior numbers, which a
+  behaviorally-identical diff (attribute removals only, no codegen change)
+  cannot explain except as host noise. **The full-suite wall-clock
+  aggregate is therefore unresolved and not reliably measurable on this
+  host**; the 10M-cycle micro-benchmark result stands as the validated
+  performance claim for this migration, and the test262 aggregate should not
+  be cited as either a win or a regression until measured on an isolated,
+  unshared machine.

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,7 +31,6 @@ enum NanTag {
 /// The NaN-boxed `JsValue` exposes this kind via `JsValue::discriminant()` so
 /// sites like `Display`,
 /// `JSON.stringify`, and `strict_equality` keep compile-time exhaustiveness.
-#[allow(dead_code)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub(crate) enum ValueKind {
     Undefined,
@@ -410,7 +409,6 @@ pub(crate) struct JsObject {
 
 // Constructor / accessor surface for `JsValue`. Callers remain decoupled from
 // the NaN-box representation and never manipulate tags or raw pointers.
-#[allow(dead_code)]
 impl NanBoxedValue {
     const BOX_SIGNATURE: u64 = 0xFFF8_0000_0000_0000;
     const BOX_SIGNATURE_MASK: u64 = 0xFFF8_0000_0000_0000;
@@ -632,6 +630,10 @@ impl NanBoxedValue {
         })
     }
 
+    /// Only exercised by tests today (`with_bigint` covers every production
+    /// read path) — kept for symmetry with `into_string` and to keep this
+    /// tag's forget/`Arc::from_raw` transfer under test.
+    #[allow(dead_code)]
     pub(crate) fn into_bigint(self) -> Option<JsBigInt> {
         if self.tag() != Some(NanTag::BigInt) {
             return None;
@@ -1620,7 +1622,7 @@ mod tests {
         ];
 
         let cloned = std::thread::spawn(move || {
-            let cloned: Vec<_> = values.iter().cloned().collect();
+            let cloned: Vec<_> = values.to_vec();
             assert_eq!(
                 cloned[4].as_number().unwrap().to_bits(),
                 (-0.0_f64).to_bits()


### PR DESCRIPTION
## Summary

Phase 4 (final) cleanup for the NaN-boxing epic (#69), now that Phase 3 (#414,
PR #439) has merged.

- Removed two blanket `#[allow(dead_code)]` suppressions in `src/types.rs`
  (`ValueKind`, and the `NanBoxedValue` accessor impl) that predated Phase 2's
  call-site conversions and are no longer needed now everything under them is
  genuinely used. Removing them surfaced one real leftover: `into_bigint` is
  only ever called from test code (its production-code sibling `into_string`
  is used in `eval.rs`/`helpers.rs`; nothing calls the BigInt variant outside
  tests). Kept it — rather than deleting it — with a narrow, explained
  `#[allow(dead_code)]`, since deleting it would have dropped the only test
  coverage of the unsafe forget/`Arc::from_raw` ownership-transfer pattern for
  the BigInt tag specifically.
- Fixed a pre-existing `clippy::iter_cloned_collect` warning in a nan-box unit
  test (`values.iter().cloned().collect()` → `values.to_vec()`). It slipped
  through because CI's `cargo clippy -- -D warnings` doesn't pass
  `--all-targets` and so never compiles `#[cfg(test)]` code; this repo's local
  pre-commit hook does, which is how it surfaced.
- **Enum-match cleanup item (issue's first bullet) is a no-op**: grepped for
  any residual `JsValue::Foo(...)` direct-enum-match pattern across `src/` —
  none exist. Not possible for any to have survived, since `JsValue` is a
  `#[repr(transparent)]` struct today, not an enum; anything written against
  the old enum shape would fail to compile.
- **No feature flag exists to remove** (issue's third bullet, conditional):
  #402 ratified the no-flag rollout and it held through Phase 3 — nothing to
  clean up here either.
- Added an "As Landed" section to the design doc
  (`docs/specs/2026-07-26-nan-boxed-js-value-design.md`) plus a pointer from
  ADR 0003, reconciling two things discovered during this cleanup pass:
  - The actual pre-swap `JsValue` size was **16 bytes**, not the ~32 bytes the
    epic/ADR originally cited — Phase 1 (#403/#404 Arc-wrapping BigInt/Symbol)
    had already captured half the shrink before Phase 3 ran. The swap itself
    delivered a further 2x (16→8), not the 4x (32→8) the original framing
    implied.
  - PR #439's full-test262 wall-clock comparison (394.30s → 497.07s, +26%) is
    a single run each side on a shared, non-dedicated development machine. A
    clean re-measurement attempt during this PR came back at 8:26 (506.45s) —
    slower than *both* prior numbers, coinciding with unrelated load from
    other users on the host (`uptime` load average ~190 against 61 cores)
    *and* with this PR's own library-harness battery running concurrently.
    Since this PR's diff has zero production codegen change, that result can
    only be host noise, which also throws doubt on #439's own comparison. Note
    that PR #439's other number — the 10M clone/read micro-benchmark
    (248.9ms → 96.0ms, ~2.6x) — is *also* a single, unrepeated
    `Instant::elapsed()` measurement, and while a short single-threaded loop
    is less exposed than test262 to the subprocess-fork/exec noise that
    dominates the timing comparison above, that's a difference of degree, not
    proof it's clean. The design doc now states plainly that **neither number
    should be cited as a validated performance result — win or regression —
    until re-measured with repeated trials on an isolated, unshared machine.**

Fixes #415

## Test plan

- [x] `./scripts/lint.sh` (rustfmt + clippy) — clean
- [x] `cargo test --release` — 461 passed, 0 failed, 1 ignored (unchanged from
  PR #439's own gate)
- [x] Full test262 (`uv run python scripts/run-test262.py -j 32`) — 100.00%
  (99,568/99,568), 0 regressions, pinned corpus `f2d1435`
- [x] Full library-harness battery re-run as a final cross-check on #439's
  tree — all 19 configs under `scripts/libs/` ran. 15 exact-match greens
  against locked counts (`js-md5` 550, `js-sha256` 916, `lodash` 6794, `qs`
  1013, `uuid` 75, `ajv` 5480, `prismjs`, `big.js` 47456, `tweetnacl-js` 5470,
  `uglify-js` 4233, `highlight.js` 731, `esprima` 80153, `acorn` 13507, plus
  `bignumber.js` 65143/65143 and `moment` 162868/162868 — both now fully
  green; their previously-recorded partial baselines were stale, confirmed
  via closed tracking issues jsse#238 and jsse#311). 3 reds, none
  attributable to this PR (zero production codegen change) and each above or
  matching its recorded baseline: `css-tree` 16726/16727 (one isolated
  assertion failure, still above the 16725 baseline), `luxon` 1009/1152
  (above the 1002 baseline), `decimal.js` (the pre-documented
  `Decimal.random()`/crypto-shim count drift called out in #414's own
  testing notes). 1 anomaly investigated and reported upstream: `zod`
  reproduces a complete zero-case wipeout in isolation on a quiet host
  (jsse exits 0 after only the TAP header, no test cases run) — not a
  build/exec race, and worse than its previously-recorded 2176/2184; posted
  as a comment on the relevant open tracking issue, jsse#310.
