### PR TITLE
refactor(builtins): complete the relative-index resolution helpers

### DIFF
--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -2966,26 +2966,22 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let len = match length_of_array_like(interp, &o) {
-                Ok(v) => v as i64,
+                Ok(v) => v,
                 Err(c) => return c,
             };
             let relative_index = if let Some(v) = args.first() {
                 match interp.to_integer_or_infinity_value(v) {
-                    Ok(n) => n as i64,
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
-                0
+                0.0
             };
-            let k = if relative_index >= 0 {
-                relative_index
-            } else {
-                len + relative_index
+            let k = match resolve_element_index(relative_index, len) {
+                Some(k) => k,
+                None => return Completion::Normal(JsValue::UNDEFINED),
             };
-            if k < 0 || k >= len {
-                return Completion::Normal(JsValue::UNDEFINED);
-            }
-            match obj_get(interp, &o, &(k as usize).to_string()) {
+            match obj_get(interp, &o, &k.to_string()) {
                 Ok(v) => Completion::Normal(v),
                 Err(c) => c,
             }
@@ -2998,7 +2994,7 @@ impl Interpreter {
                 Err(c) => return c,
             };
             let len = match length_of_array_like(interp, &o) {
-                Ok(v) => v as i64,
+                Ok(v) => v,
                 Err(c) => return c,
             };
             if len as u64 > 0xFFFF_FFFF {
@@ -3006,24 +3002,20 @@ impl Interpreter {
             }
             let relative_index = if let Some(v) = args.first() {
                 match interp.to_integer_or_infinity_value(v) {
-                    Ok(n) => n as i64,
+                    Ok(n) => n,
                     Err(e) => return Completion::Throw(e),
                 }
             } else {
-                0
+                0.0
             };
-            let actual = if relative_index >= 0 {
-                relative_index
-            } else {
-                len + relative_index
+            let actual = match resolve_element_index(relative_index, len) {
+                Some(k) => k,
+                None => return Completion::Throw(interp.create_range_error("Invalid index")),
             };
-            if actual < 0 || actual >= len {
-                return Completion::Throw(interp.create_range_error("Invalid index"));
-            }
             let value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
-            let mut result = Vec::with_capacity(len as usize);
-            for k in 0..len as usize {
-                if k == actual as usize {
+            let mut result = Vec::with_capacity(len);
+            for k in 0..len {
+                if k == actual {
                     result.push(value.clone());
                 } else {
                     result.push(match obj_get(interp, &o, &k.to_string()) {

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -428,25 +428,14 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let units = &js_str.code_units;
-                    let len = units.len() as f64;
-                    let int_start = match args.first() {
-                        Some(v) => match to_int_or_inf(interp, v) {
-                            Ok(n) => n,
-                            Err(c) => return c,
-                        },
-                        None => 0.0,
+                    let from = match resolve_start_index(interp, args.first(), units.len()) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
-                    let int_end = match args.get(1) {
-                        Some(v) if !(v).is_undefined() => match to_int_or_inf(interp, v) {
-                            Ok(n) => n,
-                            Err(c) => return c,
-                        },
-                        _ => len,
+                    let to = match resolve_end_index(interp, args.get(1), units.len()) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
-                    let from = resolve_relative_index(int_start, len as usize);
-                    let to = resolve_relative_index(int_end, len as usize);
-                    let from = from.min(units.len());
-                    let to = to.min(units.len());
                     if from >= to {
                         return Completion::Normal(JsValue::string(JsString::from_str("")));
                     }
@@ -1098,21 +1087,18 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let units = &js_str.code_units;
-                    let len = units.len() as i64;
                     let idx = match args.first() {
                         Some(v) => match to_int_or_inf(interp, v) {
-                            Ok(n) => n as i64,
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
-                        None => 0,
+                        None => 0.0,
                     };
-                    let actual = if idx < 0 { len + idx } else { idx };
-                    if actual < 0 || actual >= len {
-                        return Completion::Normal(JsValue::UNDEFINED);
-                    }
-                    Completion::Normal(JsValue::string(JsString::from_vec(vec![
-                        units[actual as usize],
-                    ])))
+                    let actual = match resolve_element_index(idx, units.len()) {
+                        Some(k) => k,
+                        None => return Completion::Normal(JsValue::UNDEFINED),
+                    };
+                    Completion::Normal(JsValue::string(JsString::from_vec(vec![units[actual]])))
                 }),
             ),
             (

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1620,16 +1620,16 @@ impl Interpreter {
                         }
                     };
                     // Capture len BEFORE argument coercion (may resize buffer)
-                    let len = typed_array_length(&ta) as i64;
+                    let len = typed_array_length(&ta);
                     let idx_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
                     let idx = match interp.to_integer_or_infinity_value(&idx_val) {
-                        Ok(n) => n as i64,
+                        Ok(n) => n,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let actual = if idx < 0 { len + idx } else { idx };
-                    if actual < 0 || actual >= len {
-                        return Completion::Normal(JsValue::UNDEFINED);
-                    }
+                    let actual = match resolve_element_index(idx, len) {
+                        Some(k) => k,
+                        None => return Completion::Normal(JsValue::UNDEFINED),
+                    };
                     // Use Get semantics (checks OOB post-resize via is_valid_integer_index)
                     let key = actual.to_string();
                     return interp.get_object_property(o, &key, this_val);
@@ -1825,29 +1825,15 @@ impl Interpreter {
                     } else {
                         typed_array_length(&ta) as i64
                     };
-                    let begin = {
-                        let n = to_integer_or_infinity(if let Some(a) = args.first() {
-                            match interp.to_number_value(a) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            0.0
-                        });
-                        resolve_relative_index(n, src_len as usize)
+                    let begin = match resolve_start_index(interp, args.first(), src_len as usize) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
                     let end_is_undefined =
                         args.len() <= 1 || args.get(1).is_some_and(|v| v.is_undefined());
-                    let end = {
-                        let n = if !end_is_undefined {
-                            match interp.to_integer_or_infinity_value(&args[1]) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            src_len as f64
-                        };
-                        resolve_relative_index(n, src_len as usize)
+                    let end = match resolve_end_index(interp, args.get(1), src_len as usize) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
                     let new_len = end.saturating_sub(begin);
                     let bpe = ta.kind.bytes_per_element();
@@ -1891,27 +1877,13 @@ impl Interpreter {
                         }
                     };
                     let len = typed_array_length(&ta) as i64;
-                    let begin = {
-                        let n = to_integer_or_infinity(if let Some(a) = args.first() {
-                            match interp.to_number_value(a) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            0.0
-                        });
-                        resolve_relative_index(n, len as usize)
+                    let begin = match resolve_start_index(interp, args.first(), len as usize) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
-                    let end = {
-                        let n = if args.len() > 1 && !args[1].is_undefined() {
-                            match interp.to_integer_or_infinity_value(&args[1]) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            len as f64
-                        };
-                        resolve_relative_index(n, len as usize)
+                    let end = match resolve_end_index(interp, args.get(1), len as usize) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
                     let count = end.saturating_sub(begin);
 
@@ -2029,34 +2001,17 @@ impl Interpreter {
                         return c;
                     }
                     let len = typed_array_length(&ta) as i64;
-                    let target = {
-                        let n = match interp.to_integer_or_infinity_value(
-                            args.first().unwrap_or(JsValue::undefined_ref()),
-                        ) {
-                            Ok(n) => n,
-                            Err(e) => return Completion::Throw(e),
-                        };
-                        resolve_relative_index(n, len as usize)
+                    let target = match resolve_start_index(interp, args.first(), len as usize) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
-                    let start = {
-                        let n = match interp.to_integer_or_infinity_value(
-                            args.get(1).unwrap_or(JsValue::undefined_ref()),
-                        ) {
-                            Ok(n) => n,
-                            Err(e) => return Completion::Throw(e),
-                        };
-                        resolve_relative_index(n, len as usize)
+                    let start = match resolve_start_index(interp, args.get(1), len as usize) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
-                    let end = {
-                        let n = if args.len() > 2 && !args[2].is_undefined() {
-                            match interp.to_integer_or_infinity_value(&args[2]) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            len as f64
-                        };
-                        resolve_relative_index(n, len as usize)
+                    let end = match resolve_end_index(interp, args.get(2), len as usize) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
                     // Re-check detach and OOB after coercion
                     if let Err(c) = check_detached_or_out_of_bounds(interp, &ta) {
@@ -2126,28 +2081,13 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
                     };
-                    let len_f = len as f64;
-                    let start = {
-                        let v = to_integer_or_infinity(if args.len() > 1 {
-                            match interp.to_number_value(&args[1]) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            0.0
-                        });
-                        resolve_relative_index(v, len)
+                    let start = match resolve_start_index(interp, args.get(1), len) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
-                    let end = {
-                        let v = if args.len() > 2 && !args[2].is_undefined() {
-                            match interp.to_integer_or_infinity_value(&args[2]) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            len_f
-                        };
-                        resolve_relative_index(v, len)
+                    let end = match resolve_end_index(interp, args.get(2), len) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
                     // Re-check detach and OOB after coercion (buffer may have been resized)
                     if ta.is_detached.get() {

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -14,6 +14,27 @@ pub(crate) fn resolve_relative_index(n: f64, len: usize) -> usize {
     }
 }
 
+// Resolves a spec "relative index" for element access — the `.prototype.at` and
+// `.prototype.with` methods of Array, String and TypedArray — where an
+// out-of-range index yields no element rather than being clamped. `relative`
+// must already have passed through ToIntegerOrInfinity. Returns `Some(k)` when
+// the resolved index lies in `[0, len)` (the caller reads or writes element
+// `k`); returns `None` when it is out of range (`.at` returns `undefined`,
+// `.with` throws a RangeError). Contrast `resolve_relative_index`, which clamps
+// into `[0, len]` for the range-based methods (slice/fill/copyWithin/...).
+pub(crate) fn resolve_element_index(relative: f64, len: usize) -> Option<usize> {
+    let k = if relative < 0.0 {
+        len as f64 + relative
+    } else {
+        relative
+    };
+    if k >= 0.0 && k < len as f64 {
+        Some(k as usize)
+    } else {
+        None
+    }
+}
+
 // Resolves a spec "start"-style relative-index argument for the range-based
 // Array methods (slice, fill, copyWithin, splice, toSpliced). An absent
 // argument defaults to index 0; otherwise the argument is passed through
@@ -2780,6 +2801,83 @@ mod resolve_relative_index_tests {
     fn zero_length_clamps_everything_to_zero() {
         assert_eq!(resolve_relative_index(-1.0, 0), 0);
         assert_eq!(resolve_relative_index(5.0, 0), 0);
+    }
+}
+
+#[cfg(test)]
+mod resolve_element_index_tests {
+    use super::resolve_element_index;
+
+    // --- in-range indices resolve to a concrete position ---
+
+    #[test]
+    fn positive_in_range_is_itself() {
+        assert_eq!(resolve_element_index(3.0, 10), Some(3));
+    }
+
+    #[test]
+    fn negative_counts_back_from_length() {
+        assert_eq!(resolve_element_index(-3.0, 10), Some(7));
+    }
+
+    #[test]
+    fn last_valid_positive_index_is_in_range() {
+        // relative == len - 1 is the largest in-range positive index.
+        assert_eq!(resolve_element_index(9.0, 10), Some(9));
+    }
+
+    #[test]
+    fn most_negative_in_range_index_is_zero() {
+        // relative == -len maps to index 0 (the first element).
+        assert_eq!(resolve_element_index(-10.0, 10), Some(0));
+    }
+
+    // --- out-of-range indices resolve to None (no element) ---
+
+    #[test]
+    fn index_equal_to_length_is_out_of_range() {
+        assert_eq!(resolve_element_index(10.0, 10), None);
+    }
+
+    #[test]
+    fn negative_one_past_the_start_is_out_of_range() {
+        // relative == -(len) - 1 falls just before index 0.
+        assert_eq!(resolve_element_index(-11.0, 10), None);
+    }
+
+    #[test]
+    fn empty_length_has_no_valid_index() {
+        assert_eq!(resolve_element_index(0.0, 0), None);
+        assert_eq!(resolve_element_index(-1.0, 0), None);
+    }
+
+    // --- non-finite / huge magnitudes: equivalent to the pre-refactor
+    //     `f64 as i64` saturating casts (they always fell out of range) ---
+
+    #[test]
+    fn positive_infinity_is_out_of_range() {
+        assert_eq!(resolve_element_index(f64::INFINITY, 10), None);
+    }
+
+    #[test]
+    fn negative_infinity_is_out_of_range() {
+        assert_eq!(resolve_element_index(f64::NEG_INFINITY, 10), None);
+    }
+
+    #[test]
+    fn huge_positive_magnitude_is_out_of_range() {
+        assert_eq!(resolve_element_index(1e300, 10), None);
+    }
+
+    #[test]
+    fn huge_negative_magnitude_is_out_of_range() {
+        assert_eq!(resolve_element_index(-1e300, 10), None);
+    }
+
+    #[test]
+    fn negative_zero_resolves_to_index_zero() {
+        // -0.0 is not < 0.0, so it is treated as the positive index 0.
+        assert_eq!(resolve_element_index(-0.0, 10), Some(0));
     }
 }
 

--- a/test262-extra/TypedArray-String-range-index-argument-coercion.js
+++ b/test262-extra/TypedArray-String-range-index-argument-coercion.js
@@ -1,0 +1,87 @@
+/*---
+description: >
+  The range-based %TypedArray%.prototype methods (slice, subarray, copyWithin,
+  fill) and String.prototype.slice resolve their start/end index arguments the
+  same way Array.prototype.slice does: an absent start defaults to 0, an absent
+  OR explicitly `undefined` end defaults to the length, every present argument is
+  coerced through ToIntegerOrInfinity and the relative index is clamped against
+  the length, and a throwing coercion is propagated unchanged. This mirrors the
+  Array-range-index-argument-coercion test for the TypedArray and String
+  surfaces, which the engine factors through the shared resolve_start_index /
+  resolve_end_index helpers.
+esid: sec-%typedarray%.prototype.slice
+info: |
+  %TypedArray%.prototype.slice ( start, end )
+    ... Let relativeStart be ? ToIntegerOrInfinity(start).
+        If relativeStart is -infinity, let k be 0.
+        Else if relativeStart < 0, let k be max(len + relativeStart, 0).
+        Else, let k be min(relativeStart, len).
+    ... If end is undefined, let relativeEnd be len; else let relativeEnd be
+        ? ToIntegerOrInfinity(end). (same clamping as start)
+includes: [compareArray.js]
+---*/
+
+function i8(values) {
+  return Array.from(new Int8Array(values));
+}
+
+// ---------------------------------------------------------------------------
+// TypedArray.prototype.slice: start default 0, end default (absent/undefined) len
+// ---------------------------------------------------------------------------
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).slice()), [1, 2, 3, 4, 5], "slice(): whole array");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).slice(1)), [2, 3, 4, 5], "slice(1)");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).slice(-2)), [4, 5], "slice(-2)");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).slice(1, -1)), [2, 3, 4], "slice(1, -1)");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).slice(1, undefined)), [2, 3, 4, 5], "slice(1, undefined): undefined end is length");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).slice(-100, 100)), [1, 2, 3, 4, 5], "slice clamps out-of-range to [0, len]");
+
+// ---------------------------------------------------------------------------
+// TypedArray.prototype.subarray: same start/end resolution
+// ---------------------------------------------------------------------------
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).subarray(1)), [2, 3, 4, 5], "subarray(1)");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).subarray(-2)), [4, 5], "subarray(-2)");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).subarray(1, -1)), [2, 3, 4], "subarray(1, -1)");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).subarray(1, undefined)), [2, 3, 4, 5], "subarray(1, undefined): undefined end is length");
+
+// ---------------------------------------------------------------------------
+// TypedArray.prototype.copyWithin: target and start are `start`-style, end `end`-style
+// ---------------------------------------------------------------------------
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).copyWithin(0, 3)), [4, 5, 3, 4, 5], "copyWithin(0, 3)");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).copyWithin(0, 3, undefined)), [4, 5, 3, 4, 5], "copyWithin end undefined is length");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).copyWithin(0, undefined)), [1, 2, 3, 4, 5], "copyWithin start undefined is 0");
+assert.compareArray(i8(new Int8Array([1, 2, 3, 4, 5]).copyWithin(-2, 0)), [1, 2, 3, 1, 2], "copyWithin(-2, 0): negative target");
+
+// ---------------------------------------------------------------------------
+// TypedArray.prototype.fill: value coerced first, then start/end resolution
+// ---------------------------------------------------------------------------
+assert.compareArray(i8(new Int8Array([0, 0, 0, 0, 0]).fill(7)), [7, 7, 7, 7, 7], "fill(7): absent start/end");
+assert.compareArray(i8(new Int8Array([0, 0, 0, 0, 0]).fill(7, undefined)), [7, 7, 7, 7, 7], "fill(v, undefined): undefined start is 0");
+assert.compareArray(i8(new Int8Array([0, 0, 0, 0, 0]).fill(9, -2)), [0, 0, 0, 9, 9], "fill(v, -2)");
+assert.compareArray(i8(new Int8Array([0, 0, 0, 0, 0]).fill(7, 1, undefined)), [0, 7, 7, 7, 7], "fill(v, 1, undefined): undefined end is length");
+assert.compareArray(i8(new Int8Array([0, 0, 0, 0, 0]).fill(3, 1, -1)), [0, 3, 3, 3, 0], "fill(v, 1, -1)");
+
+// ---------------------------------------------------------------------------
+// String.prototype.slice: start default 0, end default (absent/undefined) len
+// ---------------------------------------------------------------------------
+assert.sameValue("abcde".slice(), "abcde", "String.slice(): whole string");
+assert.sameValue("abcde".slice(undefined), "abcde", "String.slice(undefined): undefined start is 0");
+assert.sameValue("abcde".slice(1), "bcde", "String.slice(1)");
+assert.sameValue("abcde".slice(-2), "de", "String.slice(-2)");
+assert.sameValue("abcde".slice(1, -1), "bcd", "String.slice(1, -1)");
+assert.sameValue("abcde".slice(1, undefined), "bcde", "String.slice(1, undefined): undefined end is length");
+assert.sameValue("abcde".slice(-100, 100), "abcde", "String.slice clamps out-of-range to [0, len]");
+
+// ---------------------------------------------------------------------------
+// a throwing coercion is propagated unchanged from every coerced position
+// ---------------------------------------------------------------------------
+var boom = { valueOf: function () { throw new Test262Error("coercion ran"); } };
+
+assert.throws(Test262Error, function () { new Int8Array([1, 2, 3]).slice(boom); }, "TA slice start throw propagates");
+assert.throws(Test262Error, function () { new Int8Array([1, 2, 3]).slice(0, boom); }, "TA slice end throw propagates");
+assert.throws(Test262Error, function () { new Int8Array([1, 2, 3]).subarray(boom); }, "TA subarray start throw propagates");
+assert.throws(Test262Error, function () { new Int8Array([1, 2, 3]).copyWithin(boom, 0); }, "TA copyWithin target throw propagates");
+assert.throws(Test262Error, function () { new Int8Array([1, 2, 3]).copyWithin(0, boom); }, "TA copyWithin start throw propagates");
+assert.throws(Test262Error, function () { new Int8Array([1, 2, 3]).fill(0, boom); }, "TA fill start throw propagates");
+assert.throws(Test262Error, function () { new Int8Array([1, 2, 3]).fill(0, 0, boom); }, "TA fill end throw propagates");
+assert.throws(Test262Error, function () { "abc".slice(boom); }, "String slice start throw propagates");
+assert.throws(Test262Error, function () { "abc".slice(0, boom); }, "String slice end throw propagates");

