### PR TITLE
fix(interpreter): route private accessor get/set through one PrivateGet/PrivateSet MOP

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2662,19 +2662,28 @@ impl Interpreter {
                 // §13.4 UpdateExpression on a private reference desugars to
                 // PrivateGet -> ToNumeric -> PrivateSet, so accessor-backed
                 // privates read through their getter and write through their
-                // setter just like a data field does.
-                let old = match self.private_get(&obj_val, name, env) {
-                    Completion::Normal(v) => v,
-                    other => return other,
-                };
-                let (old_val, new_val) = match self.apply_update_numeric(&old, op) {
-                    Ok(pair) => pair,
-                    Err(e) => return Completion::Throw(e),
-                };
-                if let Err(e) = self.set_private_field(&obj_val, name, new_val.clone(), env) {
-                    return Completion::Throw(e);
-                }
-                return Completion::Normal(if prefix { new_val } else { old_val });
+                // setter just like a data field does. The receiver has to stay
+                // rooted across all three steps: ToNumeric runs a user
+                // `valueOf` that can reach a GC safepoint while `obj_val`
+                // exists only as a Rust local, invisible to the collector.
+                let gc_frame = self.gc_root_frame();
+                self.gc_root_value(&obj_val);
+                let result = (|| {
+                    let old = match self.private_get(&obj_val, name, env) {
+                        Completion::Normal(v) => v,
+                        other => return other,
+                    };
+                    let (old_val, new_val) = match self.apply_update_numeric(&old, op) {
+                        Ok(pair) => pair,
+                        Err(e) => return Completion::Throw(e),
+                    };
+                    if let Err(e) = self.set_private_field(&obj_val, name, new_val.clone(), env) {
+                        return Completion::Throw(e);
+                    }
+                    Completion::Normal(if prefix { new_val } else { old_val })
+                })();
+                self.gc_unroot_frame(gc_frame);
+                return result;
             }
             let key = match prop {
                 MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
@@ -3817,27 +3826,38 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                let lval = match self.private_get(&obj_val, name, env) {
-                    Completion::Normal(v) => v,
-                    other => return other,
-                };
-                let should_assign = match op {
-                    AssignOp::LogicalAndAssign => self.to_boolean_val(&lval),
-                    AssignOp::LogicalOrAssign => !self.to_boolean_val(&lval),
-                    AssignOp::NullishAssign => lval.is_null() || lval.is_undefined(),
-                    _ => unreachable!(),
-                };
-                if !should_assign {
-                    return Completion::Normal(lval);
-                }
-                let rval = match self.eval_expr(right, env) {
-                    Completion::Normal(v) => v,
-                    other => return other,
-                };
-                if let Err(e) = self.set_private_field(&obj_val, name, rval.clone(), env) {
-                    return Completion::Throw(e);
-                }
-                Completion::Normal(rval)
+                // The receiver has to survive PrivateGet (which may call a
+                // user getter) and the right-hand side evaluation before
+                // PrivateSet writes through the setter. Both steps run user
+                // code that can reach a GC safepoint while `obj_val` exists
+                // only as a Rust local, invisible to the collector.
+                let gc_frame = self.gc_root_frame();
+                self.gc_root_value(&obj_val);
+                let result = (|| {
+                    let lval = match self.private_get(&obj_val, name, env) {
+                        Completion::Normal(v) => v,
+                        other => return other,
+                    };
+                    let should_assign = match op {
+                        AssignOp::LogicalAndAssign => self.to_boolean_val(&lval),
+                        AssignOp::LogicalOrAssign => !self.to_boolean_val(&lval),
+                        AssignOp::NullishAssign => lval.is_null() || lval.is_undefined(),
+                        _ => unreachable!(),
+                    };
+                    if !should_assign {
+                        return Completion::Normal(lval);
+                    }
+                    let rval = match self.eval_expr(right, env) {
+                        Completion::Normal(v) => v,
+                        other => return other,
+                    };
+                    if let Err(e) = self.set_private_field(&obj_val, name, rval.clone(), env) {
+                        return Completion::Throw(e);
+                    }
+                    Completion::Normal(rval)
+                })();
+                self.gc_unroot_frame(gc_frame);
+                result
             }
             Expression::Member(obj_expr, prop, _) => {
                 // Super property logical assignment: super.p &&= / ||= / ??=

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2659,36 +2659,22 @@ impl Interpreter {
                 other => return other,
             };
             if let MemberProperty::Private(name) = prop {
-                let branded = self.resolve_private_name(name, env);
-                return match obj_val.as_object_id() {
-                    Some(id) => {
-                        let o = crate::types::JsObject { id };
-                        if let Some(obj) = self.get_object(o.id) {
-                            let elem = obj.borrow().private_fields.get(&branded).cloned();
-                            match elem {
-                                Some(PrivateElement::Field(cur)) => {
-                                    let (old_val, new_val) =
-                                        match self.apply_update_numeric(&cur, op) {
-                                            Ok(pair) => pair,
-                                            Err(e) => return Completion::Throw(e),
-                                        };
-                                    obj.borrow_mut()
-                                        .private_fields
-                                        .insert(branded, PrivateElement::Field(new_val.clone()));
-                                    Completion::Normal(if prefix { new_val } else { old_val })
-                                }
-                                _ => Completion::Throw(self.create_type_error(&format!(
-                                    "Cannot update private member #{name}"
-                                ))),
-                            }
-                        } else {
-                            Completion::Normal(JsValue::number(f64::NAN))
-                        }
-                    }
-                    None => Completion::Throw(
-                        self.create_type_error("Cannot read private member from a non-object"),
-                    ),
+                // §13.4 UpdateExpression on a private reference desugars to
+                // PrivateGet -> ToNumeric -> PrivateSet, so accessor-backed
+                // privates read through their getter and write through their
+                // setter just like a data field does.
+                let old = match self.private_get(&obj_val, name, env) {
+                    Completion::Normal(v) => v,
+                    other => return other,
                 };
+                let (old_val, new_val) = match self.apply_update_numeric(&old, op) {
+                    Ok(pair) => pair,
+                    Err(e) => return Completion::Throw(e),
+                };
+                if let Err(e) = self.set_private_field(&obj_val, name, new_val.clone(), env) {
+                    return Completion::Throw(e);
+                }
+                return Completion::Normal(if prefix { new_val } else { old_val });
             }
             let key = match prop {
                 MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
@@ -2797,53 +2783,7 @@ impl Interpreter {
                     _ => return Ok(()),
                 };
                 if let MemberProperty::Private(name) = prop {
-                    let branded = self.resolve_private_name(name, env);
-                    return match obj_val.as_object_id() {
-                        Some(id) => {
-                            let o = crate::types::JsObject { id };
-                            if let Some(obj) = self.get_object_cell(o.id) {
-                                let elem = obj.borrow().private_fields.get(&branded).cloned();
-                                match elem {
-                                    Some(PrivateElement::Field(_)) => {
-                                        obj.borrow_mut().private_fields.insert(
-                                            branded,
-                                            PrivateElement::Field(value),
-                                        );
-                                        Ok(())
-                                    }
-                                    Some(PrivateElement::Method(_)) => Err(self
-                                        .create_type_error(&format!(
-                                            "Cannot assign to private method #{name}"
-                                        ))),
-                                    Some(PrivateElement::Accessor { set, .. }) => {
-                                        if let Some(setter) = set {
-                                            let obj_val2 = obj_val.clone();
-                                            match self.call_function(
-                                                &setter,
-                                                &obj_val2,
-                                                std::slice::from_ref(&value),
-                                            ) {
-                                                Completion::Throw(e) => Err(e),
-                                                _ => Ok(()),
-                                            }
-                                        } else {
-                                            Err(self.create_type_error(&format!(
-                                                "Cannot set private member #{name} which has no setter"
-                                            )))
-                                        }
-                                    }
-                                    None => Err(self.create_type_error(&format!(
-                                        "Cannot write private member #{name} to an object whose class did not declare it"
-                                    ))),
-                                }
-                            } else {
-                                Ok(())
-                            }
-                        }
-                        None => Err(self.create_type_error(&format!(
-                            "Cannot write private member #{name} to a non-object"
-                        ))),
-                    };
+                    return self.set_private_field(&obj_val, name, value, env);
                 }
                 let key = match prop {
                     MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
@@ -3213,82 +3153,38 @@ impl Interpreter {
                 self.gc_root_value(&obj_val);
                 let result = (|| {
                     if let MemberProperty::Private(name) = prop {
-                        let branded = self.resolve_private_name(name, env);
+                        // The RHS is evaluated first (preserving jsse's existing
+                        // evaluation order). A plain `= ` performs PrivateSet with
+                        // no preceding PrivateGet; every compound operator desugars
+                        // to PrivateGet -> op -> PrivateSet, so accessor-backed
+                        // privates read through the getter and write through the
+                        // setter exactly as a data field does.
                         let rval = match self.eval_expr(right, env) {
                             Completion::Normal(v) => v,
                             other => return other,
                         };
-                        return match obj_val.as_object_id() {
-                            Some(id) => {
-                                let o = crate::types::JsObject { id };
-                                if let Some(obj) = self.get_object(o.id) {
-                                    let elem = obj.borrow().private_fields.get(&branded).cloned();
-                                    match elem {
-                                    Some(PrivateElement::Field(_)) => {
-                                        let final_val = if op == AssignOp::Assign {
-                                            rval
-                                        } else {
-                                            let lval = if let Some(PrivateElement::Field(v)) = obj.borrow().private_fields.get(&branded) {
-                                                v.clone()
-                                            } else {
-                                                JsValue::UNDEFINED
-                                            };
-                                            match self.apply_compound_assign(op, lval, rval) {
-                                                Completion::Normal(v) => v,
-                                                other => return other,
-                                            }
-                                        };
-                                        obj.borrow_mut()
-                                            .private_fields
-                                            .insert(branded.clone(), PrivateElement::Field(final_val.clone()));
-                                        Completion::Normal(final_val)
-                                    }
-                                    Some(PrivateElement::Method(_)) => {
-                                        Completion::Throw(self.create_type_error(&format!(
-                                            "Cannot assign to private method #{name}"
-                                        )))
-                                    }
-                                    Some(PrivateElement::Accessor { get, set }) => {
-                                        if let Some(setter) = &set {
-                                            let final_val = if op == AssignOp::Assign {
-                                                rval
-                                            } else {
-                                                let lval = if let Some(ref getter) = get {
-                                                    match self.call_function(getter, &obj_val, &[]) {
-                                                        Completion::Normal(v) => v,
-                                                        other => return other,
-                                                    }
-                                                } else {
-                                                    JsValue::UNDEFINED
-                                                };
-                                                match self.apply_compound_assign(op, lval, rval) {
-                                                    Completion::Normal(v) => v,
-                                                    other => return other,
-                                                }
-                                            };
-                                            let setter = setter.clone();
-                                            if let Completion::Throw(e) = self.call_function(&setter, &obj_val, std::slice::from_ref(&final_val)) { return Completion::Throw(e) }
-                                            Completion::Normal(final_val)
-                                        } else {
-                                            Completion::Throw(self.create_type_error(&format!(
-                                                "Cannot set private member #{name} which has no setter"
-                                            )))
-                                        }
-                                    }
-                                    None => {
-                                        Completion::Throw(self.create_type_error(&format!(
-                                            "Cannot write private member #{name} to an object whose class did not declare it"
-                                        )))
-                                    }
-                                }
-                                } else {
-                                    Completion::Normal(JsValue::UNDEFINED)
-                                }
+                        if op == AssignOp::Assign {
+                            if let Err(e) =
+                                self.set_private_field(&obj_val, name, rval.clone(), env)
+                            {
+                                return Completion::Throw(e);
                             }
-                            None => Completion::Throw(self.create_type_error(&format!(
-                                "Cannot write private member #{name} to a non-object"
-                            ))),
+                            return Completion::Normal(rval);
+                        }
+                        let lval = match self.private_get(&obj_val, name, env) {
+                            Completion::Normal(v) => v,
+                            other => return other,
                         };
+                        let final_val = match self.apply_compound_assign(op, lval, rval) {
+                            Completion::Normal(v) => v,
+                            other => return other,
+                        };
+                        if let Err(e) =
+                            self.set_private_field(&obj_val, name, final_val.clone(), env)
+                        {
+                            return Completion::Throw(e);
+                        }
+                        return Completion::Normal(final_val);
                     }
                     // Evaluate computed key expression before RHS
                     let key_val = match prop {
@@ -3917,43 +3813,13 @@ impl Interpreter {
                 self.put_value_by_ref(name, rval, &id_ref, env)
             }
             Expression::Member(obj_expr, MemberProperty::Private(name), _) => {
-                let branded = self.resolve_private_name(name, env);
                 let obj_val = match self.eval_expr(obj_expr, env) {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                let lval = match obj_val.as_object_id() {
-                    Some(id) => {
-                        if let Some(obj) = self.get_object_cell(id) {
-                            let elem = obj.borrow().private_fields.get(&branded).cloned();
-                            match elem {
-                                Some(PrivateElement::Field(v)) => v,
-                                Some(PrivateElement::Method(v)) => v,
-                                Some(PrivateElement::Accessor { get, .. }) => {
-                                    if let Some(ref getter) = get {
-                                        match self.call_function(getter, &obj_val, &[]) {
-                                            Completion::Normal(v) => v,
-                                            other => return other,
-                                        }
-                                    } else {
-                                        JsValue::UNDEFINED
-                                    }
-                                }
-                                None => {
-                                    return Completion::Throw(self.create_type_error(&format!(
-                                        "Cannot read private member #{name} from an object whose class did not declare it"
-                                    )));
-                                }
-                            }
-                        } else {
-                            JsValue::UNDEFINED
-                        }
-                    }
-                    None => {
-                        return Completion::Throw(self.create_type_error(&format!(
-                            "Cannot read private member #{name} from a non-object"
-                        )));
-                    }
+                let lval = match self.private_get(&obj_val, name, env) {
+                    Completion::Normal(v) => v,
+                    other => return other,
                 };
                 let should_assign = match op {
                     AssignOp::LogicalAndAssign => self.to_boolean_val(&lval),
@@ -3968,49 +3834,8 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                match obj_val.as_object_id() {
-                    Some(id) => {
-                        if let Some(obj) = self.get_object_cell(id) {
-                            let elem = obj.borrow().private_fields.get(&branded).cloned();
-                            match elem {
-                                Some(PrivateElement::Field(_)) => {
-                                    obj.borrow_mut().private_fields.insert(
-                                        branded.clone(),
-                                        PrivateElement::Field(rval.clone()),
-                                    );
-                                }
-                                Some(PrivateElement::Method(_)) => {
-                                    return Completion::Throw(self.create_type_error(&format!(
-                                        "Cannot assign to private method #{name}"
-                                    )));
-                                }
-                                Some(PrivateElement::Accessor { set, .. }) => {
-                                    if let Some(setter) = &set {
-                                        let setter = setter.clone();
-                                        self.call_function(
-                                            &setter,
-                                            &obj_val,
-                                            std::slice::from_ref(&rval),
-                                        );
-                                    } else {
-                                        return Completion::Throw(self.create_type_error(&format!(
-                                            "Cannot set private member #{name} which has no setter"
-                                        )));
-                                    }
-                                }
-                                None => {
-                                    return Completion::Throw(self.create_type_error(&format!(
-                                        "Cannot write private member #{name} to an object whose class did not declare it"
-                                    )));
-                                }
-                            }
-                        }
-                    }
-                    None => {
-                        return Completion::Throw(self.create_type_error(&format!(
-                            "Cannot write private member #{name} to a non-object"
-                        )));
-                    }
+                if let Err(e) = self.set_private_field(&obj_val, name, rval.clone(), env) {
+                    return Completion::Throw(e);
                 }
                 Completion::Normal(rval)
             }
@@ -4485,6 +4310,42 @@ impl Interpreter {
             _ => return Ok(()),
         };
         self.set_member_property_with_base(obj_val, prop, val, env)
+    }
+
+    /// PrivateGet ( O, P ) — §7.3.28. Resolves the private name `name` in `env`
+    /// and performs the private-element MOP: a data field or method returns its
+    /// stored value; an accessor invokes its getter, or throws a TypeError when
+    /// it has none; a private name the object's class never declared, and a
+    /// non-object receiver, both throw a TypeError. This is the single read
+    /// operation that every `o.#x` reference form routes through.
+    fn private_get(&mut self, obj_val: &JsValue, name: &str, env: &EnvRef) -> Completion {
+        let branded = self.resolve_private_name(name, env);
+        let Some(obj_id) = obj_val.as_object_id() else {
+            return Completion::Throw(self.create_type_error(&format!(
+                "Cannot read private member #{name} from a non-object"
+            )));
+        };
+        let Some(obj) = self.get_object_cell(obj_id) else {
+            return Completion::Normal(JsValue::UNDEFINED);
+        };
+        let elem = obj.borrow().private_fields.get(&branded).cloned();
+        match elem {
+            Some(PrivateElement::Field(v)) | Some(PrivateElement::Method(v)) => {
+                Completion::Normal(v)
+            }
+            Some(PrivateElement::Accessor { get, .. }) => {
+                if let Some(getter) = get {
+                    self.call_function(&getter, obj_val, &[])
+                } else {
+                    Completion::Throw(self.create_type_error(&format!(
+                        "Cannot read private member #{name} which has no getter"
+                    )))
+                }
+            }
+            None => Completion::Throw(self.create_type_error(&format!(
+                "Cannot read private member #{name} from an object whose class did not declare it"
+            ))),
+        }
     }
 
     fn set_private_field(

--- a/src/interpreter/eval/access.rs
+++ b/src/interpreter/eval/access.rs
@@ -674,33 +674,7 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                let branded = self.resolve_private_name(name, env);
-                let Some(obj_id) = obj_val.as_object_id() else {
-                    return Completion::Throw(self.create_type_error(&format!(
-                        "Cannot read private member #{name} from a non-object"
-                    )));
-                };
-                return if let Some(obj_rc) = self.get_object_cell(obj_id) {
-                    let elem = obj_rc.borrow().private_fields.get(&branded).cloned();
-                    match elem {
-                        Some(PrivateElement::Field(v))
-                        | Some(PrivateElement::Method(v)) => Completion::Normal(v),
-                        Some(PrivateElement::Accessor { get, .. }) => {
-                            if let Some(getter) = get {
-                                self.call_function(&getter, &obj_val, &[])
-                            } else {
-                                Completion::Throw(self.create_type_error(&format!(
-                                    "Cannot read private member #{name} which has no getter"
-                                )))
-                            }
-                        }
-                        None => Completion::Throw(self.create_type_error(&format!(
-                            "Cannot read private member #{name} from an object whose class did not declare it"
-                        ))),
-                    }
-                } else {
-                    Completion::Normal(JsValue::UNDEFINED)
-                };
+                return self.private_get(&obj_val, name, env);
             }
 
             // Step 2: GetThisBinding — throws ReferenceError if this is in TDZ
@@ -750,34 +724,7 @@ impl Interpreter {
             other => return other,
         };
         if let MemberProperty::Private(name) = prop {
-            let branded = self.resolve_private_name(name, env);
-            let Some(obj_id) = obj_val.as_object_id() else {
-                return Completion::Throw(self.create_type_error(&format!(
-                    "Cannot read private member #{name} from a non-object"
-                )));
-            };
-            return if let Some(obj) = self.get_object_cell(obj_id) {
-                let elem = obj.borrow().private_fields.get(&branded).cloned();
-                match elem {
-                    Some(PrivateElement::Field(v)) | Some(PrivateElement::Method(v)) => {
-                        Completion::Normal(v)
-                    }
-                    Some(PrivateElement::Accessor { get, .. }) => {
-                        if let Some(getter) = get {
-                            self.call_function(&getter, &obj_val, &[])
-                        } else {
-                            Completion::Throw(self.create_type_error(&format!(
-                                "Cannot read private member #{name} which has no getter"
-                            )))
-                        }
-                    }
-                    None => Completion::Throw(self.create_type_error(&format!(
-                        "Cannot read private member #{name} from an object whose class did not declare it"
-                    ))),
-                }
-            } else {
-                Completion::Normal(JsValue::UNDEFINED)
-            };
+            return self.private_get(&obj_val, name, env);
         }
         // For computed properties, evaluate the expression but defer ToPropertyKey
         // until after we check that the base is not null/undefined (spec: ToObject

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -883,6 +883,51 @@ fn array_literal_releases_temp_roots_after_abrupt_completion() {
 }
 
 #[test]
+fn private_update_releases_temp_roots_after_abrupt_completion() {
+    // The private update branch roots its receiver across
+    // PrivateGet -> ToNumeric -> PrivateSet. Every abrupt exit inside that
+    // window must still release the temp-root frame.
+    let interp = run_script(
+        r#"
+        class C {
+            get #x() { return { valueOf() { throw new Error("coercion"); } }; }
+            set #x(v) {}
+            static bump() { return (new C()).#x++; }
+        }
+        try { C.bump(); } catch (e) {}
+        "#,
+    );
+
+    assert!(
+        interp.gc_temp_roots.is_empty(),
+        "private update temporary roots must be released after a throw"
+    );
+}
+
+#[test]
+fn private_logical_assign_releases_temp_roots_after_abrupt_completion() {
+    // Same contract for the logical-assignment branch, whose rooted window
+    // spans PrivateGet -> right-hand side evaluation -> PrivateSet.
+    let interp = run_script(
+        r#"
+        class C {
+            get #x() { return undefined; }
+            set #x(v) {}
+            static assign() {
+                return (new C()).#x ??= (function () { throw new Error("rhs"); })();
+            }
+        }
+        try { C.assign(); } catch (e) {}
+        "#,
+    );
+
+    assert!(
+        interp.gc_temp_roots.is_empty(),
+        "private logical-assignment temporary roots must be released after a throw"
+    );
+}
+
+#[test]
 fn private_method_call_with_non_iterable_spread_throws() {
     // A spread argument that is not iterable must throw a TypeError, even when the
     // callee is a private method reached through `this.#m(...)`. The private-call

--- a/test262-extra/private-accessor-gc-rooting.js
+++ b/test262-extra/private-accessor-gc-rooting.js
@@ -1,0 +1,191 @@
+/*---
+description: >
+  A private reference's receiver stays reachable while an update expression
+  coerces the value its getter returned, and while a logical assignment
+  evaluates its right-hand side.
+esid: sec-privateset
+features: [class, class-methods-private]
+info: |
+  13.4.2.1 Runtime Semantics: Evaluation (UpdateExpression)
+    1. Let expr be ? Evaluation of UnaryExpression.
+    2. Let oldValue be ? ToNumeric(? GetValue(expr)).
+    ...
+    5. Perform ? PutValue(expr, newValue).
+
+  13.15.2 Runtime Semantics: Evaluation
+      (AssignmentExpression : LeftHandSideExpression &&= / ||= / ??= AssignmentExpression)
+    1. Let lref be ? Evaluation of LeftHandSideExpression.
+    2. Let lval be ? GetValue(lref).
+    ...
+    5. Perform ? PutValue(lref, rval).
+
+  In both forms the Reference produced in step 1 must survive until PutValue
+  runs, even though the intervening steps call user code: ToNumeric invokes
+  valueOf, and the right-hand side of a logical assignment is arbitrary. When
+  the base of that Reference is a temporary object -- `(new C()).#x++` -- an
+  implementation that holds it only in a native local can collect it during
+  those calls and then skip PutValue, so the private setter never runs and any
+  abrupt completion it would have produced is lost, even though the expression
+  completes normally.
+---*/
+
+// A pre-existing coercible object, so only the receiver is unreachable when
+// the collector runs.
+var collectingCoercible = {
+  valueOf: function () {
+    $262.gc();
+    return 1;
+  },
+};
+
+function collectAndReturnSeven() {
+  $262.gc();
+  return 7;
+}
+
+// ---------------------------------------------------------------------------
+// UpdateExpression: the getter hands back a coercible object whose valueOf
+// collects, and PrivateSet must still reach the setter on the same receiver.
+// ---------------------------------------------------------------------------
+
+var postfixWrites = [];
+
+class Postfix {
+  get #x() {
+    return collectingCoercible;
+  }
+  set #x(value) {
+    postfixWrites.push(value);
+  }
+  static bump() {
+    return (new Postfix()).#x++;
+  }
+}
+
+assert.sameValue(Postfix.bump(), 1, "o.#x++ returns ToNumeric of the getter result");
+assert.sameValue(postfixWrites.length, 1, "o.#x++ runs the setter exactly once");
+assert.sameValue(postfixWrites[0], 2, "o.#x++ passes the incremented value to the setter");
+
+var prefixWrites = [];
+
+class Prefix {
+  get #x() {
+    return collectingCoercible;
+  }
+  set #x(value) {
+    prefixWrites.push(value);
+  }
+  static bump() {
+    return --(new Prefix()).#x;
+  }
+}
+
+assert.sameValue(Prefix.bump(), 0, "--o.#x returns the decremented value");
+assert.sameValue(prefixWrites.length, 1, "--o.#x runs the setter exactly once");
+assert.sameValue(prefixWrites[0], 0, "--o.#x passes the decremented value to the setter");
+
+// ---------------------------------------------------------------------------
+// Logical assignment: the right-hand side collects between PrivateGet and
+// PrivateSet, and the setter must still receive the value.
+// ---------------------------------------------------------------------------
+
+var nullishWrites = [];
+
+class Nullish {
+  get #x() {
+    return undefined;
+  }
+  set #x(value) {
+    nullishWrites.push(value);
+  }
+  static assign() {
+    return (new Nullish()).#x ??= collectAndReturnSeven();
+  }
+}
+
+assert.sameValue(Nullish.assign(), 7, "o.#x ??= rhs evaluates to the right-hand side");
+assert.sameValue(nullishWrites.length, 1, "o.#x ??= rhs runs the setter exactly once");
+assert.sameValue(nullishWrites[0], 7, "o.#x ??= rhs passes the right-hand side to the setter");
+
+var orWrites = [];
+
+class Or {
+  get #x() {
+    return false;
+  }
+  set #x(value) {
+    orWrites.push(value);
+  }
+  static assign() {
+    return (new Or()).#x ||= collectAndReturnSeven();
+  }
+}
+
+assert.sameValue(Or.assign(), 7, "o.#x ||= rhs evaluates to the right-hand side");
+assert.sameValue(orWrites.length, 1, "o.#x ||= rhs runs the setter exactly once");
+assert.sameValue(orWrites[0], 7, "o.#x ||= rhs passes the right-hand side to the setter");
+
+var andWrites = [];
+
+class And {
+  get #x() {
+    return true;
+  }
+  set #x(value) {
+    andWrites.push(value);
+  }
+  static assign() {
+    return (new And()).#x &&= collectAndReturnSeven();
+  }
+}
+
+assert.sameValue(And.assign(), 7, "o.#x &&= rhs evaluates to the right-hand side");
+assert.sameValue(andWrites.length, 1, "o.#x &&= rhs runs the setter exactly once");
+assert.sameValue(andWrites[0], 7, "o.#x &&= rhs passes the right-hand side to the setter");
+
+// ---------------------------------------------------------------------------
+// A throwing setter proves the write is not merely unobserved: PrivateSet's
+// abrupt completion must still propagate out of the whole expression.
+// ---------------------------------------------------------------------------
+
+class SetterThrew extends Error {}
+
+class ThrowingUpdate {
+  get #x() {
+    return collectingCoercible;
+  }
+  set #x(value) {
+    throw new SetterThrew("update setter ran");
+  }
+  static bump() {
+    return (new ThrowingUpdate()).#x++;
+  }
+}
+
+assert.throws(
+  SetterThrew,
+  function () {
+    ThrowingUpdate.bump();
+  },
+  "o.#x++ propagates a throw from the setter after a collecting coercion"
+);
+
+class ThrowingLogical {
+  get #x() {
+    return undefined;
+  }
+  set #x(value) {
+    throw new SetterThrew("logical setter ran");
+  }
+  static assign() {
+    return (new ThrowingLogical()).#x ??= collectAndReturnSeven();
+  }
+}
+
+assert.throws(
+  SetterThrew,
+  function () {
+    ThrowingLogical.assign();
+  },
+  "o.#x ??= rhs propagates a throw from the setter after a collecting rhs"
+);

--- a/test262-extra/private-accessor-get-set-mop.js
+++ b/test262-extra/private-accessor-get-set-mop.js
@@ -1,0 +1,353 @@
+// Copyright (C) 2026 jsse contributors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Reads and writes of a private accessor member go through the PrivateGet and
+  PrivateSet abstract operations regardless of the surrounding expression form.
+  A read of an accessor that has no getter throws a TypeError; a write whose
+  setter throws propagates that throw; a logical assignment (&&=, ||=, ??=), a
+  compound assignment (+=, -=, ...), and an update (++, --) all desugar to the
+  same PrivateGet/PrivateSet pair, so an accessor-backed private behaves exactly
+  as a data-field private would through each of those forms.
+esid: sec-privateget
+features: [class, class-fields-private, class-methods-private, BigInt]
+info: |
+  7.3.28 PrivateGet ( O, P )
+    3. Assert: P.[[Kind]] is accessor.
+    3.a. If P does not have a [[Get]] field, throw a TypeError exception.
+    3.b. Let getter be P.[[Get]].
+    3.c. Return ? Call(getter, O).
+
+  7.3.29 PrivateSet ( O, P, value )
+    4. Else, Assert: P.[[Kind]] is accessor.
+    4.a. If P does not have a [[Set]] field, throw a TypeError exception.
+    4.b. Let setter be P.[[Set]].
+    4.c. Perform ? Call(setter, O, << value >>).
+
+  13.15.2 AssignmentExpression : LeftHandSideExpression {&&=,||=,??=} ...
+    Evaluates the reference, GetValue (PrivateGet) it, short-circuits on the
+    boolean/nullish test, and only then PutValue (PrivateSet).
+---*/
+
+// ---------------------------------------------------------------------------
+// PrivateGet on an accessor with no getter throws a TypeError, and the throw
+// surfaces through every logical-assignment operator that must read first.
+// ---------------------------------------------------------------------------
+
+class SetOnly {
+  set #x(v) {}
+  static nullish(o) {
+    return o.#x ??= 1;
+  }
+  static or(o) {
+    return o.#x ||= 1;
+  }
+  static and(o) {
+    return o.#x &&= 1;
+  }
+}
+
+assert.throws(
+  TypeError,
+  function () {
+    SetOnly.nullish(new SetOnly());
+  },
+  "??= reads the set-only accessor and PrivateGet throws"
+);
+
+assert.throws(
+  TypeError,
+  function () {
+    SetOnly.or(new SetOnly());
+  },
+  "||= reads the set-only accessor and PrivateGet throws"
+);
+
+assert.throws(
+  TypeError,
+  function () {
+    SetOnly.and(new SetOnly());
+  },
+  "&&= reads the set-only accessor and PrivateGet throws"
+);
+
+// Control: a get-only accessor whose value is non-nullish short-circuits the
+// assignment, so the getter's value is returned and no setter is needed.
+class GetOnly {
+  get #x() {
+    return 7;
+  }
+  static nullish(o) {
+    return o.#x ??= 1;
+  }
+}
+
+assert.sameValue(
+  GetOnly.nullish(new GetOnly()),
+  7,
+  "??= on a non-nullish accessor read short-circuits without assigning"
+);
+
+// ---------------------------------------------------------------------------
+// When a logical assignment does reach the write, PrivateSet invokes the
+// setter, and an abrupt completion from the setter propagates (it must not be
+// swallowed). A distinct error subclass proves it is the setter's throw.
+// ---------------------------------------------------------------------------
+
+class SetterThrew extends Error {}
+
+class ThrowingSetter {
+  #v;
+  constructor(v) {
+    this.#v = v;
+  }
+  get #x() {
+    return this.#v;
+  }
+  set #x(value) {
+    throw new SetterThrew("setter ran");
+  }
+  static or(o) {
+    return o.#x ||= 1;
+  }
+  static and(o) {
+    return o.#x &&= 1;
+  }
+  static nullish(o) {
+    return o.#x ??= 1;
+  }
+}
+
+assert.throws(
+  SetterThrew,
+  function () {
+    // getter returns 0 (falsy) -> ||= assigns -> setter throws
+    ThrowingSetter.or(new ThrowingSetter(0));
+  },
+  "||= assigns through the setter and the setter's throw propagates"
+);
+
+assert.throws(
+  SetterThrew,
+  function () {
+    // getter returns 1 (truthy) -> &&= assigns -> setter throws
+    ThrowingSetter.and(new ThrowingSetter(1));
+  },
+  "&&= assigns through the setter and the setter's throw propagates"
+);
+
+assert.throws(
+  SetterThrew,
+  function () {
+    // getter returns null (nullish) -> ??= assigns -> setter throws
+    ThrowingSetter.nullish(new ThrowingSetter(null));
+  },
+  "??= assigns through the setter and the setter's throw propagates"
+);
+
+// Control: a successful setter records the assigned value and the assignment
+// expression evaluates to the assigned value.
+class RecordingSetter {
+  #v = 0;
+  get #x() {
+    return this.#v;
+  }
+  set #x(value) {
+    this.#v = value;
+  }
+  static or(o) {
+    return o.#x ||= 5;
+  }
+  static read(o) {
+    return o.#x;
+  }
+}
+
+var rec = new RecordingSetter();
+assert.sameValue(
+  RecordingSetter.or(rec),
+  5,
+  "||= through a setter evaluates to the assigned value"
+);
+assert.sameValue(
+  RecordingSetter.read(rec),
+  5,
+  "||= through a setter updates the backing field"
+);
+
+// ---------------------------------------------------------------------------
+// An update expression (++ / --) on an accessor-backed private desugars to
+// PrivateGet -> ToNumeric -> PrivateSet, exactly as for a data field: the
+// getter supplies the operand, ToNumeric coerces it, and the setter receives
+// the incremented/decremented value.
+// ---------------------------------------------------------------------------
+
+class Counter {
+  #v;
+  constructor(v) {
+    this.#v = v;
+  }
+  get #x() {
+    return this.#v;
+  }
+  set #x(value) {
+    this.#v = value;
+  }
+  static postInc(o) {
+    return o.#x++;
+  }
+  static preDec(o) {
+    return --o.#x;
+  }
+  static read(o) {
+    return o.#x;
+  }
+}
+
+var c = new Counter(5);
+assert.sameValue(Counter.postInc(c), 5, "o.#x++ evaluates to the old value");
+assert.sameValue(Counter.read(c), 6, "o.#x++ writes the incremented value via the setter");
+assert.sameValue(Counter.preDec(c), 5, "--o.#x evaluates to the new value");
+assert.sameValue(Counter.read(c), 5, "--o.#x writes the decremented value via the setter");
+
+// ToNumeric is applied to the getter result: a string getter yields a Number.
+class StringGetter {
+  last;
+  get #x() {
+    return "5";
+  }
+  set #x(value) {
+    this.last = value;
+  }
+  static postInc(o) {
+    return o.#x++;
+  }
+}
+
+var sg = new StringGetter();
+var sgResult = StringGetter.postInc(sg);
+assert.sameValue(typeof sgResult, "number", "o.#x++ result is ToNumeric-coerced");
+assert.sameValue(sgResult, 5, 'o.#x++ coerces the "5" getter result to 5');
+assert.sameValue(sg.last, 6, "the setter receives the incremented Number");
+
+// BigInt operands stay BigInt through the update.
+class BigCounter {
+  #v = 5n;
+  get #x() {
+    return this.#v;
+  }
+  set #x(value) {
+    this.#v = value;
+  }
+  static postInc(o) {
+    return o.#x++;
+  }
+  static read(o) {
+    return o.#x;
+  }
+}
+
+var bc = new BigCounter();
+assert.sameValue(BigCounter.postInc(bc), 5n, "o.#x++ evaluates to the old BigInt");
+assert.sameValue(BigCounter.read(bc), 6n, "o.#x++ increments the BigInt via the setter");
+
+// An update through an accessor with no getter throws (PrivateGet step 3.a).
+class SetOnlyUpdate {
+  set #x(value) {}
+  static postInc(o) {
+    return o.#x++;
+  }
+}
+
+assert.throws(
+  TypeError,
+  function () {
+    SetOnlyUpdate.postInc(new SetOnlyUpdate());
+  },
+  "o.#x++ reads the set-only accessor first and PrivateGet throws"
+);
+
+// ---------------------------------------------------------------------------
+// A compound assignment (+=, -=, ...) on a private reference also desugars to
+// PrivateGet -> op -> PrivateSet, so it reads through the getter. A plain
+// assignment (=) performs no PrivateGet, so a set-only accessor accepts it.
+// ---------------------------------------------------------------------------
+
+// Compound assignment reads the accessor, so a set-only accessor throws.
+class SetOnlyCompound {
+  set #x(value) {}
+  static addAssign(o) {
+    return o.#x += 1;
+  }
+}
+
+assert.throws(
+  TypeError,
+  function () {
+    SetOnlyCompound.addAssign(new SetOnlyCompound());
+  },
+  "o.#x += 1 reads the set-only accessor first and PrivateGet throws"
+);
+
+// Plain assignment does NOT read, so the same set-only accessor accepts `=`.
+class SetOnlyPlain {
+  last;
+  set #x(value) {
+    this.last = value;
+  }
+  static assign(o) {
+    return o.#x = 9;
+  }
+}
+
+var sop = new SetOnlyPlain();
+assert.sameValue(
+  SetOnlyPlain.assign(sop),
+  9,
+  "o.#x = v evaluates to the assigned value with no PrivateGet"
+);
+assert.sameValue(sop.last, 9, "plain assignment reaches the setter");
+
+// Compound assignment round-trips through getter and setter.
+class Accumulator {
+  #v = 10;
+  get #x() {
+    return this.#v;
+  }
+  set #x(value) {
+    this.#v = value;
+  }
+  static addAssign(o) {
+    return o.#x += 5;
+  }
+  static read(o) {
+    return o.#x;
+  }
+}
+
+var acc = new Accumulator();
+assert.sameValue(Accumulator.addAssign(acc), 15, "o.#x += 5 evaluates to the computed value");
+assert.sameValue(Accumulator.read(acc), 15, "o.#x += 5 writes the computed value via the setter");
+
+// A throwing setter reached through a compound assignment propagates.
+class CompoundThrows {
+  get #x() {
+    return 0;
+  }
+  set #x(value) {
+    throw new SetterThrew("compound setter ran");
+  }
+  static addAssign(o) {
+    return o.#x += 1;
+  }
+}
+
+assert.throws(
+  SetterThrew,
+  function () {
+    CompoundThrows.addAssign(new CompoundThrows());
+  },
+  "o.#x += 1 assigns through the setter and its throw propagates"
+);
+


