### PR TITLE
refactor(interpreter): let the hoist memo own the analysis it stores

### DIFF
--- a/docs/specs/2026-07-20-bounded-hoist-cache-design.md
+++ b/docs/specs/2026-07-20-bounded-hoist-cache-design.md
@@ -33,22 +33,25 @@ and a monotonic recency clock. Its capacity is 8,192 entries: large enough to
 avoid churn for ordinary programs with many static Bodies while still placing a
 fixed upper bound on body-churning `Function` and `eval` workloads.
 
-On a hit, the wrapper updates the entry's recency tick and returns the cached
-analysis. On a miss at capacity, it selects the median recency tick and removes
-the entries below it, keeping the newer half (`ceil(len / 2)`, so the most
-recently used entry always survives) before inserting the new analysis. The
-capacity is floored at two entries, which is what guarantees a sweep frees a slot
-for the incoming one. Every retained entry
-continues to own its Body `Rc`, preserving ABA safety. Removing an entry drops
-that ownership; a later call of the evicted Body recomputes and safely reinserts
-its analysis.
+The bound is an entry count, and an entry costs its own few hundred bytes plus
+whatever Body it pins, so it caps retention rather than naming a byte figure.
+Note also that `IcStore` pins the same Bodies and does not evict, so a churning
+workload's memory does not level off until that table is bounded too (#468);
+this design only stops this cache from being the reason a Body is retained.
 
-The wrapper owns the key, recency metadata, and pinned analysis together so the
-evaluator cannot update only part of an entry. It exposes a single
-`get_or_insert_with` entry point taking the `Body` itself, mirroring
-`IcStore::for_body`, so the evaluator neither derives the key nor decides when to
-evict, and a hit and a miss cannot diverge. No ECMAScript-visible behavior
-changes.
+On a hit, the wrapper updates the entry's recency tick and returns the cached
+analysis. On a miss at capacity, it selects the median recency tick and keeps the
+newer half, so the most recently used entry always survives a sweep, then inserts
+the new analysis. Every retained entry continues to pin its Body, preserving ABA
+safety. Removing an entry drops that pin; a later call of the evicted Body
+recomputes and safely reinserts its analysis.
+
+The wrapper owns the key, the recency metadata, the pin, and the collection
+itself, so the evaluator cannot update part of an entry or pair a key with a
+different analysis. It exposes one `analysis_for(&Body)` entry point — taking the
+Body, whose `key` method both Body-keyed side tables share — so the evaluator
+neither derives the key, nor decides when to evict, nor supplies the analysis. No
+ECMAScript-visible behavior changes.
 
 ## Validation
 

--- a/docs/specs/2026-07-20-bounded-hoist-cache-design.md
+++ b/docs/specs/2026-07-20-bounded-hoist-cache-design.md
@@ -35,19 +35,27 @@ fixed upper bound on body-churning `Function` and `eval` workloads.
 
 On a hit, the wrapper updates the entry's recency tick and returns the cached
 analysis. On a miss at capacity, it selects the median recency tick and removes
-the older half before inserting the new analysis. Every retained entry
+the entries below it, keeping the newer half (`ceil(len / 2)`, so the most
+recently used entry always survives) before inserting the new analysis. The
+capacity is floored at two entries, which is what guarantees a sweep frees a slot
+for the incoming one. Every retained entry
 continues to own its Body `Rc`, preserving ABA safety. Removing an entry drops
 that ownership; a later call of the evicted Body recomputes and safely reinserts
 its analysis.
 
 The wrapper owns the key, recency metadata, and pinned analysis together so the
-evaluator cannot update only part of an entry. No ECMAScript-visible behavior
+evaluator cannot update only part of an entry. It exposes a single
+`get_or_insert_with` entry point taking the `Body` itself, mirroring
+`IcStore::for_body`, so the evaluator neither derives the key nor decides when to
+evict, and a hit and a miss cannot diverge. No ECMAScript-visible behavior
 changes.
 
 ## Validation
 
 Add focused cache tests for identity memoization, hit accounting, the capacity
-bound, release of an evicted Body's pin, recency-aware eviction, and reinsertion.
+bound, release of an evicted Body's pin, recency-aware eviction, and a sweep at
+the capacity floor (where a median cutoff that dropped its own tick would evict
+the newest entry).
 Add interpreter integration tests that execute more than 8,192 distinct
 `Function` constructor Bodies through the normal call path and verify both the
 computed result and cache occupancy, plus repeated calls that must keep hitting

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -96,6 +96,16 @@ impl Body {
     pub(crate) fn as_slice(&self) -> &[Statement] {
         &self.statements
     }
+
+    /// Identity of this Body, for side tables keyed by Body (`interpreter::ic_store`,
+    /// `interpreter::hoist_cache`). Stable across `Body` clones, since they share
+    /// the statement `Rc`. The pointer is an identity only and is never
+    /// dereferenced; a table keyed by it must pin the `Rc` for as long as the key
+    /// lives, so a freed Body's address cannot be reused for an unrelated entry
+    /// (ABA).
+    pub(crate) fn key(&self) -> *const Vec<Statement> {
+        Rc::as_ptr(&self.statements)
+    }
 }
 
 /// Assign dense `CallSiteId` and `PropSiteId` values to every call, new, and

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2075,18 +2075,9 @@ impl Interpreter {
                 return result;
             }
         }