--- a/test262-extra/element-access-relative-index-resolution.js
+++ b/test262-extra/element-access-relative-index-resolution.js
@@ -1,0 +1,103 @@
+/*---
+description: >
+  The element-access methods Array.prototype.at, String.prototype.at,
+  %TypedArray%.prototype.at, Array.prototype.with and %TypedArray%.prototype.with
+  resolve a spec "relative index" argument consistently: the argument is coerced
+  through ToIntegerOrInfinity, a negative result counts back from the length, and
+  an index that lands outside [0, len) yields no element — `.at` returns
+  `undefined`, `.with` throws a RangeError. This differs from the range-based
+  methods (slice/fill/copyWithin), which clamp an out-of-range index into
+  [0, len]. This test pins the out-of-range / +-Infinity / boundary behaviour and
+  the ToIntegerOrInfinity coercion (including that a throwing coercion is
+  propagated unchanged), which the engine factors through the
+  resolve_element_index helper.
+esid: sec-array.prototype.at
+info: |
+  Array.prototype.at ( index )
+    3. Let relativeIndex be ? ToIntegerOrInfinity(index).
+    4. If relativeIndex >= 0, let k be relativeIndex.
+       Else, let k be len + relativeIndex.
+    5. If k < 0 or k >= len, return undefined.
+
+  Array.prototype.with ( index, value )
+    3. Let relativeIndex be ? ToIntegerOrInfinity(index).
+    4. If relativeIndex >= 0, let actualIndex be relativeIndex.
+       Else, let actualIndex be len + relativeIndex.
+    5. If actualIndex >= len or actualIndex < 0, throw a RangeError exception.
+includes: [compareArray.js]
+---*/
+
+// ---------------------------------------------------------------------------
+// .at — in-range indices (positive and from-the-end) return the element
+// ---------------------------------------------------------------------------
+assert.sameValue([10, 20, 30].at(0), 10, "Array.at(0)");
+assert.sameValue([10, 20, 30].at(2), 30, "Array.at(2): last element");
+assert.sameValue([10, 20, 30].at(-1), 30, "Array.at(-1): counts back from the end");
+assert.sameValue([10, 20, 30].at(-3), 10, "Array.at(-len): first element");
+
+assert.sameValue("abc".at(-1), "c", "String.at(-1)");
+assert.sameValue("abc".at(0), "a", "String.at(0)");
+
+var ta = new Int8Array([5, 6, 7]);
+assert.sameValue(ta.at(-1), 7, "TypedArray.at(-1)");
+assert.sameValue(ta.at(0), 5, "TypedArray.at(0)");
+
+// ---------------------------------------------------------------------------
+// .at — out-of-range indices return undefined (NOT clamped)
+// ---------------------------------------------------------------------------
+assert.sameValue([10, 20, 30].at(3), undefined, "Array.at(len) is out of range");
+assert.sameValue([10, 20, 30].at(-4), undefined, "Array.at(-(len)-1) is out of range");
+assert.sameValue([10, 20, 30].at(Infinity), undefined, "Array.at(Infinity) is out of range");
+assert.sameValue([10, 20, 30].at(-Infinity), undefined, "Array.at(-Infinity) is out of range");
+assert.sameValue([10, 20, 30].at(1e300), undefined, "Array.at(huge) is out of range");
+
+assert.sameValue("abc".at(3), undefined, "String.at(len) is out of range");
+assert.sameValue("abc".at(-4), undefined, "String.at(-(len)-1) is out of range");
+assert.sameValue("abc".at(-Infinity), undefined, "String.at(-Infinity) is out of range");
+
+assert.sameValue(ta.at(3), undefined, "TypedArray.at(len) is out of range");
+assert.sameValue(ta.at(-4), undefined, "TypedArray.at(-(len)-1) is out of range");
+assert.sameValue(ta.at(Infinity), undefined, "TypedArray.at(Infinity) is out of range");
+
+// ---------------------------------------------------------------------------
+// .at — ToIntegerOrInfinity coercion (NaN -> 0, truncation, -0 -> 0)
+// ---------------------------------------------------------------------------
+assert.sameValue([10, 20, 30].at(NaN), 10, "Array.at(NaN) coerces to 0");
+assert.sameValue([10, 20, 30].at(undefined), 10, "Array.at(undefined) coerces to 0");
+assert.sameValue([10, 20, 30].at(1.9), 20, "Array.at(1.9) truncates to 1");
+assert.sameValue([10, 20, 30].at(-0), 10, "Array.at(-0) is index 0");
+assert.sameValue([10, 20, 30].at("x"), 10, "Array.at(non-numeric string) coerces to 0");
+assert.sameValue([10, 20, 30].at("2"), 30, "Array.at('2') coerces to 2");
+
+// ---------------------------------------------------------------------------
+// .with — in-range writes produce a new array with one element replaced
+// ---------------------------------------------------------------------------
+assert.compareArray([1, 2, 3].with(0, 9), [9, 2, 3], "Array.with(0, v)");
+assert.compareArray([1, 2, 3].with(-1, 9), [1, 2, 9], "Array.with(-1, v) counts from the end");
+assert.compareArray([1, 2, 3].with(-3, 9), [9, 2, 3], "Array.with(-len, v)");
+
+assert.compareArray(
+  Array.from(new Int8Array([1, 2, 3]).with(-1, 9)),
+  [1, 2, 9],
+  "TypedArray.with(-1, v)"
+);
+
+// ---------------------------------------------------------------------------
+// .with — out-of-range indices throw RangeError (NOT clamped)
+// ---------------------------------------------------------------------------
+assert.throws(RangeError, function () { [1, 2, 3].with(3, 9); }, "Array.with(len) throws");
+assert.throws(RangeError, function () { [1, 2, 3].with(-4, 9); }, "Array.with(-(len)-1) throws");
+assert.throws(RangeError, function () { [1, 2, 3].with(Infinity, 9); }, "Array.with(Infinity) throws");
+assert.throws(RangeError, function () { [1, 2, 3].with(-Infinity, 9); }, "Array.with(-Infinity) throws");
+assert.throws(RangeError, function () { new Int8Array([1, 2, 3]).with(3, 9); }, "TypedArray.with(len) throws");
+assert.throws(RangeError, function () { new Int8Array([1, 2, 3]).with(-4, 9); }, "TypedArray.with(-(len)-1) throws");
+
+// ---------------------------------------------------------------------------
+// a throwing index coercion is propagated unchanged
+// ---------------------------------------------------------------------------
+var boom = { valueOf: function () { throw new Test262Error("coercion ran"); } };
+
+assert.throws(Test262Error, function () { [1, 2, 3].at(boom); }, "Array.at index coercion throw propagates");
+assert.throws(Test262Error, function () { "abc".at(boom); }, "String.at index coercion throw propagates");
+assert.throws(Test262Error, function () { new Int8Array([1, 2, 3]).at(boom); }, "TypedArray.at index coercion throw propagates");
+assert.throws(Test262Error, function () { [1, 2, 3].with(boom, 0); }, "Array.with index coercion throw propagates");