### PR DESCRIPTION
## Refactoring goal

Architecture audit (via the `improve-codebase-architecture` skill) surfaced the private-member access logic as the strongest **deepening opportunity**: the private-element read/write match (`Field|Method → value`, `Accessor → call getter/setter or throw`, `None → throw`, non-object → throw) was **hand-inlined at ~10 sites** across `eval.rs` and `eval/access.rs`. With no single interface, the copies drifted — and four had **diverged into spec violations**.

This applies the maintainer's established "unify … into one spec-correct operation" pattern: introduce one deep read helper, `Interpreter::private_get` (**PrivateGet**, §7.3.28), next to the existing correct write helper `set_private_field` (**PrivateSet**, §7.3.29), and route every `o.#x` reference form through the pair. The interface stays tiny; all the behaviour hides behind it; fix-once-fixed-everywhere locality replaces ~10 divergent copies.

## Bugs fixed (verified against the spec and Node)

| # | Form | Before | After (spec / Node) |
|---|------|--------|---------------------|
| A | `o.#x ??=/\|\|=/&&= v` on a **getter-less** accessor | returned a value | **throws TypeError** (PrivateGet 3.a) |
| B | `o.#x \|\|= v` whose **setter throws** | throw **swallowed** | throw **propagates** |
| C | `o.#x++` / `--o.#x` on an **accessor-backed** private | threw "Cannot update private member" | PrivateGet → ToNumeric → PrivateSet (e.g. `5,3,3`) |
| D | `o.#x += v` reading a **getter-less** accessor | used `undefined` | **throws TypeError** |

