### PR TITLE
fix(arraybuffer): resolve slice bounds via shared relative-index helpers

### DIFF
--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -254,36 +254,18 @@ impl Interpreter {
                             let obj_ref = obj.borrow();
                             buffer_len(obj_ref.arraybuffer_data().unwrap())
                         };
-                        let len = buf_len as f64;
-                        let start_arg = if let Some(a) = args.first() {
-                            match interp.to_number_value(a) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            0.0
+                        // Steps 6-9: resolve start/end via ToIntegerOrInfinity then
+                        // clamp against the pre-coercion length. Coerce start before
+                        // end; a truncating relative-index resolution (e.g. -0.9 → 0,
+                        // not len + (-0.9)) is shared with the Array/TypedArray/String
+                        // range methods.
+                        let start = match resolve_start_index(interp, args.first(), buf_len) {
+                            Ok(v) => v,
+                            Err(c) => return c,
                         };
-                        let start = if start_arg.is_nan() {
-                            0
-                        } else if start_arg < 0.0 {
-                            ((len + start_arg) as isize).max(0) as usize
-                        } else {
-                            (start_arg as usize).min(buf_len)
-                        };
-                        let end_arg = if args.len() > 1 && !args[1].is_undefined() {
-                            match interp.to_number_value(&args[1]) {
-                                Ok(n) => n,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        } else {
-                            len
-                        };
-                        let end = if end_arg.is_nan() {
-                            0
-                        } else if end_arg < 0.0 {
-                            ((len + end_arg) as isize).max(0) as usize
-                        } else {
-                            (end_arg as usize).min(buf_len)
+                        let end = match resolve_end_index(interp, args.get(1), buf_len) {
+                            Ok(v) => v,
+                            Err(c) => return c,
                         };
                         let new_len = end.saturating_sub(start);
 
@@ -714,51 +696,18 @@ impl Interpreter {
                     let obj_ref = obj.borrow();
                     buffer_len(obj_ref.arraybuffer_data().unwrap())
                 };
-                let len_f = len as f64;
-
-                // ResolveBounds via ToIntegerOrInfinity semantics.
-                // Truncate is needed: e.g. -0.9 → 0, not (len + -0.9).
-                let resolve = |num: f64| -> usize {
-                    if num.is_nan() || num == 0.0 {
-                        return 0;
-                    }
-                    if num == f64::NEG_INFINITY {
-                        return 0;
-                    }
-                    if num == f64::INFINITY {
-                        return len;
-                    }
-                    let int_val = num.trunc();
-                    if int_val < 0.0 {
-                        ((len_f + int_val) as isize).max(0) as usize
-                    } else if int_val >= len_f {
-                        len
-                    } else {
-                        int_val as usize
-                    }
+                // Step 6: ResolveBounds(len, start, end) — coerce start first, then
+                // end, via the shared truncating relative-index resolution
+                // (ToIntegerOrInfinity then clamp; e.g. -0.9 → 0, not len + (-0.9)),
+                // as used by ArrayBuffer/SharedArrayBuffer.prototype.slice.
+                let first = match resolve_start_index(interp, args.first(), len) {
+                    Ok(v) => v,
+                    Err(c) => return c,
                 };
-
-                // Step 6: ResolveBounds(len, start, end). Coerce start first, then end.
-                let start_num = if let Some(a) = args.first() {
-                    match interp.to_number_value(a) {
-                        Ok(n) => n,
-                        Err(e) => return Completion::Throw(e),
-                    }
-                } else {
-                    0.0
+                let final_to = match resolve_end_index(interp, args.get(1), len) {
+                    Ok(v) => v,
+                    Err(c) => return c,
                 };
-                let first = resolve(start_num);
-
-                let end_undefined = args.len() < 2 || args[1].is_undefined();
-                let end_num = if end_undefined {
-                    len_f
-                } else {
-                    match interp.to_number_value(&args[1]) {
-                        Ok(n) => n,
-                        Err(e) => return Completion::Throw(e),
-                    }
-                };
-                let final_to = resolve(end_num);
 
                 // Step 9: newLen = max(final - first, 0)
                 let new_len = final_to.saturating_sub(first);
@@ -1267,36 +1216,17 @@ impl Interpreter {
                             );
                         }
                     };
-                    let len = buf_len as f64;
-                    let start_arg = if let Some(a) = args.first() {
-                        match interp.to_number_value(a) {
-                            Ok(n) => n,
-                            Err(e) => return Completion::Throw(e),
-                        }
-                    } else {
-                        0.0
+                    // Resolve start/end via ToIntegerOrInfinity then clamp against
+                    // the byte length, sharing the truncating relative-index
+                    // resolution used by ArrayBuffer.prototype.slice and the
+                    // Array/TypedArray/String range methods.
+                    let start = match resolve_start_index(interp, args.first(), buf_len) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
-                    let start = if start_arg.is_nan() {
-                        0
-                    } else if start_arg < 0.0 {
-                        ((len + start_arg) as isize).max(0) as usize
-                    } else {
-                        (start_arg as usize).min(buf_len)
-                    };
-                    let end_arg = if args.len() > 1 && !args[1].is_undefined() {
-                        match interp.to_number_value(&args[1]) {
-                            Ok(n) => n,
-                            Err(e) => return Completion::Throw(e),
-                        }
-                    } else {
-                        len
-                    };
-                    let end = if end_arg.is_nan() {
-                        0
-                    } else if end_arg < 0.0 {
-                        ((len + end_arg) as isize).max(0) as usize
-                    } else {
-                        (end_arg as usize).min(buf_len)
+                    let end = match resolve_end_index(interp, args.get(1), buf_len) {
+                        Ok(v) => v,
+                        Err(c) => return c,
                     };
                     let new_len = end.saturating_sub(start);
 

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -36,9 +36,11 @@ pub(crate) fn resolve_element_index(relative: f64, len: usize) -> Option<usize> 
 }
 
 // Resolves a spec "start"-style relative-index argument for the range-based
-// Array methods (slice, fill, copyWithin, splice, toSpliced). An absent
-// argument defaults to index 0; otherwise the argument is passed through
-// ToIntegerOrInfinity and clamped against `len` by `resolve_relative_index`.
+// methods of Array (slice, fill, copyWithin, splice, toSpliced), TypedArray,
+// String, and the ArrayBuffer/SharedArrayBuffer slice family (slice,
+// sliceToImmutable). An absent argument defaults to index 0; otherwise the
+// argument is passed through ToIntegerOrInfinity and clamped against `len` by
+// `resolve_relative_index`.
 // Unlike the "end" argument, an explicit `undefined` is NOT special-cased —
 // it coerces to 0 like any other non-numeric value.
 // `len` must be the array length captured *before* this coercion runs, since a
@@ -58,10 +60,11 @@ pub(crate) fn resolve_start_index(
     Ok(resolve_relative_index(relative, len))
 }
 
-// Resolves a spec "end"-style relative-index argument for the range-based Array
-// methods. An absent argument *or* an explicit `undefined` defaults to `len`;
-// otherwise the argument is passed through ToIntegerOrInfinity and clamped
-// against `len`. See `resolve_start_index` for the `len` capture invariant.
+// Resolves a spec "end"-style relative-index argument for the range-based
+// methods (see `resolve_start_index` for the surfaces this covers). An absent
+// argument *or* an explicit `undefined` defaults to `len`; otherwise the
+// argument is passed through ToIntegerOrInfinity and clamped against `len`. See
+// `resolve_start_index` for the `len` capture invariant.
 pub(crate) fn resolve_end_index(
     interp: &mut Interpreter,
     arg: Option<&JsValue>,

--- a/test262-extra/ArrayBuffer-slice-range-index-argument-coercion.js
+++ b/test262-extra/ArrayBuffer-slice-range-index-argument-coercion.js
@@ -1,0 +1,152 @@
+/*---
+description: >
+  ArrayBuffer.prototype.slice, SharedArrayBuffer.prototype.slice and
+  ArrayBuffer.prototype.sliceToImmutable resolve their start/end index arguments
+  the same way Array.prototype.slice does: an absent start defaults to 0, an
+  absent OR explicitly `undefined` end defaults to the byte length, every present
+  argument is coerced through ToIntegerOrInfinity — truncating toward zero BEFORE
+  the relative offset is computed — and the relative index is clamped against the
+  length. A negative *fractional* argument such as -0.9 must therefore truncate to
+  0 (a full-length copy), not fall through to `len + (-0.9)`. This mirrors the
+  Array / TypedArray / String range-index coercion tests; the engine factors all
+  three ArrayBuffer slice surfaces through the shared resolve_start_index /
+  resolve_end_index helpers.
+esid: sec-arraybuffer.prototype.slice
+info: |
+  ArrayBuffer.prototype.slice ( start, end )
+    5. Let len be O.[[ArrayBufferByteLength]].
+    6. Let relativeStart be ? ToIntegerOrInfinity(start).
+    7. If relativeStart is -infinity, let first be 0.
+       Else if relativeStart < 0, let first be max(len + relativeStart, 0).
+       Else, let first be min(relativeStart, len).
+    8. If end is undefined, let relativeEnd be len;
+       else let relativeEnd be ? ToIntegerOrInfinity(end).
+    9. If relativeEnd is -infinity, let final be 0.
+       Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
+       Else, let final be min(relativeEnd, len).
+   10. Let newLen be max(final - first, 0).
+  ToIntegerOrInfinity ( argument )
+    Let number be ? ToNumber(argument).
+    ... return truncate(number).
+includes: [compareArray.js]
+features: [SharedArrayBuffer, immutable-arraybuffer]
+---*/
+
+// bytesOf(buffer) → the buffer's bytes as a plain Array. Works for ArrayBuffer,
+// SharedArrayBuffer and immutable ArrayBuffer alike (a Uint8Array view reads any
+// of them).
+function bytesOf(buffer) {
+  return Array.from(new Uint8Array(buffer));
+}
+
+// filled(len) → a fresh ArrayBuffer of `len` bytes holding 0, 1, 2, ... len-1,
+// so a slice's byte content pins the resolved [first, final) offsets — not just
+// the resulting byteLength.
+function filled(len) {
+  var buf = new ArrayBuffer(len);
+  var view = new Uint8Array(buf);
+  for (var i = 0; i < len; i++) view[i] = i;
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// ArrayBuffer.prototype.slice
+// ---------------------------------------------------------------------------
+
+// Absent / undefined defaults.
+assert.compareArray(bytesOf(filled(5).slice()), [0, 1, 2, 3, 4], "slice(): whole buffer");
+assert.compareArray(bytesOf(filled(5).slice(1)), [1, 2, 3, 4], "slice(1): absent end is length");
+assert.compareArray(bytesOf(filled(5).slice(1, undefined)), [1, 2, 3, 4], "slice(1, undefined): undefined end is length");
+
+// Negative arguments count back from the length.
+assert.compareArray(bytesOf(filled(5).slice(-2)), [3, 4], "slice(-2)");
+assert.compareArray(bytesOf(filled(5).slice(1, -1)), [1, 2, 3], "slice(1, -1)");
+
+// Out-of-range clamps into [0, len].
+assert.compareArray(bytesOf(filled(5).slice(-100, 100)), [0, 1, 2, 3, 4], "slice(-100, 100): clamps to [0, len]");
+
+// Negative *fractional* arguments truncate toward zero FIRST, then take the
+// relative offset. -0.9 truncates to -0 → 0 (a full copy), NOT len + (-0.9).
+assert.sameValue(filled(10).slice(-0.9).byteLength, 10, "slice(-0.9).byteLength: -0.9 truncates to 0");
+assert.compareArray(bytesOf(filled(10).slice(-0.9)), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "slice(-0.9): full copy, not a 1-byte tail");
+assert.compareArray(bytesOf(filled(10).slice(-0.9, -0.9)), [], "slice(-0.9, -0.9): empty, both ends truncate to 0");
+
+// A negative fractional pair that resolves to real offsets: -3.9 → 7, -1.9 → 9.
+// The byteLength alone (2) does not catch a truncation bug — the byte *content*
+// does: an untruncated resolve would read [6, 7] instead of [7, 8].
+assert.compareArray(bytesOf(filled(10).slice(-3.9, -1.9)), [7, 8], "slice(-3.9, -1.9): offsets 7..9, not 6..8");
+
+// Positive fractional truncates toward zero: 2.9 → 2.
+assert.compareArray(bytesOf(filled(10).slice(2.9)), [2, 3, 4, 5, 6, 7, 8, 9], "slice(2.9): start truncates to 2");
+
+// NaN → 0; -Infinity → 0; +Infinity → len.
+assert.compareArray(bytesOf(filled(4).slice(NaN)), [0, 1, 2, 3], "slice(NaN): NaN is 0");
+assert.compareArray(bytesOf(filled(4).slice(-Infinity)), [0, 1, 2, 3], "slice(-Infinity): -Infinity is 0");
+assert.compareArray(bytesOf(filled(4).slice(Infinity)), [], "slice(Infinity): +Infinity is len");
+
+// ---------------------------------------------------------------------------
+// SharedArrayBuffer.prototype.slice — the same resolution
+// ---------------------------------------------------------------------------
+
+// filledShared(len) → a SharedArrayBuffer of `len` bytes holding 0, 1, ... len-1.
+function filledShared(len) {
+  var sab = new SharedArrayBuffer(len);
+  var view = new Uint8Array(sab);
+  for (var i = 0; i < len; i++) view[i] = i;
+  return sab;
+}
+
+assert.compareArray(bytesOf(filledShared(5).slice(1)), [1, 2, 3, 4], "SAB slice(1): absent end is length");
+assert.compareArray(bytesOf(filledShared(5).slice(1, undefined)), [1, 2, 3, 4], "SAB slice(1, undefined): undefined end is length");
+assert.compareArray(bytesOf(filledShared(5).slice(1, -1)), [1, 2, 3], "SAB slice(1, -1)");
+
+// Negative fractional truncates toward zero before the relative offset.
+assert.sameValue(filledShared(10).slice(-0.9).byteLength, 10, "SAB slice(-0.9).byteLength: -0.9 truncates to 0");
+assert.compareArray(bytesOf(filledShared(10).slice(-0.9)), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "SAB slice(-0.9): full copy");
+assert.compareArray(bytesOf(filledShared(10).slice(-3.9, -1.9)), [7, 8], "SAB slice(-3.9, -1.9): offsets 7..9, not 6..8");
+assert.compareArray(bytesOf(filledShared(10).slice(2.9)), [2, 3, 4, 5, 6, 7, 8, 9], "SAB slice(2.9): start truncates to 2");
+assert.compareArray(bytesOf(filledShared(4).slice(NaN)), [0, 1, 2, 3], "SAB slice(NaN): NaN is 0");
+
+// ---------------------------------------------------------------------------
+// ArrayBuffer.prototype.sliceToImmutable — the same resolution
+// ---------------------------------------------------------------------------
+
+if (typeof ArrayBuffer.prototype.sliceToImmutable === "function") {
+  assert.compareArray(bytesOf(filled(5).sliceToImmutable(1)), [1, 2, 3, 4], "sliceToImmutable(1): absent end is length");
+  assert.compareArray(bytesOf(filled(5).sliceToImmutable(1, undefined)), [1, 2, 3, 4], "sliceToImmutable(1, undefined): undefined end is length");
+  assert.compareArray(bytesOf(filled(5).sliceToImmutable(1, -1)), [1, 2, 3], "sliceToImmutable(1, -1)");
+  assert.compareArray(bytesOf(filled(10).sliceToImmutable(-0.9)), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "sliceToImmutable(-0.9): full copy");
+  assert.compareArray(bytesOf(filled(10).sliceToImmutable(-3.9, -1.9)), [7, 8], "sliceToImmutable(-3.9, -1.9): offsets 7..9");
+  assert.compareArray(bytesOf(filled(10).sliceToImmutable(2.9)), [2, 3, 4, 5, 6, 7, 8, 9], "sliceToImmutable(2.9): start truncates to 2");
+  assert.compareArray(bytesOf(filled(4).sliceToImmutable(NaN)), [0, 1, 2, 3], "sliceToImmutable(NaN): NaN is 0");
+}
+
+// ---------------------------------------------------------------------------
+// Coercion order: start is coerced before end, and a throwing start argument
+// short-circuits before end is touched. All three surfaces share this order.
+// ---------------------------------------------------------------------------
+
+function orderLog(makeBuffer, method) {
+  var log = [];
+  var start = { valueOf: function() { log.push("start"); return 1; } };
+  var end = { valueOf: function() { log.push("end"); return 3; } };
+  makeBuffer()[method](start, end);
+  return log.join(",");
+}
+
+assert.sameValue(orderLog(function() { return new ArrayBuffer(5); }, "slice"), "start,end", "ArrayBuffer.slice coerces start then end");
+assert.sameValue(orderLog(function() { return new SharedArrayBuffer(5); }, "slice"), "start,end", "SharedArrayBuffer.slice coerces start then end");
+if (typeof ArrayBuffer.prototype.sliceToImmutable === "function") {
+  assert.sameValue(orderLog(function() { return new ArrayBuffer(5); }, "sliceToImmutable"), "start,end", "sliceToImmutable coerces start then end");
+}
+
+function throwsBeforeEnd(makeBuffer, method) {
+  var endTouched = false;
+  var start = { valueOf: function() { throw new Test262Error("start"); } };
+  var end = { valueOf: function() { endTouched = true; return 0; } };
+  assert.throws(Test262Error, function() { makeBuffer()[method](start, end); }, method + ": throwing start propagates");
+  return endTouched;
+}
+
+assert.sameValue(throwsBeforeEnd(function() { return new ArrayBuffer(5); }, "slice"), false, "ArrayBuffer.slice: throwing start never coerces end");
+assert.sameValue(throwsBeforeEnd(function() { return new SharedArrayBuffer(5); }, "slice"), false, "SharedArrayBuffer.slice: throwing start never coerces end");


### PR DESCRIPTION
## What & why

This started as an **architecture review** (`improve-codebase-architecture` skill): scan the built-in coercion/clamping surfaces for **deepening opportunities** — spec abstract-operations open-coded across several builtins where a tested *deep helper* already exists. The top candidate turned out to also be a live correctness bug, so it's a `fix:`, not a `refactor:`.

`ArrayBuffer.prototype.slice` and `SharedArrayBuffer.prototype.slice` open-coded their start/end index resolution on the **raw float** from `ToNumber`, skipping the `ToIntegerOrInfinity` truncation the spec requires (steps 6–9). A negative *fractional* argument fell through to `(len + arg) as isize` instead of truncating toward zero first:

| expression (10-byte buffer `[0..9]`) | before (jsse) | spec / node |
| --- | --- | --- |
| `slice(-0.9).byteLength` | `1` ❌ | `10` |
| `slice(-3.9, -1.9)` bytes | `6,7` ❌ | `7,8` |

Note the second row: `byteLength` is `2` either way — the bug copies the **wrong bytes**, not merely the wrong length, so a length-only test wouldn't catch it.

## The deepening

All three ArrayBuffer slice surfaces now route through the existing `resolve_start_index` / `resolve_end_index` helpers (`ToIntegerOrInfinity` → relative-index clamp) — the same helpers the Array / TypedArray / String range methods already use. This:

- **Fixes** the two buggy copies (`slice`, `SharedArrayBuffer.slice`).
- **Consolidates** the already-correct `sliceToImmutable` copy, deleting ~30 lines of bespoke bounds math per call site (net **−108 / +41** in `typedarray.rs`).
- **Completes** the #424 / #443 relative-index helper series by extending it to the ArrayBuffer slice family.

Coercion order (start before end; a throwing start short-circuits before end is touched) and the pre-coercion length capture are preserved.

## Tests (TDD)

New `test262-extra/ArrayBuffer-slice-range-index-argument-coercion.js`, written test-first in three red→green cycles (AB.slice, then SAB.slice, then `sliceToImmutable` as a declared behavior-preserving consolidation). It asserts **byte content** (via `compareArray`), not just `byteLength`, plus the default / `undefined` / `NaN` / `±Infinity` edges and coercion order across all three surfaces. Fills a genuine test262 coverage gap — upstream `number-conversion.js` only checks *integer* coercion + order, never a negative fractional argument.

## Validation

- `cargo build --release`, `cargo test --release` (473 + 3 + smoke, **0 failed**), `./scripts/lint.sh` (rustfmt + clippy clean), `run-custom-tests.py` (11/11).
- **test262-extra**, full suite, **both** default and `--bytecode` modes: **134/134**.
- Bounded test262 subset `built-ins/{ArrayBuffer,SharedArrayBuffer,DataView,TypedArray,TypedArrayConstructors}` — **6,094 scenarios, 0 regressions**. The 2 reported "new passes" are one unrelated `TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js` (baseline drift; it references none of the changed methods).
- Full test262 suite not run in this environment; README pass count intentionally left unchanged (a bounded subset must not overwrite the recorded number).

## Other candidates surfaced (follow-ups, not in this PR)

The review ranked four deepening opportunities in the coercion surfaces:

| # | Candidate | Files | Strength |
| --- | --- | --- | --- |
| **1** | **ArrayBuffer/SAB `slice` bounds → shared helpers** (this PR) | `typedarray.rs` | Strong |
| 2 | `indexOf`/`lastIndexOf`/`includes` fromIndex resolution (forward reuses `resolve_relative_index`; backward is a new pure helper) | `array.rs`, `typedarray.rs` | Worth exploring |
| 3 | DataView `GetViewByteLength` + OOB check (pure `fn(offset,len,buf_len,tracking) -> Option<usize>`) duplicated across the get/set macros | `typedarray.rs` | Worth exploring |
| 4 | String `clamp(x, [0,len])` — 5 sites, but concentrated in one file | `string.rs` | Speculative |