### PR DESCRIPTION
## Goal

An architecture-deepening audit (via the `improve-codebase-architecture` skill) found that the ECMAScript **relative-index resolution** logic is a *half-built module*. PR #424 factored the "relative index" argument dance out of `Array.prototype` into shared helpers in `interpreter/helpers.rs` (`resolve_relative_index`, `resolve_start_index`, `resolve_end_index`) — but the extraction stopped halfway. The element-access family (`.at` / `.with`) and several `TypedArray`/`String` range methods still open-coded the same spec operation.

This PR finishes the module, turning a shallow, scattered pattern into one deep, unit-tested seam.

### Audit candidate ranking (most impactful first)
1. **Add the missing OOB-aware sibling + route `.at`/`.with` through it** — *Strong* (this PR)
2. **Route the remaining range methods through `resolve_start_index`/`resolve_end_index`** — *Strong* (this PR)
3. Extract the array-iteration preamble (`ToObject → LengthOfArrayLike → require_callable`) — *Worth exploring* (follow-up: higher raw impact but not unit-testable, reduce/sort scoping landmines)
4. `nonfinite_number_string` guard in `number.rs` — *Speculative* (shallow win)

_(A full visual HTML report was generated at `/tmp/architecture-review-*.html`; it is ephemeral and machine-local, so the ranking is summarized inline here.)_