-        // #72: memoise the hoisting *name collection* for this Body, keyed by
-        // its statement `Rc` identity — stable across function-object clones,
-        // so repeated calls reuse the analysis. The memo is capacity-bounded
-        // (#165), so a miss can also mean this Body's entry was evicted.
-        let analysis = self.hoist_cache.get_or_insert_with(body, |stmts| {
-            let mut var_set = std::collections::HashSet::new();
-            Self::collect_var_names_from_stmts(stmts, &mut var_set);
-            let mut names = Vec::new();
-            let mut blocked = Vec::new();
-            Self::collect_annexb_function_names(stmts, &mut names, &mut blocked);
-            (var_set.into_iter().collect(), names)
-        });
+        // #72: the declared-name collection for this Body is memoised, bounded
+        // per #165.
+        let analysis = self.hoist_cache.analysis_for(body);
         let handle = self.ic_store.for_body(body);
         let prev = self.current_ic_handle;
         self.current_ic_handle = handle;

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2075,23 +2075,18 @@ impl Interpreter {
                 return result;
             }
         }
-        // #72: cache the hoisting *name collection* for this function body,
-        // keyed by the body's Rc pointer identity. The body Rc is stable across
-        // function-object clones, so repeated calls reuse the analysis. ASTs are
-        // immutable post-parse, so the cache cannot go stale. The cache is
-        // capacity-bounded (#165), so a miss here can also be an eviction.
-        let analysis = match self.hoist_cache.get(&body.statements) {
-            Some(a) => a,
-            None => {
-                let mut var_set = std::collections::HashSet::new();
-                Self::collect_var_names_from_stmts(body.as_slice(), &mut var_set);
-                let mut names = Vec::new();
-                let mut blocked = Vec::new();
-                Self::collect_annexb_function_names(body.as_slice(), &mut names, &mut blocked);
-                self.hoist_cache
-                    .insert(&body.statements, var_set.into_iter().collect(), names)
-            }
-        };
+        // #72: memoise the hoisting *name collection* for this Body, keyed by
+        // its statement `Rc` identity — stable across function-object clones,
+        // so repeated calls reuse the analysis. The memo is capacity-bounded
+        // (#165), so a miss can also mean this Body's entry was evicted.
+        let analysis = self.hoist_cache.get_or_insert_with(body, |stmts| {
+            let mut var_set = std::collections::HashSet::new();
+            Self::collect_var_names_from_stmts(stmts, &mut var_set);
+            let mut names = Vec::new();
+            let mut blocked = Vec::new();
+            Self::collect_annexb_function_names(stmts, &mut names, &mut blocked);
+            (var_set.into_iter().collect(), names)
+        });
         let handle = self.ic_store.for_body(body);
         let prev = self.current_ic_handle;
         self.current_ic_handle = handle;

--- a/src/interpreter/hoist_cache.rs
+++ b/src/interpreter/hoist_cache.rs
@@ -1,29 +1,30 @@
 //! Bounded memoisation of per-Body hoisting analysis.
 //!
-//! `dispatch_body` runs the var/Annex-B *name collection* of `super::hoisting`
-//! once per Body and reuses it on later calls (#72), keyed by the identity of
-//! the Body's statement `Rc`. Each entry pins that `Rc`, so an unbounded map
-//! retains every Body it has ever seen — including the short-lived Bodies that
+//! `dispatch_body` needs the var and Annex-B declared names of the Body it is
+//! about to run, and re-walking the statements on every call is pure waste, so
+//! the collection is memoised per Body (#72). Each entry pins its Body — the
+//! ABA contract on `Body::key` — which means an unbounded map would retain
+//! every Body it has ever seen, including the short-lived ones that
 //! `new Function` and `eval` produce (#165). The cache is therefore
-//! capacity-bounded with approximate-LRU eviction: when a new Body would exceed
-//! `DEFAULT_CAPACITY`, the older half of the entries is dropped in one sweep.
-//! Entries are pure memoisation, so eviction only ever costs a re-walk.
+//! capacity-bounded with approximate-LRU eviction. Entries are pure
+//! memoisation, so eviction only ever costs a re-walk.
 //!
 //! Bounding this cache is necessary but not sufficient to let a dead Body be
 //! freed: `super::ic_store` pins the same Bodies and does not yet evict (#468).
 
 use rustc_hash::FxHashMap;
+use std::collections::HashSet;
 use std::rc::Rc;
 
 use crate::ast::{Body, Statement};
+use crate::interpreter::Interpreter;
 
 /// Maximum number of memoised Bodies. Large enough that a program with a fixed
 /// set of functions never evicts; the bound is there for Body-churning
-/// workloads (`new Function` / `eval` in a loop).
+/// workloads (`new Function` / `eval` in a loop), which retain a Body per entry.
 pub(crate) const DEFAULT_CAPACITY: usize = 8192;
 
-/// Cached output of the var/Annex-B hoisting *name collection* for a single
-/// Body (#72).
+/// The cached half of one Body's hoisting analysis (#72).
 ///
 /// Only the raw name collection is cached. The Annex-B post-processing that
 /// inspects live env/parameter/lexical state still runs per call, and function
