### PR TITLE
fix(interpreter): bound the per-body hoist-analysis cache

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2078,23 +2078,18 @@ impl Interpreter {
         // #72: cache the hoisting *name collection* for this function body,
         // keyed by the body's Rc pointer identity. The body Rc is stable across
         // function-object clones, so repeated calls reuse the analysis. ASTs are
-        // immutable post-parse, so the cache cannot go stale.
-        let key = Rc::as_ptr(&body.statements);
-        let analysis = match self.hoist_cache.get(&key) {
-            Some(a) => a.clone(),
+        // immutable post-parse, so the cache cannot go stale. The cache is
+        // capacity-bounded (#165), so a miss here can also be an eviction.
+        let analysis = match self.hoist_cache.get(&body.statements) {
+            Some(a) => a,
             None => {
                 let mut var_set = std::collections::HashSet::new();
                 Self::collect_var_names_from_stmts(body.as_slice(), &mut var_set);
                 let mut names = Vec::new();
                 let mut blocked = Vec::new();
                 Self::collect_annexb_function_names(body.as_slice(), &mut names, &mut blocked);
-                let a = Rc::new(HoistAnalysis {
-                    var_names: var_set.into_iter().collect(),
-                    annexb_names: names,
-                    _body: body.statements.clone(),
-                });
-                self.hoist_cache.insert(key, a.clone());
-                a
+                self.hoist_cache
+                    .insert(&body.statements, var_set.into_iter().collect(), names)
             }
         };
         let handle = self.ic_store.for_body(body);

--- a/src/interpreter/hoist_cache.rs
+++ b/src/interpreter/hoist_cache.rs
@@ -1,0 +1,260 @@
+//! Bounded memoisation of per-function-body hoisting analysis.
+//!
+//! `dispatch_body` runs the var/Annex-B *name collection* of
+//! `super::hoisting` once per function body and reuses it on later calls (#72),
+//! keyed by the identity of the body's statement `Rc`. Each entry pins that
+//! `Rc` so its address cannot be reused by a freed-then-reallocated body
+//! (ABA), which means an unbounded map would retain every body it has ever
+//! seen — including the short-lived bodies of `new Function` / `eval` (#165).
+//!
+//! (Bounding this cache is necessary but not sufficient to let such a body be
+//! freed: `super::ic_store` pins the same bodies and does not yet evict — #468.)
+//!
+//! The cache is therefore capacity-bounded with approximate-LRU eviction: when
+//! a new body would exceed `DEFAULT_CAPACITY`, the least-recently-used half of
+//! the entries is dropped in one sweep. Entries are pure memoisation, so eviction only ever
+//! costs a re-walk of the body. Eviction removes the map key and its pinned
+//! body together, so every surviving key still names a live body and the ABA
+//! invariant holds.
+
+use rustc_hash::FxHashMap;
+use std::rc::Rc;
+
+use crate::ast::Statement;
+
+/// Maximum number of memoised bodies. Large enough that a program with a fixed
+/// set of functions never evicts — the bound exists for body-churning workloads
+/// (`new Function` / `eval` in a loop). An entry costs a few hundred bytes plus
+/// the body it pins, so a full cache stays in the low megabytes for the small
+/// bodies such workloads produce.
+pub(crate) const DEFAULT_CAPACITY: usize = 8192;
+
+/// Cached output of the var/Annex-B hoisting *name collection* for a single
+/// function body (#72).
+///
+/// Only the raw name collection is cached. The Annex-B post-processing that
+/// inspects live env/parameter/lexical state still runs per call, and function
+/// declarations are never cached as values (fresh closures are built per call).
+/// The body `Rc` is pinned to prevent pointer (ABA) reuse from aliasing a
+/// freed body onto a fresh one with the same address.
+pub(crate) struct HoistAnalysis {
+    /// Deduped output of `collect_var_names_from_stmts`.
+    pub(crate) var_names: Vec<String>,
+    /// Raw `names` output of `collect_annexb_function_names`. (The companion
+    /// `blocked` accumulator is internal to the walk and discarded afterwards
+    /// by the original code, so it is intentionally not cached.)
+    pub(crate) annexb_names: Vec<String>,
+    /// Pins the body so its `Rc::as_ptr` key cannot be reused for another body.
+    _body: Rc<Vec<Statement>>,
+}
+
+struct Entry {
+    analysis: Rc<HoistAnalysis>,
+    /// Clock value of this entry's most recent lookup or insertion.
+    last_used: u64,
+}
+
+/// Capacity-bounded, approximate-LRU cache of `HoistAnalysis` keyed by body
+/// identity. The key `*const Vec<Statement>` is an identity only — never
+/// dereferenced. Entries cannot go stale: ASTs are immutable post-parse and
+/// each entry pins the body it is keyed by.
+pub(crate) struct HoistCache {
+    entries: FxHashMap<*const Vec<Statement>, Entry>,
+    capacity: usize,
+    clock: u64,
+    hits: u64,
+}
+
+impl HoistCache {
+    pub(crate) fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: FxHashMap::default(),
+            capacity: capacity.max(2),
+            clock: 0,
+            hits: 0,
+        }
+    }
+
+    /// Return the memoised analysis for `body`, marking it most-recently used.
+    pub(crate) fn get(&mut self, body: &Rc<Vec<Statement>>) -> Option<Rc<HoistAnalysis>> {
+        let key = Rc::as_ptr(body);
+        self.clock += 1;
+        let clock = self.clock;
+        let entry = self.entries.get_mut(&key)?;
+        entry.last_used = clock;
+        let analysis = entry.analysis.clone();
+        self.hits += 1;
+        Some(analysis)
+    }
+
+    /// Memoise the analysis of `body`, evicting the least-recently-used half of
+    /// the cache first if this entry would exceed the capacity.
+    pub(crate) fn insert(
+        &mut self,
+        body: &Rc<Vec<Statement>>,
+        var_names: Vec<String>,
+        annexb_names: Vec<String>,
+    ) -> Rc<HoistAnalysis> {
+        let key = Rc::as_ptr(body);
+        if self.entries.len() >= self.capacity && !self.entries.contains_key(&key) {
+            self.evict_lru_half();
+        }
+        let analysis = Rc::new(HoistAnalysis {
+            var_names,
+            annexb_names,
+            _body: body.clone(),
+        });
+        self.clock += 1;
+        self.entries.insert(
+            key,
+            Entry {
+                analysis: analysis.clone(),
+                last_used: self.clock,
+            },
+        );
+        analysis
+    }
+
+    /// Number of memoised bodies. Whitebox accessor used by the tests that
+    /// pin down the capacity bound; not exposed to JS.
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Number of lookups served from the cache. Whitebox accessor used by the
+    /// test that pins down that repeated calls still reuse one analysis; not
+    /// exposed to JS.
+    #[allow(dead_code)]
+    pub(crate) fn hits(&self) -> u64 {
+        self.hits
+    }
+
+    /// Drop the older half of the entries by `last_used` (the median entry
+    /// included, so at least `capacity / 2` slots come free). Halving rather
+    /// than evicting a single entry keeps this an amortised O(1)-per-insert
+    /// sweep. Each removal drops the entry's pinned body together with its key,
+    /// so no surviving key can be aliased by a later body at the same address.
+    fn evict_lru_half(&mut self) {
+        let mut ticks: Vec<u64> = self.entries.values().map(|e| e.last_used).collect();
+        let mid = ticks.len() / 2;
+        let (_, &mut cutoff, _) = ticks.select_nth_unstable(mid);
+        self.entries.retain(|_, e| e.last_used > cutoff);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body(n: usize) -> Rc<Vec<Statement>> {
+        // Distinct allocations; contents are irrelevant to the cache.
+        Rc::new(vec![Statement::Empty; n])
+    }
+
+    fn insert(cache: &mut HoistCache, b: &Rc<Vec<Statement>>) {
+        cache.insert(b, vec!["x".to_string()], Vec::new());
+    }
+
+    #[test]
+    fn memoises_by_body_identity() {
+        let mut cache = HoistCache::new();
+        let b = body(1);
+        assert!(cache.get(&b).is_none());
+        insert(&mut cache, &b);
+        let hit = cache.get(&b).expect("cached analysis");
+        assert_eq!(hit.var_names, vec!["x".to_string()]);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn hits_count_only_lookups_served_from_the_cache() {
+        let mut cache = HoistCache::new();
+        let b = body(1);
+        assert!(cache.get(&b).is_none());
+        assert_eq!(cache.hits(), 0);
+        insert(&mut cache, &b);
+        assert!(cache.get(&b).is_some());
+        assert!(cache.get(&b).is_some());
+        assert_eq!(cache.hits(), 2);
+    }
+
+    #[test]
+    fn distinct_bodies_get_distinct_entries() {
+        let mut cache = HoistCache::new();
+        let a = body(1);
+        let b = body(2);
+        insert(&mut cache, &a);
+        insert(&mut cache, &b);
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn stays_within_capacity_across_many_bodies() {
+        let mut cache = HoistCache::with_capacity(8);
+        // Bodies are dropped immediately, exactly as short-lived dynamic
+        // function bodies are; only the cache's own pin could retain them.
+        for i in 0..1000 {
+            let b = body(i % 4 + 1);
+            insert(&mut cache, &b);
+            assert!(cache.len() <= 8, "cache grew to {}", cache.len());
+        }
+        assert!(cache.len() <= 8);
+    }
+
+    #[test]
+    fn eviction_releases_the_pinned_body() {
+        let mut cache = HoistCache::with_capacity(2);
+        let pinned = body(1);
+        let weak = Rc::downgrade(&pinned);
+        insert(&mut cache, &pinned);
+        drop(pinned);
+        assert!(weak.upgrade().is_some(), "cache must pin a live entry");
+        for i in 0..8 {
+            let b = body(i + 2);
+            insert(&mut cache, &b);
+        }
+        assert!(
+            weak.upgrade().is_none(),
+            "evicted entry must release its body"
+        );
+    }
+
+    #[test]
+    fn recently_used_entries_survive_eviction() {
+        let mut cache = HoistCache::with_capacity(4);
+        let hot = body(1);
+        insert(&mut cache, &hot);
+        let mut cold = Vec::new();
+        for i in 0..3 {
+            let b = body(i + 2);
+            insert(&mut cache, &b);
+            cold.push(b);
+        }
+        // Touch the first body so it is the most-recently used, then force a
+        // sweep by inserting a new body.
+        assert!(cache.get(&hot).is_some());
+        let fresh = body(99);
+        insert(&mut cache, &fresh);
+        assert!(
+            cache.get(&hot).is_some(),
+            "most-recently-used entry must survive eviction"
+        );
+    }
+
+    #[test]
+    fn reinsert_of_a_cached_body_does_not_evict() {
+        let mut cache = HoistCache::with_capacity(2);
+        let a = body(1);
+        let b = body(2);
+        insert(&mut cache, &a);
+        insert(&mut cache, &b);
+        insert(&mut cache, &b);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get(&a).is_some());
+    }
+}

--- a/src/interpreter/ic_store.rs
+++ b/src/interpreter/ic_store.rs
@@ -27,6 +27,10 @@ pub(crate) struct IcStore {
     /// same cache. Each `BodyIcStore` pins a clone of the body's statement `Rc`
     /// so the pointer key cannot be reused by a freed-then-reallocated body
     /// (ABA), matching the `HoistAnalysis` cache pattern.
+    ///
+    /// Unlike that cache (`super::hoist_cache`, bounded per #165), this table
+    /// never evicts, so it retains every body it has ever run — bounding it
+    /// needs handle-lifetime work and is tracked in #468.
     index: HashMap<*const Vec<crate::ast::Statement>, usize>,
     stores: Vec<BodyIcStore>,
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -28,6 +28,8 @@ mod exec;
 mod gc;
 pub(crate) mod generator_analysis;
 pub(crate) mod generator_transform;
+mod hoist_cache;
+pub(crate) use hoist_cache::{HoistAnalysis, HoistCache};
 mod hoisting;
 pub(crate) mod ic;
 pub(crate) mod ic_store;
@@ -58,25 +60,6 @@ fn import_module_type(attrs: &[(String, String)]) -> Option<ImportModuleType> {
         }
     }
     None
-}
-
-/// Cached output of the var/Annex-B hoisting *name collection* for a single
-/// function body, keyed by the body's `Rc` pointer identity (#72).
-///
-/// Only the raw name collection is cached. The Annex-B post-processing that
-/// inspects live env/parameter/lexical state still runs per call, and function
-/// declarations are never cached as values (fresh closures are built per call).
-/// The body `Rc` is pinned to prevent pointer (ABA) reuse from aliasing a
-/// freed body onto a fresh one with the same address.
-pub(crate) struct HoistAnalysis {
-    /// Deduped output of `collect_var_names_from_stmts`.
-    pub(crate) var_names: Vec<String>,
-    /// Raw `names` output of `collect_annexb_function_names`. (The companion
-    /// `blocked` accumulator is internal to the walk and discarded afterwards
-    /// by the original code, so it is intentionally not cached.)
-    pub(crate) annexb_names: Vec<String>,
-    /// Pins the body so its `Rc::as_ptr` key cannot be reused for another body.
-    _body: Rc<Vec<Statement>>,
 }
 
 pub(crate) struct Interpreter {
@@ -178,10 +161,9 @@ pub(crate) struct Interpreter {
     /// enabled so elapsed nanoseconds are measured from a stable origin.
     pub(crate) host_clock_start: Option<std::time::Instant>,
     /// Per-function-body hoisting-analysis cache keyed by body `Rc` identity
-    /// (#72). The key `*const Vec<Statement>` is used purely as an identity —
-    /// never dereferenced. Cannot go stale: ASTs are immutable post-parse and
-    /// the keyed body is pinned in the value.
-    pub(crate) hoist_cache: FxHashMap<*const Vec<Statement>, Rc<HoistAnalysis>>,
+    /// (#72), bounded so body-churning workloads cannot retain every body they
+    /// ever ran (#165). See `hoist_cache`.
+    pub(crate) hoist_cache: HoistCache,
     /// Per-body inline-cache store. Bodies are keyed by the `Rc` pointer to
     /// their statement vector so closures of the same function body share the
     /// same cache. See `docs/adr/0001-inline-cache-ast-seam.md`.
@@ -429,7 +411,7 @@ impl Interpreter {
             node_host_enabled: false,
             pending_exit: None,
             host_clock_start: None,
-            hoist_cache: FxHashMap::default(),
+            hoist_cache: HoistCache::new(),
             ic_store: ic_store::IcStore::new(),
             current_ic_handle: ic_store::BodyStoreHandle(0),
             call_depth: 0,

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -2292,6 +2292,57 @@ fn date_set_utc_full_year_on_invalid_date_seeds_missing_args_from_epoch_not_nan(
     assert_eq!(global_number(&interp, "__d"), 1.0);
 }
 
+// #165: the per-body hoisting-analysis cache pins each body it memoises, so an
+// unbounded map would retain every `new Function` / `eval` body the program ever
+// ran. These pin the bound and the memoisation it must not lose.
+#[test]
+fn hoist_cache_stays_bounded_across_many_distinct_dynamic_function_bodies() {
+    let bodies = super::hoist_cache::DEFAULT_CAPACITY + 2000;
+    let interp = run_script(&format!(
+        r#"
+        var sum = 0;
+        for (var i = 0; i < {bodies}; i++) {{
+          // A distinct source per iteration, so each call dispatches a body the
+          // cache has never seen, with both var and Annex-B names to collect.
+          var f = new Function("var x" + i + " = 1; {{ function g" + i + "(){{}} }} return x" + i + ";");
+          sum += f();
+        }}
+        globalThis.__sum = sum;
+        "#
+    ));
+    assert_eq!(global_number(&interp, "__sum"), bodies as f64);
+    assert!(
+        interp.hoist_cache.len() <= super::hoist_cache::DEFAULT_CAPACITY,
+        "hoist cache grew to {} entries for {bodies} dynamic bodies",
+        interp.hoist_cache.len()
+    );
+    // Guards against the bound passing vacuously: these bodies must really be
+    // reaching the cache, which means it fills and then evicts.
+    assert!(
+        interp.hoist_cache.len() > super::hoist_cache::DEFAULT_CAPACITY / 2,
+        "expected the dynamic bodies to fill the cache, got {} entries",
+        interp.hoist_cache.len()
+    );
+}
+
+#[test]
+fn hoist_cache_still_reuses_one_analysis_across_repeated_calls() {
+    let interp = run_script(
+        r#"
+        function f(n) { var acc = 0; for (var i = 0; i < n; i++) { acc += i; } return acc; }
+        var total = 0;
+        for (var k = 0; k < 50; k++) { total += f(3); }
+        globalThis.__total = total;
+        "#,
+    );
+    assert_eq!(global_number(&interp, "__total"), 150.0);
+    assert!(
+        interp.hoist_cache.hits() >= 49,
+        "expected the repeatedly-called body to be memoised, got {} hits",
+        interp.hoist_cache.hits()
+    );
+}
+
 // Loop and labelled-statement completion values are the observable surface of
 // the `v = val` folding consolidated into `handle_loop_body_completion`
 // (src/interpreter/exec.rs). These pin the behaviour across the six loop heads


### PR DESCRIPTION
## Summary

- The #72 hoisting-analysis memo (`Interpreter::hoist_cache`) was an unbounded `FxHashMap<*const Vec<Statement>, Rc<HoistAnalysis>>` whose entries each pin the analysed body's `Rc` (so the pointer key cannot ABA-collide). Nothing evicted, so every dynamic body a program ever ran — `new Function`, `eval` — was retained for the life of the interpreter.
- Replaced with a `HoistCache` in a new `src/interpreter/hoist_cache.rs`: capacity-bounded at 8,192 bodies, approximate-LRU, dropping the older half in one sweep when a new body would overflow. Entries are pure memoisation, so eviction only ever costs a re-walk of that body.
- `HoistAnalysis` moves into the same module and can only be constructed by the cache, which makes the ABA-safety invariant structural: a key exists only while the cache holds its body alive, and eviction removes the key and drops the pinned body in the same operation.
- Recency is tracked on lookup as well as insertion, so a hot body cannot be evicted ahead of a cold one — the `dispatch_body` fast path #72 added is preserved (`hoist_cache_still_reuses_one_analysis_across_repeated_calls` asserts the memo is still hit across repeated calls).

Fixes #165

## Scope: this bounds the cache; it does not on its own flatten RSS

`dispatch_body` populates two caches per body, and `IcStore` (`ic_store.rs`) pins the same `Rc<Vec<Statement>>` with no eviction of its own. The two pins are co-dominant: while either survives, the body's AST cannot be freed. Peak RSS on a loop of N distinct `new Function` bodies, each function object dropped right after its single call (release build; probe builds skip one or both pins):

| N | before | after (this PR) | hoist pin skipped | IcStore pin skipped | both skipped |
|---|---|---|---|---|---|
| 5,000 | 50.5 MB | 50.0 MB | 48.4 MB | 50.3 MB | 36.4 MB |
| 10,000 | 71.2 MB | 69.9 MB | — | — | — |
| 20,000 | 111.3 MB | 107.2 MB | 104.3 MB | 111.6 MB | 38.8 MB |
| 60,000 | — | 254.4 MB | — | — | — |

(The 60,000-body row is post-fix and well past the 8,192 cap: ~3.68 KB/body with no plateau, which is the `IcStore` pin, not this cache.) So: the cache itself is now bounded (and below the cap nothing changes by design — 5,000 bodies never evict), but total RSS still grows ~3.7 KB per dynamic body because `IcStore` holds every body. Bounding that needs handle-lifetime work — `BodyStoreHandle` is a bare index held in `current_ic_handle` and in `prev` locals across recursion — so it is filed separately as **#468** rather than widened into this PR. (The bytecode path in `dispatch_body` returns before the hoist-cache block, so this change is inert under `--bytecode` and needs no separate run there.) Wall-clock on the same workload is unchanged within noise on this (shared, loaded) machine; no throughput claim is made either way.

## Test plan

- [x] `cargo test --release` — 502 + 3 + 1 passing, 0 failed (9 new: 7 unit tests on the cache, 2 interpreter-level)
  - unit: memoisation by body identity, hit accounting, capacity bound over 1,000 churned bodies, eviction actually releases the pinned body (`Weak::upgrade` goes `None`), most-recently-used entry survives a sweep, re-insert of a cached body does not evict
  - interpreter-level: 10,192 distinct `new Function` bodies stay within `DEFAULT_CAPACITY` *and* fill it (guards the bound against passing vacuously), with the computed result asserted so eviction cannot silently change hoisting behaviour
- [x] `./scripts/lint.sh` — rustfmt + clippy `-D warnings` clean
- [x] test262 (`-j 32`): **99,568 / 99,568 (100.0%)**, 0 regressions
- [x] test262-extra: 144 / 144 (100.0%)
- [x] custom tests (`run-custom-tests.py`): 11 / 11
- [x] Manual repro (`new Function` churn at N = 5k/10k/20k) confirms the cache no longer grows past the cap; residual RSS growth attributed and filed as #468