## Changes

- **New pure helper** `resolve_element_index(relative: f64, len: usize) -> Option<usize>` — the out-of-bounds-aware sibling of `resolve_relative_index`. Returns `Some(k)` when the resolved index is in `[0, len)` and `None` when out of range, letting each caller keep its own out-of-range action (`.at` → `undefined`, `.with` → `RangeError`). **Built test-first** (red → green) with an exhaustive unit-test module.
- **Routed through it:** `Array.prototype.at`, `Array.prototype.with`, `String.prototype.at`, `%TypedArray%.prototype.at` — replacing four hand-rolled `i64` index dances.
- **Routed through the existing `resolve_start_index`/`resolve_end_index`:** `%TypedArray%.prototype.{subarray,slice,copyWithin,fill}` and `String.prototype.slice` — erasing the inline default plumbing (and two dead `String.slice` re-clamps).

Net: ~144 lines of duplicated coercion/clamp logic removed; the relative-index module now has exactly three well-named shapes — *clamp* (`resolve_relative_index`), *arg-plumbing* (`resolve_start/end_index`), and *OOB-aware* (`resolve_element_index`).

### Deliberately excluded
- **`%TypedArray%.prototype.with`** is left as-is: per spec it coerces the value (an observable `valueOf`) **before** its bounds check, and the check is `IsValidIntegerIndex` against the possibly-resized array — not a `[0, len)` test against the pre-coercion length. An early `None` return would skip the mandatory coercion.
- **Bucket C** (`ArrayBuffer`/`SharedArrayBuffer.slice`, `String.substr`) is out of scope — those coerce with `ToNumber`, not `ToIntegerOrInfinity`; routing them through the helpers would be a behavior change dressed as a refactor.

