### PR TITLE
fix(interpreter): route [[Set]] on Array length and primitive receivers through spec MOP

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -4424,6 +4424,12 @@ impl Interpreter {
         strict: bool,
     ) -> Result<(), JsValue> {
         let key = key.to_js_property_key();
+        // §6.2.5.6 PutValue: [[Set]] is invoked on ToObject(base), but the
+        // receiver argument stays the original base value. For a primitive
+        // base that means the receiver is never an object, so OrdinarySet's
+        // "Receiver is not an Object" rejection (§10.1.9.2 step 3) applies —
+        // capture it before boxing, not after.
+        let receiver = obj_val.clone();
         // Auto-box primitives for property access.
         let obj_val = if !(obj_val).is_object() {
             match self.to_object(&obj_val) {
@@ -4445,9 +4451,7 @@ impl Interpreter {
         // Delegate to the canonical [[Set]] entry point: proxy `set` trap,
         // module-namespace reject, TypedArray integer-index set, accessor
         // setters, and the OrdinarySet prototype-chain walk all live in
-        // `property.rs`. The receiver is the object itself, matching this
-        // assignment path's PutValue semantics.
-        let receiver = obj_val.clone();
+        // `property.rs`.
         let success = self.set_object_property(obj_id, &key, val, &receiver)?;
         if !success && strict {
             return Err(self.read_only_assignment_error(obj_id, &key));

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -796,6 +796,13 @@ impl Interpreter {
                     if key.as_property_key_str() == Some("length")
                         && obj.borrow().class_name == "Array"
                     {
+                        // Call ArraySetLength directly with a native descriptor —
+                        // round-tripping through from_property_descriptor +
+                        // to_property_descriptor would build a JS object whose
+                        // [[Prototype]] is Object.prototype, and ToPropertyDescriptor
+                        // reads fields via [[HasProperty]] (prototype-chain walk), so
+                        // an unrelated Object.prototype mutation (e.g. a non-callable
+                        // "get") would leak into this internal, value-only descriptor.
                         let val_desc = crate::interpreter::types::PropertyDescriptor {
                             value: Some(value),
                             writable: None,
@@ -804,12 +811,7 @@ impl Interpreter {
                             get: None,
                             set: None,
                         };
-                        let desc_val = self.from_property_descriptor(&val_desc);
-                        return self.proxy_define_own_property(
-                            obj_id,
-                            key.to_js_property_key(),
-                            &desc_val,
-                        );
+                        return self.array_set_length(obj_id as usize, val_desc);
                     }
                     self.gc_write_barrier_value(&obj, &value);
                     return Ok(obj.borrow_mut_untracked().set_property_value(key, value));

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -418,15 +418,22 @@ impl Interpreter {
     /// destructuring-assignment target) can otherwise be collected out from
     /// under this function, turning `get_object_cell(obj_id).unwrap()` into
     /// a panic.
+    ///
+    /// Unroots only this receiver on the way out (mirrors
+    /// `call_function_inner`'s operand cleanup), not a bulk
+    /// `gc_unroot_frame`: the `valueOf` call above can itself leave a
+    /// *persistent* root on the stack — e.g. `Atomics.waitAsync`'s resolver,
+    /// meant to survive until the async completion settles — and a frame
+    /// truncate would discard that too.
     pub(crate) fn array_set_length(
         &mut self,
         obj_id: usize,
         desc: PropertyDescriptor,
     ) -> Result<bool, JsValue> {
-        let gc_frame = self.gc_root_frame();
-        self.gc_root_value(&JsValue::object(obj_id as u64));
+        let receiver = JsValue::object(obj_id as u64);
+        self.gc_root_value(&receiver);
         let result = self.array_set_length_inner(obj_id, desc);
-        self.gc_unroot_frame(gc_frame);
+        self.gc_unroot_value(&receiver);
         result
     }
 

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -410,7 +410,27 @@ impl Interpreter {
     }
 
     /// §10.4.2.4 ArraySetLength(A, Desc)
+    ///
+    /// Roots `obj_id` for the whole operation: ToUint32/ToNumber on
+    /// `desc.value` below can invoke a user `valueOf` that reaches a GC
+    /// safepoint, and every step after that re-derefs `obj_id` — an
+    /// unrooted, ephemeral receiver (e.g. an array literal used only as a
+    /// destructuring-assignment target) can otherwise be collected out from
+    /// under this function, turning `get_object_cell(obj_id).unwrap()` into
+    /// a panic.
     pub(crate) fn array_set_length(
+        &mut self,
+        obj_id: usize,
+        desc: PropertyDescriptor,
+    ) -> Result<bool, JsValue> {
+        let gc_frame = self.gc_root_frame();
+        self.gc_root_value(&JsValue::object(obj_id as u64));
+        let result = self.array_set_length_inner(obj_id, desc);
+        self.gc_unroot_frame(gc_frame);
+        result
+    }
+
+    fn array_set_length_inner(
         &mut self,
         obj_id: usize,
         desc: PropertyDescriptor,

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -784,12 +784,18 @@ impl Interpreter {
                 // OrdinarySetWithOwnDescriptor step 3.c: use Receiver.[[GetOwnProperty]] / [[DefineOwnProperty]]
                 let recv_id = receiver.as_object_id();
                 if recv_id == Some(obj_id) {
-                    // Common case: receiver is the same object. Ordinary objects can
-                    // take the direct route, but Array's "length" is exotic — it must
-                    // go through [[DefineOwnProperty]] (ArraySetLength, §10.4.2.4) or
-                    // its ToUint32 coercion / RangeError / element-deletion semantics
-                    // are silently skipped.
-                    if obj.borrow().class_name == "Array" {
+                    // Common case: receiver is the same object. Ordinary objects
+                    // (and ordinary Array properties) can take the direct route;
+                    // only Array's "length" is exotic and must go through
+                    // [[DefineOwnProperty]] (ArraySetLength, §10.4.2.4) or its
+                    // ToUint32 coercion / RangeError / element-deletion semantics
+                    // are silently skipped. Gate on the key too, not just the
+                    // class — routing every existing-element write (e.g. `a[0]++`)
+                    // through descriptor allocation regressed a 200k-iteration
+                    // increment loop by ~1.7-2x.
+                    if key.as_property_key_str() == Some("length")
+                        && obj.borrow().class_name == "Array"
+                    {
                         let val_desc = crate::interpreter::types::PropertyDescriptor {
                             value: Some(value),
                             writable: None,

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -784,7 +784,27 @@ impl Interpreter {
                 // OrdinarySetWithOwnDescriptor step 3.c: use Receiver.[[GetOwnProperty]] / [[DefineOwnProperty]]
                 let recv_id = receiver.as_object_id();
                 if recv_id == Some(obj_id) {
-                    // Common case: receiver is the same object, direct set
+                    // Common case: receiver is the same object. Ordinary objects can
+                    // take the direct route, but Array's "length" is exotic — it must
+                    // go through [[DefineOwnProperty]] (ArraySetLength, §10.4.2.4) or
+                    // its ToUint32 coercion / RangeError / element-deletion semantics
+                    // are silently skipped.
+                    if obj.borrow().class_name == "Array" {
+                        let val_desc = crate::interpreter::types::PropertyDescriptor {
+                            value: Some(value),
+                            writable: None,
+                            enumerable: None,
+                            configurable: None,
+                            get: None,
+                            set: None,
+                        };
+                        let desc_val = self.from_property_descriptor(&val_desc);
+                        return self.proxy_define_own_property(
+                            obj_id,
+                            key.to_js_property_key(),
+                            &desc_val,
+                        );
+                    }
                     self.gc_write_barrier_value(&obj, &value);
                     return Ok(obj.borrow_mut_untracked().set_property_value(key, value));
                 }
@@ -837,8 +857,11 @@ impl Interpreter {
                         );
                     }
                 }
-                self.gc_write_barrier_value(&obj, &value);
-                return Ok(obj.borrow_mut_untracked().set_property_value(key, value));
+                // Receiver is not an Object: [[Set]] must return false, never
+                // fall back to writing the property onto `obj` itself — `obj`
+                // may be a shared prototype reached by walking up from the
+                // (non-object) receiver's own [[Prototype]] chain.
+                return Ok(false);
             }
             // No own property, walk prototype chain
             let proto = obj.borrow().prototype_id;
@@ -905,8 +928,9 @@ impl Interpreter {
                         .set_property_value(key, value));
                 }
             }
-            self.gc_write_barrier_value(&obj, &value);
-            Ok(obj.borrow_mut_untracked().set_property_value(key, value))
+            // Receiver is not an Object (or resolved to no live object): [[Set]]
+            // must return false, never fall back to writing onto `obj` itself.
+            Ok(false)
         } else {
             Ok(false)
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1620,7 +1620,7 @@ mod tests {
         ];
 
         let cloned = std::thread::spawn(move || {
-            let cloned: Vec<_> = values.iter().cloned().collect();
+            let cloned: Vec<_> = values.to_vec();
             assert_eq!(
                 cloned[4].as_number().unwrap().to_bits(),
                 (-0.0_f64).to_bits()

--- a/test262-extra/Array-length-set-gc-rooting.js
+++ b/test262-extra/Array-length-set-gc-rooting.js
@@ -1,0 +1,36 @@
+/*---
+description: >
+  ArraySetLength's Array receiver must remain strongly reachable across the
+  ToUint32/ToNumber coercion of the new length value, even when that
+  coercion (via a user valueOf) triggers garbage collection and the
+  receiver is otherwise reachable only through a Rust-local reference
+  (e.g. an array literal used solely as a destructuring-assignment target,
+  never bound to a variable).
+info: |
+  jsse issue #417/#416 fix, PR #442: a follow-up review comment found that
+  the new ArraySetLength dispatch path could crash (Rust panic, exit 101)
+  when the Array receiver was ephemeral. ArraySetLength's ToUint32(Desc.
+  [[Value]]) / ToNumber(Desc.[[Value]]) steps run user code (valueOf), and
+  every step after that re-derefs the receiver by id — an unrooted,
+  ephemeral receiver could be collected in between, turning the
+  implementation's internal object lookup into a null dereference.
+esid: sec-arraysetlength
+---*/
+
+var gcRan = false;
+var rhs = {
+  valueOf: function () {
+    $262.gc();
+    gcRan = true;
+    return 1;
+  },
+};
+
+// The array literal is the destructuring-assignment target itself — never
+// bound to a variable, so it is reachable only through the engine's own
+// transient state while the assignment runs. Surviving this without
+// crashing is the property under test; there is no post-assignment handle
+// to assert a length on, since the array is discarded immediately after.
+({ x: [].length } = { x: rhs });
+
+assert(gcRan, "the valueOf side effect must have actually run");

--- a/test262-extra/array-length-set-must-not-consult-object-prototype.js
+++ b/test262-extra/array-length-set-must-not-consult-object-prototype.js
@@ -1,0 +1,37 @@
+/*---
+description: >
+  Assigning to an Array's "length" property through a path that reaches
+  ArraySetLength via the engine's internal [[DefineOwnProperty]] dispatch
+  (e.g. a destructuring assignment target) must not be affected by
+  properties inherited from Object.prototype. The internal descriptor built
+  for this operation only ever carries [[Value]]; it must never be
+  round-tripped through an ordinary JS object (which inherits from
+  Object.prototype) and back, since doing so lets an unrelated
+  Object.prototype mutation leak into ToPropertyDescriptor's validation.
+info: |
+  jsse issue #417/#416 fix, PR #442: a follow-up review comment found that
+  the new ArraySetLength dispatch path built a JS descriptor object via
+  FromPropertyDescriptor (whose [[Prototype]] is Object.prototype) and then
+  read it back via ToPropertyDescriptor (which uses [[HasProperty]], walking
+  the prototype chain) before calling ArraySetLength. A non-callable
+  Object.prototype.get therefore caused a plain length assignment to
+  incorrectly throw "Getter must be a function".
+esid: sec-arraysetlength
+---*/
+
+Object.defineProperty(Object.prototype, 'get', {
+  value: 1,
+  configurable: true,
+});
+
+var a = [1, 2, 3];
+({ length: a.length } = { length: 1 });
+
+if (a.length !== 1) {
+  throw new Test262Error('destructuring-assigned a.length must become 1, got ' + a.length);
+}
+if (a[1] !== undefined) {
+  throw new Test262Error('elements at or beyond the new length must be removed');
+}
+
+delete Object.prototype.get;

--- a/test262-extra/primitive-receiver-set-must-not-mutate-prototype.js
+++ b/test262-extra/primitive-receiver-set-must-not-mutate-prototype.js
@@ -1,0 +1,52 @@
+/*---
+description: >
+  A property write on a primitive base (e.g. `sym.toString = 0`) invokes
+  [[Set]] on ToObject(base), but the receiver argument passed to [[Set]] stays
+  the *original primitive*, never the disposable wrapper. Since the receiver
+  is not an Object, OrdinarySetWithOwnDescriptor's "Receiver is not an Object"
+  check must reject the write, and in strict mode that rejection must surface
+  as a TypeError.
+info: |
+  jsse issue #417 / #416: a receiver-shadowing bug made this write silently
+  succeed on the throwaway wrapper object instead of being rejected, so
+  strict mode never threw. A naive fix that corrects only the receiver
+  (without also guarding [[Set]]'s prototype-chain-walk fallthrough) would
+  regress into something worse: writing the property directly onto whatever
+  prototype object happens to be found while walking the chain from the
+  primitive's own [[Prototype]] — i.e. mutating shared, engine-wide state.
+  This test pins both: the throw, and that the prototype is left untouched.
+esid: sec-putvalue
+flags: [onlyStrict]
+---*/
+
+var sym = Symbol('probe');
+var threw = false;
+try {
+  sym.toString = 0;
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+if (!threw) {
+  throw new Test262Error('sym.toString = 0 in strict mode must throw TypeError');
+}
+if (typeof Symbol.prototype.toString !== 'function') {
+  throw new Test262Error('Symbol.prototype.toString must remain the native function, not be overwritten');
+}
+
+// Same shape, one level deeper: an inherited writable data property reached
+// only by walking a user-defined prototype chain from a primitive base.
+Number.prototype.probeValue = 1;
+var n = 5;
+threw = false;
+try {
+  n.probeValue = 99;
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+if (!threw) {
+  throw new Test262Error('n.probeValue = 99 in strict mode must throw TypeError');
+}
+if (Number.prototype.probeValue !== 1) {
+  throw new Test262Error('Number.prototype.probeValue must not be mutated by a primitive-receiver write');
+}
+delete Number.prototype.probeValue;

--- a/test262-extra/primitive-receiver-sloppy-set-must-not-mutate-prototype.js
+++ b/test262-extra/primitive-receiver-sloppy-set-must-not-mutate-prototype.js
@@ -1,0 +1,24 @@
+/*---
+description: >
+  Sloppy-mode counterpart to primitive-receiver-set-must-not-mutate-prototype:
+  a property write on a primitive base whose receiver walks up to an inherited
+  writable data property must be silently rejected (no throw), and — this is
+  the part a receiver-shadowing bug can get wrong even when the throw-vs-not
+  distinction is masked by sloppy mode — the inherited property itself must
+  never be mutated as a side effect of the rejected write.
+info: |
+  jsse issue #417 / #416. See primitive-receiver-set-must-not-mutate-prototype.js
+  for the strict-mode half of this regression pin.
+esid: sec-putvalue
+flags: [noStrict]
+---*/
+
+Number.prototype.probeValue = 1;
+var n = 5;
+n.probeValue = 99;
+if (Number.prototype.probeValue !== 1) {
+  throw new Test262Error(
+    'sloppy-mode n.probeValue = 99 must not mutate Number.prototype.probeValue'
+  );
+}
+delete Number.prototype.probeValue;


### PR DESCRIPTION
## Summary

- `proxy_set`'s "receiver is the same object" fast path wrote Array `length` directly to raw property storage, bypassing `ArraySetLength`'s ToUint32 coercion, RangeError, and non-configurable-element-deletion semantics (§10.4.2.4). It now routes through `[[DefineOwnProperty]]` for Arrays, mirroring what the "receiver differs" branch already does.
- `set_object_with_key` computed the `[[Set]]` receiver from the already-auto-boxed wrapper instead of the original primitive base, so `OrdinarySetWithOwnDescriptor`'s "Receiver is not an Object" rejection (§10.1.9.2 step 3) never triggered — `CreateDataProperty` silently succeeded on the disposable wrapper instead of being rejected.
- Fixing the receiver alone would have exposed a second, more severe bug: `proxy_set`'s prototype-chain-walk fallthroughs assumed a non-object receiver could never reach them, and fell back to writing the property directly onto whatever object was currently being walked — i.e. mutating a shared prototype (e.g. `Symbol.prototype`). Both fallthroughs now return `false` per spec instead of falling through to a raw write.
- Also fixed an unrelated pre-existing clippy violation in `types.rs` (`iter().cloned().collect()` → `to_vec()`) that was blocking the format/lint hook on any edit.

Fixes #417
Fixes #416 (filed separately against the same root cause — its own analysis of the receiver-shadowing bug and the prototype-pollution risk matches this fix exactly)

## Test plan

- [x] `./scripts/lint.sh` — clean
- [x] `cargo build --release`
- [x] `cargo test --release` — 461 unit tests + host_time_zone + smoke oracle, all passing
- [x] `uv run python scripts/run-custom-tests.py` — 11/11
- [x] `uv run python scripts/run-test262.py test262-extra/` — 120/120 (includes 2 new regression tests added in this PR)
- [x] `uv run python scripts/run-test262.py -j 32` (default mode) — 99,568/99,568, 0 regressions, 323 new passes (the primitive-receiver bug also affected tree-walker compound-assignment/destructuring call sites, not just bytecode)
- [x] `uv run python scripts/run-test262.py --bytecode -j 32` (bytecode mode) — 99,568/99,568, 0 regressions, 323 new passes — closes both #417's 7 scenarios and #416's `Symbol/auto-boxing-strict.js`
- [x] Manual repro confirms the bug is fixed (issue #417's exact repro command now reports 7/7 passing; issue #416's exact repro no longer prints `NO THROW`)
- [x] New regression tests added (`test262-extra/primitive-receiver-set-must-not-mutate-prototype.js`, `test262-extra/primitive-receiver-sloppy-set-must-not-mutate-prototype.js`) pin both the throw and the "prototype is left unmutated" invariant, which test262 itself doesn't check