### PR TITLE
fix(modules): resolve the `<module source>` host specifier in every import phase

### DIFF
--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -8038,7 +8038,7 @@ impl Interpreter {
                         return interp.create_rejected_promise(err);
                     }
                 };
-                let resolved_canon = module_path.canonicalize().unwrap_or(module_path.clone());
+                let resolved_canon = Interpreter::canonicalize_module_path(&module_path);
                 let mut stack = vec![];
                 if interp
                     .inner_module_evaluation(&resolved_canon, &mut stack, 0)

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1271,6 +1271,7 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
+                let mut source_import_type: Option<super::ImportModuleType> = None;
                 if let Some(opts_expr) = options_expr {
                     match self.eval_expr(opts_expr, env) {
                         Completion::Normal(opts_val) => {
@@ -1286,11 +1287,31 @@ impl Interpreter {
                                     .map(|id| crate::types::JsObject { id })
                                 {
                                     let wv = self.get_property_on_id(o.id, "with");
-                                    if !wv.is_undefined() && !(wv).is_object() {
-                                        let err = self.create_type_error(
-                                            "The 'with' option must be an object",
-                                        );
-                                        return self.create_rejected_promise(err);
+                                    if !wv.is_undefined() {
+                                        if !(wv).is_object() {
+                                            let err = self.create_type_error(
+                                                "The 'with' option must be an object",
+                                            );
+                                            return self.create_rejected_promise(err);
+                                        }
+                                        // The requested type is part of the module
+                                        // request, so the source phase must see it
+                                        // too — otherwise the completion for one
+                                        // (referrer, specifier, attributes) triple
+                                        // would depend on the phase.
+                                        if let Some(with_obj) = (wv)
+                                            .as_object_id()
+                                            .map(|id| crate::types::JsObject { id })
+                                        {
+                                            let tv = self.get_property_on_id(with_obj.id, "type");
+                                            if let Some(sv) = (tv).as_string() {
+                                                source_import_type = match sv.to_string().as_str() {
+                                                    "text" => Some(super::ImportModuleType::Text),
+                                                    "bytes" => Some(super::ImportModuleType::Bytes),
+                                                    _ => None,
+                                                };
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -1306,7 +1327,11 @@ impl Interpreter {
                 // target module's [[ModuleSource]]. A Source Text Module has an
                 // empty [[ModuleSource]] (GetModuleSource throws SyntaxError).
                 let referrer = self.current_module_path.clone();
-                match self.resolve_source_phase_target(&source, referrer.as_deref()) {
+                match self.resolve_source_phase_target(
+                    &source,
+                    referrer.as_deref(),
+                    source_import_type,
+                ) {
                     Ok((_, Some(ms))) => self.create_resolved_promise(ms),
                     Ok((_, None)) => {
                         let err = self.create_error(

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -39,15 +39,33 @@ enum DestructLRef {
 }
 
 impl Interpreter {
-    /// §2.1.1.1 EvaluateImportCall steps 9-11: validate an import call's options
-    /// object and read the requested module type off its `with` attributes.
+    /// §2.1.1.1 EvaluateImportCall steps 9-11: evaluate an import call's options
+    /// expression and read the requested module type off its `with` attributes.
+    /// `Err` carries the `Completion` the caller should return — an abrupt
+    /// completion from the options expression, or a rejected promise.
     ///
     /// Import attributes are the *enumerable own* properties of `with`, so an
-    /// inherited or non-enumerable `type` is not an attribute. All three import
-    /// forms (`import()`, `import.source()`, `import.defer()`) go through here —
-    /// they previously each had their own copy, and the shorter copies read
-    /// `type` straight off the object, turning an inherited `type` into a
-    /// spurious rejection.
+    /// inherited or non-enumerable `type` is not an attribute. `import()`,
+    /// `import.source()` and `import.defer()` all go through here; they each had
+    /// their own copy, and the two shorter copies read `type` straight off the
+    /// object, turning an inherited `type` into a spurious rejection.
+    fn import_call_options_type(
+        &mut self,
+        options_expr: Option<&Expression>,
+        env: &EnvRef,
+        callee: &str,
+    ) -> Result<Option<super::ImportModuleType>, Completion> {
+        let Some(options_expr) = options_expr else {
+            return Ok(None);
+        };
+        let opts_val = match self.eval_expr(options_expr, env) {
+            Completion::Normal(v) => v,
+            other => return Err(other),
+        };
+        self.import_call_module_type(&opts_val, callee)
+            .map_err(|e| self.create_rejected_promise(e))
+    }
+
     fn import_call_module_type(
         &mut self,
         opts_val: &JsValue,
@@ -56,18 +74,12 @@ impl Interpreter {
         if opts_val.is_undefined() {
             return Ok(None);
         }
-        if !opts_val.is_object() {
+        let Some(opts_id) = opts_val.as_object_id() else {
             return Err(self.create_type_error(&format!(
                 "The second argument to {callee} must be an object"
             )));
-        }
-        let Some(o) = opts_val
-            .as_object_id()
-            .map(|id| crate::types::JsObject { id })
-        else {
-            return Ok(None);
         };
-        let wv = match self.get_object_property(o.id, "with", opts_val) {
+        let wv = match self.get_object_property(opts_id, "with", opts_val) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(e),
             _ => return Err(self.create_type_error("Invalid import options")),
@@ -75,16 +87,13 @@ impl Interpreter {
         if wv.is_undefined() {
             return Ok(None);
         }
-        if !wv.is_object() {
+        let Some(with_id) = wv.as_object_id() else {
             return Err(self.create_type_error("The 'with' option must be an object"));
-        }
-        let Some(with_obj) = (wv).as_object_id().map(|id| crate::types::JsObject { id }) else {
-            return Ok(None);
         };
 
         let mut itype = None;
-        for k in crate::interpreter::helpers::enumerable_own_keys(self, with_obj.id)? {
-            let v = match self.get_object_property(with_obj.id, &k, &wv) {
+        for k in crate::interpreter::helpers::enumerable_own_keys(self, with_id)? {
+            let v = match self.get_object_property(with_id, &k, &wv) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
                 _ => return Err(self.create_type_error("Invalid import attribute")),
@@ -92,12 +101,9 @@ impl Interpreter {
             let Some(sv) = (v).as_string() else {
                 return Err(self.create_type_error("Import attribute values must be strings"));
             };
+            // Every value is string-checked, so keep going past "type".
             if k.eq_str("type") {
-                itype = match sv.to_string().as_str() {
-                    "text" => Some(super::ImportModuleType::Text),
-                    "bytes" => Some(super::ImportModuleType::Bytes),
-                    _ => None,
-                };
+                itype = super::ImportModuleType::from_attr_value(&sv.to_rust_string());
             }
         }
         Ok(itype)
@@ -1186,18 +1192,11 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                // Evaluate options expression if present (abrupt completions propagate directly)
-                let mut dynamic_import_type: Option<super::ImportModuleType> = None;
-                if let Some(opts_expr) = options_expr {
-                    let opts_val = match self.eval_expr(opts_expr, env) {
-                        Completion::Normal(v) => v,
-                        other => return other,
+                let dynamic_import_type =
+                    match self.import_call_options_type(options_expr.as_deref(), env, "import()") {
+                        Ok(t) => t,
+                        Err(c) => return c,
                     };
-                    match self.import_call_module_type(&opts_val, "import()") {
-                        Ok(t) => dynamic_import_type = t,
-                        Err(e) => return self.create_rejected_promise(e),
-                    }
-                }
                 // Per spec: ToString(specifier) errors produce a rejected promise
                 let source = match self.to_string_value(&source_val) {
                     Ok(s) => s,
@@ -1210,17 +1209,14 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                let mut defer_import_type: Option<super::ImportModuleType> = None;
-                if let Some(opts_expr) = options_expr {
-                    let opts_val = match self.eval_expr(opts_expr, env) {
-                        Completion::Normal(v) => v,
-                        other => return other,
-                    };
-                    match self.import_call_module_type(&opts_val, "import.defer()") {
-                        Ok(t) => defer_import_type = t,
-                        Err(e) => return self.create_rejected_promise(e),
-                    }
-                }
+                let defer_import_type = match self.import_call_options_type(
+                    options_expr.as_deref(),
+                    env,
+                    "import.defer()",
+                ) {
+                    Ok(t) => t,
+                    Err(c) => return c,
+                };
                 let source = match self.to_string_value(&source_val) {
                     Ok(s) => s,
                     Err(e) => return self.create_rejected_promise(e),
@@ -1258,17 +1254,14 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                let mut source_import_type: Option<super::ImportModuleType> = None;
-                if let Some(opts_expr) = options_expr {
-                    let opts_val = match self.eval_expr(opts_expr, env) {
-                        Completion::Normal(v) => v,
-                        other => return other,
-                    };
-                    match self.import_call_module_type(&opts_val, "import.source()") {
-                        Ok(t) => source_import_type = t,
-                        Err(e) => return self.create_rejected_promise(e),
-                    }
-                }
+                let source_import_type = match self.import_call_options_type(
+                    options_expr.as_deref(),
+                    env,
+                    "import.source()",
+                ) {
+                    Ok(t) => t,
+                    Err(c) => return c,
+                };
                 let source = match self.to_string_value(&source_val) {
                     Ok(s) => s,
                     Err(e) => return self.create_rejected_promise(e),

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -39,6 +39,70 @@ enum DestructLRef {
 }
 
 impl Interpreter {
+    /// §2.1.1.1 EvaluateImportCall steps 9-11: validate an import call's options
+    /// object and read the requested module type off its `with` attributes.
+    ///
+    /// Import attributes are the *enumerable own* properties of `with`, so an
+    /// inherited or non-enumerable `type` is not an attribute. All three import
+    /// forms (`import()`, `import.source()`, `import.defer()`) go through here —
+    /// they previously each had their own copy, and the shorter copies read
+    /// `type` straight off the object, turning an inherited `type` into a
+    /// spurious rejection.
+    fn import_call_module_type(
+        &mut self,
+        opts_val: &JsValue,
+        callee: &str,
+    ) -> Result<Option<super::ImportModuleType>, JsValue> {
+        if opts_val.is_undefined() {
+            return Ok(None);
+        }
+        if !opts_val.is_object() {
+            return Err(self.create_type_error(&format!(
+                "The second argument to {callee} must be an object"
+            )));
+        }
+        let Some(o) = opts_val
+            .as_object_id()
+            .map(|id| crate::types::JsObject { id })
+        else {
+            return Ok(None);
+        };
+        let wv = match self.get_object_property(o.id, "with", opts_val) {
+            Completion::Normal(v) => v,
+            Completion::Throw(e) => return Err(e),
+            _ => return Err(self.create_type_error("Invalid import options")),
+        };
+        if wv.is_undefined() {
+            return Ok(None);
+        }
+        if !wv.is_object() {
+            return Err(self.create_type_error("The 'with' option must be an object"));
+        }
+        let Some(with_obj) = (wv).as_object_id().map(|id| crate::types::JsObject { id }) else {
+            return Ok(None);
+        };
+
+        let mut itype = None;
+        for k in crate::interpreter::helpers::enumerable_own_keys(self, with_obj.id)? {
+            let v = match self.get_object_property(with_obj.id, &k, &wv) {
+                Completion::Normal(v) => v,
+                Completion::Throw(e) => return Err(e),
+                _ => return Err(self.create_type_error("Invalid import attribute")),
+            };
+            let Some(sv) = (v).as_string() else {
+                return Err(self.create_type_error("Import attribute values must be strings"));
+            };
+            if k.eq_str("type") {
+                itype = match sv.to_string().as_str() {
+                    "text" => Some(super::ImportModuleType::Text),
+                    "bytes" => Some(super::ImportModuleType::Bytes),
+                    _ => None,
+                };
+            }
+        }
+        Ok(itype)
+    }
+
     fn resolve_private_name(&self, source_name: &str, env: &EnvRef) -> String {
         let mut current = Some(env.clone());
         while let Some(e) = current {
@@ -1125,83 +1189,13 @@ impl Interpreter {
                 // Evaluate options expression if present (abrupt completions propagate directly)
                 let mut dynamic_import_type: Option<super::ImportModuleType> = None;
                 if let Some(opts_expr) = options_expr {
-                    match self.eval_expr(opts_expr, env) {
-                        Completion::Normal(opts_val) => {
-                            // Steps 9-10: If options is not undefined, validate it
-                            if !opts_val.is_undefined() {
-                                if !(opts_val).is_object() {
-                                    let err = self.create_type_error(
-                                        "The second argument to import() must be an object",
-                                    );
-                                    return self.create_rejected_promise(err);
-                                }
-                                // Step 11: Get "with" property (must use [[Get]] to invoke getters)
-                                if let Some(o) = opts_val
-                                    .clone()
-                                    .as_object_id()
-                                    .map(|id| crate::types::JsObject { id })
-                                {
-                                    let wv = match self.get_object_property(o.id, "with", &opts_val)
-                                    {
-                                        Completion::Normal(v) => v,
-                                        Completion::Throw(e) => {
-                                            return self.create_rejected_promise(e);
-                                        }
-                                        other => return other,
-                                    };
-                                    if !wv.is_undefined() {
-                                        if !(wv).is_object() {
-                                            let err = self.create_type_error(
-                                                "The 'with' option must be an object",
-                                            );
-                                            return self.create_rejected_promise(err);
-                                        }
-                                        // §2.1.1.1 step 10d: enumerate properties, each value must be a string
-                                        if let Some(with_obj) = (wv)
-                                            .as_object_id()
-                                            .map(|id| crate::types::JsObject { id })
-                                        {
-                                            let keys = match crate::interpreter::helpers::enumerable_own_keys(self, with_obj.id) {
-                                                Ok(k) => k,
-                                                Err(e) => return self.create_rejected_promise(e),
-                                            };
-                                            for k in keys {
-                                                let v = match self.get_object_property(
-                                                    with_obj.id,
-                                                    &k,
-                                                    &wv,
-                                                ) {
-                                                    Completion::Normal(v) => v,
-                                                    Completion::Throw(e) => {
-                                                        return self.create_rejected_promise(e);
-                                                    }
-                                                    other => return other,
-                                                };
-                                                if let Some(sv) = (v).as_string() {
-                                                    if k.eq_str("type") {
-                                                        let s = sv.to_string();
-                                                        if s == "text" {
-                                                            dynamic_import_type =
-                                                                Some(super::ImportModuleType::Text);
-                                                        } else if s == "bytes" {
-                                                            dynamic_import_type = Some(
-                                                                super::ImportModuleType::Bytes,
-                                                            );
-                                                        }
-                                                    }
-                                                } else {
-                                                    let err = self.create_type_error(
-                                                        "Import attribute values must be strings",
-                                                    );
-                                                    return self.create_rejected_promise(err);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                    let opts_val = match self.eval_expr(opts_expr, env) {
+                        Completion::Normal(v) => v,
                         other => return other,
+                    };
+                    match self.import_call_module_type(&opts_val, "import()") {
+                        Ok(t) => dynamic_import_type = t,
+                        Err(e) => return self.create_rejected_promise(e),
                     }
                 }
                 // Per spec: ToString(specifier) errors produce a rejected promise
@@ -1216,31 +1210,15 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
+                let mut defer_import_type: Option<super::ImportModuleType> = None;
                 if let Some(opts_expr) = options_expr {
-                    match self.eval_expr(opts_expr, env) {
-                        Completion::Normal(opts_val) => {
-                            if !opts_val.is_undefined() {
-                                if !(opts_val).is_object() {
-                                    let err = self.create_type_error(
-                                        "The second argument to import.defer() must be an object",
-                                    );
-                                    return self.create_rejected_promise(err);
-                                }
-                                if let Some(o) = opts_val
-                                    .as_object_id()
-                                    .map(|id| crate::types::JsObject { id })
-                                {
-                                    let wv = self.get_property_on_id(o.id, "with");
-                                    if !wv.is_undefined() && !(wv).is_object() {
-                                        let err = self.create_type_error(
-                                            "The 'with' option must be an object",
-                                        );
-                                        return self.create_rejected_promise(err);
-                                    }
-                                }
-                            }
-                        }
+                    let opts_val = match self.eval_expr(opts_expr, env) {
+                        Completion::Normal(v) => v,
                         other => return other,
+                    };
+                    match self.import_call_module_type(&opts_val, "import.defer()") {
+                        Ok(t) => defer_import_type = t,
+                        Err(e) => return self.create_rejected_promise(e),
                     }
                 }
                 let source = match self.to_string_value(&source_val) {
@@ -1255,6 +1233,15 @@ impl Interpreter {
                     Ok(r) => r,
                     Err(e) => return self.create_rejected_promise(e),
                 };
+                // The synthetic Module Source module has no text or bytes in any
+                // phase, so a typed request must be refused here too, exactly as
+                // import() and import.source() refuse it.
+                if let Some(itype) = defer_import_type
+                    && Self::is_module_source_path(&resolved)
+                {
+                    let err = self.module_source_type_error(itype);
+                    return self.create_rejected_promise(err);
+                }
                 match self.load_module_no_eval(&resolved) {
                     Ok(module) => {
                         let resolved_canon = Self::canonicalize_module_path(&resolved);
@@ -1273,50 +1260,13 @@ impl Interpreter {
                 };
                 let mut source_import_type: Option<super::ImportModuleType> = None;
                 if let Some(opts_expr) = options_expr {
-                    match self.eval_expr(opts_expr, env) {
-                        Completion::Normal(opts_val) => {
-                            if !opts_val.is_undefined() {
-                                if !(opts_val).is_object() {
-                                    let err = self.create_type_error(
-                                        "The second argument to import.source() must be an object",
-                                    );
-                                    return self.create_rejected_promise(err);
-                                }
-                                if let Some(o) = opts_val
-                                    .as_object_id()
-                                    .map(|id| crate::types::JsObject { id })
-                                {
-                                    let wv = self.get_property_on_id(o.id, "with");
-                                    if !wv.is_undefined() {
-                                        if !(wv).is_object() {
-                                            let err = self.create_type_error(
-                                                "The 'with' option must be an object",
-                                            );
-                                            return self.create_rejected_promise(err);
-                                        }
-                                        // The requested type is part of the module
-                                        // request, so the source phase must see it
-                                        // too — otherwise the completion for one
-                                        // (referrer, specifier, attributes) triple
-                                        // would depend on the phase.
-                                        if let Some(with_obj) = (wv)
-                                            .as_object_id()
-                                            .map(|id| crate::types::JsObject { id })
-                                        {
-                                            let tv = self.get_property_on_id(with_obj.id, "type");
-                                            if let Some(sv) = (tv).as_string() {
-                                                source_import_type = match sv.to_string().as_str() {
-                                                    "text" => Some(super::ImportModuleType::Text),
-                                                    "bytes" => Some(super::ImportModuleType::Bytes),
-                                                    _ => None,
-                                                };
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                    let opts_val = match self.eval_expr(opts_expr, env) {
+                        Completion::Normal(v) => v,
                         other => return other,
+                    };
+                    match self.import_call_module_type(&opts_val, "import.source()") {
+                        Ok(t) => source_import_type = t,
+                        Err(e) => return self.create_rejected_promise(e),
                     }
                 }
                 let source = match self.to_string_value(&source_val) {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1257,7 +1257,7 @@ impl Interpreter {
                 };
                 match self.load_module_no_eval(&resolved) {
                     Ok(module) => {
-                        let resolved_canon = resolved.canonicalize().unwrap_or(resolved.clone());
+                        let resolved_canon = Self::canonicalize_module_path(&resolved);
                         self.evaluate_async_transitive_deps(&resolved_canon);
                         self.drain_microtasks();
                         let ns = self.create_deferred_module_namespace(&module);

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -428,7 +428,7 @@ impl Interpreter {
                     return self.create_rejected_promise(e);
                 }
             };
-            let resolved_canon = resolved.canonicalize().unwrap_or(resolved.clone());
+            let resolved_canon = Interpreter::canonicalize_module_path(&resolved);
             let mut stack = vec![];
             if let Err(ref e) = self.inner_module_evaluation(&resolved_canon, &mut stack, 0) {
                 for m_path in &stack {
@@ -461,9 +461,7 @@ impl Interpreter {
             Box::new(move |interp: &mut Interpreter| {
                 match interp.load_module(&resolved_path) {
                     Ok(m) => {
-                        let resolved_canon = resolved_path
-                            .canonicalize()
-                            .unwrap_or(resolved_path.clone());
+                        let resolved_canon = Interpreter::canonicalize_module_path(&resolved_path);
                         let mut stack = vec![];
                         if let Err(ref e) =
                             interp.inner_module_evaluation(&resolved_canon, &mut stack, 0)
@@ -555,7 +553,7 @@ impl Interpreter {
             let m = module.borrow();
             m.cycle_root
                 .clone()
-                .unwrap_or_else(|| m.path.canonicalize().unwrap_or_else(|_| m.path.clone()))
+                .unwrap_or_else(|| Interpreter::canonicalize_module_path(&m.path))
         };
         let root_module = self
             .module_registry_get(&root_path)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -997,6 +997,21 @@ impl Interpreter {
         path == Path::new(MODULE_SOURCE_SPECIFIER)
     }
 
+    /// Canonicalize a module *target* path, leaving the synthetic
+    /// `<module source>` key untouched.
+    ///
+    /// The key is a bare relative path, so a plain `canonicalize()` succeeds
+    /// whenever the process happens to run in a directory holding a real entry of
+    /// that name — silently rebinding the specifier to that file's registry slot.
+    /// Every site that canonicalizes a path which may have come from
+    /// `resolve_module_specifier` must go through here.
+    fn canonicalize_module_path(path: &Path) -> PathBuf {
+        if Self::is_module_source_path(path) {
+            return path.to_path_buf();
+        }
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    }
+
     /// The host has no text or bytes to hand back for a Module Source module, in
     /// any import phase. Built in one place so the source phase and the
     /// evaluation phase cannot report an unsatisfiable request differently.
@@ -2224,7 +2239,7 @@ impl Interpreter {
 
         // Text/bytes imports use synthetic module registry
         if let Some(ref it) = itype {
-            let canon = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
+            let canon = Self::canonicalize_module_path(&resolved);
             let key = (canon, it.clone());
             let loaded = self
                 .synthetic_module_registry
@@ -3512,9 +3527,7 @@ impl Interpreter {
         stack: &mut Vec<PathBuf>,
         index: u32,
     ) -> Result<u32, JsValue> {
-        let canon = module_path
-            .canonicalize()
-            .unwrap_or_else(|_| module_path.to_path_buf());
+        let canon = Self::canonicalize_module_path(module_path);
         let module = match self.module_registry_get(&canon) {
             Some(m) => m,
             None => return Ok(index),
@@ -3976,9 +3989,7 @@ impl Interpreter {
         result: &mut Vec<PathBuf>,
         seen: &mut HashSet<PathBuf>,
     ) {
-        let canon = module_path
-            .canonicalize()
-            .unwrap_or_else(|_| module_path.to_path_buf());
+        let canon = Self::canonicalize_module_path(module_path);
         if !seen.insert(canon.clone()) {
             return;
         }
@@ -4062,7 +4073,7 @@ impl Interpreter {
 
     /// Check if a module and all its transitive deps are ready for synchronous execution
     fn ready_for_sync_execution(&self, path: &Path, seen: &mut HashSet<PathBuf>) -> bool {
-        let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let canon = Self::canonicalize_module_path(path);
         if !seen.insert(canon.clone()) {
             return true; // cycle — spec says return true
         }
@@ -4138,9 +4149,7 @@ impl Interpreter {
         export_name: &str,
         visited: &mut HashSet<(PathBuf, String)>,
     ) -> Result<(EnvRef, String), JsValue> {
-        let canon_path = module_path
-            .canonicalize()
-            .unwrap_or_else(|_| module_path.to_path_buf());
+        let canon_path = Self::canonicalize_module_path(module_path);
         let key = (canon_path.clone(), export_name.to_string());
 
         if visited.contains(&key) {
@@ -4245,9 +4254,7 @@ impl Interpreter {
         export_name: &str,
         visited: &mut HashSet<(PathBuf, String)>,
     ) -> Result<(), JsValue> {
-        let canon_path = module_path
-            .canonicalize()
-            .unwrap_or_else(|_| module_path.to_path_buf());
+        let canon_path = Self::canonicalize_module_path(module_path);
         let key = (canon_path.clone(), export_name.to_string());
 
         // §16.2.1.6.3 step 2: circular reference → return null (not resolved)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -3209,6 +3209,11 @@ impl Interpreter {
     }
 
     fn load_text_module(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        if Self::is_module_source_path(path) {
+            return Err(JsValue::string(JsString::from_str(&format!(
+                "Module '{MODULE_SOURCE_SPECIFIER}' has no text representation"
+            ))));
+        }
         let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         let key = (canon.clone(), ImportModuleType::Text);
         if let Some(existing) = self.synthetic_module_registry.get(&key) {
@@ -3228,6 +3233,11 @@ impl Interpreter {
     }
 
     fn load_bytes_module(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        if Self::is_module_source_path(path) {
+            return Err(JsValue::string(JsString::from_str(&format!(
+                "Module '{MODULE_SOURCE_SPECIFIER}' has no bytes representation"
+            ))));
+        }
         let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         let key = (canon.clone(), ImportModuleType::Bytes);
         if let Some(existing) = self.synthetic_module_registry.get(&key) {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -49,17 +49,31 @@ enum ImportModuleType {
     Bytes,
 }
 
-fn import_module_type(attrs: &[(String, String)]) -> Option<ImportModuleType> {
-    for (key, value) in attrs {
-        if key == "type" {
-            return match value.as_str() {
-                "text" => Some(ImportModuleType::Text),
-                "bytes" => Some(ImportModuleType::Bytes),
-                _ => None,
-            };
+impl ImportModuleType {
+    /// The `type` import-attribute values jsse serves synthetic modules for.
+    /// `None` covers both an unknown type and one jsse decides another way
+    /// (`"json"` is chosen by file extension — see #475).
+    fn from_attr_value(value: &str) -> Option<Self> {
+        match value {
+            "text" => Some(Self::Text),
+            "bytes" => Some(Self::Bytes),
+            _ => None,
         }
     }
-    None
+
+    fn attr_value(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Bytes => "bytes",
+        }
+    }
+}
+
+fn import_module_type(attrs: &[(String, String)]) -> Option<ImportModuleType> {
+    attrs
+        .iter()
+        .find(|(key, _)| key == "type")
+        .and_then(|(_, value)| ImportModuleType::from_attr_value(value))
 }
 
 pub(crate) struct Interpreter {
@@ -1004,9 +1018,8 @@ impl Interpreter {
     /// whenever the process happens to run in a directory holding a real entry of
     /// that name — silently rebinding the specifier to that file's registry slot.
     /// Every site that canonicalizes a path which may have come from
-    /// `resolve_module_specifier` must go through here — twelve of them, spanning
-    /// export resolution, DFS evaluation, `import.defer`, and
-    /// `ShadowRealm.prototype.importValue`.
+    /// `resolve_module_specifier` goes through here, so the key also keeps
+    /// resolving to the synthetic record rather than missing the registry.
     fn canonicalize_module_path(path: &Path) -> PathBuf {
         if Self::is_module_source_path(path) {
             return path.to_path_buf();
@@ -1018,14 +1031,10 @@ impl Interpreter {
     /// any import phase. Built in one place so the source phase and the
     /// evaluation phase cannot report an unsatisfiable request differently.
     fn module_source_type_error(&mut self, itype: ImportModuleType) -> JsValue {
-        let repr = match itype {
-            ImportModuleType::Text => "text",
-            ImportModuleType::Bytes => "bytes",
-        };
-        self.create_error(
-            "TypeError",
-            &format!("Module '{MODULE_SOURCE_SPECIFIER}' has no {repr} representation"),
-        )
+        self.create_type_error(&format!(
+            "Module '{MODULE_SOURCE_SPECIFIER}' has no {} representation",
+            itype.attr_value()
+        ))
     }
 
     pub(crate) fn gc_root_value(&mut self, val: &JsValue) {
@@ -2642,7 +2651,7 @@ impl Interpreter {
             return Ok(self.get_or_create_module_source_module());
         }
 
-        let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let canon_path = Self::canonicalize_module_path(path);
 
         // Check if module is already loaded
         if let Some(existing) = self.module_registry_get(&canon_path) {
@@ -2974,7 +2983,7 @@ impl Interpreter {
             return Ok(self.get_or_create_module_source_module());
         }
 
-        let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let canon_path = Self::canonicalize_module_path(path);
 
         if let Some(existing) = self.module_registry_get(&canon_path) {
             // Propagate parse/link errors (module never finished loading) eagerly.
@@ -3249,7 +3258,7 @@ impl Interpreter {
         if Self::is_module_source_path(path) {
             return Err(self.module_source_type_error(ImportModuleType::Text));
         }
-        let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let canon = Self::canonicalize_module_path(path);
         let key = (canon.clone(), ImportModuleType::Text);
         if let Some(existing) = self.synthetic_module_registry.get(&key) {
             return Ok(existing.clone());
@@ -3271,7 +3280,7 @@ impl Interpreter {
         if Self::is_module_source_path(path) {
             return Err(self.module_source_type_error(ImportModuleType::Bytes));
         }
-        let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let canon = Self::canonicalize_module_path(path);
         let key = (canon.clone(), ImportModuleType::Bytes);
         if let Some(existing) = self.synthetic_module_registry.get(&key) {
             return Ok(existing.clone());

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1004,7 +1004,9 @@ impl Interpreter {
     /// whenever the process happens to run in a directory holding a real entry of
     /// that name — silently rebinding the specifier to that file's registry slot.
     /// Every site that canonicalizes a path which may have come from
-    /// `resolve_module_specifier` must go through here.
+    /// `resolve_module_specifier` must go through here — twelve of them, spanning
+    /// export resolution, DFS evaluation, `import.defer`, and
+    /// `ShadowRealm.prototype.importValue`.
     fn canonicalize_module_path(path: &Path) -> PathBuf {
         if Self::is_module_source_path(path) {
             return path.to_path_buf();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -244,9 +244,9 @@ const MAX_POOLED_FUNCTION_BINDING_CAPACITY: usize = 256;
 /// non-empty; see `Interpreter::get_or_create_module_source_module`.
 ///
 /// `HostLoadImportedModule` must hand back the same Module Record for a given
-/// (referrer, specifier) pair regardless of the request's phase, so this string
-/// is recognised by the host resolvers — not by the source-phase path alone. It
-/// is intercepted before any filesystem resolution and doubles as the module
+/// (referrer, specifier) pair regardless of the request's phase.
+///
+/// It is intercepted before any filesystem resolution and doubles as the module
 /// registry key, so it never reaches a real file of the same name.
 pub(crate) const MODULE_SOURCE_SPECIFIER: &str = "<module source>";
 
@@ -977,9 +977,13 @@ impl Interpreter {
         &mut self,
         specifier: &str,
         referrer: Option<&Path>,
+        import_type: Option<ImportModuleType>,
     ) -> Result<(PathBuf, Option<JsValue>), JsValue> {
         let resolved = self.resolve_module_specifier(specifier, referrer)?;
         if Self::is_module_source_path(&resolved) {
+            if let Some(itype) = import_type {
+                return Err(self.module_source_type_error(itype));
+            }
             let module = self.load_module(&resolved)?;
             let module_source = module.borrow().module_source.clone();
             return Ok((resolved, module_source));
@@ -990,7 +994,21 @@ impl Interpreter {
     /// Whether `path` is the module-registry key of the synthetic
     /// `<module source>` host module rather than a filesystem path.
     fn is_module_source_path(path: &Path) -> bool {
-        path.as_os_str() == std::ffi::OsStr::new(MODULE_SOURCE_SPECIFIER)
+        path == Path::new(MODULE_SOURCE_SPECIFIER)
+    }
+
+    /// The host has no text or bytes to hand back for a Module Source module, in
+    /// any import phase. Built in one place so the source phase and the
+    /// evaluation phase cannot report an unsatisfiable request differently.
+    fn module_source_type_error(&mut self, itype: ImportModuleType) -> JsValue {
+        let repr = match itype {
+            ImportModuleType::Text => "text",
+            ImportModuleType::Bytes => "bytes",
+        };
+        self.create_error(
+            "TypeError",
+            &format!("Module '{MODULE_SOURCE_SPECIFIER}' has no {repr} representation"),
+        )
     }
 
     pub(crate) fn gc_root_value(&mut self, val: &JsValue) {
@@ -2196,7 +2214,8 @@ impl Interpreter {
         // before the generic path, which binds a namespace and loads the target
         // graph; the source phase binds `[[ModuleSource]]` and stays shallow.
         if let [ImportSpecifier::SourcePhase(local)] = import.specifiers.as_slice() {
-            return self.process_source_phase_import(local, &import.source, env);
+            let itype = import_module_type(&import.attributes);
+            return self.process_source_phase_import(local, &import.source, itype, env);
         }
 
         let resolved = self.resolve_module_specifier(&import.source, module_path.as_deref())?;
@@ -2312,11 +2331,12 @@ impl Interpreter {
         &mut self,
         local: &str,
         specifier: &str,
+        import_type: Option<ImportModuleType>,
         env: &EnvRef,
     ) -> Result<(), JsValue> {
         let referrer = self.current_module_path.clone();
         let (target_path, module_source) =
-            self.resolve_source_phase_target(specifier, referrer.as_deref())?;
+            self.resolve_source_phase_target(specifier, referrer.as_deref(), import_type)?;
 
         let Some(module_source) = module_source else {
             return Err(self.create_error(
@@ -3210,9 +3230,7 @@ impl Interpreter {
 
     fn load_text_module(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
         if Self::is_module_source_path(path) {
-            return Err(JsValue::string(JsString::from_str(&format!(
-                "Module '{MODULE_SOURCE_SPECIFIER}' has no text representation"
-            ))));
+            return Err(self.module_source_type_error(ImportModuleType::Text));
         }
         let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         let key = (canon.clone(), ImportModuleType::Text);
@@ -3234,9 +3252,7 @@ impl Interpreter {
 
     fn load_bytes_module(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
         if Self::is_module_source_path(path) {
-            return Err(JsValue::string(JsString::from_str(&format!(
-                "Module '{MODULE_SOURCE_SPECIFIER}' has no bytes representation"
-            ))));
+            return Err(self.module_source_type_error(ImportModuleType::Bytes));
         }
         let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         let key = (canon.clone(), ImportModuleType::Bytes);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -236,6 +236,20 @@ pub(crate) const EVAL_DEPTH_LIMIT: usize = 50_000;
 const MAX_POOLED_FUNCTION_ENVIRONMENTS: usize = 256;
 const MAX_POOLED_FUNCTION_BINDING_CAPACITY: usize = 256;
 
+/// test262's host specifier for a Module Source. `test262/INTERPRETING.md`
+/// requires implementers to "resolve the specifier `<module source>` to a module
+/// that provides a valid Module Source" — a module record, not a source-phase-only
+/// stand-in. jsse has no concrete Module Source kind (no WebAssembly), so it
+/// resolves to a synthetic module, the only one whose `[[ModuleSource]]` is
+/// non-empty; see `Interpreter::get_or_create_module_source_module`.
+///
+/// `HostLoadImportedModule` must hand back the same Module Record for a given
+/// (referrer, specifier) pair regardless of the request's phase, so this string
+/// is recognised by the host resolvers — not by the source-phase path alone. It
+/// is intercepted before any filesystem resolution and doubles as the module
+/// registry key, so it never reaches a real file of the same name.
+pub(crate) const MODULE_SOURCE_SPECIFIER: &str = "<module source>";
+
 pub(crate) struct DeferredCallArguments {
     first: Option<JsValue>,
     rest: Vec<JsValue>,
@@ -886,11 +900,12 @@ impl Interpreter {
         None
     }
 
-    /// Get (or lazily create) the host module that the `<module source>`
-    /// test262 specifier resolves to. Its `[[ModuleSource]]` is a fresh
-    /// %AbstractModuleSource% instance; it exposes no bindings.
+    /// Get (or lazily create) the host module that test262's
+    /// `MODULE_SOURCE_SPECIFIER` resolves to, in every import phase. Its
+    /// `[[ModuleSource]]` is a fresh %AbstractModuleSource% instance; it exposes
+    /// no bindings.
     fn get_or_create_module_source_module(&mut self) -> Rc<RefCell<LoadedModule>> {
-        let sentinel = PathBuf::from("<module source>");
+        let sentinel = PathBuf::from(MODULE_SOURCE_SPECIFIER);
         if let Some(existing) = self.module_registry_get(&sentinel) {
             return existing;
         }
@@ -943,29 +958,39 @@ impl Interpreter {
     /// resolved path and the source object (`None` when the target has no
     /// source-phase representation, which the caller turns into a SyntaxError).
     ///
-    /// The test262 `<module source>` host specifier maps to a synthetic host
-    /// module whose `[[ModuleSource]]` is populated. For any other specifier,
-    /// source-phase loading is *shallow*: it resolves the requested specifier
-    /// (a genuine host-resolution failure of that specifier surfaces here as a
-    /// non-SyntaxError) but must NOT load, link, or evaluate the target — the
-    /// source phase never triggers host loads for the target's transitive
-    /// dependencies, nor consults `[[EvaluationError]]`. jsse has no concrete
-    /// Module Source kind, so every resolvable file is an ordinary Source Text
-    /// Module with an empty `[[ModuleSource]]`; returning `None` here lets the
-    /// caller reject with the source-phase SyntaxError without exposing the
-    /// target's dependency-resolution, link, or cached evaluation errors.
+    /// Host resolution runs through the shared `resolve_module_specifier`, so the
+    /// phase never changes *which* module a specifier names — only what is read
+    /// off the resulting record. `MODULE_SOURCE_SPECIFIER` resolves to the
+    /// synthetic host module whose `[[ModuleSource]]` is populated.
+    ///
+    /// For any other specifier, source-phase loading is *shallow*: it resolves
+    /// the requested specifier (a genuine host-resolution failure of that
+    /// specifier surfaces here as a non-SyntaxError) but must NOT load, link, or
+    /// evaluate the target — the source phase never triggers host loads for the
+    /// target's transitive dependencies, nor consults `[[EvaluationError]]`.
+    /// jsse has no concrete Module Source kind, so every resolvable file is an
+    /// ordinary Source Text Module with an empty `[[ModuleSource]]`; returning
+    /// `None` here lets the caller reject with the source-phase SyntaxError
+    /// without exposing the target's dependency-resolution, link, or cached
+    /// evaluation errors.
     fn resolve_source_phase_target(
         &mut self,
         specifier: &str,
         referrer: Option<&Path>,
     ) -> Result<(PathBuf, Option<JsValue>), JsValue> {
-        if specifier == "<module source>" {
-            let module = self.get_or_create_module_source_module();
-            let module_source = module.borrow().module_source.clone();
-            return Ok((PathBuf::from("<module source>"), module_source));
-        }
         let resolved = self.resolve_module_specifier(specifier, referrer)?;
+        if Self::is_module_source_path(&resolved) {
+            let module = self.load_module(&resolved)?;
+            let module_source = module.borrow().module_source.clone();
+            return Ok((resolved, module_source));
+        }
         Ok((resolved, None))
+    }
+
+    /// Whether `path` is the module-registry key of the synthetic
+    /// `<module source>` host module rather than a filesystem path.
+    fn is_module_source_path(path: &Path) -> bool {
+        path.as_os_str() == std::ffi::OsStr::new(MODULE_SOURCE_SPECIFIER)
     }
 
     pub(crate) fn gc_root_value(&mut self, val: &JsValue) {
@@ -2168,8 +2193,8 @@ impl Interpreter {
 
         // Source-phase import (`import source X from '...'`) — a source-phase
         // ImportDeclaration has exactly one SourcePhase specifier. Handle it
-        // before the generic specifier resolution, which cannot resolve the
-        // host `<module source>` specifier.
+        // before the generic path, which binds a namespace and loads the target
+        // graph; the source phase binds `[[ModuleSource]]` and stays shallow.
         if let [ImportSpecifier::SourcePhase(local)] = import.specifiers.as_slice() {
             return self.process_source_phase_import(local, &import.source, env);
         }
@@ -2526,6 +2551,12 @@ impl Interpreter {
         specifier: &str,
         referrer: Option<&Path>,
     ) -> Result<PathBuf, JsValue> {
+        // Host-provided synthetic module. Resolved here rather than in the
+        // source-phase path so that every phase names the same Module Record.
+        if specifier == MODULE_SOURCE_SPECIFIER {
+            return Ok(PathBuf::from(MODULE_SOURCE_SPECIFIER));
+        }
+
         // Relative paths: ./ or ../
         if specifier.starts_with("./") || specifier.starts_with("../") {
             if let Some(referrer) = referrer {
@@ -2570,6 +2601,10 @@ impl Interpreter {
     }
 
     fn load_module_inner(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        if Self::is_module_source_path(path) {
+            return Ok(self.get_or_create_module_source_module());
+        }
+
         let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
         // Check if module is already loaded
@@ -2779,12 +2814,11 @@ impl Interpreter {
                 }) => Some(s.as_str()),
                 _ => None,
             };
-            // The test262 `<module source>` host specifier is resolved by the
-            // host (source-phase imports), not as a file path; every other
-            // specifier — including source-phase targets like `<do not resolve>`
-            // — must still surface unresolvable-specifier errors here.
+            // `resolve_module_specifier` handles the host `<module source>`
+            // specifier itself; every other specifier — including source-phase
+            // targets like `<do not resolve>` — must surface unresolvable
+            // specifier errors here.
             if let Some(spec) = specifier
-                && spec != "<module source>"
                 && let Err(e) = self.resolve_module_specifier(spec, Some(&canon_path))
             {
                 Self::cache_module_error(&loaded_module, &e);
@@ -2899,6 +2933,10 @@ impl Interpreter {
     /// Load a module without evaluating it (for deferred imports).
     /// Parses, links, resolves exports, but does NOT execute the module body.
     fn load_module_no_eval(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        if Self::is_module_source_path(path) {
+            return Ok(self.get_or_create_module_source_module());
+        }
+
         let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
         if let Some(existing) = self.module_registry_get(&canon_path) {
@@ -3972,6 +4010,9 @@ impl Interpreter {
         specifier: &str,
         referrer: Option<&Path>,
     ) -> Result<PathBuf, JsValue> {
+        if specifier == MODULE_SOURCE_SPECIFIER {
+            return Ok(PathBuf::from(MODULE_SOURCE_SPECIFIER));
+        }
         if specifier.starts_with("./") || specifier.starts_with("../") || specifier.starts_with('/')
         {
             let base = referrer.and_then(|r| r.parent()).unwrap_or(Path::new("."));

--- a/test262-extra/source-phase-host-specifier-phase-independence.js
+++ b/test262-extra/source-phase-host-specifier-phase-independence.js
@@ -150,16 +150,13 @@ for (const type of ['text', 'bytes']) {
   }
 }
 
-const messagesByType = {};
+const messagesByType = { text: [], bytes: [] };
 for (const [name, type] of typedCases) {
   const err = await rejection(dynamicForms[name], '<module source>', { with: { type } });
   assert(
     err instanceof TypeError,
     name + ' rejects a type: ' + type + ' request with a TypeError, got: ' + err
   );
-  if (!messagesByType[type]) {
-    messagesByType[type] = [];
-  }
   messagesByType[type].push(err.message);
 }
 
@@ -185,7 +182,7 @@ for (const [label, withValue] of [
   ['an inherited', inheritedType],
   ['a non-enumerable own', nonEnumerableType],
 ]) {
-  for (const name of ['import()', 'import.source()']) {
+  for (const name of Object.keys(dynamicForms)) {
     attributeCases.push([label, withValue, name]);
   }
 }

--- a/test262-extra/source-phase-host-specifier-phase-independence.js
+++ b/test262-extra/source-phase-host-specifier-phase-independence.js
@@ -125,33 +125,77 @@ assert.sameValue(
 // The host has no text or bytes for a Module Source module. Attributes are part
 // of the module request, so this is a distinct request the host may reject; what
 // it must not do is reject in one phase and resolve in the other.
-for (const type of ['text', 'bytes']) {
-  const attrs = { with: { type } };
-  let evalErr = null;
-  let sourceErr = null;
-  try {
-    await import('<module source>', attrs);
-  } catch (e) {
-    evalErr = e;
-  }
-  try {
-    await import.source('<module source>', attrs);
-  } catch (e) {
-    sourceErr = e;
-  }
+const dynamicForms = {
+  'import()': (s, o) => import(s, o),
+  'import.source()': (s, o) => import.source(s, o),
+  'import.defer()': (s, o) => import.defer(s, o),
+};
 
+async function rejection(fn, specifier, options) {
+  try {
+    await fn(specifier, options);
+  } catch (e) {
+    return e;
+  }
+  return null;
+}
+
+// Cases are flattened into one list because `await` inside a loop nested in
+// another loop loses the outer iteration's bindings on jsse (see jsse#476);
+// a single loop level is unaffected.
+const typedCases = [];
+for (const type of ['text', 'bytes']) {
+  for (const name of Object.keys(dynamicForms)) {
+    typedCases.push([name, type]);
+  }
+}
+
+const messagesByType = {};
+for (const [name, type] of typedCases) {
+  const err = await rejection(dynamicForms[name], '<module source>', { with: { type } });
   assert(
-    evalErr instanceof TypeError,
-    'import(<module source>, type: ' + type + ') rejects with a TypeError'
+    err instanceof TypeError,
+    name + ' rejects a type: ' + type + ' request with a TypeError, got: ' + err
   );
-  assert(
-    sourceErr instanceof TypeError,
-    'import.source(<module source>, type: ' + type + ') rejects with a TypeError'
-  );
+  if (!messagesByType[type]) {
+    messagesByType[type] = [];
+  }
+  messagesByType[type].push(err.message);
+}
+
+for (const type of Object.keys(messagesByType)) {
   assert.sameValue(
-    sourceErr.message,
-    evalErr.message,
-    'both phases reject a type: ' + type + ' request with the same message'
+    new Set(messagesByType[type]).size,
+    1,
+    'every form rejects a type: ' + type + ' request with the same message, got: ' +
+      JSON.stringify(messagesByType[type])
+  );
+}
+
+// --- attributes come from enumerable own properties of `with` only ---
+// EvaluateImportCall enumerates `with`, so an inherited or non-enumerable `type`
+// is not an import attribute and must not turn into a rejection. Reading `type`
+// straight off the object instead of enumerating gets this wrong.
+const inheritedType = Object.create({ type: 'text' });
+const nonEnumerableType = {};
+Object.defineProperty(nonEnumerableType, 'type', { value: 'text', enumerable: false });
+
+const attributeCases = [];
+for (const [label, withValue] of [
+  ['an inherited', inheritedType],
+  ['a non-enumerable own', nonEnumerableType],
+]) {
+  for (const name of ['import()', 'import.source()']) {
+    attributeCases.push([label, withValue, name]);
+  }
+}
+
+for (const [label, withValue, name] of attributeCases) {
+  const err = await rejection(dynamicForms[name], '<module source>', { with: withValue });
+  assert.sameValue(
+    err,
+    null,
+    name + ' must ignore ' + label + ' `type` on `with`, but rejected with: ' + err
   );
 }
 

--- a/test262-extra/source-phase-host-specifier-phase-independence.js
+++ b/test262-extra/source-phase-host-specifier-phase-independence.js
@@ -135,6 +135,25 @@ assert.sameValue(
   'a repeated import.source() resolves to the same record'
 );
 
+// --- an import-type attribute the host cannot honour must not reach the disk ---
+// ModuleRequestsEqual compares [[Attributes]] too, so `('<module source>', text)`
+// is a *different* module request; the host has no text/bytes representation for a
+// Module Source module and must throw rather than fall through to a file read.
+for (const type of ['text', 'bytes']) {
+  let err = null;
+  try {
+    await import('<module source>', { with: { type } });
+  } catch (e) {
+    err = e;
+  }
+  assert.notSameValue(err, null, 'import(<module source>, type: ' + type + ') rejects');
+  assert.sameValue(
+    String(err).indexOf('No such file') >= 0,
+    false,
+    'the rejection for type: ' + type + ' must not leak a filesystem error'
+  );
+}
+
 // --- reaching the record through the evaluation phase adds no bindings ---
 // The host module has no exports, so its namespace carries Symbol.toStringTag
 // and nothing else, whichever phase materialised it.

--- a/test262-extra/source-phase-host-specifier-phase-independence.js
+++ b/test262-extra/source-phase-host-specifier-phase-independence.js
@@ -1,0 +1,147 @@
+/*---
+description: >
+  Host module loading must not let the import phase decide whether a specifier
+  resolves. ModuleRequestsEqual compares only [[Specifier]] and [[Attributes]] —
+  never the request's phase — so HostLoadImportedModule must hand back the same
+  Module Record for the source phase (`import source X from`,
+  `import.source()`) and for the evaluation phase (`import * as ns from`,
+  `import defer * as ns from`, `import()`). INTERPRETING.md requires the host
+  specifier `<module source>` to resolve to a *module* providing a Module Source,
+  so it must resolve in every phase, with all phases observing one record.
+esid: sec-HostLoadImportedModule
+info: |
+  16.2.1.8 HostLoadImportedModule ( referrer, moduleRequest, hostDefined, payload )
+
+  An implementation of HostLoadImportedModule must conform to the following
+  requirements:
+    [...]
+    * If this operation is called multiple times with two (referrer,
+      moduleRequest) pairs such that:
+        - the first referrer is the same as the second referrer;
+        - ModuleRequestsEqual(the first moduleRequest, the second moduleRequest)
+          is true;
+      and it performs FinishLoadingImportedModule(referrer, moduleRequest,
+      payload, result) where result is a normal completion, then it must perform
+      FinishLoadingImportedModule(referrer, moduleRequest, payload, result) with
+      the same result each time.
+
+  16.2.1.3 ModuleRequestsEqual ( left, right )
+    1. If left.[[Specifier]] is not right.[[Specifier]], return false.
+    [... attribute comparison ...]
+    8. Return true.
+
+  The phase of the request is not an input to ModuleRequestsEqual, so a
+  host-provided specifier that resolves under `import.source()` must equally
+  resolve under `import()`.
+
+  test262/INTERPRETING.md:
+    Implementers should resolve the specifier `<module source>` to a module that
+    provides a valid Module Source, such as a WebAssembly module. Tests use
+    `<module source>` specifier are guarded with a feature flag
+    `source-phase-imports-module-source`.
+
+  Not covered by test262: every upstream test reaches `<module source>` through
+  the source phase only — 105 parse-phase cases under
+  dynamic-import/syntax/{valid,invalid} that never evaluate, plus
+  module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js,
+  whose fixtures `import source ... from '<module source>'` and re-export it.
+  None performs an evaluation-phase `import('<module source>')`, so nothing
+  upstream catches a host resolver that recognises the specifier in the source
+  phase alone. See jsse#222.
+flags: [module]
+features: [source-phase-imports, source-phase-imports-module-source, dynamic-import, import-defer]
+---*/
+
+import source staticSource from '<module source>';
+import * as staticNs from '<module source>';
+import defer * as deferredNs from '<module source>';
+
+// --- the source phase still yields the [[ModuleSource]] ---
+assert.sameValue(
+  typeof staticSource,
+  'object',
+  'import source binding is a Module Source object'
+);
+assert.notSameValue(staticSource, null, 'import source binding is not null');
+
+// --- the evaluation phase resolves the same specifier ---
+// Before this was fixed, `import * as ns from '<module source>'` and
+// `import('<module source>')` failed host resolution ("Cannot resolve bare
+// module specifier") while the source phase succeeded.
+assert.sameValue(
+  typeof staticNs,
+  'object',
+  'import * as resolves the host specifier'
+);
+assert.sameValue(
+  Object.getPrototypeOf(staticNs),
+  null,
+  'a module namespace has a null [[Prototype]]'
+);
+assert.sameValue(
+  staticNs[Symbol.toStringTag],
+  'Module',
+  'a module namespace has Symbol.toStringTag "Module"'
+);
+assert.sameValue(
+  Object.isExtensible(staticNs),
+  false,
+  'a module namespace is not extensible'
+);
+assert.sameValue(
+  Object.keys(staticNs).length,
+  0,
+  'the host module exposes no bindings'
+);
+
+assert.sameValue(
+  typeof deferredNs,
+  'object',
+  'import defer * as resolves the host specifier'
+);
+assert.sameValue(
+  Object.keys(deferredNs).length,
+  0,
+  'the deferred namespace exposes no bindings'
+);
+
+// --- both phases name one Module Record ---
+// GetModuleNamespace caches [[Namespace]] on the record and GetModuleSource
+// reads [[ModuleSource]] off it, so identity across the two phases is the
+// observable proof that one record backs both.
+const dynamicNs = await import('<module source>');
+const dynamicSource = await import.source('<module source>');
+
+assert.sameValue(
+  dynamicNs,
+  staticNs,
+  'import() and import * as observe the same [[Namespace]]'
+);
+assert.sameValue(
+  dynamicSource,
+  staticSource,
+  'import.source() and import source observe the same [[ModuleSource]]'
+);
+
+// A repeat request must not mint a second record.
+assert.sameValue(
+  await import('<module source>'),
+  staticNs,
+  'a repeated import() resolves to the same record'
+);
+assert.sameValue(
+  await import.source('<module source>'),
+  staticSource,
+  'a repeated import.source() resolves to the same record'
+);
+
+// --- reaching the record through the evaluation phase adds no bindings ---
+// The host module has no exports, so its namespace carries Symbol.toStringTag
+// and nothing else, whichever phase materialised it.
+const ownKeys = Reflect.ownKeys(staticNs);
+assert.sameValue(ownKeys.length, 1, 'the namespace has exactly one own key');
+assert.sameValue(
+  ownKeys[0],
+  Symbol.toStringTag,
+  'the only own key is Symbol.toStringTag'
+);

--- a/test262-extra/source-phase-host-specifier-phase-independence.js
+++ b/test262-extra/source-phase-host-specifier-phase-independence.js
@@ -1,62 +1,71 @@
 /*---
 description: >
   Host module loading must not let the import phase decide whether a specifier
-  resolves. ModuleRequestsEqual compares only [[Specifier]] and [[Attributes]] —
-  never the request's phase — so HostLoadImportedModule must hand back the same
-  Module Record for the source phase (`import source X from`,
-  `import.source()`) and for the evaluation phase (`import * as ns from`,
-  `import defer * as ns from`, `import()`). INTERPRETING.md requires the host
-  specifier `<module source>` to resolve to a *module* providing a Module Source,
-  so it must resolve in every phase, with all phases observing one record.
+  resolves, nor how an unsatisfiable request fails. The `<module source>` host
+  specifier must resolve to one Module Record for the source phase
+  (`import source X from`, `import.source()`) and the evaluation phase
+  (`import * as ns from`, `import defer * as ns from`, bare `import`,
+  `export * from`, `import()`) alike, and a request carrying an import type the
+  host cannot honour must be rejected identically in both phases.
 esid: sec-HostLoadImportedModule
 info: |
-  16.2.1.8 HostLoadImportedModule ( referrer, moduleRequest, hostDefined, payload )
-
-  An implementation of HostLoadImportedModule must conform to the following
-  requirements:
-    [...]
-    * If this operation is called multiple times with two (referrer,
-      moduleRequest) pairs such that:
-        - the first referrer is the same as the second referrer;
-        - ModuleRequestsEqual(the first moduleRequest, the second moduleRequest)
-          is true;
-      and it performs FinishLoadingImportedModule(referrer, moduleRequest,
-      payload, result) where result is a normal completion, then it must perform
-      FinishLoadingImportedModule(referrer, moduleRequest, payload, result) with
-      the same result each time.
-
-  16.2.1.3 ModuleRequestsEqual ( left, right )
-    1. If left.[[Specifier]] is not right.[[Specifier]], return false.
-    [... attribute comparison ...]
-    8. Return true.
-
-  The phase of the request is not an input to ModuleRequestsEqual, so a
-  host-provided specifier that resolves under `import.source()` must equally
-  resolve under `import()`.
-
   test262/INTERPRETING.md:
     Implementers should resolve the specifier `<module source>` to a module that
     provides a valid Module Source, such as a WebAssembly module. Tests use
     `<module source>` specifier are guarded with a feature flag
     `source-phase-imports-module-source`.
 
-  Not covered by test262: every upstream test reaches `<module source>` through
-  the source phase only — 105 parse-phase cases under
-  dynamic-import/syntax/{valid,invalid} that never evaluate, plus
-  module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js,
-  whose fixtures `import source ... from '<module source>'` and re-export it.
-  None performs an evaluation-phase `import('<module source>')`, so nothing
-  upstream catches a host resolver that recognises the specifier in the source
-  phase alone. See jsse#222.
+  So the host specifier names a *module*, reachable in either phase — not a
+  source-phase-only stand-in.
+
+  16.2.1.8 HostLoadImportedModule ( referrer, moduleRequest, hostDefined, payload )
+    An implementation of HostLoadImportedModule must conform to the following
+    requirements:
+      [...]
+      * If this operation is called multiple times with two (referrer,
+        moduleRequest) pairs such that:
+          - the first referrer is the same as the second referrer;
+          - ModuleRequestsEqual(the first moduleRequest, the second
+            moduleRequest) is true;
+        and it performs FinishLoadingImportedModule(referrer, moduleRequest,
+        payload, result) where result is a normal completion, then it must
+        perform FinishLoadingImportedModule(referrer, moduleRequest, payload,
+        result) with the same result each time.
+
+  16.2.1.3 ModuleRequestsEqual ( left, right )
+    1. If left.[[Specifier]] is not right.[[Specifier]], return false.
+    [... attribute comparison ...]
+    8. Return true.
+
+  Module identity is therefore keyed on specifier and attributes. The request's
+  phase is not part of that key: ECMA-262 has no [[Phase]] field at all, and the
+  source-phase-imports proposal, which introduces it
+  (https://github.com/tc39/proposal-source-phase-imports), does not add it to
+  ModuleRequestsEqual. Attributes *are* part of the key, so a typed request is a
+  distinct request the host may reject — but it must reject it the same way
+  whichever phase issued it.
+
+  Not covered by test262: every upstream use reaches `<module source>` through
+  the source phase only. Of the 105 files under
+  dynamic-import/syntax/{valid,invalid}, 63 are `phase: parse` negatives and the
+  other 42 evaluate a bare `import.source(...)`; three module-code tests reach it
+  at runtime (ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js
+  and source-phase-import/reexport-source-binding-{named-import,namespace-get}.js,
+  the latter two via reexport-source-binding_FIXTURE.js). None issues an
+  evaluation-phase `import('<module source>')`, so nothing upstream catches a
+  host resolver that recognises the specifier in the source phase alone.
+  See jsse#222.
 flags: [module]
-features: [source-phase-imports, source-phase-imports-module-source, dynamic-import, import-defer]
+features: [source-phase-imports, source-phase-imports-module-source, dynamic-import, import-defer, import-attributes, top-level-await]
 ---*/
 
 import source staticSource from '<module source>';
 import * as staticNs from '<module source>';
 import defer * as deferredNs from '<module source>';
+import '<module source>';
+export * from '<module source>';
 
-// --- the source phase still yields the [[ModuleSource]] ---
+// --- the source phase yields the [[ModuleSource]] ---
 assert.sameValue(
   typeof staticSource,
   'object',
@@ -65,14 +74,7 @@ assert.sameValue(
 assert.notSameValue(staticSource, null, 'import source binding is not null');
 
 // --- the evaluation phase resolves the same specifier ---
-// Before this was fixed, `import * as ns from '<module source>'` and
-// `import('<module source>')` failed host resolution ("Cannot resolve bare
-// module specifier") while the source phase succeeded.
-assert.sameValue(
-  typeof staticNs,
-  'object',
-  'import * as resolves the host specifier'
-);
+assert.sameValue(typeof staticNs, 'object', 'import * as resolves the host specifier');
 assert.sameValue(
   Object.getPrototypeOf(staticNs),
   null,
@@ -83,22 +85,10 @@ assert.sameValue(
   'Module',
   'a module namespace has Symbol.toStringTag "Module"'
 );
-assert.sameValue(
-  Object.isExtensible(staticNs),
-  false,
-  'a module namespace is not extensible'
-);
-assert.sameValue(
-  Object.keys(staticNs).length,
-  0,
-  'the host module exposes no bindings'
-);
+assert.sameValue(Object.isExtensible(staticNs), false, 'a module namespace is not extensible');
+assert.sameValue(Object.keys(staticNs).length, 0, 'the host module exposes no bindings');
 
-assert.sameValue(
-  typeof deferredNs,
-  'object',
-  'import defer * as resolves the host specifier'
-);
+assert.sameValue(typeof deferredNs, 'object', 'import defer * as resolves the host specifier');
 assert.sameValue(
   Object.keys(deferredNs).length,
   0,
@@ -106,17 +96,13 @@ assert.sameValue(
 );
 
 // --- both phases name one Module Record ---
-// GetModuleNamespace caches [[Namespace]] on the record and GetModuleSource
-// reads [[ModuleSource]] off it, so identity across the two phases is the
-// observable proof that one record backs both.
+// GetModuleNamespace caches [[Namespace]] on the record and GetModuleSource reads
+// [[ModuleSource]] off it, so identity across phases is the observable proof that
+// one record backs both.
 const dynamicNs = await import('<module source>');
 const dynamicSource = await import.source('<module source>');
 
-assert.sameValue(
-  dynamicNs,
-  staticNs,
-  'import() and import * as observe the same [[Namespace]]'
-);
+assert.sameValue(dynamicNs, staticNs, 'import() and import * as observe the same [[Namespace]]');
 assert.sameValue(
   dynamicSource,
   staticSource,
@@ -135,32 +121,41 @@ assert.sameValue(
   'a repeated import.source() resolves to the same record'
 );
 
-// --- an import-type attribute the host cannot honour must not reach the disk ---
-// ModuleRequestsEqual compares [[Attributes]] too, so `('<module source>', text)`
-// is a *different* module request; the host has no text/bytes representation for a
-// Module Source module and must throw rather than fall through to a file read.
+// --- an unsatisfiable typed request fails identically in both phases ---
+// The host has no text or bytes for a Module Source module. Attributes are part
+// of the module request, so this is a distinct request the host may reject; what
+// it must not do is reject in one phase and resolve in the other.
 for (const type of ['text', 'bytes']) {
-  let err = null;
+  const attrs = { with: { type } };
+  let evalErr = null;
+  let sourceErr = null;
   try {
-    await import('<module source>', { with: { type } });
+    await import('<module source>', attrs);
   } catch (e) {
-    err = e;
+    evalErr = e;
   }
-  assert.notSameValue(err, null, 'import(<module source>, type: ' + type + ') rejects');
+  try {
+    await import.source('<module source>', attrs);
+  } catch (e) {
+    sourceErr = e;
+  }
+
+  assert(
+    evalErr instanceof TypeError,
+    'import(<module source>, type: ' + type + ') rejects with a TypeError'
+  );
+  assert(
+    sourceErr instanceof TypeError,
+    'import.source(<module source>, type: ' + type + ') rejects with a TypeError'
+  );
   assert.sameValue(
-    String(err).indexOf('No such file') >= 0,
-    false,
-    'the rejection for type: ' + type + ' must not leak a filesystem error'
+    sourceErr.message,
+    evalErr.message,
+    'both phases reject a type: ' + type + ' request with the same message'
   );
 }
 
 // --- reaching the record through the evaluation phase adds no bindings ---
-// The host module has no exports, so its namespace carries Symbol.toStringTag
-// and nothing else, whichever phase materialised it.
 const ownKeys = Reflect.ownKeys(staticNs);
 assert.sameValue(ownKeys.length, 1, 'the namespace has exactly one own key');
-assert.sameValue(
-  ownKeys[0],
-  Symbol.toStringTag,
-  'the only own key is Symbol.toStringTag'
-);
+assert.sameValue(ownKeys[0], Symbol.toStringTag, 'the only own key is Symbol.toStringTag');

--- a/tests/module_source_host_specifier.rs
+++ b/tests/module_source_host_specifier.rs
@@ -84,6 +84,27 @@ if (typeof S !== 'object' || S === null) throw new Error('no Module Source');
 if (Object.keys(ns).length !== 0) throw new Error('namespace leaked: ' + Object.keys(ns));
 if (Object.keys(dyn).length !== 0) throw new Error('dynamic namespace leaked');
 if (ns !== dyn) throw new Error('phases disagree on the record');
+
+// import.defer and ShadowRealm.prototype.importValue canonicalize the resolved
+// path themselves. These two are a canary, not a regression guard: the record is
+// already evaluated with no exports and no async dependencies, so a misdirected
+// registry lookup misses and no-ops, and reverting either site to a raw
+// canonicalize() still passes (verified). They start discriminating the moment
+// the synthetic record gains exports or async dependencies.
+const deferred = await import.defer('<module source>');
+if (Object.keys(deferred).length !== 0) {
+  throw new Error('deferred namespace leaked: ' + Object.keys(deferred));
+}
+
+let realmError = null;
+try {
+  await new ShadowRealm().importValue('<module source>', 'x');
+} catch (e) {
+  realmError = e;
+}
+if (realmError === null) {
+  throw new Error("ShadowRealm importValue resolved 'x' from the on-disk file");
+}
 "#,
     )
     .unwrap();

--- a/tests/module_source_host_specifier.rs
+++ b/tests/module_source_host_specifier.rs
@@ -1,0 +1,93 @@
+//! The `<module source>` host specifier must not be capturable by a real
+//! filesystem entry of the same name (jsse#222 review finding).
+//!
+//! Its module-registry key is a bare relative path, so any `canonicalize()` on
+//! it succeeds whenever jsse runs in a directory holding an entry called
+//! `<module source>` — rebinding the specifier to that file's registry slot.
+//! This lives in `tests/` rather than `test262-extra/` because the condition is
+//! the *process working directory*, which only a spawned child can control.
+
+use std::fs;
+use std::process::Command;
+
+fn run_in(dir: &std::path::Path, entry: &str) -> (bool, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_jsse"))
+        .current_dir(dir)
+        .args(["--module", entry])
+        .output()
+        .expect("failed to run jsse");
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    (output.status.success(), combined)
+}
+
+fn scratch(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("jsse-module-source-{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("failed to create scratch dir");
+    dir
+}
+
+/// A named re-export of a binding the host module does not have is a link-time
+/// SyntaxError, and stays one even when a file called `<module source>` sits in
+/// the working directory offering that very export.
+#[test]
+fn a_real_file_does_not_capture_the_host_specifier() {
+    let reexport = "export { x } from '<module source>';\n";
+
+    let clean = scratch("clean");
+    fs::write(clean.join("reexport.mjs"), reexport).unwrap();
+    let (clean_ok, clean_out) = run_in(&clean, "reexport.mjs");
+
+    let shadowed = scratch("shadowed");
+    fs::write(shadowed.join("reexport.mjs"), reexport).unwrap();
+    fs::write(
+        shadowed.join("<module source>"),
+        "export const x = 'from the file on disk';\n",
+    )
+    .unwrap();
+    let (shadowed_ok, shadowed_out) = run_in(&shadowed, "reexport.mjs");
+
+    assert!(
+        !clean_ok,
+        "re-exporting an absent binding should fail, got: {clean_out}"
+    );
+    assert!(
+        clean_out.contains("has no export named 'x'"),
+        "expected a link error naming the missing export, got: {clean_out}"
+    );
+    assert_eq!(
+        (clean_ok, clean_out.clone()),
+        (shadowed_ok, shadowed_out.clone()),
+        "a file named `<module source>` in the working directory changed the \
+         outcome: clean={clean_out:?} shadowed={shadowed_out:?}"
+    );
+}
+
+/// The synthetic record still backs every phase when the file is present: one
+/// namespace with no bindings, and a source-phase binding that is not the file.
+#[test]
+fn the_host_record_wins_over_a_real_file_in_every_phase() {
+    let dir = scratch("phases");
+    fs::write(
+        dir.join("<module source>"),
+        "export const x = 1;\nexport const secret = 'leaked';\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("main.mjs"),
+        r#"
+import source S from '<module source>';
+import * as ns from '<module source>';
+const dyn = await import('<module source>');
+if (typeof S !== 'object' || S === null) throw new Error('no Module Source');
+if (Object.keys(ns).length !== 0) throw new Error('namespace leaked: ' + Object.keys(ns));
+if (Object.keys(dyn).length !== 0) throw new Error('dynamic namespace leaked');
+if (ns !== dyn) throw new Error('phases disagree on the record');
+"#,
+    )
+    .unwrap();
+
+    let (ok, out) = run_in(&dir, "main.mjs");
+    assert!(ok, "host record did not win over the on-disk file: {out}");
+}


### PR DESCRIPTION
## Summary

`<module source>` was special-cased inside `resolve_source_phase_target`, so `import.source('<module source>')` resolved while `import('<module source>')` (and `import * as ns from`, `import defer * as ns from`, bare `import`, `export * from`) rejected with `Cannot resolve bare module specifier`.

`test262/INTERPRETING.md` requires the host to "resolve the specifier `<module source>` to a module that provides a valid Module Source" — a *module*, reachable in either phase. And module identity is keyed on specifier + attributes: `ModuleRequestsEqual` (§16.2.1.3) never consults the phase, so `HostLoadImportedModule` (§16.2.1.8) must finish loading with the same Module Record whichever phase asks.

The specifier now lives in the shared host resolvers (`resolve_module_specifier`, `resolve_module_specifier_pure`), and all four loaders (`load_module_inner`, `load_module_no_eval`, `load_text_module`, `load_bytes_module`) route it to the one synthetic record instead of the filesystem. Five scattered string literals collapse into one `MODULE_SOURCE_SPECIFIER` const plus one `is_module_source_path` predicate.

Side effect worth knowing: `resolve_export_binding` already called `load_module(<module source>)` for re-exported source imports, inside an `if let Ok(...)` that swallowed failure. It only worked because the source phase happened to populate the registry first. That is now deterministic.

Fixes #222

## Two defects found by self-review, fixed in commits 2 and 3

1. **Filesystem leak.** Making the specifier resolvable in every phase let it through to `load_text_module` / `load_bytes_module`, which read the path off disk — so `import('<module source>', { with: { type: 'text' } })` surfaced `Cannot read module '<module source>': No such file or directory`. Both loaders now reject it up front.

2. **A new phase asymmetry — the very bug class this PR is about.** The first fix left `import.source()` validating the `with` option and then discarding it, so:

   ```
   import.source('<module source>', {with:{type:'text'}})  ->  resolved
   import(       '<module source>', {with:{type:'text'}})  ->  threw
   ```

   Same (referrer, specifier, attributes) triple, completion decided by phase. Attributes *are* part of the module request, so a typed request is a distinct request the host may reject — but not in one phase only. `import.source()` now extracts the requested type, `resolve_source_phase_target` honours it, and all three sites build the rejection through one `module_source_type_error()` so the phases cannot drift apart again. The error is a real `TypeError` rather than a bare string, letting the test pin its identity instead of substring-matching a message.

   A real file is deliberately *not* symmetric here, and shouldn't be: `import('./x.txt', {type:'text'})` yields a text module while `import.source(...)` on it throws `SyntaxError`. That is a phase-dependent *read* off the same record (`GetModuleSource` on a text module throws), not a phase-dependent resolution.

3. **A real file could capture the specifier's registry key** (found by the Codex reviewer, fixed in `87fdc16`). The key is a bare relative path, so `canonicalize()` on it succeeds whenever jsse runs in a directory holding an entry of that name. With such a file present, `export { x } from '<module source>'` stopped being a link error and manufactured a phantom `x` export. The on-disk exports were never actually reachable — `import { secret }` still failed and `import * as ns` still saw `[]` — so it was a graph-shape bug, not a disclosure; the namespace forms held because the loaders were already guarded ahead of their `canonicalize()`. Module-target canonicalization now goes through one `canonicalize_module_path()` that returns the sentinel untouched, rather than repeating the check at each of the twelve reachable call sites.

   A follow-up commit (`5cb6760`) corrects that count: `87fdc16` said "ten", but auditing *every* `canonicalize()` in `src/` — not just the three files I had grepped — found twelve, two still raw (`import.defer`'s `evaluate_async_transitive_deps`, and `ShadowRealm.prototype.importValue`). Both were latent rather than live: probed with a real `<module source>` file in the working directory, each behaves identically with and without it, because the synthetic record is already evaluated with no async dependencies, so the misdirected registry lookup misses and no-ops either way. The raw calls that remain are all on paths the sentinel cannot reach — the four loaders guard before canonicalizing, the resolvers canonicalize real files after the sentinel early-returns, and the rest hold a referrer, the module being loaded, the CLI entry path, or test fixtures.

### Quality pass (commit 7, no behaviour change)

A four-angle cleanup review of this branch's own diff (reuse / simplification / efficiency / altitude) produced: the `"text"`/`"bytes"` correspondence collapsed from three copies into two `ImportModuleType` methods; the three import forms' identical options-evaluation blocks collapsed into `import_call_options_type`; two unreachable `else` arms folded into their guards (one would have silently swallowed a bad `with`); `create_type_error` in place of the legacy `create_error("TypeError", …)`; and the four loaders routed through `canonicalize_module_path` so a grep for a raw `canonicalize()` finds only the helper. Full test262 re-run after it: 99,568/99,568, 0 regressions.

Two structural findings were deliberately **not** taken here and are filed as #479: unifying the five copies of the loader-type dispatch (four of which predate this PR, and whose `None`/typed arms differ in error caching), and replacing the `PathBuf` module-registry key with a `ModuleKey` newtype. The second is the honest read on why this PR needed five review rounds — a registry key that is a fake filesystem path relies on call-site discipline, and #479 converts that into compiler help. Worth doing before a second host module kind (WebAssembly) lands.

## Notes for reviewers

- **Why no upstream test caught this.** 109 test262 files name `<module source>`, all reaching it through the source phase only: of the 105 under `dynamic-import/syntax/{valid,invalid}`, 63 are `phase: parse` negatives and the other 42 evaluate a bare `import.source(...)`; three module-code tests reach it at runtime (`ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js`, and `source-phase-import/reexport-source-binding-{named-import,namespace-get}.js` via `reexport-source-binding_FIXTURE.js`). None issues an evaluation-phase `import('<module source>')`.
- **The new test is `.js` with `flags: [module]`, not `.mjs`, deliberately.** The 17 `.mjs` files in `test262-extra/` are collected by no runner — CI runs `run-test262.py test262-extra/`, whose `find_tests` globs `*.js` only. I verified the 5 top-level `source-phase-*.mjs` files still pass by invoking jsse directly. Filed as #471 rather than widened into a runner change here.
- **Red/green proof:** stashing the `mod.rs` change and rebuilding makes the test fail with `Cannot resolve bare module specifier '<module source>'`.
- **`resolve_module_specifier_pure` is inert for evaluation order**, not just empirically but by construction: the record is created `evaluated: true` with `program_ast: None` and `has_tla: false`, so `ready_for_sync_execution` short-circuits and `get_module_dep_paths` / `gather_async_transitive_deps` list a dep that yields no further deps and no async ordering. Probed anyway with two real TLA deps plus a TLA cycle whose member source-imports the specifier, placed first/middle/last/absent — byte-identical order in all four.

### Known gap, filed separately

`import('<module source>', { with: { type: 'json' } })` still returns the Module Source record rather than `ParseJSONModule`'s result or a throw, as HostLoadImportedModule's JSON clause requires. That is **not specific to this specifier**: `import_module_type` maps only `"text"`/`"bytes"`, so `type:"json"` becomes `None` engine-wide and is ignored for every module — it reproduces on an ordinary `.mjs` file, where JSON-ness is decided by the `.json` extension instead. Root cause sits outside the host resolver, so it is #475 rather than scope creep here.

## Test plan

- [x] `cargo test --release` — 502 + 3 + 2 + 1 passing, 0 failed
- [x] `./scripts/lint.sh` — rustfmt and clippy clean
- [x] `run-test262.py test262-extra/ --fail-on-failures` — 145/145
- [x] `run-test262.py test262-extra/ --bytecode --fail-on-failures` — 145/145
- [x] `run-custom-tests.py` — 11/11
- [x] Uncollected `source-phase-*.mjs` extras run directly — 5/5 exit 0
- [x] `module-code/ambiguous-export-bindings/` + `module-code/source-phase-import/` — 14/14 (the upstream tests that exercise `resolve_export_binding`'s `load_module(<module source>)`)
- [x] Full test262 `-j 32` — 99,568/99,568, 0 failures, **0 regressions** (the run also reports 323 "new passes"; `test262-pass.txt` has 99,247 entries and was last rolled 488 commits ago, so that is pre-existing baseline drift, not an effect of this change)
- [x] `tests/module_source_host_specifier.rs` — 2 integration tests; spawns jsse with a controlled `current_dir`, verified red before the `87fdc16` fix
- [x] Phase symmetry re-probed across every form: `import()`, `import * as`, `import defer * as`, bare `import`, `export * from`, `export { x } from`, `import source X from`, `import.source()`, in module and script context, with and without `type` attributes
