### PR TITLE
refactor(date): unify Date.prototype thisTimeValue brand check into one helper

### DIFF
--- a/src/interpreter/builtins/date.rs
+++ b/src/interpreter/builtins/date.rs
@@ -15,6 +15,33 @@ fn date_field_value(t: f64, local: bool, component: fn(f64) -> f64) -> f64 {
     component(if local { local_time(t) } else { t })
 }
 
+/// Resolve `this`'s [[DateValue]] time value: `Some(t)` when `this` is a Date
+/// (an object whose `class_name` is `"Date"`), `None` otherwise. The single
+/// extractor behind every `Date.prototype` method's `thisTimeValue` brand check;
+/// `require_time_value` wraps it with the standard TypeError.
+fn this_time_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
+    if let Some(object_id) = this.as_object_id()
+        && let Some(obj) = interp.get_object_cell(object_id)
+    {
+        let object = obj.borrow();
+        if object.class_name == "Date" {
+            return object.primitive_value.as_ref().and_then(JsValue::as_number);
+        }
+    }
+    None
+}
+
+/// The `thisTimeValue(this value)` abstract operation: the Date's time value, or
+/// the standard `TypeError` when `this` has no [[DateValue]] internal slot. Every
+/// `Date.prototype` method that reads the time value brand-checks its receiver
+/// through here, so the check and its message live in exactly one place.
+fn require_time_value(interp: &mut Interpreter, this: &JsValue) -> Result<f64, JsValue> {
+    match this_time_value(interp, this) {
+        Some(t) => Ok(t),
+        None => Err(interp.create_type_error("this is not a Date object")),
+    }
+}
+
 fn date_to_locale_string(
     interp: &mut Interpreter,
     this: &JsValue,
@@ -22,24 +49,12 @@ fn date_to_locale_string(
     required: &str,
     defaults: &str,
 ) -> Completion {
-    fn this_time_value_locale(interp: &Interpreter, this: &JsValue) -> Option<f64> {
-        if let Some(object_id) = this.as_object_id()
-            && let Some(obj) = interp.get_object_cell(object_id)
-        {
-            let object = obj.borrow();
-            if object.class_name == "Date" {
-                return object.primitive_value.as_ref().and_then(JsValue::as_number);
-            }
-        }
-        None
-    }
-
-    let tv = match this_time_value_locale(interp, this) {
-        Some(t) => t,
-        None => {
-            let e = interp.create_type_error("this is not a Date object");
-            return Completion::Throw(e);
-        }
+    // thisTimeValue brand check (step 1): must run before ToDateTimeOptions
+    // processes the `options` argument below, so a non-Date receiver throws the
+    // TypeError even when the options argument would itself throw.
+    let tv = match require_time_value(interp, this) {
+        Ok(t) => t,
+        Err(e) => return Completion::Throw(e),
     };
 
     if tv.is_nan() {
@@ -224,18 +239,6 @@ impl Interpreter {
             .class_name = "Date".to_string();
         // Date.prototype does NOT have [[DateValue]] per spec
 
-        fn this_time_value(interp: &Interpreter, this: &JsValue) -> Option<f64> {
-            if let Some(object_id) = this.as_object_id()
-                && let Some(obj) = interp.get_object_cell(object_id)
-            {
-                let object = obj.borrow();
-                if object.class_name == "Date" {
-                    return object.primitive_value.as_ref().and_then(JsValue::as_number);
-                }
-            }
-            None
-        }
-
         // Guard wrapper around `date_field_value`: brand-check `this` as a Date
         // (throwing the standard TypeError otherwise), then delegate the NaN /
         // local-vs-UTC / component logic to the pure core. Every `get*` component
@@ -246,14 +249,9 @@ impl Interpreter {
             local: bool,
             component: fn(f64) -> f64,
         ) -> Completion {
-            match this_time_value(interp, this) {
-                Some(t) => {
-                    Completion::Normal(JsValue::number(date_field_value(t, local, component)))
-                }
-                None => {
-                    let e = interp.create_type_error("this is not a Date object");
-                    Completion::Throw(e)
-                }
+            match require_time_value(interp, this) {
+                Ok(t) => Completion::Normal(JsValue::number(date_field_value(t, local, component))),
+                Err(e) => Completion::Throw(e),
             }
         }
 
@@ -414,10 +412,9 @@ impl Interpreter {
                 "setTime",
                 1,
                 Rc::new(|interp, this, args| {
-                    let Some(_) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
+                    if let Err(e) = require_time_value(interp, this) {
                         return Completion::Throw(e);
-                    };
+                    }
                     let v = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
                         Err(e) => return Completion::Throw(e),
@@ -431,9 +428,9 @@ impl Interpreter {
                 "setMilliseconds",
                 1,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let ms = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -452,9 +449,9 @@ impl Interpreter {
                 "setUTCMilliseconds",
                 1,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let ms = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -471,9 +468,9 @@ impl Interpreter {
                 "setSeconds",
                 2,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let s = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -500,9 +497,9 @@ impl Interpreter {
                 "setUTCSeconds",
                 2,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let s = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -528,9 +525,9 @@ impl Interpreter {
                 "setMinutes",
                 3,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let m = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -566,9 +563,9 @@ impl Interpreter {
                 "setUTCMinutes",
                 3,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let m = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -603,9 +600,9 @@ impl Interpreter {
                 "setHours",
                 4,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let h = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -650,9 +647,9 @@ impl Interpreter {
                 "setUTCHours",
                 4,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let h = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -696,9 +693,9 @@ impl Interpreter {
                 "setDate",
                 1,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let dt = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -716,9 +713,9 @@ impl Interpreter {
                 "setUTCDate",
                 1,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let dt = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -735,9 +732,9 @@ impl Interpreter {
                 "setMonth",
                 2,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let m = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -764,9 +761,9 @@ impl Interpreter {
                 "setUTCMonth",
                 2,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let m = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -792,9 +789,9 @@ impl Interpreter {
                 "setFullYear",
                 3,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     let y = match arg_num_or(interp, args, 0, f64::NAN) {
                         Ok(n) => n,
@@ -818,9 +815,9 @@ impl Interpreter {
                 "setUTCFullYear",
                 3,
                 Rc::new(|interp, this, args| {
-                    let Some(t) = this_time_value(interp, this) else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     // Per spec: NaN check before ToNumber for setUTCFullYear
                     let t_adj = if t.is_nan() { 0.0 } else { t };
@@ -844,82 +841,83 @@ impl Interpreter {
             (
                 "toString",
                 0,
-                Rc::new(|interp, this, _args| match this_time_value(interp, this) {
-                    Some(t) if t.is_nan() => {
-                        Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")))
+                Rc::new(|interp, this, _args| {
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
+                    };
+                    if t.is_nan() {
+                        return Completion::Normal(JsValue::string(JsString::from_str(
+                            "Invalid Date",
+                        )));
                     }
-                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
-                        &format_date_string(t),
-                    ))),
-                    None => {
-                        let e = interp.create_type_error("this is not a Date object");
-                        Completion::Throw(e)
-                    }
+                    Completion::Normal(JsValue::string(JsString::from_str(&format_date_string(t))))
                 }),
             ),
             (
                 "toDateString",
                 0,
-                Rc::new(|interp, this, _args| match this_time_value(interp, this) {
-                    Some(t) if t.is_nan() => {
-                        Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")))
+                Rc::new(|interp, this, _args| {
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
+                    };
+                    if t.is_nan() {
+                        return Completion::Normal(JsValue::string(JsString::from_str(
+                            "Invalid Date",
+                        )));
                     }
-                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
+                    Completion::Normal(JsValue::string(JsString::from_str(
                         &format_date_only_string(t),
-                    ))),
-                    None => {
-                        let e = interp.create_type_error("this is not a Date object");
-                        Completion::Throw(e)
-                    }
+                    )))
                 }),
             ),
             (
                 "toTimeString",
                 0,
-                Rc::new(|interp, this, _args| match this_time_value(interp, this) {
-                    Some(t) if t.is_nan() => {
-                        Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")))
+                Rc::new(|interp, this, _args| {
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
+                    };
+                    if t.is_nan() {
+                        return Completion::Normal(JsValue::string(JsString::from_str(
+                            "Invalid Date",
+                        )));
                     }
-                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
+                    Completion::Normal(JsValue::string(JsString::from_str(
                         &format_time_only_string(t),
-                    ))),
-                    None => {
-                        let e = interp.create_type_error("this is not a Date object");
-                        Completion::Throw(e)
-                    }
+                    )))
                 }),
             ),
             (
                 "toISOString",
                 0,
-                Rc::new(|interp, this, _args| match this_time_value(interp, this) {
-                    Some(t) if !t.is_finite() => {
-                        let e = interp.create_range_error("Invalid time value");
-                        Completion::Throw(e)
+                Rc::new(|interp, this, _args| {
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
+                    };
+                    if !t.is_finite() {
+                        return Completion::Throw(interp.create_range_error("Invalid time value"));
                     }
-                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
-                        &format_iso_string(t),
-                    ))),
-                    None => {
-                        let e = interp.create_type_error("this is not a Date object");
-                        Completion::Throw(e)
-                    }
+                    Completion::Normal(JsValue::string(JsString::from_str(&format_iso_string(t))))
                 }),
             ),
             (
                 "toUTCString",
                 0,
-                Rc::new(|interp, this, _args| match this_time_value(interp, this) {
-                    Some(t) if t.is_nan() => {
-                        Completion::Normal(JsValue::string(JsString::from_str("Invalid Date")))
+                Rc::new(|interp, this, _args| {
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
+                    };
+                    if t.is_nan() {
+                        return Completion::Normal(JsValue::string(JsString::from_str(
+                            "Invalid Date",
+                        )));
                     }
-                    Some(t) => Completion::Normal(JsValue::string(JsString::from_str(
-                        &format_utc_string(t),
-                    ))),
-                    None => {
-                        let e = interp.create_type_error("this is not a Date object");
-                        Completion::Throw(e)
-                    }
+                    Completion::Normal(JsValue::string(JsString::from_str(&format_utc_string(t))))
                 }),
             ),
             // toJSON per spec:
@@ -996,10 +994,9 @@ impl Interpreter {
                 0,
                 Rc::new(|interp, this, _args| {
                     // §21.4.4.45 Date.prototype.toTemporalInstant()
-                    let t = this_time_value(interp, this);
-                    let Some(t) = t else {
-                        let e = interp.create_type_error("this is not a Date object");
-                        return Completion::Throw(e);
+                    let t = match require_time_value(interp, this) {
+                        Ok(t) => t,
+                        Err(e) => return Completion::Throw(e),
                     };
                     if t.is_nan() {
                         let e = interp.create_range_error("Invalid time value");
@@ -1378,9 +1375,9 @@ impl Interpreter {
             "setYear".to_string(),
             1,
             Rc::new(|interp, this, args| {
-                let Some(t) = this_time_value(interp, this) else {
-                    let e = interp.create_type_error("this is not a Date object");
-                    return Completion::Throw(e);
+                let t = match require_time_value(interp, this) {
+                    Ok(t) => t,
+                    Err(e) => return Completion::Throw(e),
                 };
                 let y = match arg_num_or(interp, args, 0, f64::NAN) {
                     Ok(n) => n,

--- a/test262-extra/Date-prototype-locale-format-brand-check-order.js
+++ b/test262-extra/Date-prototype-locale-format-brand-check-order.js
@@ -1,0 +1,104 @@
+/*---
+description: >
+  Date.prototype.toLocaleString, toLocaleDateString, and toLocaleTimeString run
+  the thisTimeValue brand check on their receiver BEFORE consulting the
+  `locales`/`options` arguments. A receiver without a [[DateValue]] internal
+  slot must throw a TypeError from step 1 even when the `options` argument would
+  itself throw while ToDateTimeOptions reads a property from it, and an Invalid
+  Date must short-circuit to "Invalid Date" at step 2 without ever reading the
+  options. This pins the ordering guaranteed by the shared Date brand-check
+  seam. test262's own intl402 this-value-non-date coverage calls these methods
+  with no arguments, so it never exercises this ordering.
+esid: sec-date.prototype.tolocalestring
+info: |
+  Date.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )
+    1. Let x be ? thisTimeValue(this value).
+    2. If x is NaN, return "Invalid Date".
+    3. Let options be ? ToDateTimeOptions(options, "any", "all").
+    4. Let dateFormat be ? Construct(%DateTimeFormat%, ( locales, options )).
+    5. Return ? FormatDateTime(dateFormat, x).
+
+  Date.prototype.toLocaleDateString ( [ reserved1 [ , reserved2 ] ] )
+    1. Let x be ? thisTimeValue(this value).
+    2. If x is NaN, return "Invalid Date".
+    3. Let options be ? ToDateTimeOptions(options, "date", "date").
+    ...
+
+  Date.prototype.toLocaleTimeString ( [ reserved1 [ , reserved2 ] ] )
+    1. Let x be ? thisTimeValue(this value).
+    2. If x is NaN, return "Invalid Date".
+    3. Let options be ? ToDateTimeOptions(options, "time", "time").
+    ...
+
+  thisTimeValue ( value )
+    1. If value is an Object and value has a [[DateValue]] internal slot, then
+       a. Return value.[[DateValue]].
+    2. Throw a TypeError exception.
+---*/
+
+var localeMethods = ["toLocaleString", "toLocaleDateString", "toLocaleTimeString"];
+
+// An options argument that throws the instant ToDateTimeOptions reads any
+// property from it. If the brand check (or the Invalid Date short-circuit) runs
+// first, as required, none of these getters is ever touched.
+function poisonedOptions(tag) {
+  return {
+    get localeMatcher() { throw new Test262Error("options read: " + tag); },
+    get year() { throw new Test262Error("options read: " + tag); },
+    get month() { throw new Test262Error("options read: " + tag); },
+    get hour() { throw new Test262Error("options read: " + tag); },
+    get dateStyle() { throw new Test262Error("options read: " + tag); },
+    get timeStyle() { throw new Test262Error("options read: " + tag); }
+  };
+}
+
+var nonDateReceivers = [
+  ["ordinary object", {}],
+  ["number", 5],
+  ["string", "1970"],
+  ["null", null],
+  ["undefined", undefined],
+  ["Date.prototype itself", Date.prototype],
+  ["object inheriting from Date.prototype", Object.create(Date.prototype)]
+];
+
+localeMethods.forEach(function (name) {
+  var method = Date.prototype[name];
+  assert.sameValue(typeof method, "function", "Date.prototype." + name + " is callable");
+
+  nonDateReceivers.forEach(function (entry) {
+    var label = entry[0];
+    var receiver = entry[1];
+    assert.throws(
+      TypeError,
+      function () { method.call(receiver, undefined, poisonedOptions(name)); },
+      "Date.prototype." + name + " brand-checks " + label + " before reading the options argument"
+    );
+  });
+});
+
+// An Invalid Date resolves the brand check but short-circuits to "Invalid Date"
+// at step 2, still before any option processing: the poisoned options argument
+// must not be consulted.
+localeMethods.forEach(function (name) {
+  var method = Date.prototype[name];
+  var out = method.call(new Date(NaN), undefined, poisonedOptions(name));
+  assert.sameValue(
+    out,
+    "Invalid Date",
+    "Date.prototype." + name + " on an Invalid Date returns 'Invalid Date' without reading options"
+  );
+});
+
+// Positive control: a real Date passes the brand check and formats without
+// throwing, so the assertions above are not vacuously satisfied by every call
+// throwing regardless of receiver.
+localeMethods.forEach(function (name) {
+  var method = Date.prototype[name];
+  var out = method.call(new Date(0));
+  assert.sameValue(
+    typeof out,
+    "string",
+    "Date.prototype." + name + " on a real Date returns a formatted string"
+  );
+});


### PR DESCRIPTION
## What & why

Architecture audit (via the `improve-codebase-architecture` skill) surfaced a **shallow, duplicated seam** in `src/interpreter/builtins/date.rs`: every `Date.prototype` method that reads the time value open-coded the `thisTimeValue` brand check.

- **Two byte-identical extractor functions** — `this_time_value` (nested in `setup_date_builtin`) and `this_time_value_locale` (nested in `date_to_locale_string`) — that could silently drift apart.
- **24 hand-copied throw sites** — `create_type_error("this is not a Date object")` spelled out in each getter's `date_field` guard, every `set*` method, the five formatters, `toTemporalInstant`, and Annex B `setYear`.

This is a classic deepening opportunity: the brand-check logic was spread thin across the file with no single place to test or change it.

## The change

Collapse the extractor into one module-level `this_time_value`, and route all 24 sites through a single **deep seam** — `require_time_value(interp, this) -> Result<f64, JsValue>` — that owns the brand check and its `TypeError`.

- `"this is not a Date object"` now appears **exactly once** (was 24×).
- `this_time_value` is called **exactly once** — inside `require_time_value`; the two duplicated extractors are gone.
- 24 call sites share one interface (leverage); a bug in the brand check now concentrates in one function (locality).

Behavior is unchanged — no method's throw-vs-return, error type, or check ordering moves. In `date_to_locale_string` the check is deliberately kept **before** `ToDateTimeOptions` (spec step 1 before step 3).

## TDD / validation

The refactor is behavior-preserving, so — per the `tdd` skill's own note that refactoring is not part of the red→green loop — TDD is applied as *discipline*: a characterization test at the public seam, written and confirmed green **before** the refactor, kept green after.

The safety net for the per-method brand check is the **existing test262 Date suite**, which already covers it densely (e.g. `setFullYear/this-value-non-date.js` asserts `callCount === 0`, "validation precedes input coercion" — the setter arg-coercion ordering was already covered). To avoid duplicating that, the added fixture targets the **one spec-mandated ordering test262's default coverage omits**:

`test262-extra/Date-prototype-locale-format-brand-check-order.js` — `toLocaleString`/`toLocaleDateString`/`toLocaleTimeString` must brand-check the receiver **before** reading the `options` argument (intl402's `this-value-non-date.js` passes no options, so it never exercises this), and an Invalid Date must short-circuit to `"Invalid Date"` without consulting options. Both invariants were confirmed against node before being pinned.

### Results (all green)
- **node differential** — every `Date.prototype` method × six non-Date receivers: throw-vs-return + error type identical to node, before and after; brand-check-before-argument-coercion ordering identical.
- **test262 Date subsets** — `built-ins/Date` + `intl402/Date` + `annexB/built-ins/Date` = **1260/1260 scenarios, 0 regressions** (baseline was also 1260/1260).
- **test262-extra** — 140/140 in both normal and bytecode modes (new fixture included).
- `cargo test --release` — 484 unit + integration tests pass; custom tests 11/11; `./scripts/lint.sh` clean.

### Scope note
The change is confined to `date.rs`, so validation targets the Date subsets (1260 scenarios) rather than the full suite, which was not run in this environment. `test262-pass.txt` is intentionally untouched (feature branch; no `--update-baseline`), and README's pass count is unchanged because the change is behavior-preserving (0 regressions, 0 new passes).

🤖 Generated with Claude Code