### PR TITLE
ci: batch releases on a weekly schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,14 @@
 name: Release
 
-# Releases are cut by semantic-release: on every push to main it derives the
-# next version from Conventional Commit types, builds the Linux `jsse` binary,
-# and publishes a GitHub Release (notes + CHANGELOG + tarball + checksums).
-# Replaces the previous manual workflow_dispatch pipeline.
+# Releases are cut by semantic-release on a weekly batch schedule (Sundays
+# 00:00 UTC): it derives the next version from Conventional Commit types
+# accumulated on main since the last release, builds the Linux `jsse`
+# binary, and publishes a GitHub Release (notes + CHANGELOG + tarball +
+# checksums). No-op if nothing releasable landed that week. Use
+# workflow_dispatch to cut a release on demand between scheduled runs.
 on:
-  push:
-    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## Summary
- `release.yml` was triggering `semantic-release` on every push to `main`, so nearly every merged `fix`/`feat`/`perf` PR cut its own GitHub Release.
- Switch the trigger to a weekly cron (Sundays 00:00 UTC), batching accumulated releasable commits into one release/week. `workflow_dispatch` is kept for cutting a release on demand between scheduled runs.
- No changes to `.releaserc.json` — `semantic-release`'s release-worthiness rules (commit-analyzer) are unaffected; only the cadence at which the workflow checks changes.

## Test plan
- [x] `actionlint` run locally against the modified workflow — clean.
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Confirm the scheduled run fires as expected on the next Sunday (or trigger manually via `workflow_dispatch` to sanity-check the job still runs).