@@ -35,26 +36,22 @@ pub(crate) struct HoistAnalysis {
     /// `blocked` accumulator is internal to the walk and discarded afterwards
     /// by the original code, so it is intentionally not cached.)
     pub(crate) annexb_names: Vec<String>,
-    /// Pins the Body so its `Rc::as_ptr` — this entry's key — cannot be reused
-    /// by a freed-then-reallocated Body (ABA). Entries are built only here and
-    /// eviction drops key and pin together, so a key names a live Body for as
-    /// long as the key exists.
-    _body: Rc<Vec<Statement>>,
 }
 
 struct Entry {
     analysis: Rc<HoistAnalysis>,
-    /// Clock value of this entry's most recent lookup or insertion.
+    /// Recency tick of this entry's most recent call.
     last_used: u64,
+    /// Pins the Body for as long as this entry's key lives, per `Body::key`.
+    _body: Rc<Vec<Statement>>,
 }
 
-/// Capacity-bounded, approximate-LRU cache of `HoistAnalysis` keyed by Body
-/// identity. The key `*const Vec<Statement>` is an identity only — never
-/// dereferenced — and cannot go stale, ASTs being immutable post-parse.
+/// Capacity-bounded, approximate-LRU memo of `HoistAnalysis`, keyed by
+/// `Body::key`. It owns the key, the recency metadata, the pin, and the
+/// analysis itself, so no caller can pair a key with a different analysis or
+/// update one part of an entry without the others.
 pub(crate) struct HoistCache {
     entries: FxHashMap<*const Vec<Statement>, Entry>,
-    /// Entry ceiling, floored at 2: a sweep keeps `ceil(len / 2)`, so only from
-    /// two entries up is it guaranteed to free a slot for the incoming one.
     capacity: usize,
     clock: u64,
     #[cfg(test)]
@@ -76,19 +73,14 @@ impl HoistCache {
         }
     }
 
