### PR TITLE
fix(interpreter): bound the per-body hoist-analysis cache

### DIFF
--- a/docs/specs/2026-07-20-bounded-hoist-cache-design.md
+++ b/docs/specs/2026-07-20-bounded-hoist-cache-design.md
@@ -18,32 +18,39 @@ Body must transparently fall back to collecting the same names again.
 1. Store weak Body references and discard dead entries. This follows object
    lifetime closely, but it makes pointer reuse and entry validation more subtle
    and still permits unbounded growth while many distinct functions remain live.
-2. Clear the entire map when it reaches a fixed limit, matching the compiled
-   RegExp cache. This is very small, but a single miss discards every useful
-   analysis and can cause avoidable re-analysis cliffs.
-3. Keep a fixed-capacity map plus insertion-order queue and evict one oldest
-   entry on a full-cache miss. This is selected: lookup and insertion remain
-   O(1), eviction is deterministic, and no dependency or hit-path scan is added.
+2. Keep a fixed-capacity map plus insertion-order queue and evict one oldest
+   entry on a full-cache miss. This keeps lookup and insertion O(1), but a scan
+   across more Bodies than the capacity repeatedly evicts hot analyses along
+   with cold ones.
+3. Track a recency tick per entry and discard the least-recently-used half in
+   one sweep when the cache fills. This is selected: hits preserve hot analyses,
+   and bulk eviction amortizes the O(n) selection pass across many insertions.
 
 ## Design
 
 Introduce a small `HoistCache` wrapper containing the existing pointer-keyed map
-and a FIFO queue of its keys. Its capacity is 256 entries, consistent with the
-existing compiled RegExp cache bound.
+and a monotonic recency clock. Its capacity is 8,192 entries: large enough to
+avoid churn for ordinary programs with many static Bodies while still placing a
+fixed upper bound on body-churning `Function` and `eval` workloads.
 
-On a hit, the wrapper clones and returns the cached analysis without changing
-order. On a miss at capacity, it removes the oldest key from both collections
-before inserting the new analysis. Every retained entry continues to own its
-Body `Rc`, preserving ABA safety. Removing an entry drops that ownership; a
-later call of the evicted Body recomputes and safely reinserts its analysis.
+On a hit, the wrapper updates the entry's recency tick and returns the cached
+analysis. On a miss at capacity, it selects the median recency tick and removes
+the older half before inserting the new analysis. Every retained entry
+continues to own its Body `Rc`, preserving ABA safety. Removing an entry drops
+that ownership; a later call of the evicted Body recomputes and safely reinserts
+its analysis.
 
-The wrapper owns the map/queue synchronization invariant so the evaluator cannot
-update one without the other. No ECMAScript-visible behavior changes.
+The wrapper owns the key, recency metadata, and pinned analysis together so the
+evaluator cannot update only part of an entry. No ECMAScript-visible behavior
+changes.
 
 ## Validation
 
-Add an interpreter integration test that executes more than 256 distinct
-`Function` constructor Bodies through the normal call path, calls the oldest
-function again after eviction, and checks both its result and the cache bound.
-Run the Function constructor and function-statement test262 areas, followed by
-the repository formatting, linting, release build/tests, and full test262 gate.
+Add focused cache tests for identity memoization, hit accounting, the capacity
+bound, release of an evicted Body's pin, recency-aware eviction, and reinsertion.
+Add interpreter integration tests that execute more than 8,192 distinct
+`Function` constructor Bodies through the normal call path and verify both the
+computed result and cache occupancy, plus repeated calls that must keep hitting
+one cached analysis. Run the Function constructor and function-statement test262
+areas, followed by the repository formatting, linting, release build/tests, and
+full test262 gate.

