### PR TITLE
refactor(interpreter): extract pure eval hoisting analysis into a tested module

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -13647,110 +13647,6 @@ impl Interpreter {
         self.dispose_resources(&lex_env, result.update_empty(JsValue::UNDEFINED))
     }
 
-    /// Collect top-level var-declared names from eval body (recursively into blocks, etc.)
-    fn collect_eval_var_names(stmts: &[Statement], names: &mut Vec<String>) {
-        for stmt in stmts {
-            Self::collect_eval_var_names_from_stmt(stmt, names);
-        }
-    }
-
-    fn collect_eval_var_names_from_stmt(stmt: &Statement, names: &mut Vec<String>) {
-        match stmt {
-            Statement::Variable(decl) if decl.kind == VarKind::Var => {
-                for d in &decl.declarations {
-                    d.pattern.bound_names(names);
-                }
-            }
-            Statement::Block(stmts) => {
-                for s in stmts {
-                    Self::collect_eval_var_names_from_stmt(s, names);
-                }
-            }
-            Statement::If(i) => {
-                Self::collect_eval_var_names_from_stmt(&i.consequent, names);
-                if let Some(alt) = &i.alternate {
-                    Self::collect_eval_var_names_from_stmt(alt, names);
-                }
-            }
-            Statement::While(w) => Self::collect_eval_var_names_from_stmt(&w.body, names),
-            Statement::DoWhile(d) => Self::collect_eval_var_names_from_stmt(&d.body, names),
-            Statement::For(f) => {
-                if let Some(ForInit::Variable(decl)) = &f.init
-                    && decl.kind == VarKind::Var
-                {
-                    for d in &decl.declarations {
-                        d.pattern.bound_names(names);
-                    }
-                }
-                Self::collect_eval_var_names_from_stmt(&f.body, names);
-            }
-            Statement::ForIn(fi) => {
-                if let ForInOfLeft::Variable(decl) = &fi.left
-                    && decl.kind == VarKind::Var
-                {
-                    for d in &decl.declarations {
-                        d.pattern.bound_names(names);
-                    }
-                }
-                Self::collect_eval_var_names_from_stmt(&fi.body, names);
-            }
-            Statement::ForOf(fo) => {
-                if let ForInOfLeft::Variable(decl) = &fo.left
-                    && decl.kind == VarKind::Var
-                {
-                    for d in &decl.declarations {
-                        d.pattern.bound_names(names);
-                    }
-                }
-                Self::collect_eval_var_names_from_stmt(&fo.body, names);
-            }
-            Statement::Switch(sw) => {
-                for case in &sw.cases {
-                    for s in &case.consequent {
-                        Self::collect_eval_var_names_from_stmt(s, names);
-                    }
-                }
-            }
-            Statement::Try(t) => {
-                for s in &t.block {
-                    Self::collect_eval_var_names_from_stmt(s, names);
-                }
-                if let Some(handler) = &t.handler {
-                    for s in &handler.body {
-                        Self::collect_eval_var_names_from_stmt(s, names);
-                    }
-                }
-                if let Some(finalizer) = &t.finalizer {
-                    for s in finalizer {
-                        Self::collect_eval_var_names_from_stmt(s, names);
-                    }
-                }
-            }
-            Statement::Labeled(_, inner) => {
-                Self::collect_eval_var_names_from_stmt(inner, names);
-            }
-            Statement::With(_, inner) => {
-                Self::collect_eval_var_names_from_stmt(inner, names);
-            }
-            _ => {}
-        }
-    }
-
-    /// Collect top-level function declarations from eval body (only top-level, not inside blocks)
-    fn collect_eval_function_decls(stmts: &[Statement]) -> Vec<FunctionDecl> {
-        let mut funcs = Vec::new();
-        for stmt in stmts {
-            if let Some(f) = Self::unwrap_labeled_function(stmt) {
-                funcs.push(f.clone());
-            }
-        }
-        // Per spec: reverse order, keep last occurrence of each name
-        funcs.reverse();
-        let mut seen = HashSet::new();
-        funcs.retain(|f| seen.insert(f.name.clone()));
-        funcs
-    }
-
     /// EvalDeclarationInstantiation per spec 19.2.1.4
     fn eval_declaration_instantiation(
         &mut self,
@@ -13764,13 +13660,12 @@ impl Interpreter {
         let is_global = var_env.borrow().global_object_id.is_some();
 
         // Collect function declarations to initialize
-        let functions_to_init = Self::collect_eval_function_decls(body);
+        let functions_to_init = super::hoisting::collect_function_decls(body);
         let declared_func_names: Vec<String> =
             functions_to_init.iter().map(|f| f.name.clone()).collect();
 
         // Collect var-declared names (excluding those that are also function names)
-        let mut all_var_names = Vec::new();
-        Self::collect_eval_var_names(body, &mut all_var_names);
+        let all_var_names = super::hoisting::collect_var_names(body);
         let declared_var_names: Vec<String> = {
             let mut seen = HashSet::new();
             all_var_names

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -95,7 +95,7 @@ impl Interpreter {
         for stmt in stmts {
             // Check for function declarations (including inside labels). This
             // builds fresh closures per call and is never cached.
-            if let Some(f) = Self::unwrap_labeled_function(stmt) {
+            if let Some(f) = super::hoisting::unwrap_labeled_function(stmt) {
                 self.hoist_function_decl(f, env, is_global);
             }
         }
@@ -231,14 +231,6 @@ impl Interpreter {
         result
     }
 
-    pub(crate) fn unwrap_labeled_function(stmt: &Statement) -> Option<&FunctionDecl> {
-        match stmt {
-            Statement::FunctionDeclaration(f) => Some(f),
-            Statement::Labeled(_, inner) => Self::unwrap_labeled_function(inner),
-            _ => None,
-        }
-    }
-
     /// §9.1.1.4.16 CanDeclareGlobalFunction
     fn can_declare_global_function(gb: &JsObjectData, name: &str) -> bool {
         if let Some(desc) = gb.properties.get(name) {
@@ -344,7 +336,7 @@ impl Interpreter {
         // Collect function declaration names (step 10)
         let mut declared_function_names: Vec<String> = Vec::new();
         for stmt in stmts.iter().rev() {
-            if let Some(f) = Self::unwrap_labeled_function(stmt)
+            if let Some(f) = super::hoisting::unwrap_labeled_function(stmt)
                 && !declared_function_names.contains(&f.name)
             {
                 // Step 6 also applies to function decl names
@@ -2305,7 +2297,7 @@ impl Interpreter {
         // (only regular functions, not generators/async — those stay block-scoped)
         for case in &s.cases {
             for stmt in &case.consequent {
-                let unwrapped = Self::unwrap_labeled_function(stmt);
+                let unwrapped = super::hoisting::unwrap_labeled_function(stmt);
                 if let Some(f) = unwrapped
                     && !f.is_generator
                     && !f.is_async

--- a/src/interpreter/hoisting.rs
+++ b/src/interpreter/hoisting.rs
@@ -1,0 +1,226 @@
+//! Static-semantics analysis of a statement list for declaration hoisting.
+//!
+//! Pure functions over the AST used by `EvalDeclarationInstantiation`
+//! (§19.2.1.4) and by block/global declaration processing: collecting the
+//! `var`-declared names and the hoistable top-level function declarations of a
+//! body. Kept free of `Interpreter` state so the subtle scope-traversal rules
+//! (descend into blocks/`if`/loops/`try` but *not* into nested functions) are
+//! unit-testable in isolation. Distinct from the runtime per-body hoisting
+//! *cache* on `Interpreter` (#72), which memoises the output of this analysis.
+
+use crate::ast::{ForInOfLeft, ForInit, FunctionDecl, Statement, VarKind};
+use std::collections::HashSet;
+
+/// Unwrap a (possibly label-wrapped) function declaration. A `FunctionDeclaration`
+/// nested under any number of `Labeled` statements is still a function
+/// declaration for hoisting purposes (§14.13.4); anything else is not.
+pub(crate) fn unwrap_labeled_function(stmt: &Statement) -> Option<&FunctionDecl> {
+    match stmt {
+        Statement::FunctionDeclaration(f) => Some(f),
+        Statement::Labeled(_, inner) => unwrap_labeled_function(inner),
+        _ => None,
+    }
+}
+
+/// Collect the top-level `var`-declared names of a statement list, descending
+/// into nested statements (blocks, `if`, loops, `switch`, `try`, labels,
+/// `with`) but never into nested function bodies. Order and duplicates mirror
+/// source order; de-duplication is the caller's responsibility.
+pub(crate) fn collect_var_names(stmts: &[Statement]) -> Vec<String> {
+    let mut names = Vec::new();
+    for stmt in stmts {
+        collect_var_names_from_stmt(stmt, &mut names);
+    }
+    names
+}
+
+/// Collect the top-level hoistable function declarations of a statement list
+/// (only top level — including under labels — never inside nested blocks), with
+/// the spec's "keep the last declaration of each name" de-duplication
+/// (§19.2.1.4 / Annex B). The returned order is the consumption contract of
+/// `EvalDeclarationInstantiation`: reverse of source order, keeping, for each
+/// name, its last source occurrence.
+pub(crate) fn collect_function_decls(stmts: &[Statement]) -> Vec<FunctionDecl> {
+    let mut funcs = Vec::new();
+    for stmt in stmts {
+        if let Some(f) = unwrap_labeled_function(stmt) {
+            funcs.push(f.clone());
+        }
+    }
+    // Per spec: reverse order, keep last occurrence of each name.
+    funcs.reverse();
+    let mut seen = HashSet::new();
+    funcs.retain(|f| seen.insert(f.name.clone()));
+    funcs
+}
+
+fn collect_var_names_from_stmt(stmt: &Statement, names: &mut Vec<String>) {
+    match stmt {
+        Statement::Variable(decl) if decl.kind == VarKind::Var => {
+            for d in &decl.declarations {
+                d.pattern.bound_names(names);
+            }
+        }
+        Statement::Block(stmts) => {
+            for s in stmts {
+                collect_var_names_from_stmt(s, names);
+            }
+        }
+        Statement::If(i) => {
+            collect_var_names_from_stmt(&i.consequent, names);
+            if let Some(alt) = &i.alternate {
+                collect_var_names_from_stmt(alt, names);
+            }
+        }
+        Statement::While(w) => collect_var_names_from_stmt(&w.body, names),
+        Statement::DoWhile(d) => collect_var_names_from_stmt(&d.body, names),
+        Statement::For(f) => {
+            if let Some(ForInit::Variable(decl)) = &f.init
+                && decl.kind == VarKind::Var
+            {
+                for d in &decl.declarations {
+                    d.pattern.bound_names(names);
+                }
+            }
+            collect_var_names_from_stmt(&f.body, names);
+        }
+        Statement::ForIn(fi) => {
+            if let ForInOfLeft::Variable(decl) = &fi.left
+                && decl.kind == VarKind::Var
+            {
+                for d in &decl.declarations {
+                    d.pattern.bound_names(names);
+                }
+            }
+            collect_var_names_from_stmt(&fi.body, names);
+        }
+        Statement::ForOf(fo) => {
+            if let ForInOfLeft::Variable(decl) = &fo.left
+                && decl.kind == VarKind::Var
+            {
+                for d in &decl.declarations {
+                    d.pattern.bound_names(names);
+                }
+            }
+            collect_var_names_from_stmt(&fo.body, names);
+        }
+        Statement::Switch(sw) => {
+            for case in &sw.cases {
+                for s in &case.consequent {
+                    collect_var_names_from_stmt(s, names);
+                }
+            }
+        }
+        Statement::Try(t) => {
+            for s in &t.block {
+                collect_var_names_from_stmt(s, names);
+            }
+            if let Some(handler) = &t.handler {
+                for s in &handler.body {
+                    collect_var_names_from_stmt(s, names);
+                }
+            }
+            if let Some(finalizer) = &t.finalizer {
+                for s in finalizer {
+                    collect_var_names_from_stmt(s, names);
+                }
+            }
+        }
+        Statement::Labeled(_, inner) => {
+            collect_var_names_from_stmt(inner, names);
+        }
+        Statement::With(_, inner) => {
+            collect_var_names_from_stmt(inner, names);
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::Parser;
+
+    fn parse(source: &str) -> crate::ast::Program {
+        Parser::new(source)
+            .expect("parser init")
+            .parse_program()
+            .expect("parse program")
+    }
+
+    fn var_names(source: &str) -> Vec<String> {
+        collect_var_names(parse(source).body.as_slice())
+    }
+
+    #[test]
+    fn collects_top_level_and_block_nested_var_names() {
+        // A bare `var` and a `var` nested in a block both hoist to the body.
+        assert_eq!(var_names("var x; { var y; }"), vec!["x", "y"]);
+    }
+
+    #[test]
+    fn does_not_descend_into_nested_function_declarations() {
+        // `var z` inside a nested function does NOT hoist to the enclosing body.
+        // (Node: `eval("var a; function g(){ var b; } a")` defines `a`, not `b`.)
+        assert_eq!(var_names("var a; function g(){ var b; }"), vec!["a"]);
+    }
+
+    fn unwrapped_name(source: &str) -> Option<String> {
+        let program = parse(source);
+        let first = &program.body.as_slice()[0];
+        unwrap_labeled_function(first).map(|f| f.name.clone())
+    }
+
+    #[test]
+    fn unwraps_plain_and_labeled_function_declarations() {
+        assert_eq!(unwrapped_name("function f(){}"), Some("f".to_string()));
+        assert_eq!(unwrapped_name("l: function g(){}"), Some("g".to_string()));
+        assert_eq!(
+            unwrapped_name("l1: l2: function h(){}"),
+            Some("h".to_string())
+        );
+    }
+
+    #[test]
+    fn unwrap_rejects_non_function_statements() {
+        assert_eq!(unwrapped_name("var x;"), None);
+        assert_eq!(unwrapped_name("l: var y;"), None);
+        assert_eq!(unwrapped_name("{ function f(){} }"), None);
+    }
+
+    fn func_decls(source: &str) -> Vec<FunctionDecl> {
+        collect_function_decls(parse(source).body.as_slice())
+    }
+
+    #[test]
+    fn dedups_function_declarations_keeping_last() {
+        // Duplicate `f` collapses to one entry; the retained one is the LAST in
+        // source order — here distinguished by arity (Node: the second `f`
+        // wins, `eval("function f(){return 1} function f(){return 2} f()")` == 2).
+        let decls = func_decls("function f(){} function f(a,b){} function g(){}");
+        assert_eq!(decls.len(), 2);
+        let f = decls.iter().find(|d| d.name == "f").expect("f present");
+        assert_eq!(f.params.len(), 2, "kept the last declaration of `f`");
+        assert!(decls.iter().any(|d| d.name == "g"));
+    }
+
+    #[test]
+    fn function_decls_include_labeled_but_not_block_nested() {
+        // Labeled top-level function declarations count; ones inside a block do not.
+        let decls = func_decls("lbl: function a(){} { function b(){} }");
+        let names: Vec<&str> = decls.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["a"]);
+    }
+
+    #[test]
+    fn collects_var_names_from_control_flow_and_try() {
+        let names = var_names(
+            "if (t) { var a; } else { var b; }\
+             for (var c = 0;;) {}\
+             try { var d; } catch (e) { var f; } finally { var g; }\
+             switch (s) { case 1: var h; }\
+             lbl: { var i; }",
+        );
+        assert_eq!(names, vec!["a", "b", "c", "d", "f", "g", "h", "i"]);
+    }
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -28,6 +28,7 @@ mod exec;
 mod gc;
 pub(crate) mod generator_analysis;
 pub(crate) mod generator_transform;
+mod hoisting;
 pub(crate) mod ic;
 pub(crate) mod ic_store;
 pub(crate) mod key_intern;


### PR DESCRIPTION
## Refactoring goal

Deepen the interpreter's most-churned file. An architecture audit (using the *improve-codebase-architecture* skill's process) flagged the `eval.rs` god file (17k lines, most-changed file in the last 200 commits) as the top hot spot. The most impactful, lowest-risk **deepening opportunity** there was a cluster of **pure AST static-semantics functions** that were buried inside `impl Interpreter` purely for namespacing:

- `collect_eval_var_names` / `collect_eval_var_names_from_stmt` / `collect_eval_function_decls` (in `eval.rs`)
- `unwrap_labeled_function` (in `exec.rs`)

They take no `self`, yet they encode a subtle, correctness-sensitive rule — descend into blocks / `if` / loops / `switch` / `try` / labels / `with`, but **never into nested function bodies** — and had **no test coverage**, because they could not be exercised without booting the whole interpreter. This is the classic *shallow-because-untestable* smell: the logic is pure, but its home hides it from tests (fails the deletion test only in the sense that its complexity was *hidden*, not *earned in place*).

### What changed
- New pure module `src/interpreter/hoisting.rs` with a small interface: `collect_var_names`, `collect_function_decls`, `unwrap_labeled_function`. No `Interpreter` state — so the traversal rules are unit-testable in isolation.
- `eval.rs` (−107 net) and `exec.rs` (−11 net) now call the module; ~120 lines of buried logic leave the god files.
- **No behavior change**: identical traversal, identical "keep the last function declaration of each name" de-duplication, identical consumption order for `EvalDeclarationInstantiation`.

### Before / after
```
Before: pure fns inside impl Interpreter (eval.rs 17k) + exec.rs  →  unreachable from cargo test
After:  interpreter::hoisting (pure, small interface)             →  7 unit tests, shared by eval + exec
```

## Tests that validate it (TDD)

Built test-first via the *tdd* skill in vertical slices (stub → red → implement → green), one seam at a time. Expected values are derived from the ECMAScript spec and cross-checked against `node` (authority order per CLAUDE.md: spec > test262 > node):

- **`collect_var_names`** — top-level and block-nested `var` hoist; control-flow / `try` traversal; **does NOT descend into nested function declarations** (`eval("var a; function g(){ var b; } a")` defines `a`, not `b`).
- **`unwrap_labeled_function`** — plain and (multiply-)labeled function declarations unwrap; non-functions and block-nested functions do not.
- **`collect_function_decls`** — de-duplication keeps the **last** declaration of each name (node: the second `f` wins), distinguished by arity; labeled top-level counts, block-nested does not.

### Validation results
- `cargo test --release`: **491 passed** (was 484), 0 failed — the +7 are the new module tests; the rest of the suite is unchanged.
- `./scripts/lint.sh`: rustfmt + `clippy -D warnings` clean.
- test262, 0 regressions: `language/eval-code` 454/454 · `language/statements/switch` 216/216 · `language/statements/function` 783/783 · `language/global-code` 75/75 · `annexB/language/function-code` 159/159.

## Notes for the reviewer
- This was an **autonomous** run. The skill's interactive "which candidate do you want?" step was resolved without an operator. The full candidate report (6 options, before/after diagrams, top recommendation) was generated to `/tmp/architecture-review-20260819-013053.html`.
- **Runner-up, deliberately deferred:** a confirmed latent bug — the typed-array element-coercion `to_number` at `src/interpreter/types.rs:3696` re-implements `helpers::to_number` and skips whitespace trimming and `0x`/`0o`/`0b` literals (reachable via `Object.defineProperty(typedarray, i, {value:"0x10"})`). It was **not** taken here because the fix is behavior-changing and MOP-invasive, which needs a full test262 sweep an operator-free run can't validate confidently. Filed as a follow-up issue.

🤖 Generated with Claude Code