### PR TITLE
fix(interpreter): throw on non-iterable spread in private-method calls

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -5399,32 +5399,31 @@ impl Interpreter {
                                         )));
                                 }
                             };
-                            let mut evaluated_args = Vec::new();
-                            for arg in args {
-                                match arg {
-                                    Expression::Spread(inner) => {
-                                        let spread_val = match self.eval_expr(inner, env) {
-                                            Completion::Normal(v) => v,
-                                            other => return other,
-                                        };
-                                        if let Ok(items) = self.iterate_to_vec(&spread_val) {
-                                            evaluated_args.extend(items);
-                                        }
-                                    }
-                                    _ => match self.eval_expr(arg, env) {
-                                        Completion::Normal(v) => evaluated_args.push(v),
-                                        other => return other,
-                                    },
+                            // Evaluate the call arguments through the shared spread
+                            // seam so a non-iterable spread throws (rather than being
+                            // silently dropped) and every argument is GC-rooted, exactly
+                            // as the ordinary member-call path does.
+                            let gc_frame = self.gc_root_frame();
+                            self.gc_root_value(&func_val);
+                            self.gc_root_value(&obj_val);
+                            let evaluated_args = match self.eval_spread_args(args, env) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    self.gc_unroot_frame(gc_frame);
+                                    return Completion::Throw(e);
                                 }
-                            }
+                            };
                             if saved_tail {
+                                self.gc_unroot_frame(gc_frame);
                                 return Completion::TailCall {
                                     func: func_val,
                                     this: obj_val,
                                     args: evaluated_args,
                                 };
                             }