--- a/docs/specs/2026-07-20-bounded-hoist-cache-design.md
+++ b/docs/specs/2026-07-20-bounded-hoist-cache-design.md
@@ -1,0 +1,49 @@
+# Bounded Hoisting-Analysis Cache
+
+## Problem
+
+JSSE caches the declaration-name analysis used when executing a Body. The cache
+is keyed by the Body's `Rc` identity, and each `HoistAnalysis` owns a clone of
+that `Rc` so a freed Body address cannot be reused for an unrelated entry. This
+ABA-safety invariant also means the interpreter-global cache retains every Body
+it has seen. Repeatedly creating and calling distinct dynamic functions therefore
+grows the cache without bound.
+
+The cache is only an optimization. `FunctionDeclarationInstantiation` still
+requires declaration bindings to be instantiated for every call, and an evicted
+Body must transparently fall back to collecting the same names again.
+
+## Approaches Considered
+
+1. Store weak Body references and discard dead entries. This follows object
+   lifetime closely, but it makes pointer reuse and entry validation more subtle
+   and still permits unbounded growth while many distinct functions remain live.
+2. Clear the entire map when it reaches a fixed limit, matching the compiled
+   RegExp cache. This is very small, but a single miss discards every useful
+   analysis and can cause avoidable re-analysis cliffs.
+3. Keep a fixed-capacity map plus insertion-order queue and evict one oldest
+   entry on a full-cache miss. This is selected: lookup and insertion remain
+   O(1), eviction is deterministic, and no dependency or hit-path scan is added.
+
+## Design
+
+Introduce a small `HoistCache` wrapper containing the existing pointer-keyed map
+and a FIFO queue of its keys. Its capacity is 256 entries, consistent with the
+existing compiled RegExp cache bound.
+
+On a hit, the wrapper clones and returns the cached analysis without changing
+order. On a miss at capacity, it removes the oldest key from both collections
+before inserting the new analysis. Every retained entry continues to own its
+Body `Rc`, preserving ABA safety. Removing an entry drops that ownership; a
+later call of the evicted Body recomputes and safely reinserts its analysis.
+
+The wrapper owns the map/queue synchronization invariant so the evaluator cannot
+update one without the other. No ECMAScript-visible behavior changes.
+
+## Validation
+
+Add an interpreter integration test that executes more than 256 distinct
+`Function` constructor Bodies through the normal call path, calls the oldest
+function again after eviction, and checks both its result and the cache bound.
+Run the Function constructor and function-statement test262 areas, followed by
+the repository formatting, linting, release build/tests, and full test262 gate.

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2078,23 +2078,18 @@ impl Interpreter {
         // #72: cache the hoisting *name collection* for this function body,
         // keyed by the body's Rc pointer identity. The body Rc is stable across
         // function-object clones, so repeated calls reuse the analysis. ASTs are
-        // immutable post-parse, so the cache cannot go stale.
-        let key = Rc::as_ptr(&body.statements);
-        let analysis = match self.hoist_cache.get(&key) {
-            Some(a) => a.clone(),
+        // immutable post-parse, so the cache cannot go stale. The cache is
+        // capacity-bounded (#165), so a miss here can also be an eviction.
+        let analysis = match self.hoist_cache.get(&body.statements) {
+            Some(a) => a,
             None => {
                 let mut var_set = std::collections::HashSet::new();
                 Self::collect_var_names_from_stmts(body.as_slice(), &mut var_set);
                 let mut names = Vec::new();
                 let mut blocked = Vec::new();
                 Self::collect_annexb_function_names(body.as_slice(), &mut names, &mut blocked);
-                let a = Rc::new(HoistAnalysis {
-                    var_names: var_set.into_iter().collect(),
-                    annexb_names: names,
-                    _body: body.statements.clone(),
-                });
-                self.hoist_cache.insert(key, a.clone());
-                a
+                self.hoist_cache
+                    .insert(&body.statements, var_set.into_iter().collect(), names)
             }
         };
         let handle = self.ic_store.for_body(body);

--- a/src/interpreter/hoist_cache.rs
+++ b/src/interpreter/hoist_cache.rs
@@ -1,0 +1,260 @@
+//! Bounded memoisation of per-function-body hoisting analysis.
+//!
+//! `dispatch_body` runs the var/Annex-B *name collection* of
+//! `super::hoisting` once per function body and reuses it on later calls (#72),
+//! keyed by the identity of the body's statement `Rc`. Each entry pins that
+//! `Rc` so its address cannot be reused by a freed-then-reallocated body
+//! (ABA), which means an unbounded map would retain every body it has ever
+//! seen — including the short-lived bodies of `new Function` / `eval` (#165).
+//!
+//! (Bounding this cache is necessary but not sufficient to let such a body be
+//! freed: `super::ic_store` pins the same bodies and does not yet evict — #468.)
+//!
+//! The cache is therefore capacity-bounded with approximate-LRU eviction: when
+//! a new body would exceed `DEFAULT_CAPACITY`, the least-recently-used half of
+//! the entries is dropped in one sweep. Entries are pure memoisation, so eviction only ever
+//! costs a re-walk of the body. Eviction removes the map key and its pinned
+//! body together, so every surviving key still names a live body and the ABA
+//! invariant holds.
+
+use rustc_hash::FxHashMap;
+use std::rc::Rc;
+
+use crate::ast::Statement;
+
+/// Maximum number of memoised bodies. Large enough that a program with a fixed
+/// set of functions never evicts — the bound exists for body-churning workloads
+/// (`new Function` / `eval` in a loop). An entry costs a few hundred bytes plus
+/// the body it pins, so a full cache stays in the low megabytes for the small
+/// bodies such workloads produce.
+pub(crate) const DEFAULT_CAPACITY: usize = 8192;
+
+/// Cached output of the var/Annex-B hoisting *name collection* for a single
+/// function body (#72).
+///
+/// Only the raw name collection is cached. The Annex-B post-processing that
+/// inspects live env/parameter/lexical state still runs per call, and function
+/// declarations are never cached as values (fresh closures are built per call).
+/// The body `Rc` is pinned to prevent pointer (ABA) reuse from aliasing a
+/// freed body onto a fresh one with the same address.
+pub(crate) struct HoistAnalysis {
+    /// Deduped output of `collect_var_names_from_stmts`.
+    pub(crate) var_names: Vec<String>,
+    /// Raw `names` output of `collect_annexb_function_names`. (The companion
+    /// `blocked` accumulator is internal to the walk and discarded afterwards
+    /// by the original code, so it is intentionally not cached.)
+    pub(crate) annexb_names: Vec<String>,
+    /// Pins the body so its `Rc::as_ptr` key cannot be reused for another body.
+    _body: Rc<Vec<Statement>>,
+}
+
+struct Entry {
+    analysis: Rc<HoistAnalysis>,
+    /// Clock value of this entry's most recent lookup or insertion.
+    last_used: u64,
+}
+
+/// Capacity-bounded, approximate-LRU cache of `HoistAnalysis` keyed by body
+/// identity. The key `*const Vec<Statement>` is an identity only — never
+/// dereferenced. Entries cannot go stale: ASTs are immutable post-parse and
+/// each entry pins the body it is keyed by.
+pub(crate) struct HoistCache {
+    entries: FxHashMap<*const Vec<Statement>, Entry>,
+    capacity: usize,
+    clock: u64,
+    hits: u64,
+}
+
+impl HoistCache {
+    pub(crate) fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: FxHashMap::default(),
+            capacity: capacity.max(2),
+            clock: 0,
+            hits: 0,
+        }
+    }
+
+    /// Return the memoised analysis for `body`, marking it most-recently used.
+    pub(crate) fn get(&mut self, body: &Rc<Vec<Statement>>) -> Option<Rc<HoistAnalysis>> {
+        let key = Rc::as_ptr(body);
+        self.clock += 1;
+        let clock = self.clock;
+        let entry = self.entries.get_mut(&key)?;
+        entry.last_used = clock;
+        let analysis = entry.analysis.clone();
+        self.hits += 1;
+        Some(analysis)
+    }
+
+    /// Memoise the analysis of `body`, evicting the least-recently-used half of
+    /// the cache first if this entry would exceed the capacity.
+    pub(crate) fn insert(
+        &mut self,
+        body: &Rc<Vec<Statement>>,
+        var_names: Vec<String>,
+        annexb_names: Vec<String>,
+    ) -> Rc<HoistAnalysis> {
+        let key = Rc::as_ptr(body);
+        if self.entries.len() >= self.capacity && !self.entries.contains_key(&key) {
+            self.evict_lru_half();
+        }
+        let analysis = Rc::new(HoistAnalysis {
+            var_names,
+            annexb_names,
+            _body: body.clone(),
+        });
+        self.clock += 1;
+        self.entries.insert(
+            key,
+            Entry {
+                analysis: analysis.clone(),
+                last_used: self.clock,
+            },
+        );
+        analysis
+    }
+
+    /// Number of memoised bodies. Whitebox accessor used by the tests that
+    /// pin down the capacity bound; not exposed to JS.
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Number of lookups served from the cache. Whitebox accessor used by the
+    /// test that pins down that repeated calls still reuse one analysis; not
+    /// exposed to JS.
+    #[allow(dead_code)]
+    pub(crate) fn hits(&self) -> u64 {
+        self.hits
+    }
+
+    /// Drop the older half of the entries by `last_used` (the median entry
+    /// included, so at least `capacity / 2` slots come free). Halving rather
+    /// than evicting a single entry keeps this an amortised O(1)-per-insert
+    /// sweep. Each removal drops the entry's pinned body together with its key,
+    /// so no surviving key can be aliased by a later body at the same address.
+    fn evict_lru_half(&mut self) {
+        let mut ticks: Vec<u64> = self.entries.values().map(|e| e.last_used).collect();
+        let mid = ticks.len() / 2;
+        let (_, &mut cutoff, _) = ticks.select_nth_unstable(mid);
+        self.entries.retain(|_, e| e.last_used > cutoff);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body(n: usize) -> Rc<Vec<Statement>> {
+        // Distinct allocations; contents are irrelevant to the cache.
+        Rc::new(vec![Statement::Empty; n])
+    }
+
+    fn insert(cache: &mut HoistCache, b: &Rc<Vec<Statement>>) {
+        cache.insert(b, vec!["x".to_string()], Vec::new());
+    }
+
+    #[test]
+    fn memoises_by_body_identity() {
+        let mut cache = HoistCache::new();
+        let b = body(1);
+        assert!(cache.get(&b).is_none());
+        insert(&mut cache, &b);
+        let hit = cache.get(&b).expect("cached analysis");
+        assert_eq!(hit.var_names, vec!["x".to_string()]);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn hits_count_only_lookups_served_from_the_cache() {
+        let mut cache = HoistCache::new();
+        let b = body(1);
+        assert!(cache.get(&b).is_none());
+        assert_eq!(cache.hits(), 0);
+        insert(&mut cache, &b);
+        assert!(cache.get(&b).is_some());
+        assert!(cache.get(&b).is_some());
+        assert_eq!(cache.hits(), 2);
+    }
+
+    #[test]
+    fn distinct_bodies_get_distinct_entries() {
+        let mut cache = HoistCache::new();
+        let a = body(1);
+        let b = body(2);
+        insert(&mut cache, &a);
+        insert(&mut cache, &b);
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn stays_within_capacity_across_many_bodies() {
+        let mut cache = HoistCache::with_capacity(8);
+        // Bodies are dropped immediately, exactly as short-lived dynamic
+        // function bodies are; only the cache's own pin could retain them.
+        for i in 0..1000 {
+            let b = body(i % 4 + 1);
+            insert(&mut cache, &b);
+            assert!(cache.len() <= 8, "cache grew to {}", cache.len());
+        }
+        assert!(cache.len() <= 8);
+    }
+
+    #[test]
+    fn eviction_releases_the_pinned_body() {
+        let mut cache = HoistCache::with_capacity(2);
+        let pinned = body(1);
+        let weak = Rc::downgrade(&pinned);
+        insert(&mut cache, &pinned);
+        drop(pinned);
+        assert!(weak.upgrade().is_some(), "cache must pin a live entry");
+        for i in 0..8 {
+            let b = body(i + 2);
+            insert(&mut cache, &b);
+        }
+        assert!(
+            weak.upgrade().is_none(),
+            "evicted entry must release its body"
+        );
+    }
+
+    #[test]
+    fn recently_used_entries_survive_eviction() {
+        let mut cache = HoistCache::with_capacity(4);
+        let hot = body(1);
+        insert(&mut cache, &hot);
+        let mut cold = Vec::new();
+        for i in 0..3 {
+            let b = body(i + 2);
+            insert(&mut cache, &b);
+            cold.push(b);
+        }
+        // Touch the first body so it is the most-recently used, then force a
+        // sweep by inserting a new body.
+        assert!(cache.get(&hot).is_some());
+        let fresh = body(99);
+        insert(&mut cache, &fresh);
+        assert!(
+            cache.get(&hot).is_some(),
+            "most-recently-used entry must survive eviction"
+        );
+    }
+
+    #[test]
+    fn reinsert_of_a_cached_body_does_not_evict() {
+        let mut cache = HoistCache::with_capacity(2);
+        let a = body(1);
+        let b = body(2);
+        insert(&mut cache, &a);
+        insert(&mut cache, &b);
+        insert(&mut cache, &b);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get(&a).is_some());
+    }
+}

--- a/src/interpreter/ic_store.rs
+++ b/src/interpreter/ic_store.rs
@@ -27,6 +27,10 @@ pub(crate) struct IcStore {
     /// same cache. Each `BodyIcStore` pins a clone of the body's statement `Rc`
     /// so the pointer key cannot be reused by a freed-then-reallocated body
     /// (ABA), matching the `HoistAnalysis` cache pattern.
+    ///
+    /// Unlike that cache (`super::hoist_cache`, bounded per #165), this table
+    /// never evicts, so it retains every body it has ever run — bounding it
+    /// needs handle-lifetime work and is tracked in #468.
     index: HashMap<*const Vec<crate::ast::Statement>, usize>,
     stores: Vec<BodyIcStore>,
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -28,6 +28,8 @@ mod exec;
 mod gc;
 pub(crate) mod generator_analysis;
 pub(crate) mod generator_transform;
+mod hoist_cache;
+pub(crate) use hoist_cache::{HoistAnalysis, HoistCache};
 mod hoisting;
 pub(crate) mod ic;
 pub(crate) mod ic_store;
@@ -58,25 +60,6 @@ fn import_module_type(attrs: &[(String, String)]) -> Option<ImportModuleType> {
         }
     }
     None
-}
-
-/// Cached output of the var/Annex-B hoisting *name collection* for a single
-/// function body, keyed by the body's `Rc` pointer identity (#72).
-///
-/// Only the raw name collection is cached. The Annex-B post-processing that
-/// inspects live env/parameter/lexical state still runs per call, and function
-/// declarations are never cached as values (fresh closures are built per call).
-/// The body `Rc` is pinned to prevent pointer (ABA) reuse from aliasing a
-/// freed body onto a fresh one with the same address.
-pub(crate) struct HoistAnalysis {
-    /// Deduped output of `collect_var_names_from_stmts`.
-    pub(crate) var_names: Vec<String>,
-    /// Raw `names` output of `collect_annexb_function_names`. (The companion
-    /// `blocked` accumulator is internal to the walk and discarded afterwards
-    /// by the original code, so it is intentionally not cached.)
-    pub(crate) annexb_names: Vec<String>,
-    /// Pins the body so its `Rc::as_ptr` key cannot be reused for another body.
-    _body: Rc<Vec<Statement>>,
 }
 
 pub(crate) struct Interpreter {
@@ -178,10 +161,9 @@ pub(crate) struct Interpreter {
     /// enabled so elapsed nanoseconds are measured from a stable origin.
     pub(crate) host_clock_start: Option<std::time::Instant>,
     /// Per-function-body hoisting-analysis cache keyed by body `Rc` identity
-    /// (#72). The key `*const Vec<Statement>` is used purely as an identity —
-    /// never dereferenced. Cannot go stale: ASTs are immutable post-parse and
-    /// the keyed body is pinned in the value.
-    pub(crate) hoist_cache: FxHashMap<*const Vec<Statement>, Rc<HoistAnalysis>>,
+    /// (#72), bounded so body-churning workloads cannot retain every body they
+    /// ever ran (#165). See `hoist_cache`.
+    pub(crate) hoist_cache: HoistCache,
     /// Per-body inline-cache store. Bodies are keyed by the `Rc` pointer to
     /// their statement vector so closures of the same function body share the
     /// same cache. See `docs/adr/0001-inline-cache-ast-seam.md`.
@@ -429,7 +411,7 @@ impl Interpreter {
             node_host_enabled: false,
             pending_exit: None,
             host_clock_start: None,
-            hoist_cache: FxHashMap::default(),
+            hoist_cache: HoistCache::new(),
             ic_store: ic_store::IcStore::new(),
             current_ic_handle: ic_store::BodyStoreHandle(0),
             call_depth: 0,

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -2292,6 +2292,57 @@ fn date_set_utc_full_year_on_invalid_date_seeds_missing_args_from_epoch_not_nan(
     assert_eq!(global_number(&interp, "__d"), 1.0);
 }
 
+// #165: the per-body hoisting-analysis cache pins each body it memoises, so an
+// unbounded map would retain every `new Function` / `eval` body the program ever
+// ran. These pin the bound and the memoisation it must not lose.
+#[test]
+fn hoist_cache_stays_bounded_across_many_distinct_dynamic_function_bodies() {
+    let bodies = super::hoist_cache::DEFAULT_CAPACITY + 2000;
+    let interp = run_script(&format!(
+        r#"
+        var sum = 0;
+        for (var i = 0; i < {bodies}; i++) {{
+          // A distinct source per iteration, so each call dispatches a body the
+          // cache has never seen, with both var and Annex-B names to collect.
+          var f = new Function("var x" + i + " = 1; {{ function g" + i + "(){{}} }} return x" + i + ";");
+          sum += f();
+        }}
+        globalThis.__sum = sum;
+        "#
+    ));
+    assert_eq!(global_number(&interp, "__sum"), bodies as f64);
+    assert!(
+        interp.hoist_cache.len() <= super::hoist_cache::DEFAULT_CAPACITY,
+        "hoist cache grew to {} entries for {bodies} dynamic bodies",
+        interp.hoist_cache.len()
+    );
+    // Guards against the bound passing vacuously: these bodies must really be
+    // reaching the cache, which means it fills and then evicts.
+    assert!(
+        interp.hoist_cache.len() > super::hoist_cache::DEFAULT_CAPACITY / 2,
+        "expected the dynamic bodies to fill the cache, got {} entries",
+        interp.hoist_cache.len()
+    );
+}
+
+#[test]
+fn hoist_cache_still_reuses_one_analysis_across_repeated_calls() {
+    let interp = run_script(
+        r#"
+        function f(n) { var acc = 0; for (var i = 0; i < n; i++) { acc += i; } return acc; }
+        var total = 0;
+        for (var k = 0; k < 50; k++) { total += f(3); }
+        globalThis.__total = total;
+        "#,
+    );
+    assert_eq!(global_number(&interp, "__total"), 150.0);
+    assert!(
+        interp.hoist_cache.hits() >= 49,
+        "expected the repeatedly-called body to be memoised, got {} hits",
+        interp.hoist_cache.hits()
+    );
+}
+
 // Loop and labelled-statement completion values are the observable surface of
 // the `v = val` folding consolidated into `handle_loop_body_completion`
 // (src/interpreter/exec.rs). These pin the behaviour across the six loop heads


### PR DESCRIPTION
## Summary

- replace the unbounded per-Body hoisting-analysis map with an 8,192-entry approximate-LRU cache
- evict the colder half in one amortized sweep while preserving the per-entry Body pin that prevents pointer ABA collisions
- encapsulate cache construction so keys, recency metadata, and pinned analyses are updated together
- add focused eviction, pin-release, recency, and memoization tests plus dynamic Function integration coverage
- document the selected design and note that the separately tracked IcStore retention in #468 remains out of scope

## Validation

- cargo fmt --check
- cargo clippy
- ./scripts/lint.sh
- cargo build --release
- cargo test --release (502 passed, 1 ignored; integration tests 3 passed; smoke oracle 1 passed)
- Function test262 slice: 893 / 893
- function-statement test262 slice: 783 / 783
- test262-extra: 144 / 144
- custom tests: 11 / 11
- full test262: 99,568 / 99,568, zero regressions

Closes #165