### PR TITLE
chore: enforce conventional commits via dependabot prefixes and pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,14 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: chore
     open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: ci
     open-pull-requests-limit: 5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_install_hook_types: [pre-commit, commit-msg]
+
 exclude: |
   (?x)^(
     CHANGELOG\.md$
@@ -43,3 +45,9 @@ repos:
     rev: 0.8.4
     hooks:
       - id: pydoclint
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]


### PR DESCRIPTION
Two gaps in the Conventional Commits setup that landed on `main`.

## 1. Dependabot PR titles fail `lint-pr-title`

Neither the `cargo` nor the `github-actions` block in `.github/dependabot.yml`
had a `commit-message` key, so Dependabot used its default title format
(`Bump X from Y to Z`) — no Conventional Commit type prefix, so every Dependabot
PR fails the `lint-pr-title` check.

Added:
- `cargo` → `commit-message: prefix: chore`
- `github-actions` → `commit-message: prefix: ci`

Everything else (`directory`, `schedule`, `open-pull-requests-limit`) is unchanged.

## 2. No local commit-msg enforcement

Added the [`conventional-pre-commit`](https://github.com/compilerla/conventional-pre-commit)
hook at the `commit-msg` stage so a bad commit message is caught locally rather
than in CI.

Since `.pre-commit-config.yaml` had no `default_install_hook_types`, `pre-commit install`
only wires the `pre-commit` stage and the new hook would silently never run. Added
`default_install_hook_types: [pre-commit, commit-msg]` so a plain `pre-commit install`
sets up both stages.

Existing hooks, the top-level `exclude` block, and all formatting are untouched.

## Notes

- `release.yml` is not touched — semantic-release and its weekly cron are already correct.
- Contributors who already ran `pre-commit install` need to re-run it once to pick up the `commit-msg` stage.
- `pre-commit validate-config` passes.

---

**Note for existing clones:** `default_install_hook_types` only takes effect the next time hooks are (re-)installed — it does not retroactively add `commit-msg` to a `.git/hooks/` that was set up before this PR. If you already ran the setup once, re-run it after this merges:

```
pre-commit install
```

(Flagged by an automated review comment on pmatos/rightkey#646; applies identically here.)