These sit in a genuine test262 coverage gap — test262 has no private-accessor `++`/`--` tests and no getter-less-accessor read tests — which is exactly what `test262-extra/` exists for.

## Validating tests (TDD)

Built test-first as four red→green vertical slices with **Node as the independent oracle**, in `test262-extra/private-accessor-get-set-mop.js`:

- getter-less accessor read via `??=` / `||=` / `&&=` throws; a non-nullish get-only read short-circuits (control);
- a throwing setter reached through `||=` / `&&=` / `??=` propagates (distinct `SetterThrew` subclass proves it is the setter's throw); a recording setter round-trips (control);
- `o.#x++` / `--o.#x` round-trip through getter+setter, ToNumeric-coerce a string getter to a Number, stay BigInt, and throw on a getter-less accessor;
- `o.#x += v` reads through the getter (getter-less → throws), a plain `o.#x = v` performs **no** PrivateGet (set-only accessor accepts it — guards the `= ` early-out), `+=` round-trips, and a throwing setter propagates.

## Scope / notes

- Update and compound expressions become the literal spec desugaring; the **pre-existing RHS-first evaluation order is preserved unchanged** (jsse already evaluates the RHS before the getter — untouched here, not part of this fix).
- Optional-chain private reads are intentionally **left as-is**: their return shape threads `this` and continues the chain, so they are not a clean substitution.
- Net **−240 lines** of scattered, partly-divergent logic collapse into calls to the two helpers.

## Verification (all green, run synchronously)

- `test262-extra/` **142/142** in **default and `--bytecode`** modes. (`compiler.rs` returns `CompileError::Unsupported("private field")` at both private member-access sites, so there is no bytecode-specific private-member path to change; the `--bytecode` run confirms 142/142.)
- Targeted test262 vs `origin/main` baseline, **0 regressions**: `language/{statements,expressions}/class/elements/` (5897), `expressions/{assignment,logical-assignment,compound-assignment,postfix-increment,postfix-decrement,prefix-increment,prefix-decrement,optional-chaining}/` (2090).
- Broad random 3% sample (seed 4242): **5224/5224, 0 regressions**.
- `cargo test --release` **484** unit tests + smoke oracle green; `./scripts/lint.sh` clean (rustfmt + clippy).

A bounded, representative subset of test262 was run (not the full ~99k suite) given the one-shot time budget; the touched-path directories plus a 3% sample were chosen to cover the change.

🤖 Generated with Claude Code