### PR TITLE
fix(interpreter): route typed-array element writes through the canonical ToNumber

### DIFF
--- a/src/interpreter/builtins/intl/durationformat.rs
+++ b/src/interpreter/builtins/intl/durationformat.rs
@@ -499,16 +499,15 @@ fn format_duration(data: &DurationFormatData, dur: &DurationRecord) -> String {
         };
 
         if effective_value != 0.0 || display != "auto" || display_required {
-            let sign_display_str;
-            if display_negative_sign {
+            let sign_display_str = if display_negative_sign {
                 display_negative_sign = false;
                 if value == 0.0 && value_str.is_none() && has_negative {
                     value = -0.0_f64;
                 }
-                sign_display_str = "auto";
+                "auto"
             } else {
-                sign_display_str = "never";
-            }
+                "never"
+            };
 
             let formatted = format_one_unit(
                 value,
@@ -1022,16 +1021,15 @@ fn format_to_parts_duration(
         };
 
         if effective_value != 0.0 || display != "auto" || display_required {
-            let sign_display_str;
-            if display_negative_sign {
+            let sign_display_str = if display_negative_sign {
                 display_negative_sign = false;
                 if value == 0.0 && value_str.is_none() && has_negative {
                     value = -0.0_f64;
                 }
-                sign_display_str = "auto";
+                "auto"
             } else {
-                sign_display_str = "never";
-            }
+                "never"
+            };
 
             // Get individual parts from NumberFormat
             let nf_parts = format_one_unit_parts(

--- a/src/interpreter/env_helpers.rs
+++ b/src/interpreter/env_helpers.rs
@@ -8,7 +8,6 @@
 //! A re-entrant `set` trap that calls back into `env_set` would otherwise
 //! double-borrow the same env.
 
-use super::types::*;
 use super::*;
 use crate::types::JsValue;
 

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1600,6 +1600,39 @@ fn typed_array_clamps_assigned_values() {
     assert_eq!(global_string(&interp, "result"), "255");
 }
 
+#[test]
+fn typed_array_define_own_property_coerces_string_value_via_tonumber() {
+    // A typed array's [[DefineOwnProperty]] runs IntegerIndexedElementSet, which
+    // coerces a String [[Value]] with the canonical ToNumber (§7.1.4). Reached via
+    // Object.defineProperties with a raw descriptor value, this must honour the
+    // 0x/0o/0b prefixes, trim exactly the ECMAScript whitespace set, and treat
+    // "inf" as NaN — not defer to a naive float parse.
+    let interp = run_script(
+        r#"
+        function define(TA, v) { var a = new TA(1); Object.defineProperties(a, { 0: { value: v } }); return a[0]; }
+        var hexInt8 = define(Int8Array, "0x10");
+        var octInt8 = define(Int8Array, "0o17");
+        var binInt8 = define(Int8Array, "0b101");
+        var wsInt8  = define(Int8Array, "\t\n\r 5 ");
+        var hexF64  = define(Float64Array, "0x10");
+        var wsF64   = define(Float64Array, " 3.5 ");
+        var infF64  = String(define(Float64Array, "inf"));
+        var num300  = define(Int8Array, 300);
+        var boolT   = define(Int8Array, true);
+        "#,
+    );
+    assert_eq!(global_number(&interp, "hexInt8"), 16.0);
+    assert_eq!(global_number(&interp, "octInt8"), 15.0);
+    assert_eq!(global_number(&interp, "binInt8"), 5.0);
+    assert_eq!(global_number(&interp, "wsInt8"), 5.0);
+    assert_eq!(global_number(&interp, "hexF64"), 16.0);
+    assert_eq!(global_number(&interp, "wsF64"), 3.5);
+    assert_eq!(global_string(&interp, "infF64"), "NaN");
+    // Non-String branches of ToNumber are unchanged.
+    assert_eq!(global_number(&interp, "num300"), 44.0);
+    assert_eq!(global_number(&interp, "boolT"), 1.0);
+}
+
 // -- Resizable ArrayBuffer / growable SharedArrayBuffer invariants (issue #25) -----
 // Whitebox checks on the length-tracking bookkeeping in types.rs. A bug here is a
 // Rust panic or an out-of-bounds slice access, not just a wrong JS-visible value, so

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1,9 +1,9 @@
 use crate::ast::*;
 use crate::interpreter::PropertyMap;
 use crate::interpreter::generator_transform::{GeneratorStateMachine, SentValueBinding};
-use crate::interpreter::helpers::same_value;
+use crate::interpreter::helpers::{same_value, to_number};
 use crate::interpreter::key_intern::intern_js_key;
-use crate::types::{JsPropertyKey, JsString, JsValue, PropertyKeyLike, ValueKind, number_ops};
+use crate::types::{JsPropertyKey, JsString, JsValue, PropertyKeyLike, number_ops};
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
@@ -3691,29 +3691,12 @@ pub(crate) fn typed_array_set_index(ta: &TypedArrayInfo, idx: usize, value: &JsV
     })
 }
 
-fn to_number(v: &JsValue) -> f64 {
-    match v.kind() {
-        ValueKind::Number => v.as_number().expect("kind checked"),
-        ValueKind::Boolean => {
-            if v.as_boolean().expect("kind checked") {
-                1.0
-            } else {
-                0.0
-            }
-        }
-        ValueKind::Null => 0.0,
-        ValueKind::Undefined => f64::NAN,
-        ValueKind::String => v
-            .with_string(|units| {
-                String::from_utf16_lossy(units)
-                    .parse::<f64>()
-                    .unwrap_or(f64::NAN)
-            })
-            .expect("kind checked"),
-        ValueKind::Symbol | ValueKind::BigInt | ValueKind::Object => f64::NAN,
-    }
-}
-
+// Typed-array element writes coerce their value with the single canonical
+// ToNumber (§7.1.4) in `helpers`; these encoders (ToInt8 … Float branches) apply
+// ToInt32/ToUint32 etc. on top of it. `to_bigint64`/`to_biguint64` below still
+// only read an already-`BigInt` value — a raw non-BigInt reaching them yields 0
+// rather than running the throwing ToBigInt, a pre-existing gap that requires an
+// error-propagating set-index signature to close and is out of scope here.
 fn to_int8(v: &JsValue) -> i8 {
     number_ops::to_int32(to_number(v)) as i8
 }

--- a/test262-extra/TypedArray-defineProperties-string-value-coercion.js
+++ b/test262-extra/TypedArray-defineProperties-string-value-coercion.js
@@ -1,0 +1,70 @@
+// A typed array's [[DefineOwnProperty]] on a canonical numeric index runs
+// IntegerIndexedElementSet, which coerces the descriptor's [[Value]] with the
+// abstract operation ToNumber (§7.1.4) — the same StringToNumber (§7.1.4.1)
+// that backs Number(str), unary +, and arithmetic. A String value must therefore
+// honour NonDecimalIntegerLiteral prefixes (0x / 0o / 0b), strip exactly the
+// ECMAScript StrWhiteSpace set, and treat host-parser spellings such as "inf" as
+// NaN — not defer to a naive float parse.
+//
+// Object.defineProperties reaches the exotic [[DefineOwnProperty]] with the raw
+// (un-coerced) descriptor value, so it is the path that exercises the coercion.
+// (Direct element assignment `ta[i] = s` and Reflect.set coerce earlier and were
+// already correct; test262's DefineOwnProperty/set-value.js only ever defines a
+// Number via Reflect.defineProperty, so the String coercion is otherwise
+// unverified.) Expected values cross-checked with Node.
+//
+// Spec: ECMAScript
+//   sec-integer-indexed-exotic-objects-defineownproperty-p-desc (§10.4.5.3)
+//   sec-integerindexedelementset
+//   sec-tonumber (§7.1.4), sec-stringtonumber (§7.1.4.1)
+
+function assertEq(actual, expected, msg) {
+  // Distinguish +0 from -0 as well as ordinary inequality.
+  if (actual !== expected || 1 / actual !== 1 / expected) {
+    throw new Test262Error(
+      msg + ": expected " + expected + " but got " + actual
+    );
+  }
+}
+
+function assertNaN(actual, msg) {
+  if (actual === actual) {
+    throw new Test262Error(msg + ": expected NaN but got " + actual);
+  }
+}
+
+// Define index 0 of a fresh typed array of `TA` with a raw descriptor value and
+// read the element back.
+function defineFirst(TA, value) {
+  var ta = new TA(1);
+  Object.defineProperties(ta, { 0: { value: value } });
+  return ta[0];
+}
+
+// (1) NonDecimalIntegerLiteral prefixes are honoured on an integer element type.
+assertEq(defineFirst(Int8Array, "0x10"), 16, "hex string -> Int8 element");
+assertEq(defineFirst(Int8Array, "0o17"), 15, "octal string -> Int8 element");
+assertEq(defineFirst(Int8Array, "0b101"), 5, "binary string -> Int8 element");
+
+// (2) Exactly the ECMAScript whitespace set is trimmed before parsing.
+assertEq(defineFirst(Int8Array, "  5  "), 5, "space-padded decimal -> Int8 element");
+assertEq(defineFirst(Int8Array, "\t\n\r 5 "), 5, "ASCII whitespace trimmed -> Int8 element");
+assertEq(defineFirst(Float64Array, " 3.5 "), 3.5, "space-padded float -> Float64 element");
+
+// (3) The float element type also routes through ToNumber, so the same prefix
+//     and host-spelling rules apply.
+assertEq(defineFirst(Float64Array, "0x10"), 16, "hex string -> Float64 element");
+assertNaN(defineFirst(Float64Array, "inf"), "'inf' is not Infinity -> Float64 element");
+assertEq(defineFirst(Float64Array, "Infinity"), Infinity, "'Infinity' word -> Float64 element");
+
+// (4) The non-String branches of ToNumber are unchanged: Number, Boolean, and
+//     empty/whitespace-only strings coerce as before.
+assertEq(defineFirst(Int8Array, 300), 44, "Number wraps to Int8 (ToInt8(300))");
+assertEq(defineFirst(Int8Array, true), 1, "Boolean true -> 1 -> Int8 element");
+assertEq(defineFirst(Float64Array, ""), 0, "empty string -> +0 -> Float64 element");
+
+// (5) Object.defineProperty (single) already routed through the spec ToNumber;
+//     both define entry points must now agree.
+var single = new Int8Array(1);
+Object.defineProperty(single, "0", { value: "0x10" });
+assertEq(single[0], 16, "Object.defineProperty agrees with Object.defineProperties");


### PR DESCRIPTION
## Refactoring goal — deepen ToNumber into one canonical module

Produced by an `improve-codebase-architecture` audit of the interpreter's hot
spots, implemented test-first per the `tdd` skill.

The audit surfaced a **shallow, divergent duplicate** of a core abstract
operation. `src/interpreter/types.rs` carried a private `to_number(&JsValue) ->
f64` used only by the typed-array element encoders, sitting beside the canonical
`helpers::to_number` (§7.1.4 ToNumber). Its String branch was a naive
`String::from_utf16_lossy(units).parse::<f64>()`:

- no `0x` / `0o` / `0b` NonDecimalIntegerLiteral prefixes,
- no ECMAScript `StrWhiteSpace` trim,
- and it accepted Rust float spellings (`inf`, `infinity`, `nan`) the spec rejects.

**Deepening:** delete the shallow copy and route the encoders through the single
`helpers::to_number` → `string_to_number` (§7.1.4.1). One ToNumber, one place to
test, one place a coercion bug can live. Deletion test passes — the coercion
rules concentrate rather than move.

## Why this candidate

Of the ten candidates the audit produced (logical-assign predicate, while/do-while
dedup, `PropertyDescriptor::value_only`, a DisposableStack receiver guard, …),
this is the **only one with a genuine red-first test**: the others are
behavior-preserving and would yield green-from-birth characterization tests. A
refactor that can fail first is the one that actually satisfies TDD — and here
the duplicate wasn't just redundant, it was wrong.

## The bug it fixes

A typed array's `[[DefineOwnProperty]]` runs `IntegerIndexedElementSet`, which
coerces the value with ToNumber. `Object.defineProperties` reaches that path with
the **raw** descriptor value, so it hit the divergent copy:

```js
Object.defineProperties(new Int8Array(1), {0:{value:"0x10"}})[0]
// before: 0   after: 16   (Node/spec: 16)
```

Direct assignment (`ta[i] = s`) and `Reflect.set` pre-coerce via
`to_number_value`, so only the raw-value define path diverged;
`Object.defineProperty` (single) already used the correct path and is unchanged.

**Scoped out:** the sibling `to_bigint64` / `to_biguint64` encoders have a
distinct, pre-existing gap — a raw non-BigInt yields `0` instead of running the
*throwing* ToBigInt. Closing it needs an error-propagating set-index signature
(a larger change), so it is left as-is and documented in a comment.

## Tests that validate it (red before, green after)

- `src/interpreter/tests.rs::typed_array_define_own_property_coerces_string_value_via_tonumber`
  — drives the fix through the engine's public JS seam (`run_script`) and reads
  the element back; also pins the unchanged Number/Boolean branches.
- `test262-extra/TypedArray-defineProperties-string-value-coercion.js` — spec-cited
  (§10.4.5.3 → IntegerIndexedElementSet → §7.1.4), covering hex/octal/binary,
  whitespace-trim, and the `"inf"` case, on both integer and float element types.
  Runs in CI in normal and `--bytecode` modes. test262's own
  `DefineOwnProperty/set-value.js` only ever defines a Number via
  `Reflect.defineProperty`, so the String coercion was otherwise unverified.

## Verification

- Full test262: **99,568 / 99,568 (100.00%)**, **0 regressions**.
- `cargo test --bin jsse`: 541 passed.
- `./scripts/lint.sh`: rustfmt + clippy clean.
- `test262-extra` (normal + bytecode): green.

The seam and rationale are stated here in lieu of the `tdd` skill's
"confirm the seams with the user" step (autonomous run, no operator).


## CI unblock (unrelated to the refactor)

Rust stable moved to 1.98 after `main` last went green, so CI's
`cargo clippy -- -D warnings` began rejecting three pre-existing sites this
branch never touched — a redundant `use super::types::*` in `env_helpers.rs`
and two `needless_late_init` bindings in `intl/durationformat.rs`. They are
fixed in a separate, behaviour-neutral commit here (`main` has no other open
PR to carry them, and the squash-merge lands them for everyone). Verified
against a pinned 1.98.0 toolchain with the exact CI invocations:
`cargo fmt --check` and `cargo clippy -- -D warnings` clean,
`cargo test --release --bin jsse` 541 passed.