## Why it's behavior-preserving
`to_integer_or_infinity_value(v) ≡ to_integer_or_infinity(to_number_value(v))`, so the coercion is identical at every swapped site. The new helper does the resolve+bounds arithmetic in `f64` and only casts once the index is known in-range; this is observably equivalent to the old `f64 as i64` (saturating) then i64-arithmetic — `±Infinity` and `≥2^63` magnitudes fall out of range either way, and `len + i64::MIN` stays in range. The unit tests pin those outcomes directly (`±Inf`, `1e300`, `-1e300`, boundary, `-0`).

## Tests

Two new `test262-extra` characterization files (test262-harness shape, run in CI in both default and bytecode modes):
- `element-access-relative-index-resolution.js` — `.at`/`.with` across Array/String/TypedArray: in-range, out-of-range → `undefined`/`RangeError`, `±Infinity`, `NaN`/`-0`/truncation coercion, and throwing-coercion propagation.
- `TypedArray-String-range-index-argument-coercion.js` — `slice`/`subarray`/`copyWithin`/`fill` + `String.slice`: absent/`undefined`/negative/out-of-range defaults and throwing-coercion propagation (mirrors #424 for the TypedArray/String surfaces).

Plus a 12-case Rust unit-test module (`resolve_element_index_tests`) for the new helper.

## Verification (bounded subset — **not** the full test262 suite)

- `cargo build --release` ✔ · `cargo test --release` ✔ (477 tests incl. the new helper tests and the random test262 smoke oracle) · `./scripts/lint.sh` ✔ (rustfmt + clippy)
- `test262-extra/`: **122/122** in default mode, **122/122** in bytecode mode, 0 regressions.
- Affected `built-ins/{Array,String,TypedArray}` method directories (`at`, `with`, `slice`, `subarray`, `copyWithin`, `fill`): **1056/1056 pass, 0 regressions** vs the `origin/main` baseline. (The `new_passes: 2` reported is one *newly-added* test262 file — `TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js`, added in the pinned test262 commit, postdating the recorded baseline — not a behavior change from this diff.)

🤖 Generated with Claude Code