-                            return self.call_function(&func_val, &obj_val, &evaluated_args);
+                            let result = self.call_function(&func_val, &obj_val, &evaluated_args);
+                            self.gc_unroot_frame(gc_frame);
+                            return result;
                         }
                         return Completion::Throw(self.create_type_error(&format!(
                             "Cannot read private member #{name} from a non-object"

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -883,6 +883,46 @@ fn array_literal_releases_temp_roots_after_abrupt_completion() {
 }
 
 #[test]
+fn private_method_call_with_non_iterable_spread_throws() {
+    // A spread argument that is not iterable must throw a TypeError, even when the
+    // callee is a private method reached through `this.#m(...)`. The private-call
+    // path used to hand-roll argument evaluation and silently drop the iteration
+    // error, invoking the method with zero arguments instead of throwing.
+    let interp = run_script(
+        r#"
+        var result = "";
+        class C {
+            #m() { return "called"; }
+            run() { return this.#m(...5); }
+        }
+        try {
+            new C().run();
+            result = "no-throw";
+        } catch (e) {
+            result = e.constructor.name;
+        }
+        "#,
+    );
+    assert_eq!(global_string(&interp, "result"), "TypeError");
+}
+
+#[test]
+fn private_method_call_forwards_iterable_spread_arguments() {
+    // The private-method call path must forward spread arguments from an iterable,
+    // matching the ordinary member-call path.
+    let interp = run_script(
+        r#"
+        class D {
+            #m(a, b, c) { return a + b + c; }
+            run() { return this.#m(1, ...[2, 3]); }
+        }
+        var result = new D().run();
+        "#,
+    );
+    assert_eq!(global_number(&interp, "result"), 6.0);
+}
+
+#[test]
 fn shared_array_buffer_atomics_smoke() {
     let interp = run_script(
         r#"

--- a/test262-extra/private-method-call-spread-argument-evaluation.js
+++ b/test262-extra/private-method-call-spread-argument-evaluation.js
@@ -1,0 +1,80 @@
+/*---
+description: >
+  A spread argument in a private-method call is evaluated through the shared
+  argument-list evaluation: a non-iterable spread throws a TypeError, an
+  iterable spread is forwarded, and arguments already accumulated stay reachable
+  across a garbage collection triggered while a later argument is evaluated.
+esid: sec-argument-lists-runtime-semantics-argumentlistevaluation
+features: [class-methods-private, Symbol.iterator]
+info: |
+  ArgumentListEvaluation for an `... AssignmentExpression` element performs
+  GetIterator(spreadObj, sync). GetIterator throws a TypeError when the value has
+  no @@iterator method, and this must hold regardless of how the callee is
+  reached -- including a call to a private method, `this.#m(...)`. The already
+  evaluated arguments must also remain strongly reachable while the remaining
+  arguments (and their iterator steps) are evaluated, so an object accumulated
+  before a garbage collection is not swept before the call is performed.
+---*/
+
+// A non-iterable spread argument throws a TypeError even for a private method.
+class NonIterable {
+  #m() {
+    return "unreachable";
+  }
+  run() {
+    return this.#m(...5);
+  }
+}
+assert.throws(
+  TypeError,
+  function () {
+    new NonIterable().run();
+  },
+  "a non-iterable spread argument to a private method throws a TypeError"
+);
+
+// An iterable spread argument is forwarded to the private method.
+class Forward {
+  #m(a, b, c) {
+    return a + b + c;
+  }
+  run() {
+    return this.#m(1, ...[2, 3]);
+  }
+}
+assert.sameValue(
+  new Forward().run(),
+  6,
+  "iterable spread arguments are forwarded to the private method"
+);
+
+// An earlier argument survives a garbage collection triggered while a later
+// spread's iterator is stepped.
+class Survive {
+  #m(earlier) {
+    return earlier.marker;
+  }
+  run() {
+    var collectingIterator = {
+      [Symbol.iterator]: function () {
+        var produced = false;
+        return {
+          next: function () {
+            if (!produced) {
+              produced = true;
+              return { value: { marker: "later" }, done: false };
+            }
+            $262.gc();
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    };
+    return this.#m({ marker: "earlier" }, ...collectingIterator);
+  }
+}
+assert.sameValue(
+  new Survive().run(),
+  "earlier",
+  "an earlier object argument survives GC during a later spread's iterator step"
+);


### PR DESCRIPTION
## Refactoring goal

This branch came out of an architecture audit run with the `improve-codebase-architecture` skill (deepening opportunities: turn a **shallow**, hand-rolled copy of logic into a call on a **deep** shared seam, improving locality and testability). The audit's top finding was a *Category-4* locality defect: a seam already exists (`eval_spread_args`), but one call site re-implemented it and drifted — and the drift is an observable bug.

### The friction

The private-method call path (`this.#m(...)`, `MemberProperty::Private` in `eval.rs`) hand-rolled its own argument-evaluation loop and **silently swallowed** the iteration error:

```rust
if let Ok(items) = self.iterate_to_vec(&spread_val) {
    evaluated_args.extend(items);
}   // the Err arm is dropped on the floor
```

Consequences:
- A non-iterable spread such as `this.#m(...5)` must throw a **TypeError** (GetIterator on a non-iterable, per *sec-argument-lists-runtime-semantics-argumentlistevaluation*). Instead the dropped `Err` caused `#m` to be invoked with **zero arguments** and no throw.
- The loop also skipped the **GC rooting** that every other call path performs, so argument values could be swept mid-evaluation.

This was the only error-swallowing `iterate_to_vec` call site in the file; every other spread goes through `eval_spread_args`.

### The change (the deepening)

Route the private-method call site onto the shared `eval_spread_args` seam that the ordinary member-call, direct-`eval`, `super()`, and `new` paths already use. It propagates the iteration error (`?`) and GC-roots each argument, using the exact GC-frame idiom of the public call path. The private path now **behaves identically to the public one** instead of maintaining a divergent copy — the hand-rolled loop is deleted and complexity concentrates in the seam (passes the deletion test).

Behavioural note: for non-spread arguments, the old loop propagated *all* abrupt completions while `eval_spread_args` maps non-`Throw` completions to `undefined` — this now matches the public call path exactly (which already uses `eval_spread_args`), and the full `gen-private-method` / `async-private-method` / `async-gen-private-method` test262 suites pass.

## Tests (TDD, red → green)

Built test-first with the `tdd` skill; seams were documented here rather than confirmed with a user (autonomous run).

- **`src/interpreter/tests.rs`** (interpreter eval seam):
  - `private_method_call_with_non_iterable_spread_throws` — `this.#m(...5)` must throw `TypeError`. **Red before the fix** (returned `"no-throw"`), green after. Cross-checked against Node.
  - `private_method_call_forwards_iterable_spread_arguments` — `this.#m(1, ...[2, 3])` returns `6`, locking the happy path.
- **`test262-extra/private-method-call-spread-argument-evaluation.js`** (spec-compliance, test262 format with `esid`/`info`): the throw, argument forwarding, and survival of an earlier argument across a `$262.gc()` triggered during a later spread's iterator step (documents the restored rooting). Passes in both default and bytecode modes.

## Validation

- `./scripts/lint.sh` — rustfmt + clippy (`-D warnings`) clean.
- `cargo test --release` — 475 passed, 0 failed.
- Targeted test262 (all `call/` + class `elements/` incl. private methods & TCO): 6,068 scenarios, 0 regressions.
- **Full test262: 99,568 scenarios, 100% pass, 0 regressions.**

Baseline left untouched (no `--update-baseline`) since this is a feature branch targeting `main`.

🤖 Generated with Claude Code