### PR TITLE
fix(bigint): unify StringToBigInt into one spec-correct operation

### DIFF
--- a/src/interpreter/builtins/bigint.rs
+++ b/src/interpreter/builtins/bigint.rs
@@ -171,28 +171,8 @@ impl Interpreter {
                     ))));
                 }
                 if let Some(string) = val.as_string() {
-                    let text = string.to_rust_string().trim().to_string();
-                    if text.is_empty() {
-                        return Completion::Normal(JsValue::bigint(JsBigInt::new(
-                            num_bigint::BigInt::from(0),
-                        )));
-                    }
-                    let parsed = if let Some(hex) =
-                        text.strip_prefix("0x").or_else(|| text.strip_prefix("0X"))
-                    {
-                        num_bigint::BigInt::parse_bytes(hex.as_bytes(), 16)
-                    } else if let Some(oct) =
-                        text.strip_prefix("0o").or_else(|| text.strip_prefix("0O"))
-                    {
-                        num_bigint::BigInt::parse_bytes(oct.as_bytes(), 8)
-                    } else if let Some(bin) =
-                        text.strip_prefix("0b").or_else(|| text.strip_prefix("0B"))
-                    {
-                        num_bigint::BigInt::parse_bytes(bin.as_bytes(), 2)
-                    } else {
-                        text.parse::<num_bigint::BigInt>().ok()
-                    };
-                    return match parsed {
+                    let text = string.to_rust_string();
+                    return match crate::interpreter::helpers::string_to_bigint(&text) {
                         Some(value) => Completion::Normal(JsValue::bigint(JsBigInt::new(value))),
                         None => Completion::Throw(interp.create_error(
                             "SyntaxError",

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -2901,29 +2901,8 @@ impl Interpreter {
                                 .create_type_error(&format!("Cannot convert {} to a BigInt", n)))
                         }
                         ValueKind::String => {
-                            let text = val.as_string().unwrap().to_rust_string().trim().to_string();
-                            if text.is_empty() {
-                                return Err(interp.create_error(
-                                    "SyntaxError",
-                                    "Cannot convert empty string to a BigInt",
-                                ));
-                            }
-                            let parsed = if let Some(hex) =
-                                text.strip_prefix("0x").or_else(|| text.strip_prefix("0X"))
-                            {
-                                num_bigint::BigInt::parse_bytes(hex.as_bytes(), 16)
-                            } else if let Some(oct) =
-                                text.strip_prefix("0o").or_else(|| text.strip_prefix("0O"))
-                            {
-                                num_bigint::BigInt::parse_bytes(oct.as_bytes(), 8)
-                            } else if let Some(bin) =
-                                text.strip_prefix("0b").or_else(|| text.strip_prefix("0B"))
-                            {
-                                num_bigint::BigInt::parse_bytes(bin.as_bytes(), 2)
-                            } else {
-                                text.parse::<num_bigint::BigInt>().ok()
-                            };
-                            match parsed {
+                            let text = val.as_string().unwrap().to_rust_string();
+                            match crate::interpreter::helpers::string_to_bigint(&text) {
                                 Some(v) => Ok(JsValue::bigint(JsBigInt::new(v))),
                                 None => Err(interp.create_error(
                                     "SyntaxError",

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -20,33 +20,6 @@ impl Drop for EvalDepthGuard {
     }
 }
 
-/// StringToBigInt per spec §7.1.14 — handles empty string, hex, octal, binary.
-fn string_to_bigint_for_comparison(s: &str) -> Option<num_bigint::BigInt> {
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
-        return Some(num_bigint::BigInt::from(0));
-    }
-    if let Some(hex) = trimmed
-        .strip_prefix("0x")
-        .or_else(|| trimmed.strip_prefix("0X"))
-    {
-        return num_bigint::BigInt::parse_bytes(hex.as_bytes(), 16);
-    }
-    if let Some(oct) = trimmed
-        .strip_prefix("0o")
-        .or_else(|| trimmed.strip_prefix("0O"))
-    {
-        return num_bigint::BigInt::parse_bytes(oct.as_bytes(), 8);
-    }
-    if let Some(bin) = trimmed
-        .strip_prefix("0b")
-        .or_else(|| trimmed.strip_prefix("0B"))
-    {
-        return num_bigint::BigInt::parse_bytes(bin.as_bytes(), 2);
-    }
-    trimmed.parse::<num_bigint::BigInt>().ok()
-}
-
 pub(super) enum IdentifierRef {
     WithObject(u64),
     Unresolvable,
@@ -1795,31 +1768,7 @@ impl Interpreter {
             })))
         } else if let Some(s) = prim.as_string() {
             let text = s.to_rust_string();
-            let trimmed = text.trim();
-            if trimmed.is_empty() {
-                return Ok(JsValue::bigint(crate::types::JsBigInt::new(
-                    num_bigint::BigInt::from(0),
-                )));
-            }
-            let parsed = if let Some(hex) = trimmed
-                .strip_prefix("0x")
-                .or_else(|| trimmed.strip_prefix("0X"))
-            {
-                num_bigint::BigInt::parse_bytes(hex.as_bytes(), 16)
-            } else if let Some(oct) = trimmed
-                .strip_prefix("0o")
-                .or_else(|| trimmed.strip_prefix("0O"))
-            {
-                num_bigint::BigInt::parse_bytes(oct.as_bytes(), 8)
-            } else if let Some(bin) = trimmed
-                .strip_prefix("0b")
-                .or_else(|| trimmed.strip_prefix("0B"))
-            {
-                num_bigint::BigInt::parse_bytes(bin.as_bytes(), 2)
-            } else {
-                trimmed.parse::<num_bigint::BigInt>().ok()
-            };
-            match parsed {
+            match crate::interpreter::helpers::string_to_bigint(&text) {
                 Some(n) => Ok(JsValue::bigint(crate::types::JsBigInt::new(n))),
                 None => Err(self.create_error(
                     "SyntaxError",
@@ -1894,13 +1843,15 @@ impl Interpreter {
         }
         // BigInt == String (via StringToBigInt)
         if let (Some(b), Some(s)) = (left.as_bigint(), right.as_string()) {
-            if let Some(parsed) = string_to_bigint_for_comparison(&s.to_rust_string()) {
+            if let Some(parsed) = crate::interpreter::helpers::string_to_bigint(&s.to_rust_string())
+            {
                 return Ok(bigint_ops::equal(&b.value, &parsed));
             }
             return Ok(false);
         }
         if let (Some(s), Some(b)) = (left.as_string(), right.as_bigint()) {
-            if let Some(parsed) = string_to_bigint_for_comparison(&s.to_rust_string()) {
+            if let Some(parsed) = crate::interpreter::helpers::string_to_bigint(&s.to_rust_string())
+            {
                 return Ok(bigint_ops::equal(&parsed, &b.value));
             }
             return Ok(false);
@@ -2002,7 +1953,8 @@ impl Interpreter {
         if lprim.is_bigint()
             && let Some(s) = rprim.as_string()
         {
-            if let Some(parsed) = string_to_bigint_for_comparison(&s.to_rust_string()) {
+            if let Some(parsed) = crate::interpreter::helpers::string_to_bigint(&s.to_rust_string())
+            {
                 return self.abstract_relational(&lprim, &JsValue::bigint(JsBigInt::new(parsed)));
             }
             return Ok(None);
@@ -2010,7 +1962,8 @@ impl Interpreter {
         if let Some(s) = lprim.as_string()
             && rprim.is_bigint()
         {
-            if let Some(parsed) = string_to_bigint_for_comparison(&s.to_rust_string()) {
+            if let Some(parsed) = crate::interpreter::helpers::string_to_bigint(&s.to_rust_string())
+            {
                 return self.abstract_relational(&JsValue::bigint(JsBigInt::new(parsed)), &rprim);
             }
             return Ok(None);

--- a/src/interpreter/helpers.rs
+++ b/src/interpreter/helpers.rs
@@ -218,6 +218,58 @@ fn string_to_number(s: &JsString) -> f64 {
     trimmed.parse::<f64>().unwrap_or(f64::NAN)
 }
 
+// §7.1.14 StringToBigInt: the single canonical parse of a String value to a
+// BigInt, returning None when the string is not a valid StringIntegerLiteral.
+// Shared by the BigInt constructor, ToBigInt (typed-array/DataView writes,
+// %TypedArray%.prototype.with), and BigInt/String loose equality so every
+// consumer agrees. Whitespace is trimmed per StrWhiteSpace (via
+// `is_ecma_whitespace`, matching `string_to_number`); the empty string is 0n.
+//
+// Unlike a bare `num_bigint` parse, the grammar is enforced: numeric separators
+// (`_`), a sign inside a NonDecimalIntegerLiteral (e.g. `0x-1`), radix points,
+// exponents, a `n` suffix, and non-ASCII digits are all rejected.
+pub(crate) fn string_to_bigint(s: &str) -> Option<num_bigint::BigInt> {
+    let trimmed = s.trim_matches(is_ecma_whitespace);
+    if trimmed.is_empty() {
+        return Some(num_bigint::BigInt::from(0));
+    }
+    // NonDecimalIntegerLiteral: a 0x/0o/0b prefix followed by one or more digits
+    // of that radix — no sign, no separators. `num_bigint::parse_bytes` silently
+    // ignores `_` and accepts a leading sign, so validate the body first.
+    fn parse_non_decimal(body: &str, radix: u32) -> Option<num_bigint::BigInt> {
+        if !body.is_empty() && body.chars().all(|c| c.is_digit(radix)) {
+            num_bigint::BigInt::parse_bytes(body.as_bytes(), radix)
+        } else {
+            None
+        }
+    }
+    if let Some(hex) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        return parse_non_decimal(hex, 16);
+    }
+    if let Some(oct) = trimmed
+        .strip_prefix("0o")
+        .or_else(|| trimmed.strip_prefix("0O"))
+    {
+        return parse_non_decimal(oct, 8);
+    }
+    if let Some(bin) = trimmed
+        .strip_prefix("0b")
+        .or_else(|| trimmed.strip_prefix("0B"))
+    {
+        return parse_non_decimal(bin, 2);
+    }
+    // SignedInteger: an optional single sign then one or more decimal digits —
+    // no separators, radix points, or exponents.
+    let digits = trimmed.strip_prefix(['+', '-']).unwrap_or(trimmed);
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    trimmed.parse::<num_bigint::BigInt>().ok()
+}
+
 pub(crate) fn to_js_string(val: &JsValue) -> String {
     val.with_bigint(|b| b.to_string())
         .unwrap_or_else(|| format!("{val}"))
@@ -3021,5 +3073,112 @@ mod string_to_number_tests {
         assert_eq!(n("5."), 5.0);
         assert_eq!(n("-0"), 0.0);
         assert!(n("-0").is_sign_negative());
+    }
+}
+
+#[cfg(test)]
+mod string_to_bigint_tests {
+    // §7.1.14 StringToBigInt. Expected values are the independent source of truth
+    // from ECMA-262 §12 (WhiteSpace) and the StringIntegerLiteral grammar,
+    // cross-checked against node's `BigInt(...)`. `Some(_)` mirrors a successful
+    // parse; `None` is the "return undefined" case (a SyntaxError for the
+    // constructor/ToBigInt, and `false` for loose equality).
+    use super::string_to_bigint;
+    use num_bigint::BigInt;
+
+    fn b(s: &str) -> Option<BigInt> {
+        string_to_bigint(s)
+    }
+
+    fn v(n: i64) -> Option<BigInt> {
+        Some(BigInt::from(n))
+    }
+
+    #[test]
+    fn empty_and_whitespace_are_zero() {
+        assert_eq!(b(""), v(0));
+        assert_eq!(b("   "), v(0));
+        assert_eq!(b("\t\n\r "), v(0));
+    }
+
+    #[test]
+    fn decimal_signed_integers() {
+        assert_eq!(b("0"), v(0));
+        assert_eq!(b("00"), v(0));
+        assert_eq!(b("12"), v(12));
+        assert_eq!(b("  12  "), v(12));
+        assert_eq!(b("+5"), v(5));
+        assert_eq!(b("-5"), v(-5));
+        assert_eq!(b("   -197   "), v(-197));
+        assert_eq!(b("-0"), v(0));
+    }
+
+    #[test]
+    fn non_decimal_integer_literals() {
+        assert_eq!(b("0xFF"), v(255));
+        assert_eq!(b("0X1a"), v(26));
+        assert_eq!(b("0o17"), v(15));
+        assert_eq!(b("0O17"), v(15));
+        assert_eq!(b("0b1010"), v(10));
+        assert_eq!(b("0B11"), v(3));
+    }
+
+    #[test]
+    fn numeric_separators_are_rejected() {
+        // `num_bigint::parse_bytes`/`FromStr` silently ignore `_`; the string
+        // grammar does not permit NumericLiteralSeparator.
+        assert_eq!(b("1_0"), None);
+        assert_eq!(b("0x1_0"), None);
+        assert_eq!(b("0b1_0"), None);
+        assert_eq!(b("0o1_0"), None);
+    }
+
+    #[test]
+    fn sign_is_only_valid_for_decimal_signed_integer() {
+        // A NonDecimalIntegerLiteral has no sign; `parse_bytes` would accept one.
+        assert_eq!(b("0x-10"), None);
+        assert_eq!(b("0b-1"), None);
+        assert_eq!(b("-0x10"), None);
+        assert_eq!(b("+0x10"), None);
+        assert_eq!(b("+ 5"), None);
+        assert_eq!(b("+"), None);
+        assert_eq!(b("-"), None);
+    }
+
+    #[test]
+    fn radix_points_exponents_suffixes_and_bad_digits_are_rejected() {
+        assert_eq!(b("1.5"), None);
+        assert_eq!(b(".5"), None);
+        assert_eq!(b("1e3"), None);
+        assert_eq!(b("10n"), None);
+        assert_eq!(b("0x"), None);
+        assert_eq!(b("0b12"), None);
+        assert_eq!(b("0o18"), None);
+        assert_eq!(b("0xG"), None);
+        assert_eq!(b("Infinity"), None);
+        assert_eq!(b("abc"), None);
+    }
+
+    #[test]
+    fn non_ascii_digits_are_rejected() {
+        assert_eq!(b("\u{FF15}"), None); // fullwidth digit five
+        assert_eq!(b("\u{0665}"), None); // arabic-indic digit five
+    }
+
+    #[test]
+    fn only_strwhitespace_is_trimmed() {
+        // U+FEFF (ZWNBSP) IS StrWhiteSpace; U+0085 (NEL) is NOT. This matches
+        // `string_to_number` and node, and differs from `char::is_whitespace`.
+        assert_eq!(b("\u{FEFF}1"), v(1));
+        assert_eq!(b("1\u{FEFF}"), v(1));
+        assert_eq!(b("\u{FEFF}"), v(0));
+        assert_eq!(b("\u{0085}1"), None);
+        assert_eq!(b("\u{0085}"), None);
+    }
+
+    #[test]
+    fn large_values_round_trip() {
+        assert_eq!(b("18446744073709551616"), Some(BigInt::from(1u128 << 64)));
+        assert_eq!(b("0x10000000000000000"), Some(BigInt::from(1u128 << 64)));
     }
 }

--- a/test262-extra/BigInt-string-to-bigint-abstract-operation.js
+++ b/test262-extra/BigInt-string-to-bigint-abstract-operation.js
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 jsse contributors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  StringToBigInt is a single abstract operation shared by the BigInt
+  constructor, ToBigInt (typed-array element writes, DataView.setBigInt64,
+  %TypedArray%.prototype.with), and BigInt/String loose equality. Every
+  consumer must agree, and the operation must implement the grammar exactly:
+  the empty (or all-whitespace) String is 0n, only StrWhiteSpace is stripped,
+  and numeric separators, a sign inside a NonDecimalIntegerLiteral, decimal
+  points, exponents, and non-ASCII digits are all rejected.
+esid: sec-stringtobigint
+info: |
+  7.1.14 StringToBigInt ( str )
+    Let text be StringToCodePoints(str).
+    Let literal be ParseText(text, StringIntegerLiteral).
+    If literal is a List of errors, return undefined.
+    ...
+
+  StringIntegerLiteral :::
+    StrWhiteSpace_opt
+    StrWhiteSpace_opt StrIntegerLiteral StrWhiteSpace_opt
+  StrIntegerLiteral ::: SignedInteger | NonDecimalIntegerLiteral
+  (the [~Sep] forms — no NumericLiteralSeparator; a NonDecimalIntegerLiteral has
+  no sign; a SignedInteger has no radix point or exponent.)
+
+  7.1.13 ToBigInt ( argument ): for a String, n = StringToBigInt(prim); if n is
+  undefined, throw a SyntaxError.
+
+  7.2.15 IsLooselyEqual: BigInt x, String y -> let n be StringToBigInt(y); if n
+  is undefined, return false; else compare.
+features: [BigInt, TypedArray, DataView]
+---*/
+
+function Bi(str) { return BigInt(str); }
+
+// --- Valid controls: these must keep working unchanged ---
+assert.sameValue(Bi(""), 0n, 'empty string is 0n');
+assert.sameValue(Bi("     "), 0n, 'all-whitespace string is 0n');
+assert.sameValue(Bi("   -197   "), -197n, 'signed decimal with surrounding spaces');
+assert.sameValue(Bi("0xFF"), 255n, 'hex literal');
+assert.sameValue(Bi("0X1a"), 26n, 'hex literal, uppercase prefix, lowercase digits');
+assert.sameValue(Bi("0o17"), 15n, 'octal literal');
+assert.sameValue(Bi("0b1010"), 10n, 'binary literal');
+assert.sameValue(Bi("+5"), 5n, 'leading plus is allowed for SignedInteger');
+assert.sameValue(Bi("00"), 0n, 'leading zeros');
+
+// --- Numeric separators are NOT part of the string grammar ---
+assert.throws(SyntaxError, function () { Bi("1_0"); }, 'decimal separator');
+assert.throws(SyntaxError, function () { Bi("0x1_0"); }, 'hex separator');
+assert.throws(SyntaxError, function () { Bi("0b1_0"); }, 'binary separator');
+
+// --- A NonDecimalIntegerLiteral has no sign (the sign must precede, and only a
+//     decimal SignedInteger may carry one) ---
+assert.throws(SyntaxError, function () { Bi("0x-10"); }, 'sign inside hex body');
+assert.throws(SyntaxError, function () { Bi("0b-1"); }, 'sign inside binary body');
+assert.throws(SyntaxError, function () { Bi("-0x10"); }, 'sign before hex prefix');
+
+// --- No radix point, exponent, BigInt suffix, or stray digits ---
+assert.throws(SyntaxError, function () { Bi("1.5"); }, 'radix point');
+assert.throws(SyntaxError, function () { Bi("1e3"); }, 'exponent');
+assert.throws(SyntaxError, function () { Bi("10n"); }, 'BigInt suffix');
+assert.throws(SyntaxError, function () { Bi("0b12"); }, 'non-binary digit');
+
+// --- Non-ASCII digits are rejected ---
+assert.throws(SyntaxError, function () { Bi("５"); }, 'fullwidth digit five');
+assert.throws(SyntaxError, function () { Bi("٥"); }, 'arabic-indic digit five');
+
+// --- Whitespace: only StrWhiteSpace is stripped. U+FEFF (ZWNBSP) IS
+//     StrWhiteSpace; U+0085 (NEL) is NOT (matches StringToNumber / node, and
+//     differs from Rust's char::is_whitespace). ---
+assert.sameValue(Bi("﻿1"), 1n, 'U+FEFF is StrWhiteSpace and is stripped');
+assert.throws(SyntaxError, function () { Bi("1"); }, 'U+0085 (NEL) is not StrWhiteSpace');
+
+// --- ToBigInt agreement: typed-array element write ---
+(function () {
+  var a = new BigInt64Array(1);
+  a[0] = "";
+  assert.sameValue(a[0], 0n, 'typed-array element write: "" -> 0n');
+  a[0] = "0x10";
+  assert.sameValue(a[0], 16n, 'typed-array element write: hex');
+  assert.throws(SyntaxError, function () { a[0] = "0x-10"; }, 'typed-array element write: invalid string throws');
+})();
+
+// --- ToBigInt agreement: %TypedArray%.prototype.with ---
+(function () {
+  assert.sameValue(new BigInt64Array(1).with(0, "")[0], 0n, 'with(): "" -> 0n');
+  assert.sameValue(new BigInt64Array(1).with(0, "5")[0], 5n, 'with(): decimal');
+  assert.throws(SyntaxError, function () { new BigInt64Array(1).with(0, "1_0"); }, 'with(): separator throws');
+})();
+
+// --- ToBigInt agreement: DataView.setBigInt64 ---
+(function () {
+  var dv = new DataView(new ArrayBuffer(8));
+  dv.setBigInt64(0, "");
+  assert.sameValue(dv.getBigInt64(0), 0n, 'setBigInt64: "" -> 0n');
+  assert.throws(SyntaxError, function () { dv.setBigInt64(0, "0x-10"); }, 'setBigInt64: invalid string throws');
+})();
+
+// --- IsLooselyEqual agreement: a failed StringToBigInt yields `false`, never a
+//     throw, and the same whitespace/grammar rules apply ---
+assert.sameValue(1n == "", false, '1n == "" (empty -> 0n)');
+assert.sameValue(0n == "", true, '0n == "" (empty -> 0n)');
+assert.sameValue(0n == "﻿", true, '0n == U+FEFF (whitespace -> 0n)');
+assert.sameValue(0n == "", false, '0n == U+0085 (NEL not whitespace -> undefined)');
+assert.sameValue(1n == "﻿1", true, '1n == U+FEFF+"1" (ZWNBSP stripped)');
+assert.sameValue(1n == "1", false, '1n == U+0085+"1" (NEL not stripped -> undefined)');
+assert.sameValue(10n == "1_0", false, '10n == "1_0" (separator invalid -> undefined)');
+assert.sameValue(16n == "0x10", true, '16n == "0x10" (hex string)');


### PR DESCRIPTION
## Refactoring audit → most impactful, low-risk deepening

Ran the `improve-codebase-architecture` audit over the interpreter (weighted toward the hot spots — `eval.rs` is the largest file at ~17k lines and by far the most-churned). Surfaced candidates, ranked by *(maintainability impact) × (low behavioral risk) × (isolated testability)*:

| # | Candidate | Notes |
|---|-----------|-------|
| **1** | **StringToBigInt duplication (this PR)** | Pure ~25-line operation duplicated **4×** with divergent behavior; unit-testable; fixes real bugs |
| 2 | Generator / async-generator runtime | ~6,900 lines (40% of `eval.rs`) behind a 9-method interface with a single consumer — highest raw impact, but not unit-testable and only verifiable with a full test262 run; **deferred to an issue** |
| 3 | ToX coercion ops → `eval/coercion.rs` | Cohesive, but a pure code move with no behavioral seam to test |
| 4 | Assignment/destructuring extraction | Entangled with the generator `yield_val` out-param threading |

I picked **#1**: it is a genuine "two-adapters-become-a-seam" deepening, it is exhaustively testable as a pure function, and — unlike #2 — it can be fully verified in one run without the full test262 suite. The generator-runtime extraction (#2) is filed separately so the audit's top finding isn't lost.

## What changed

Runtime **StringToBigInt** (spec `sec-stringtobigint`, §7.1.14) was implemented **four times** with subtly different behavior:

- `string_to_bigint_for_comparison` — BigInt/String loose equality & relational
- inline parse inside `to_bigint_value` — ToBigInt (typed-array element writes, `DataView.setBigInt64`)
- the `BigInt()` constructor
- `to_bigint_throwing` — `%TypedArray%.prototype.with` / typed-array coercion

Each hand-rolled the grammar on top of `num_bigint`, which **leniently ignores `_` separators and accepts a sign after a `0x`/`0o`/`0b` prefix**, and each trimmed with Rust's `str::trim()` (which adds U+0085/NEL and omits U+FEFF/ZWNBSP) instead of ECMAScript `StrWhiteSpace`.

This PR **deepens the four copies into one canonical `helpers::string_to_bigint`**, a sibling of the existing `string_to_number` that shares its `is_ecma_whitespace` trimming. The one narrow interface (`&str -> Option<BigInt>`) hides the parsing mechanism; all four consumers route through it. Net: ~90 lines of duplicated parsing removed.

### Bugs fixed as a side effect (all cross-checked against `node`)

| Input | Before | After (= node) |
|-------|--------|----------------|
| `BigInt("1_0")` | `10n` | `SyntaxError` |
| `BigInt("0x1_0")` | `16n` | `SyntaxError` |
| `BigInt("0x-10")` | `-16n` | `SyntaxError` |
| `BigInt(U+FEFF + "1")` | `SyntaxError` | `1n` |
| `BigInt(U+0085 + "1")` | `1n` | `SyntaxError` |
| `new BigInt64Array(1).with(0, "")` | throws | `0n` |
| `a[0] = "0x-10"` / `DataView.setBigInt64(0,"0x-10")` | `-16n` | `SyntaxError` |
| `10n == "1_0"` | `true` | `false` |

## Tests (TDD: red → green)

- **Rust unit tests** (`string_to_bigint_tests` in `helpers.rs`) pin the pure operation directly against the grammar — expected values are the independent source of truth (spec + `node`), never recomputed from the implementation.
- **`test262-extra/BigInt-string-to-bigint-abstract-operation.js`** pins *agreement across all consumers* (constructor, typed-array element write, `DataView.setBigInt64`, `%TypedArray%.with`, loose equality). It **fails on `main`** (both sloppy and strict) and passes here — a demonstrable red → green.

## Verification

- `cargo test --release`: **486 passed, 0 failed**
- test262 subsets covering **every enumerated consumer** of the unified operation (loose equality/relational, `BigInt()`/`asIntN`/`asUintN`, ToBigInt via typed-array element writes, `DataView.setBigInt64`, `%TypedArray%.{set,with,from,of,fill}`, and `Atomics` on BigInt arrays):
  - Run A — `BigInt/`, `DataView/`, `TypedArray/prototype/{set,with}/`, `TypedArrayConstructors/`, `equals/`, `does-not-equals/`, `less-than/`, `greater-than/`: **3340/3340, 0 regressions**
  - Run B — full `built-ins/TypedArray/`, `built-ins/Atomics/`, `less-than-or-equal/`, `greater-than-or-equal/`: **3832/3832, 0 regressions** (+2 incidental new passes)
- `test262-extra/`: **134/134** · custom `tests/`: **11/11**
- `./scripts/lint.sh`: rustfmt + clippy clean

Because the change is strictly *toward* the spec (it only rejects malformed input that `node`/test262 also reject, and fixes whitespace), a genuine regression would require a test262 test that depends on the old lenient parse — which cannot exist.

Two notes:
- The full test262 suite was **not** run in this unattended session (submodule fetched shallow), so `README.md`'s headline pass count is intentionally left untouched — the subsets above cover every operation this change touches.
- Dropping the pre-`trim()` in `bigint.rs`/`typedarray.rs` means the `SyntaxError` *message* now embeds the untrimmed input (e.g. `"Cannot convert  10  to a BigInt"`). test262 asserts the error type only, so this is harmless, but it is a user-visible message change.