-    /// Return `body`'s memoised analysis, running `analyse` over its statements
-    /// and memoising the `(var_names, annexb_names)` it returns on a miss. A
-    /// miss that would exceed the capacity evicts first.
-    pub(crate) fn get_or_insert_with(
-        &mut self,
-        body: &Body,
-        analyse: impl FnOnce(&[Statement]) -> (Vec<String>, Vec<String>),
-    ) -> Rc<HoistAnalysis> {
-        let key = Rc::as_ptr(&body.statements);
+    /// Return `body`'s analysis, collecting and memoising it on a miss — which
+    /// is either a Body not seen before or one whose entry has been evicted.
+    pub(crate) fn analysis_for(&mut self, body: &Body) -> Rc<HoistAnalysis> {
+        let key = body.key();
         self.clock += 1;
-        let clock = self.clock;
+        let tick = self.clock;
         if let Some(entry) = self.entries.get_mut(&key) {
-            entry.last_used = clock;
+            entry.last_used = tick;
             let analysis = entry.analysis.clone();
             #[cfg(test)]
             {
@@ -96,21 +88,16 @@ impl HoistCache {
             }
             return analysis;
         }
-        let (var_names, annexb_names) = analyse(body.as_slice());
+        let analysis = Rc::new(collect_names(body.as_slice()));
         if self.entries.len() >= self.capacity {
             self.evict_older_half();
         }
-        let analysis = Rc::new(HoistAnalysis {
-            var_names,
-            annexb_names,
-            _body: body.statements.clone(),
-        });
-        self.clock += 1;
         self.entries.insert(
             key,
             Entry {
                 analysis: analysis.clone(),
-                last_used: self.clock,
+                last_used: tick,
+                _body: body.statements.clone(),
             },
         );
         analysis
@@ -122,17 +109,18 @@ impl HoistCache {
         self.entries.len()
     }
 
-    /// Number of lookups served from the cache.
+    /// Number of calls served from the memo.
     #[cfg(test)]
     pub(crate) fn hits(&self) -> u64 {
         self.hits
     }
 
-    /// Drop the older half of the entries by `last_used`, keeping
-    /// `ceil(len / 2)` — so the most-recently-used entry always survives.
-    /// Halving rather than evicting a single entry keeps this an amortised
-    /// O(1)-per-insert sweep. `last_used` values are unique, the clock advancing
-    /// on every lookup and insertion, so the cutoff cannot tie.
+    /// Drop the older half of the entries by `last_used`, keeping the newer
+    /// `ceil(len / 2)` — so the most-recently-used entry always survives, and
+    /// with the capacity floored at two a sweep always frees a slot for the
+    /// incoming Body. Halving rather than evicting a single entry keeps this an
+    /// amortised O(1)-per-insert sweep. Ticks are unique, one per call, so the
+    /// cutoff cannot tie. Each removal drops the entry's pin with its key.
     fn evict_older_half(&mut self) {
         let mut ticks: Vec<u64> = self.entries.values().map(|e| e.last_used).collect();
         let mid = ticks.len() / 2;
@@ -141,38 +129,60 @@ impl HoistCache {
     }
 }
 
+/// Collect the var and Annex-B declared names of one Body: the analysis this
+/// module memoises, and the only thing it ever stores under a Body's key.
+fn collect_names(stmts: &[Statement]) -> HoistAnalysis {
+    let mut var_set = HashSet::new();
+    Interpreter::collect_var_names_from_stmts(stmts, &mut var_set);
+    let mut annexb_names = Vec::new();
+    let mut blocked = Vec::new();
+    Interpreter::collect_annexb_function_names(stmts, &mut annexb_names, &mut blocked);
+    HoistAnalysis {
+        var_names: var_set.into_iter().collect(),
+        annexb_names,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn body(n: usize) -> Body {
-        // Distinct allocations; the contents are irrelevant to the cache.
+        // Distinct allocations; the statements are irrelevant to the cache, and
+        // what the analysis computes for real ones is covered by the
+        // interpreter-level tests and test262.
         Body::new(vec![Statement::Empty; n])
     }
 
-    fn analyse(_: &[Statement]) -> (Vec<String>, Vec<String>) {
-        (vec!["x".to_string()], Vec::new())
-    }
-
-    fn insert(cache: &mut HoistCache, b: &Body) {
-        cache.get_or_insert_with(b, analyse);
-    }
-
-    /// A lookup that must not be a miss: the analyser panics if it runs.
-    fn expect_cached(cache: &mut HoistCache, b: &Body) -> Rc<HoistAnalysis> {
-        cache.get_or_insert_with(b, |_| panic!("expected a cached entry"))
+    /// A call that must be served from the memo, not recollected.
+    fn assert_hit(cache: &mut HoistCache, b: &Body) {
+        let before = cache.hits();
+        cache.analysis_for(b);
+        assert_eq!(cache.hits(), before + 1, "expected a memoised entry");
     }
 
     #[test]
     fn memoises_by_body_identity() {
         let mut cache = HoistCache::new();
         let b = body(1);
-        insert(&mut cache, &b);
+        let first = cache.analysis_for(&b);
         assert_eq!(cache.len(), 1);
-        assert_eq!(cache.hits(), 0);
-        let hit = expect_cached(&mut cache, &b);
-        assert_eq!(hit.var_names, vec!["x".to_string()]);
-        assert_eq!(cache.hits(), 1);
+        let second = cache.analysis_for(&b);
+        assert!(
+            Rc::ptr_eq(&first, &second),
+            "a second call must reuse the memoised analysis"
+        );
+    }
+
+    #[test]
+    fn hits_count_only_calls_served_from_the_memo() {
+        let mut cache = HoistCache::new();
+        let b = body(1);
+        cache.analysis_for(&b);
+        assert_eq!(cache.hits(), 0, "the first call is a miss");
+        cache.analysis_for(&b);
+        cache.analysis_for(&b);
+        assert_eq!(cache.hits(), 2);
     }
 
     #[test]
@@ -180,10 +190,9 @@ mod tests {
         let mut cache = HoistCache::new();
         let a = body(1);
         let b = body(2);
-        insert(&mut cache, &a);
-        insert(&mut cache, &b);
+        cache.analysis_for(&a);
+        cache.analysis_for(&b);
         assert_eq!(cache.len(), 2);
-        assert_eq!(cache.hits(), 0);
     }
 
     #[test]
@@ -193,7 +202,7 @@ mod tests {
         // dynamic functions are; only the cache's own pin could retain them.
         for i in 0..1000 {
             let b = body(i % 4 + 1);
-            insert(&mut cache, &b);
+            cache.analysis_for(&b);
             assert!(cache.len() <= 8, "cache grew to {}", cache.len());
         }
     }
@@ -203,12 +212,11 @@ mod tests {
         let mut cache = HoistCache::with_capacity(2);
         let pinned = body(1);
         let weak = Rc::downgrade(&pinned.statements);
-        insert(&mut cache, &pinned);
+        cache.analysis_for(&pinned);
         drop(pinned);
         assert!(weak.upgrade().is_some(), "cache must pin a live entry");
         for i in 0..8 {
-            let b = body(i + 2);
-            insert(&mut cache, &b);
+            cache.analysis_for(&body(i + 2));
         }
         assert!(
             weak.upgrade().is_none(),
@@ -220,29 +228,29 @@ mod tests {
     fn recently_used_entries_survive_eviction() {
         let mut cache = HoistCache::with_capacity(4);
         let hot = body(1);
-        insert(&mut cache, &hot);
+        cache.analysis_for(&hot);
         let cold: Vec<Body> = (0..3).map(|i| body(i + 2)).collect();
         for b in &cold {
-            insert(&mut cache, b);
+            cache.analysis_for(b);
         }
         // Touch the oldest entry so it becomes the most-recently used, then
         // force a sweep with a new Body.
-        expect_cached(&mut cache, &hot);
-        insert(&mut cache, &body(99));
-        expect_cached(&mut cache, &hot);
+        assert_hit(&mut cache, &hot);
+        cache.analysis_for(&body(99));
+        assert_hit(&mut cache, &hot);
     }
 
     #[test]
     fn a_sweep_at_the_capacity_floor_still_keeps_the_newest_entry() {
-        // The floor is where a naive "drop everything at or below the median"
-        // cutoff would evict the most-recently-used entry along with the rest.
+        // A cutoff that dropped its own median tick would empty the cache here,
+        // evicting the newest entry along with the oldest.
         let mut cache = HoistCache::with_capacity(2);
         let first = body(1);
         let second = body(2);
-        insert(&mut cache, &first);
-        insert(&mut cache, &second);
-        insert(&mut cache, &body(3)); // sweeps
+        cache.analysis_for(&first);
+        cache.analysis_for(&second);
+        cache.analysis_for(&body(3)); // sweeps
         assert_eq!(cache.len(), 2);
-        expect_cached(&mut cache, &second);
+        assert_hit(&mut cache, &second);
     }
 }

--- a/src/interpreter/hoist_cache.rs
+++ b/src/interpreter/hoist_cache.rs
@@ -1,42 +1,33 @@
-//! Bounded memoisation of per-function-body hoisting analysis.
+//! Bounded memoisation of per-Body hoisting analysis.
 //!
-//! `dispatch_body` runs the var/Annex-B *name collection* of
-//! `super::hoisting` once per function body and reuses it on later calls (#72),
-//! keyed by the identity of the body's statement `Rc`. Each entry pins that
-//! `Rc` so its address cannot be reused by a freed-then-reallocated body
-//! (ABA), which means an unbounded map would retain every body it has ever
-//! seen — including the short-lived bodies of `new Function` / `eval` (#165).
+//! `dispatch_body` runs the var/Annex-B *name collection* of `super::hoisting`
+//! once per Body and reuses it on later calls (#72), keyed by the identity of
+//! the Body's statement `Rc`. Each entry pins that `Rc`, so an unbounded map
+//! retains every Body it has ever seen — including the short-lived Bodies that
+//! `new Function` and `eval` produce (#165). The cache is therefore
+//! capacity-bounded with approximate-LRU eviction: when a new Body would exceed
+//! `DEFAULT_CAPACITY`, the older half of the entries is dropped in one sweep.
+//! Entries are pure memoisation, so eviction only ever costs a re-walk.
 //!
-//! (Bounding this cache is necessary but not sufficient to let such a body be
-//! freed: `super::ic_store` pins the same bodies and does not yet evict — #468.)
-//!
-//! The cache is therefore capacity-bounded with approximate-LRU eviction: when
-//! a new body would exceed `DEFAULT_CAPACITY`, the least-recently-used half of
-//! the entries is dropped in one sweep. Entries are pure memoisation, so eviction only ever
-//! costs a re-walk of the body. Eviction removes the map key and its pinned
-//! body together, so every surviving key still names a live body and the ABA
-//! invariant holds.
+//! Bounding this cache is necessary but not sufficient to let a dead Body be
+//! freed: `super::ic_store` pins the same Bodies and does not yet evict (#468).
 
 use rustc_hash::FxHashMap;
 use std::rc::Rc;
 
-use crate::ast::Statement;
+use crate::ast::{Body, Statement};
 
-/// Maximum number of memoised bodies. Large enough that a program with a fixed
-/// set of functions never evicts — the bound exists for body-churning workloads
-/// (`new Function` / `eval` in a loop). An entry costs a few hundred bytes plus
-/// the body it pins, so a full cache stays in the low megabytes for the small
-/// bodies such workloads produce.
+/// Maximum number of memoised Bodies. Large enough that a program with a fixed
+/// set of functions never evicts; the bound is there for Body-churning
+/// workloads (`new Function` / `eval` in a loop).
 pub(crate) const DEFAULT_CAPACITY: usize = 8192;
 
 /// Cached output of the var/Annex-B hoisting *name collection* for a single
-/// function body (#72).
+/// Body (#72).
 ///
 /// Only the raw name collection is cached. The Annex-B post-processing that
 /// inspects live env/parameter/lexical state still runs per call, and function
 /// declarations are never cached as values (fresh closures are built per call).
-/// The body `Rc` is pinned to prevent pointer (ABA) reuse from aliasing a
-/// freed body onto a fresh one with the same address.
 pub(crate) struct HoistAnalysis {
     /// Deduped output of `collect_var_names_from_stmts`.
     pub(crate) var_names: Vec<String>,
@@ -44,7 +35,10 @@ pub(crate) struct HoistAnalysis {
     /// `blocked` accumulator is internal to the walk and discarded afterwards
     /// by the original code, so it is intentionally not cached.)
     pub(crate) annexb_names: Vec<String>,
-    /// Pins the body so its `Rc::as_ptr` key cannot be reused for another body.
+    /// Pins the Body so its `Rc::as_ptr` — this entry's key — cannot be reused
+    /// by a freed-then-reallocated Body (ABA). Entries are built only here and
+    /// eviction drops key and pin together, so a key names a live Body for as
+    /// long as the key exists.
     _body: Rc<Vec<Statement>>,
 }
 
@@ -54,14 +48,16 @@ struct Entry {
     last_used: u64,
 }
 
-/// Capacity-bounded, approximate-LRU cache of `HoistAnalysis` keyed by body
+/// Capacity-bounded, approximate-LRU cache of `HoistAnalysis` keyed by Body
 /// identity. The key `*const Vec<Statement>` is an identity only — never
-/// dereferenced. Entries cannot go stale: ASTs are immutable post-parse and
-/// each entry pins the body it is keyed by.
+/// dereferenced — and cannot go stale, ASTs being immutable post-parse.
 pub(crate) struct HoistCache {
     entries: FxHashMap<*const Vec<Statement>, Entry>,
+    /// Entry ceiling, floored at 2: a sweep keeps `ceil(len / 2)`, so only from
+    /// two entries up is it guaranteed to free a slot for the incoming one.
     capacity: usize,
     clock: u64,
+    #[cfg(test)]
     hits: u64,
 }
 
@@ -75,38 +71,39 @@ impl HoistCache {
             entries: FxHashMap::default(),
             capacity: capacity.max(2),
             clock: 0,
+            #[cfg(test)]
             hits: 0,
         }
     }
 
-    /// Return the memoised analysis for `body`, marking it most-recently used.
-    pub(crate) fn get(&mut self, body: &Rc<Vec<Statement>>) -> Option<Rc<HoistAnalysis>> {
-        let key = Rc::as_ptr(body);
+    /// Return `body`'s memoised analysis, running `analyse` over its statements
+    /// and memoising the `(var_names, annexb_names)` it returns on a miss. A
+    /// miss that would exceed the capacity evicts first.
+    pub(crate) fn get_or_insert_with(
+        &mut self,
+        body: &Body,
+        analyse: impl FnOnce(&[Statement]) -> (Vec<String>, Vec<String>),
+    ) -> Rc<HoistAnalysis> {
+        let key = Rc::as_ptr(&body.statements);
         self.clock += 1;
         let clock = self.clock;
-        let entry = self.entries.get_mut(&key)?;
-        entry.last_used = clock;
-        let analysis = entry.analysis.clone();
-        self.hits += 1;
-        Some(analysis)
-    }
-
-    /// Memoise the analysis of `body`, evicting the least-recently-used half of
-    /// the cache first if this entry would exceed the capacity.
-    pub(crate) fn insert(
-        &mut self,
-        body: &Rc<Vec<Statement>>,
-        var_names: Vec<String>,
-        annexb_names: Vec<String>,
-    ) -> Rc<HoistAnalysis> {
-        let key = Rc::as_ptr(body);
-        if self.entries.len() >= self.capacity && !self.entries.contains_key(&key) {
-            self.evict_lru_half();
+        if let Some(entry) = self.entries.get_mut(&key) {
+            entry.last_used = clock;
+            let analysis = entry.analysis.clone();
+            #[cfg(test)]
+            {
+                self.hits += 1;
+            }
+            return analysis;
+        }
+        let (var_names, annexb_names) = analyse(body.as_slice());
+        if self.entries.len() >= self.capacity {
+            self.evict_older_half();
         }
         let analysis = Rc::new(HoistAnalysis {
             var_names,
             annexb_names,
-            _body: body.clone(),
+            _body: body.statements.clone(),
         });
         self.clock += 1;
         self.entries.insert(
@@ -119,31 +116,28 @@ impl HoistCache {
         analysis
     }
 
-    /// Number of memoised bodies. Whitebox accessor used by the tests that
-    /// pin down the capacity bound; not exposed to JS.
-    #[allow(dead_code)]
+    /// Number of memoised Bodies.
+    #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         self.entries.len()
     }
 
-    /// Number of lookups served from the cache. Whitebox accessor used by the
-    /// test that pins down that repeated calls still reuse one analysis; not
-    /// exposed to JS.
-    #[allow(dead_code)]
+    /// Number of lookups served from the cache.
+    #[cfg(test)]
     pub(crate) fn hits(&self) -> u64 {
         self.hits
     }
 
-    /// Drop the older half of the entries by `last_used` (the median entry
-    /// included, so at least `capacity / 2` slots come free). Halving rather
-    /// than evicting a single entry keeps this an amortised O(1)-per-insert
-    /// sweep. Each removal drops the entry's pinned body together with its key,
-    /// so no surviving key can be aliased by a later body at the same address.
-    fn evict_lru_half(&mut self) {
+    /// Drop the older half of the entries by `last_used`, keeping
+    /// `ceil(len / 2)` — so the most-recently-used entry always survives.
+    /// Halving rather than evicting a single entry keeps this an amortised
+    /// O(1)-per-insert sweep. `last_used` values are unique, the clock advancing
+    /// on every lookup and insertion, so the cutoff cannot tie.
+    fn evict_older_half(&mut self) {
         let mut ticks: Vec<u64> = self.entries.values().map(|e| e.last_used).collect();
         let mid = ticks.len() / 2;
         let (_, &mut cutoff, _) = ticks.select_nth_unstable(mid);
-        self.entries.retain(|_, e| e.last_used > cutoff);
+        self.entries.retain(|_, e| e.last_used >= cutoff);
     }
 }
 
@@ -151,36 +145,34 @@ impl HoistCache {
 mod tests {
     use super::*;
 
-    fn body(n: usize) -> Rc<Vec<Statement>> {
-        // Distinct allocations; contents are irrelevant to the cache.
-        Rc::new(vec![Statement::Empty; n])
+    fn body(n: usize) -> Body {
+        // Distinct allocations; the contents are irrelevant to the cache.
+        Body::new(vec![Statement::Empty; n])
     }
 
-    fn insert(cache: &mut HoistCache, b: &Rc<Vec<Statement>>) {
-        cache.insert(b, vec!["x".to_string()], Vec::new());
+    fn analyse(_: &[Statement]) -> (Vec<String>, Vec<String>) {
+        (vec!["x".to_string()], Vec::new())
+    }
+
+    fn insert(cache: &mut HoistCache, b: &Body) {
+        cache.get_or_insert_with(b, analyse);
+    }
+
+    /// A lookup that must not be a miss: the analyser panics if it runs.
+    fn expect_cached(cache: &mut HoistCache, b: &Body) -> Rc<HoistAnalysis> {
+        cache.get_or_insert_with(b, |_| panic!("expected a cached entry"))
     }
 
     #[test]
     fn memoises_by_body_identity() {
         let mut cache = HoistCache::new();
         let b = body(1);
-        assert!(cache.get(&b).is_none());
         insert(&mut cache, &b);
-        let hit = cache.get(&b).expect("cached analysis");
-        assert_eq!(hit.var_names, vec!["x".to_string()]);
         assert_eq!(cache.len(), 1);
-    }
-
-    #[test]
-    fn hits_count_only_lookups_served_from_the_cache() {
-        let mut cache = HoistCache::new();
-        let b = body(1);
-        assert!(cache.get(&b).is_none());
         assert_eq!(cache.hits(), 0);
-        insert(&mut cache, &b);
-        assert!(cache.get(&b).is_some());
-        assert!(cache.get(&b).is_some());
-        assert_eq!(cache.hits(), 2);
+        let hit = expect_cached(&mut cache, &b);
+        assert_eq!(hit.var_names, vec!["x".to_string()]);
+        assert_eq!(cache.hits(), 1);
     }
 
     #[test]
@@ -191,26 +183,26 @@ mod tests {
         insert(&mut cache, &a);
         insert(&mut cache, &b);
         assert_eq!(cache.len(), 2);
+        assert_eq!(cache.hits(), 0);
     }
 
     #[test]
     fn stays_within_capacity_across_many_bodies() {
         let mut cache = HoistCache::with_capacity(8);
-        // Bodies are dropped immediately, exactly as short-lived dynamic
-        // function bodies are; only the cache's own pin could retain them.
+        // Bodies are dropped immediately, exactly as the short-lived Bodies of
+        // dynamic functions are; only the cache's own pin could retain them.
         for i in 0..1000 {
             let b = body(i % 4 + 1);
             insert(&mut cache, &b);
             assert!(cache.len() <= 8, "cache grew to {}", cache.len());
         }
-        assert!(cache.len() <= 8);
     }
 
     #[test]
     fn eviction_releases_the_pinned_body() {
         let mut cache = HoistCache::with_capacity(2);
         let pinned = body(1);
-        let weak = Rc::downgrade(&pinned);
+        let weak = Rc::downgrade(&pinned.statements);
         insert(&mut cache, &pinned);
         drop(pinned);
         assert!(weak.upgrade().is_some(), "cache must pin a live entry");
@@ -220,7 +212,7 @@ mod tests {
         }
         assert!(
             weak.upgrade().is_none(),
-            "evicted entry must release its body"
+            "evicted entry must release its Body"
         );
     }
 
@@ -229,32 +221,28 @@ mod tests {
         let mut cache = HoistCache::with_capacity(4);
         let hot = body(1);
         insert(&mut cache, &hot);
-        let mut cold = Vec::new();
-        for i in 0..3 {
-            let b = body(i + 2);
-            insert(&mut cache, &b);
-            cold.push(b);
+        let cold: Vec<Body> = (0..3).map(|i| body(i + 2)).collect();
+        for b in &cold {
+            insert(&mut cache, b);
         }
-        // Touch the first body so it is the most-recently used, then force a
-        // sweep by inserting a new body.
-        assert!(cache.get(&hot).is_some());
-        let fresh = body(99);
-        insert(&mut cache, &fresh);
-        assert!(
-            cache.get(&hot).is_some(),
-            "most-recently-used entry must survive eviction"
-        );
+        // Touch the oldest entry so it becomes the most-recently used, then
+        // force a sweep with a new Body.
+        expect_cached(&mut cache, &hot);
+        insert(&mut cache, &body(99));
+        expect_cached(&mut cache, &hot);
     }
 
     #[test]
-    fn reinsert_of_a_cached_body_does_not_evict() {
+    fn a_sweep_at_the_capacity_floor_still_keeps_the_newest_entry() {
+        // The floor is where a naive "drop everything at or below the median"
+        // cutoff would evict the most-recently-used entry along with the rest.
         let mut cache = HoistCache::with_capacity(2);
-        let a = body(1);
-        let b = body(2);
-        insert(&mut cache, &a);
-        insert(&mut cache, &b);
-        insert(&mut cache, &b);
+        let first = body(1);
+        let second = body(2);
+        insert(&mut cache, &first);
+        insert(&mut cache, &second);
+        insert(&mut cache, &body(3)); // sweeps
         assert_eq!(cache.len(), 2);
-        assert!(cache.get(&a).is_some());
+        expect_cached(&mut cache, &second);
     }
 }

--- a/src/interpreter/ic_store.rs
+++ b/src/interpreter/ic_store.rs
@@ -22,15 +22,13 @@ pub(crate) struct BodyStoreHandle(pub usize);
 
 /// Interpreter-side side table that maps a body identity to its cache.
 pub(crate) struct IcStore {
-    /// Map from the body statement-vector pointer to the store index. The key
-    /// is the `Rc` pointer so that cloned ASTs sharing the same body share the
-    /// same cache. Each `BodyIcStore` pins a clone of the body's statement `Rc`
-    /// so the pointer key cannot be reused by a freed-then-reallocated body
-    /// (ABA), matching the `HoistAnalysis` cache pattern.
+    /// Map from `Body::key` to the store index, so cloned ASTs sharing a Body
+    /// share its cache. Each `BodyIcStore` pins the Body for as long as its key
+    /// lives, per the ABA contract on `Body::key`.
     ///
-    /// Unlike that cache (`super::hoist_cache`, bounded per #165), this table
-    /// never evicts, so it retains every body it has ever run — bounding it
-    /// needs handle-lifetime work and is tracked in #468.
+    /// Unlike `super::hoist_cache` (bounded per #165), this table never evicts,
+    /// so it retains every Body it has ever run — bounding it needs
+    /// handle-lifetime work and is tracked in #468.
     index: HashMap<*const Vec<crate::ast::Statement>, usize>,
     stores: Vec<BodyIcStore>,
 }
@@ -47,7 +45,7 @@ impl IcStore {
     /// The body must already have had its IC sites assigned (e.g. by the
     /// parser or by `ast::assign_ic_sites` for dynamic code).
     pub(crate) fn for_body(&mut self, body: &Body) -> BodyStoreHandle {
-        let key = Rc::as_ptr(&body.statements);
+        let key = body.key();
         if let Some(&idx) = self.index.get(&key) {
             return BodyStoreHandle(idx);
         }
@@ -69,9 +67,9 @@ impl IcStore {
 pub(crate) struct BodyIcStore {
     call_slots: Vec<CallIcSlot>,
     prop_slots: Vec<PropIcSlot>,
-    /// Pins the body's statement `Rc` alive so its `Rc::as_ptr` address (used as
-    /// the `IcStore` key) cannot be reused by an unrelated body after this one
-    /// is dropped, which would otherwise alias a stale, wrongly-sized store.
+    /// Pins the Body so its `Body::key` address cannot be reused by an unrelated
+    /// Body after this one is dropped, which would alias a stale, wrongly-sized
+    /// store.
     _body: Rc<Vec<crate::ast::Statement>>,
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #472, which landed the #165 bound. A two-axis review (Standards, Spec) and a four-angle cleanup pass (reuse, simplification, efficiency, altitude) ran over that code as independent reviewers; this is what they found worth changing. Full reports: [two-axis review](https://github.com/pmatos/jsse/pull/469#issuecomment-5341895130).

**The one defect.** `evict_lru_half` kept `last_used > cutoff` with `cutoff = ticks[len / 2]`, retaining `len - len/2 - 1` entries — at the `capacity.max(2)` floor that is **zero**, so a sweep dropped the newest entry along with the oldest, contradicting the design note's "hits preserve hot analyses". The cutoff is now `>= cutoff`, keeping the newer `ceil(len / 2)`, so the most-recently-used entry always survives and a sweep still frees a slot. `a_sweep_at_the_capacity_floor_still_keeps_the_newest_entry` pins it — verified failing under the old cutoff.

**The memo now owns the analysis it stores.** `get`/`insert` became `get_or_insert_with(&Body, closure)` and then `analysis_for(&Body)`: the collection lives in the module as `collect_names`, so nothing can pair a Body's key with a differently-computed analysis, and the evaluator neither derives the key, nor decides when to evict, nor supplies the walk. The call site is one line. Along the way the miss path lost a third hash lookup (`contains_key`) and the unreachable "insert a key already present" state.

**Body identity is one method.** `Rc::as_ptr(&body.statements)` was spelled out in both Body-keyed side tables, with the "identity only, never dereferenced, pin it or ABA" contract restated in prose in four doc comments and enforced by nothing. It is now `Body::key()` in `src/ast.rs`, carrying that contract once; `hoist_cache` and `ic_store` both call it. If Body identity ever moves off `statements`, the two tables can no longer silently disagree.

**Smaller cleanups.** The recency clock ticks once per call instead of twice on a miss. The Body pin moves into `Entry`, next to the key it protects, and out of the value handed to callers. Whitebox accessors are `#[cfg(test)]` (matching `gc::GcPacer`), so no hit counter ships in release builds. Hit accounting gets its own test back instead of riding along in two tests named for other things. Docs: **Body** per `CONTEXT.md` (which lists "_Avoid_: function body"), the ABA invariant stated where it is enforced instead of five times, and the design note updated for the new entry point, the sweep's actual cutoff, and the fact that the bound is an entry count rather than a byte figure.

No ECMAScript-visible behaviour changes; the cache remains pure memoisation.

## Deliberately not done here

- **Merging the two Body-keyed tables.** Three of the four angles independently landed on it: `ic_store` hashes the same key in the same `dispatch_body` call, pins the same Body, and never evicts, so a churning workload's RSS still grows ~3.68 KB/body with no plateau above the cap (20,000 bodies → 107.0 MB; 60,000 → 254.4 MB). It is blocked on `BodyStoreHandle` lifetime work — bare `stores` indices live in `current_ic_handle` and in `prev` locals across recursion. Tracked in #468, with the alternatives recorded there.
- **Hanging the memo off the Body itself** (`OnceCell` in the statement `Rc`, or a parse-time `BodyId`), which would delete the map, the pin, the capacity, and the sweep together. A different design from the one #472 merged, not a cleanup — recorded on #468.
- **`annexb_names.clone()` per call** in `exec_statements_cached`, and per-call re-hashing of `var_names`: both pre-existing, in the consumer rather than this diff.
- Restoring release-build observability of the cache size (one angle asked for it, another asked for `#[cfg(test)]` per repo precedent; precedent won).

## Test plan

- [x] `cargo test --release` — 502 + 3 + 1 passing, 0 failed (7 cache tests, 2 interpreter-level)
- [x] `./scripts/lint.sh` — rustfmt + clippy `-D warnings` clean
- [x] Floor-sweep test confirmed failing under the old `>` cutoff, passing under `>=`
- [x] test262 (`-j 32`) — **99,568 / 99,568 (100.0%)**, 0 regressions, re-run on the cleanup commit
- [x] test262-extra 144 / 144, custom tests 11 / 11
