### PR TITLE
refactor(builtins): adopt define_method for iterator/promise/disposable installs

### DIFF
--- a/src/interpreter/builtins/disposable.rs
+++ b/src/interpreter/builtins/disposable.rs
@@ -24,15 +24,10 @@ impl Interpreter {
                 );
         }
 
-        // dispose()
-        let dispose_fn = self.create_function(JsFunction::native(
-            "dispose".to_string(),
-            0,
-            |interp, this, _args| interp.disposable_stack_dispose(this, false),
-        ));
-        self.get_object_cell_expect(ds_proto_id)
-            .borrow_mut()
-            .insert_builtin("dispose".to_string(), dispose_fn.clone());
+        // dispose() — also aliased under @@dispose below
+        let dispose_fn = self.define_method(ds_proto_id, "dispose", 0, |interp, this, _args| {
+            interp.disposable_stack_dispose(this, false)
+        });
 
         // Symbol.dispose = dispose
         if let Some(key) = self.get_symbol_key("dispose") {
@@ -66,269 +61,251 @@ impl Interpreter {
         });
 
         // use(value)
-        let use_fn = self.create_function(JsFunction::native(
-            "use".to_string(),
-            1,
-            |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if let Some(object_id) = this.as_object_id()
-                    && interp.get_object_cell(object_id).is_some()
-                {
-                    enum Probe {
-                        NotStack,
-                        AlreadyDisposed,
-                        Active,
+        self.define_method(ds_proto_id, "use", 1, |interp, this, args| {
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if let Some(object_id) = this.as_object_id()
+                && interp.get_object_cell(object_id).is_some()
+            {
+                enum Probe {
+                    NotStack,
+                    AlreadyDisposed,
+                    Active,
+                }
+                let probe = {
+                    let b = interp.get_object_cell_expect(object_id).borrow();
+                    if b.class_name != "DisposableStack" {
+                        Probe::NotStack
+                    } else {
+                        match b.disposable_stack() {
+                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                            Some(_) => Probe::Active,
+                            None => Probe::NotStack,
+                        }
                     }
-                    let probe = {
-                        let b = interp.get_object_cell_expect(object_id).borrow();
-                        if b.class_name != "DisposableStack" {
-                            Probe::NotStack
-                        } else {
-                            match b.disposable_stack() {
-                                Some(ds) if ds.disposed => Probe::AlreadyDisposed,
-                                Some(_) => Probe::Active,
-                                None => Probe::NotStack,
-                            }
-                        }
-                    };
-                    match probe {
-                        Probe::NotStack => {
-                            return Completion::Throw(
-                                interp.create_type_error("Not a DisposableStack"),
-                            );
-                        }
-                        Probe::AlreadyDisposed => {
-                            return Completion::Throw(interp.create_reference_error(
+                };
+                match probe {
+                    Probe::NotStack => {
+                        return Completion::Throw(
+                            interp.create_type_error("Not a DisposableStack"),
+                        );
+                    }
+                    Probe::AlreadyDisposed => {
+                        return Completion::Throw(
+                            interp.create_reference_error(
                                 "DisposableStack has already been disposed",
-                            ));
+                            ),
+                        );
+                    }
+                    Probe::Active => {}
+                }
+                if (value).is_nullish() {
+                    return Completion::Normal(value);
+                }
+                if !(value).is_object() {
+                    return Completion::Throw(
+                        interp.create_type_error("Using requires an object or null/undefined"),
+                    );
+                }
+                // GetMethod(V, @@dispose) - uses get_object_property to invoke getters
+                let method = if let Some(key) = interp.get_symbol_key("dispose") {
+                    if let Some(value_id) = value.as_object_id() {
+                        match interp.get_object_property(value_id, &key, &value) {
+                            Completion::Normal(m) => {
+                                if (m).is_nullish() {
+                                    return Completion::Throw(interp.create_type_error(
+                                        "Object does not have a [Symbol.dispose] method",
+                                    ));
+                                }
+                                m
+                            }
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => JsValue::UNDEFINED,
                         }
-                        Probe::Active => {}
-                    }
-                    if (value).is_nullish() {
-                        return Completion::Normal(value);
-                    }
-                    if !(value).is_object() {
+                    } else {
                         return Completion::Throw(
                             interp.create_type_error("Using requires an object or null/undefined"),
                         );
                     }
-                    // GetMethod(V, @@dispose) - uses get_object_property to invoke getters
-                    let method =
-                        if let Some(key) = interp.get_symbol_key("dispose") {
-                            if let Some(value_id) = value.as_object_id() {
-                                match interp.get_object_property(value_id, &key, &value) {
-                                    Completion::Normal(m) => {
-                                        if (m).is_nullish() {
-                                            return Completion::Throw(interp.create_type_error(
-                                                "Object does not have a [Symbol.dispose] method",
-                                            ));
-                                        }
-                                        m
-                                    }
-                                    Completion::Throw(e) => return Completion::Throw(e),
-                                    _ => JsValue::UNDEFINED,
-                                }
-                            } else {
-                                return Completion::Throw(interp.create_type_error(
-                                    "Using requires an object or null/undefined",
-                                ));
-                            }
-                        } else {
-                            return Completion::Throw(
-                                interp.create_type_error("Symbol.dispose not available"),
-                            );
-                        };
-                    if !interp.is_callable(&method) {
-                        return Completion::Throw(
-                            interp.create_type_error("[Symbol.dispose] is not a function"),
-                        );
-                    }
-                    let resource = DisposableResource {
-                        value: value.clone(),
-                        hint: DisposeHint::Sync,
-                        dispose_method: method,
-                    };
-                    if let Some(cell) = interp.get_object_cell(object_id) {
-                        let mut b = cell.borrow_mut();
-                        if let Some(ds) = b.disposable_stack_mut() {
-                            ds.stack.push(resource);
-                        }
-                    }
-                    return Completion::Normal(value);
+                } else {
+                    return Completion::Throw(
+                        interp.create_type_error("Symbol.dispose not available"),
+                    );
+                };
+                if !interp.is_callable(&method) {
+                    return Completion::Throw(
+                        interp.create_type_error("[Symbol.dispose] is not a function"),
+                    );
                 }
-                Completion::Throw(interp.create_type_error("Not a DisposableStack"))
-            },
-        ));
-        self.get_object_cell_expect(ds_proto_id)
-            .borrow_mut()
-            .insert_builtin("use".to_string(), use_fn);
+                let resource = DisposableResource {
+                    value: value.clone(),
+                    hint: DisposeHint::Sync,
+                    dispose_method: method,
+                };
+                if let Some(cell) = interp.get_object_cell(object_id) {
+                    let mut b = cell.borrow_mut();
+                    if let Some(ds) = b.disposable_stack_mut() {
+                        ds.stack.push(resource);
+                    }
+                }
+                return Completion::Normal(value);
+            }
+            Completion::Throw(interp.create_type_error("Not a DisposableStack"))
+        });
 
         // adopt(value, onDispose)
-        let adopt_fn = self.create_function(JsFunction::native(
-            "adopt".to_string(),
-            2,
-            |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let on_dispose = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
-                if let Some(object_id) = this.as_object_id()
-                    && interp.get_object_cell(object_id).is_some()
-                {
-                    enum Probe {
-                        AlreadyDisposed,
-                        NotStack,
-                        Active,
+        self.define_method(ds_proto_id, "adopt", 2, |interp, this, args| {
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let on_dispose = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            if let Some(object_id) = this.as_object_id()
+                && interp.get_object_cell(object_id).is_some()
+            {
+                enum Probe {
+                    AlreadyDisposed,
+                    NotStack,
+                    Active,
+                }
+                let probe = {
+                    let b = interp.get_object_cell_expect(object_id).borrow();
+                    match b.disposable_stack() {
+                        Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                        Some(_) => Probe::Active,
+                        None => Probe::NotStack,
                     }
-                    let probe = {
-                        let b = interp.get_object_cell_expect(object_id).borrow();
-                        match b.disposable_stack() {
-                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
-                            Some(_) => Probe::Active,
-                            None => Probe::NotStack,
-                        }
-                    };
-                    match probe {
-                        Probe::AlreadyDisposed => {
-                            return Completion::Throw(interp.create_reference_error(
-                                "DisposableStack has already been disposed",
-                            ));
-                        }
-                        Probe::NotStack => {
-                            return Completion::Throw(
-                                interp.create_type_error("Not a DisposableStack"),
-                            );
-                        }
-                        Probe::Active => {}
-                    }
-                    if !interp.is_callable(&on_dispose) {
+                };
+                match probe {
+                    Probe::AlreadyDisposed => {
                         return Completion::Throw(
-                            interp.create_type_error("onDispose must be a function"),
+                            interp.create_reference_error(
+                                "DisposableStack has already been disposed",
+                            ),
                         );
                     }
-                    // Create a wrapper that calls onDispose(value)
-                    let wrapper_val = value.clone();
-                    let wrapper_dispose = on_dispose.clone();
-                    let wrapper_fn = interp.create_function(JsFunction::native(
-                        "".to_string(),
-                        0,
-                        move |interp2, _this2, _args2| {
-                            interp2.call_function(
-                                &wrapper_dispose,
-                                &JsValue::UNDEFINED,
-                                std::slice::from_ref(&wrapper_val),
-                            )
-                        },
-                    ));
-                    let resource = DisposableResource {
-                        value: JsValue::UNDEFINED,
-                        hint: DisposeHint::Sync,
-                        dispose_method: wrapper_fn,
-                    };
-                    if let Some(cell) = interp.get_object_cell(object_id) {
-                        let mut b = cell.borrow_mut();
-                        if let Some(ds) = b.disposable_stack_mut() {
-                            ds.stack.push(resource);
-                        }
+                    Probe::NotStack => {
+                        return Completion::Throw(
+                            interp.create_type_error("Not a DisposableStack"),
+                        );
                     }
-                    return Completion::Normal(value);
+                    Probe::Active => {}
                 }
-                Completion::Throw(interp.create_type_error("Not a DisposableStack"))
-            },
-        ));
-        self.get_object_cell_expect(ds_proto_id)
-            .borrow_mut()
-            .insert_builtin("adopt".to_string(), adopt_fn);
+                if !interp.is_callable(&on_dispose) {
+                    return Completion::Throw(
+                        interp.create_type_error("onDispose must be a function"),
+                    );
+                }
+                // Create a wrapper that calls onDispose(value)
+                let wrapper_val = value.clone();
+                let wrapper_dispose = on_dispose.clone();
+                let wrapper_fn = interp.create_function(JsFunction::native(
+                    "".to_string(),
+                    0,
+                    move |interp2, _this2, _args2| {
+                        interp2.call_function(
+                            &wrapper_dispose,
+                            &JsValue::UNDEFINED,
+                            std::slice::from_ref(&wrapper_val),
+                        )
+                    },
+                ));
+                let resource = DisposableResource {
+                    value: JsValue::UNDEFINED,
+                    hint: DisposeHint::Sync,
+                    dispose_method: wrapper_fn,
+                };
+                if let Some(cell) = interp.get_object_cell(object_id) {
+                    let mut b = cell.borrow_mut();
+                    if let Some(ds) = b.disposable_stack_mut() {
+                        ds.stack.push(resource);
+                    }
+                }
+                return Completion::Normal(value);
+            }
+            Completion::Throw(interp.create_type_error("Not a DisposableStack"))
+        });
 
         // defer(onDispose)
-        let defer_fn = self.create_function(JsFunction::native(
-            "defer".to_string(),
-            1,
-            |interp, this, args| {
-                let on_dispose = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if let Some(object_id) = this.as_object_id()
-                    && interp.get_object_cell(object_id).is_some()
-                {
-                    enum Probe {
-                        AlreadyDisposed,
-                        NotStack,
-                        Active,
+        self.define_method(ds_proto_id, "defer", 1, |interp, this, args| {
+            let on_dispose = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if let Some(object_id) = this.as_object_id()
+                && interp.get_object_cell(object_id).is_some()
+            {
+                enum Probe {
+                    AlreadyDisposed,
+                    NotStack,
+                    Active,
+                }
+                let probe = {
+                    let b = interp.get_object_cell_expect(object_id).borrow();
+                    match b.disposable_stack() {
+                        Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                        Some(_) => Probe::Active,
+                        None => Probe::NotStack,
                     }
-                    let probe = {
-                        let b = interp.get_object_cell_expect(object_id).borrow();
-                        match b.disposable_stack() {
-                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
-                            Some(_) => Probe::Active,
-                            None => Probe::NotStack,
-                        }
-                    };
-                    match probe {
-                        Probe::AlreadyDisposed => {
-                            return Completion::Throw(interp.create_reference_error(
-                                "DisposableStack has already been disposed",
-                            ));
-                        }
-                        Probe::NotStack => {
-                            return Completion::Throw(
-                                interp.create_type_error("Not a DisposableStack"),
-                            );
-                        }
-                        Probe::Active => {}
-                    }
-                    if !interp.is_callable(&on_dispose) {
+                };
+                match probe {
+                    Probe::AlreadyDisposed => {
                         return Completion::Throw(
-                            interp.create_type_error("onDispose must be a function"),
+                            interp.create_reference_error(
+                                "DisposableStack has already been disposed",
+                            ),
                         );
                     }
-                    let resource = DisposableResource {
-                        value: JsValue::UNDEFINED,
-                        hint: DisposeHint::Sync,
-                        dispose_method: on_dispose,
-                    };
-                    if let Some(cell) = interp.get_object_cell(object_id) {
-                        let mut b = cell.borrow_mut();
-                        if let Some(ds) = b.disposable_stack_mut() {
-                            ds.stack.push(resource);
-                        }
+                    Probe::NotStack => {
+                        return Completion::Throw(
+                            interp.create_type_error("Not a DisposableStack"),
+                        );
                     }
-                    return Completion::Normal(JsValue::UNDEFINED);
+                    Probe::Active => {}
                 }
-                Completion::Throw(interp.create_type_error("Not a DisposableStack"))
-            },
-        ));
-        self.get_object_cell_expect(ds_proto_id)
-            .borrow_mut()
-            .insert_builtin("defer".to_string(), defer_fn);
+                if !interp.is_callable(&on_dispose) {
+                    return Completion::Throw(
+                        interp.create_type_error("onDispose must be a function"),
+                    );
+                }
+                let resource = DisposableResource {
+                    value: JsValue::UNDEFINED,
+                    hint: DisposeHint::Sync,
+                    dispose_method: on_dispose,
+                };
+                if let Some(cell) = interp.get_object_cell(object_id) {
+                    let mut b = cell.borrow_mut();
+                    if let Some(ds) = b.disposable_stack_mut() {
+                        ds.stack.push(resource);
+                    }
+                }
+                return Completion::Normal(JsValue::UNDEFINED);
+            }
+            Completion::Throw(interp.create_type_error("Not a DisposableStack"))
+        });
 
         // move()
-        let move_fn = self.create_function(JsFunction::native(
-            "move".to_string(),
-            0,
-            |interp, this, _args| {
-                if let Some(object_id) = this.as_object_id()
-                    && interp.get_object_cell(object_id).is_some()
-                {
-                    enum Probe {
-                        NotStack,
-                        AlreadyDisposed,
-                        Moved(Vec<DisposableResource>),
-                    }
-                    let probe = {
-                        let cell = interp.get_object_cell_expect(object_id);
-                        let mut b = cell.borrow_mut();
-                        if b.class_name != "DisposableStack" {
-                            Probe::NotStack
-                        } else {
-                            match b.disposable_stack_mut() {
-                                Some(ds) if ds.disposed => Probe::AlreadyDisposed,
-                                Some(ds) => {
-                                    let s = std::mem::take(&mut ds.stack);
-                                    ds.disposed = true;
-                                    Probe::Moved(s)
-                                }
-                                None => Probe::NotStack,
+        self.define_method(ds_proto_id, "move", 0, |interp, this, _args| {
+            if let Some(object_id) = this.as_object_id()
+                && interp.get_object_cell(object_id).is_some()
+            {
+                enum Probe {
+                    NotStack,
+                    AlreadyDisposed,
+                    Moved(Vec<DisposableResource>),
+                }
+                let probe = {
+                    let cell = interp.get_object_cell_expect(object_id);
+                    let mut b = cell.borrow_mut();
+                    if b.class_name != "DisposableStack" {
+                        Probe::NotStack
+                    } else {
+                        match b.disposable_stack_mut() {
+                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                            Some(ds) => {
+                                let s = std::mem::take(&mut ds.stack);
+                                ds.disposed = true;
+                                Probe::Moved(s)
                             }
+                            None => Probe::NotStack,
                         }
-                    };
-                    let stack = match probe {
+                    }
+                };
+                let stack =
+                    match probe {
                         Probe::NotStack => {
                             return Completion::Throw(
                                 interp.create_type_error("Not a DisposableStack"),
@@ -341,41 +318,37 @@ impl Interpreter {
                         }
                         Probe::Moved(s) => s,
                     };
-                    // Create a new DisposableStack with the moved resources
-                    let new_obj_id = interp.create_object_id();
+                // Create a new DisposableStack with the moved resources
+                let new_obj_id = interp.create_object_id();
+                {
+                    // Get DisposableStack prototype
+                    if let Some(ctor_val) = interp.get_global_var("DisposableStack")
+                        && let Some(constructor_id) = ctor_val.as_object_id()
                     {
-                        // Get DisposableStack prototype
-                        if let Some(ctor_val) = interp.get_global_var("DisposableStack")
-                            && let Some(constructor_id) = ctor_val.as_object_id()
-                        {
-                            let proto_val = interp.get_property_on_id(constructor_id, "prototype");
-                            if let Some(prototype_id) = proto_val.as_object_id() {
-                                interp
-                                    .get_object_cell_expect(new_obj_id)
-                                    .borrow_mut()
-                                    .prototype_id = Some(prototype_id);
-                            }
+                        let proto_val = interp.get_property_on_id(constructor_id, "prototype");
+                        if let Some(prototype_id) = proto_val.as_object_id() {
+                            interp
+                                .get_object_cell_expect(new_obj_id)
+                                .borrow_mut()
+                                .prototype_id = Some(prototype_id);
                         }
                     }
-                    {
-                        let mut b = interp.get_object_cell_expect(new_obj_id).borrow_mut();
-                        b.class_name = "DisposableStack".to_string();
-                        b.kind = crate::interpreter::types::ObjectKind::DisposableStack(
-                            DisposableStackData {
-                                stack,
-                                disposed: false,
-                            },
-                        );
-                    }
-                    let id = new_obj_id;
-                    return Completion::Normal(JsValue::object(id));
                 }
-                Completion::Throw(interp.create_type_error("Not a DisposableStack"))
-            },
-        ));
-        self.get_object_cell_expect(ds_proto_id)
-            .borrow_mut()
-            .insert_builtin("move".to_string(), move_fn);
+                {
+                    let mut b = interp.get_object_cell_expect(new_obj_id).borrow_mut();
+                    b.class_name = "DisposableStack".to_string();
+                    b.kind = crate::interpreter::types::ObjectKind::DisposableStack(
+                        DisposableStackData {
+                            stack,
+                            disposed: false,
+                        },
+                    );
+                }
+                let id = new_obj_id;
+                return Completion::Normal(JsValue::object(id));
+            }
+            Completion::Throw(interp.create_type_error("Not a DisposableStack"))
+        });
 
         // Store prototype in realm for OrdinaryCreateFromConstructor
         self.realm_mut().disposable_stack_prototype = Some(ds_proto_id);
@@ -536,10 +509,8 @@ impl Interpreter {
         }
 
         // disposeAsync()
-        let dispose_async_fn = self.create_function(JsFunction::native(
-            "disposeAsync".to_string(),
-            0,
-            |interp, this, _args| {
+        let dispose_async_fn =
+            self.define_method(ads_proto_id, "disposeAsync", 0, |interp, this, _args| {
                 let result = interp.async_disposable_stack_dispose(this);
                 // A disposer that called `__host_exit` (issue #242) surfaces as
                 // `Completion::Exit`; it must propagate abruptly (via the `other`
@@ -551,11 +522,7 @@ impl Interpreter {
                     Completion::Throw(e) => interp.create_rejected_promise(e),
                     other => other,
                 }
-            },
-        ));
-        self.get_object_cell_expect(ads_proto_id)
-            .borrow_mut()
-            .insert_builtin("disposeAsync".to_string(), dispose_async_fn.clone());
+            });
 
         // Symbol.asyncDispose = disposeAsync
         if let Some(key) = self.get_symbol_key("asyncDispose") {
@@ -592,320 +559,290 @@ impl Interpreter {
         });
 
         // use(value)
-        let use_fn = self.create_function(JsFunction::native(
-            "use".to_string(),
-            1,
-            |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if let Some(object_id) = this.as_object_id()
-                    && interp.get_object_cell(object_id).is_some()
-                {
-                    enum Probe {
-                        NotStack,
-                        AlreadyDisposed,
-                        Active,
-                    }
-                    let probe = {
-                        let b = interp.get_object_cell_expect(object_id).borrow();
-                        if b.class_name != "AsyncDisposableStack" {
-                            Probe::NotStack
-                        } else {
-                            match b.disposable_stack() {
-                                Some(ds) if ds.disposed => Probe::AlreadyDisposed,
-                                Some(_) => Probe::Active,
-                                None => Probe::NotStack,
-                            }
-                        }
-                    };
-                    match probe {
-                        Probe::NotStack => {
-                            return Completion::Throw(
-                                interp.create_type_error("Not an AsyncDisposableStack"),
-                            );
-                        }
-                        Probe::AlreadyDisposed => {
-                            return Completion::Throw(interp.create_reference_error(
-                                "AsyncDisposableStack has already been disposed",
-                            ));
-                        }
-                        Probe::Active => {}
-                    }
-                    if (value).is_nullish() {
-                        let resource = DisposableResource {
-                            value: value.clone(),
-                            hint: DisposeHint::Async,
-                            dispose_method: JsValue::UNDEFINED,
-                        };
-                        if let Some(obj2) = interp.get_object_cell(object_id)
-                            && let Some(ds) = obj2.borrow_mut().disposable_stack_mut()
-                        {
-                            ds.stack.push(resource);
-                        }
-                        return Completion::Normal(value);
-                    }
-                    // Try Symbol.asyncDispose first, then Symbol.dispose
-                    let mut method = JsValue::UNDEFINED;
-                    let mut hint = DisposeHint::Async;
-                    if let Some(key) = interp.get_symbol_key("asyncDispose")
-                        && let Some(value_id) = value.as_object_id()
-                    {
-                        let m = match interp.get_object_property(value_id, &key, &value) {
-                            Completion::Normal(v) => v,
-                            other => return other,
-                        };
-                        if !(m).is_nullish() {
-                            method = m;
+        self.define_method(ads_proto_id, "use", 1, |interp, this, args| {
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if let Some(object_id) = this.as_object_id()
+                && interp.get_object_cell(object_id).is_some()
+            {
+                enum Probe {
+                    NotStack,
+                    AlreadyDisposed,
+                    Active,
+                }
+                let probe = {
+                    let b = interp.get_object_cell_expect(object_id).borrow();
+                    if b.class_name != "AsyncDisposableStack" {
+                        Probe::NotStack
+                    } else {
+                        match b.disposable_stack() {
+                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                            Some(_) => Probe::Active,
+                            None => Probe::NotStack,
                         }
                     }
-                    if (method).is_undefined()
-                        && let Some(key) = interp.get_symbol_key("dispose")
-                        && let Some(value_id) = value.as_object_id()
-                    {
-                        let m = match interp.get_object_property(value_id, &key, &value) {
-                            Completion::Normal(v) => v,
-                            other => return other,
-                        };
-                        if !(m).is_nullish() {
-                            method = m;
-                            hint = DisposeHint::Sync;
-                        }
-                    }
-                    if (method).is_undefined() {
+                };
+                match probe {
+                    Probe::NotStack => {
                         return Completion::Throw(
-                            interp.create_type_error("Object is not disposable"),
+                            interp.create_type_error("Not an AsyncDisposableStack"),
                         );
                     }
-                    if !interp.is_callable(&method) {
-                        return Completion::Throw(
-                            interp.create_type_error("dispose method is not a function"),
-                        );
+                    Probe::AlreadyDisposed => {
+                        return Completion::Throw(interp.create_reference_error(
+                            "AsyncDisposableStack has already been disposed",
+                        ));
                     }
+                    Probe::Active => {}
+                }
+                if (value).is_nullish() {
                     let resource = DisposableResource {
                         value: value.clone(),
-                        hint,
-                        dispose_method: method,
+                        hint: DisposeHint::Async,
+                        dispose_method: JsValue::UNDEFINED,
                     };
-                    if let Some(cell) = interp.get_object_cell(object_id) {
-                        let mut b = cell.borrow_mut();
-                        if let Some(ds) = b.disposable_stack_mut() {
-                            ds.stack.push(resource);
-                        }
+                    if let Some(obj2) = interp.get_object_cell(object_id)
+                        && let Some(ds) = obj2.borrow_mut().disposable_stack_mut()
+                    {
+                        ds.stack.push(resource);
                     }
                     return Completion::Normal(value);
                 }
-                Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
-            },
-        ));
-        self.get_object_cell_expect(ads_proto_id)
-            .borrow_mut()
-            .insert_builtin("use".to_string(), use_fn);
+                // Try Symbol.asyncDispose first, then Symbol.dispose
+                let mut method = JsValue::UNDEFINED;
+                let mut hint = DisposeHint::Async;
+                if let Some(key) = interp.get_symbol_key("asyncDispose")
+                    && let Some(value_id) = value.as_object_id()
+                {
+                    let m = match interp.get_object_property(value_id, &key, &value) {
+                        Completion::Normal(v) => v,
+                        other => return other,
+                    };
+                    if !(m).is_nullish() {
+                        method = m;
+                    }
+                }
+                if (method).is_undefined()
+                    && let Some(key) = interp.get_symbol_key("dispose")
+                    && let Some(value_id) = value.as_object_id()
+                {
+                    let m = match interp.get_object_property(value_id, &key, &value) {
+                        Completion::Normal(v) => v,
+                        other => return other,
+                    };
+                    if !(m).is_nullish() {
+                        method = m;
+                        hint = DisposeHint::Sync;
+                    }
+                }
+                if (method).is_undefined() {
+                    return Completion::Throw(interp.create_type_error("Object is not disposable"));
+                }
+                if !interp.is_callable(&method) {
+                    return Completion::Throw(
+                        interp.create_type_error("dispose method is not a function"),
+                    );
+                }
+                let resource = DisposableResource {
+                    value: value.clone(),
+                    hint,
+                    dispose_method: method,
+                };
+                if let Some(cell) = interp.get_object_cell(object_id) {
+                    let mut b = cell.borrow_mut();
+                    if let Some(ds) = b.disposable_stack_mut() {
+                        ds.stack.push(resource);
+                    }
+                }
+                return Completion::Normal(value);
+            }
+            Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
+        });
 
         // adopt(value, onDispose)
-        let adopt_fn = self.create_function(JsFunction::native(
-            "adopt".to_string(),
-            2,
-            |interp, this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let on_dispose = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
-                if let Some(object_id) = this.as_object_id()
-                    && interp.get_object_cell(object_id).is_some()
-                {
-                    enum Probe {
-                        AlreadyDisposed,
-                        NotStack,
-                        Active,
+        self.define_method(ads_proto_id, "adopt", 2, |interp, this, args| {
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let on_dispose = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            if let Some(object_id) = this.as_object_id()
+                && interp.get_object_cell(object_id).is_some()
+            {
+                enum Probe {
+                    AlreadyDisposed,
+                    NotStack,
+                    Active,
+                }
+                let probe = {
+                    let b = interp.get_object_cell_expect(object_id).borrow();
+                    match b.disposable_stack() {
+                        Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                        Some(_) => Probe::Active,
+                        None => Probe::NotStack,
                     }
-                    let probe = {
-                        let b = interp.get_object_cell_expect(object_id).borrow();
-                        match b.disposable_stack() {
-                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
-                            Some(_) => Probe::Active,
-                            None => Probe::NotStack,
-                        }
-                    };
-                    match probe {
-                        Probe::AlreadyDisposed => {
-                            return Completion::Throw(interp.create_reference_error(
-                                "AsyncDisposableStack has already been disposed",
-                            ));
-                        }
-                        Probe::NotStack => {
-                            return Completion::Throw(
-                                interp.create_type_error("Not an AsyncDisposableStack"),
-                            );
-                        }
-                        Probe::Active => {}
+                };
+                match probe {
+                    Probe::AlreadyDisposed => {
+                        return Completion::Throw(interp.create_reference_error(
+                            "AsyncDisposableStack has already been disposed",
+                        ));
                     }
-                    if !interp.is_callable(&on_dispose) {
+                    Probe::NotStack => {
                         return Completion::Throw(
-                            interp.create_type_error("onDispose must be a function"),
+                            interp.create_type_error("Not an AsyncDisposableStack"),
                         );
                     }
-                    let wrapper_val = value.clone();
-                    let wrapper_dispose = on_dispose.clone();
-                    let wrapper_fn = interp.create_function(JsFunction::native(
-                        "".to_string(),
-                        0,
-                        move |interp2, _this2, _args2| {
-                            interp2.call_function(
-                                &wrapper_dispose,
-                                &JsValue::UNDEFINED,
-                                std::slice::from_ref(&wrapper_val),
-                            )
-                        },
-                    ));
-                    let resource = DisposableResource {
-                        value: JsValue::UNDEFINED,
-                        hint: DisposeHint::Async,
-                        dispose_method: wrapper_fn,
-                    };
-                    if let Some(cell) = interp.get_object_cell(object_id) {
-                        let mut b = cell.borrow_mut();
-                        if let Some(ds) = b.disposable_stack_mut() {
-                            ds.stack.push(resource);
-                        }
-                    }
-                    return Completion::Normal(value);
+                    Probe::Active => {}
                 }
-                Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
-            },
-        ));
-        self.get_object_cell_expect(ads_proto_id)
-            .borrow_mut()
-            .insert_builtin("adopt".to_string(), adopt_fn);
+                if !interp.is_callable(&on_dispose) {
+                    return Completion::Throw(
+                        interp.create_type_error("onDispose must be a function"),
+                    );
+                }
+                let wrapper_val = value.clone();
+                let wrapper_dispose = on_dispose.clone();
+                let wrapper_fn = interp.create_function(JsFunction::native(
+                    "".to_string(),
+                    0,
+                    move |interp2, _this2, _args2| {
+                        interp2.call_function(
+                            &wrapper_dispose,
+                            &JsValue::UNDEFINED,
+                            std::slice::from_ref(&wrapper_val),
+                        )
+                    },
+                ));
+                let resource = DisposableResource {
+                    value: JsValue::UNDEFINED,
+                    hint: DisposeHint::Async,
+                    dispose_method: wrapper_fn,
+                };
+                if let Some(cell) = interp.get_object_cell(object_id) {
+                    let mut b = cell.borrow_mut();
+                    if let Some(ds) = b.disposable_stack_mut() {
+                        ds.stack.push(resource);
+                    }
+                }
+                return Completion::Normal(value);
+            }
+            Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
+        });
 
         // defer(onDispose)
-        let defer_fn = self.create_function(JsFunction::native(
-            "defer".to_string(),
-            1,
-            |interp, this, args| {
-                let on_dispose = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if let Some(object_id) = this.as_object_id()
-                    && interp.get_object_cell(object_id).is_some()
-                {
-                    enum Probe {
-                        AlreadyDisposed,
-                        NotStack,
-                        Active,
+        self.define_method(ads_proto_id, "defer", 1, |interp, this, args| {
+            let on_dispose = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if let Some(object_id) = this.as_object_id()
+                && interp.get_object_cell(object_id).is_some()
+            {
+                enum Probe {
+                    AlreadyDisposed,
+                    NotStack,
+                    Active,
+                }
+                let probe = {
+                    let b = interp.get_object_cell_expect(object_id).borrow();
+                    match b.disposable_stack() {
+                        Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                        Some(_) => Probe::Active,
+                        None => Probe::NotStack,
                     }
-                    let probe = {
-                        let b = interp.get_object_cell_expect(object_id).borrow();
-                        match b.disposable_stack() {
-                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
-                            Some(_) => Probe::Active,
-                            None => Probe::NotStack,
-                        }
-                    };
-                    match probe {
-                        Probe::AlreadyDisposed => {
-                            return Completion::Throw(interp.create_reference_error(
-                                "AsyncDisposableStack has already been disposed",
-                            ));
-                        }
-                        Probe::NotStack => {
-                            return Completion::Throw(
-                                interp.create_type_error("Not an AsyncDisposableStack"),
-                            );
-                        }
-                        Probe::Active => {}
+                };
+                match probe {
+                    Probe::AlreadyDisposed => {
+                        return Completion::Throw(interp.create_reference_error(
+                            "AsyncDisposableStack has already been disposed",
+                        ));
                     }
-                    if !interp.is_callable(&on_dispose) {
+                    Probe::NotStack => {
                         return Completion::Throw(
-                            interp.create_type_error("onDispose must be a function"),
+                            interp.create_type_error("Not an AsyncDisposableStack"),
                         );
                     }
-                    let resource = DisposableResource {
-                        value: JsValue::UNDEFINED,
-                        hint: DisposeHint::Async,
-                        dispose_method: on_dispose,
-                    };
-                    if let Some(cell) = interp.get_object_cell(object_id) {
-                        let mut b = cell.borrow_mut();
-                        if let Some(ds) = b.disposable_stack_mut() {
-                            ds.stack.push(resource);
-                        }
-                    }
-                    return Completion::Normal(JsValue::UNDEFINED);
+                    Probe::Active => {}
                 }
-                Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
-            },
-        ));
-        self.get_object_cell_expect(ads_proto_id)
-            .borrow_mut()
-            .insert_builtin("defer".to_string(), defer_fn);
+                if !interp.is_callable(&on_dispose) {
+                    return Completion::Throw(
+                        interp.create_type_error("onDispose must be a function"),
+                    );
+                }
+                let resource = DisposableResource {
+                    value: JsValue::UNDEFINED,
+                    hint: DisposeHint::Async,
+                    dispose_method: on_dispose,
+                };
+                if let Some(cell) = interp.get_object_cell(object_id) {
+                    let mut b = cell.borrow_mut();
+                    if let Some(ds) = b.disposable_stack_mut() {
+                        ds.stack.push(resource);
+                    }
+                }
+                return Completion::Normal(JsValue::UNDEFINED);
+            }
+            Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
+        });
 
         // move()
-        let move_fn = self.create_function(JsFunction::native(
-            "move".to_string(),
-            0,
-            |interp, this, _args| {
-                if let Some(object_id) = this.as_object_id()
-                    && interp.get_object_cell(object_id).is_some()
-                {
-                    enum Probe {
-                        NotStack,
-                        AlreadyDisposed,
-                        Moved(Vec<DisposableResource>),
-                    }
-                    let probe = {
-                        let cell = interp.get_object_cell_expect(object_id);
-                        let mut b = cell.borrow_mut();
-                        if b.class_name != "AsyncDisposableStack" {
-                            Probe::NotStack
-                        } else {
-                            match b.disposable_stack_mut() {
-                                Some(ds) if ds.disposed => Probe::AlreadyDisposed,
-                                Some(ds) => {
-                                    let s = std::mem::take(&mut ds.stack);
-                                    ds.disposed = true;
-                                    Probe::Moved(s)
-                                }
-                                None => Probe::NotStack,
+        self.define_method(ads_proto_id, "move", 0, |interp, this, _args| {
+            if let Some(object_id) = this.as_object_id()
+                && interp.get_object_cell(object_id).is_some()
+            {
+                enum Probe {
+                    NotStack,
+                    AlreadyDisposed,
+                    Moved(Vec<DisposableResource>),
+                }
+                let probe = {
+                    let cell = interp.get_object_cell_expect(object_id);
+                    let mut b = cell.borrow_mut();
+                    if b.class_name != "AsyncDisposableStack" {
+                        Probe::NotStack
+                    } else {
+                        match b.disposable_stack_mut() {
+                            Some(ds) if ds.disposed => Probe::AlreadyDisposed,
+                            Some(ds) => {
+                                let s = std::mem::take(&mut ds.stack);
+                                ds.disposed = true;
+                                Probe::Moved(s)
                             }
-                        }
-                    };
-                    let stack = match probe {
-                        Probe::NotStack => {
-                            return Completion::Throw(
-                                interp.create_type_error("Not an AsyncDisposableStack"),
-                            );
-                        }
-                        Probe::AlreadyDisposed => {
-                            return Completion::Throw(interp.create_reference_error(
-                                "AsyncDisposableStack has already been disposed",
-                            ));
-                        }
-                        Probe::Moved(s) => s,
-                    };
-                    let new_obj_id = interp.create_object_id();
-                    {
-                        let default_proto_id = interp.realm().async_disposable_stack_prototype;
-                        if let Some(pid) = default_proto_id {
-                            interp
-                                .get_object_cell_expect(new_obj_id)
-                                .borrow_mut()
-                                .prototype_id = Some(pid);
+                            None => Probe::NotStack,
                         }
                     }
-                    {
-                        let mut b = interp.get_object_cell_expect(new_obj_id).borrow_mut();
-                        b.class_name = "AsyncDisposableStack".to_string();
-                        b.kind = crate::interpreter::types::ObjectKind::DisposableStack(
-                            DisposableStackData {
-                                stack,
-                                disposed: false,
-                            },
+                };
+                let stack = match probe {
+                    Probe::NotStack => {
+                        return Completion::Throw(
+                            interp.create_type_error("Not an AsyncDisposableStack"),
                         );
                     }
-                    let id = new_obj_id;
-                    return Completion::Normal(JsValue::object(id));
+                    Probe::AlreadyDisposed => {
+                        return Completion::Throw(interp.create_reference_error(
+                            "AsyncDisposableStack has already been disposed",
+                        ));
+                    }
+                    Probe::Moved(s) => s,
+                };
+                let new_obj_id = interp.create_object_id();
+                {
+                    let default_proto_id = interp.realm().async_disposable_stack_prototype;
+                    if let Some(pid) = default_proto_id {
+                        interp
+                            .get_object_cell_expect(new_obj_id)
+                            .borrow_mut()
+                            .prototype_id = Some(pid);
+                    }
                 }
-                Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
-            },
-        ));
-        self.get_object_cell_expect(ads_proto_id)
-            .borrow_mut()
-            .insert_builtin("move".to_string(), move_fn);
+                {
+                    let mut b = interp.get_object_cell_expect(new_obj_id).borrow_mut();
+                    b.class_name = "AsyncDisposableStack".to_string();
+                    b.kind = crate::interpreter::types::ObjectKind::DisposableStack(
+                        DisposableStackData {
+                            stack,
+                            disposed: false,
+                        },
+                    );
+                }
+                let id = new_obj_id;
+                return Completion::Normal(JsValue::object(id));
+            }
+            Completion::Throw(interp.create_type_error("Not an AsyncDisposableStack"))
+        });
 
         // Store prototype in realm for OrdinaryCreateFromConstructor
         self.realm_mut().async_disposable_stack_prototype = Some(ads_proto_id);

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -852,228 +852,34 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Array Iterator".to_string();
 
-        let arr_iter_next = self.create_function(JsFunction::native(
-            "next".to_string(),
-            0,
-            |interp, this, _args| {
-                if let Some(this_id) = this.as_object_id() {
-                    if let Some(obj) = interp.get_object(this_id) {
-                        let state = obj.borrow().iterator_state().cloned();
-                        if let Some(IteratorState::ArrayIterator {
-                            array_id,
-                            index,
-                            kind,
-                            done,
-                        }) = state
-                        {
-                            if done {
-                                return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
-                                );
-                            }
-                            let is_proxy = interp
-                                .get_object_cell(array_id)
-                                .is_some_and(|o| o.borrow().is_proxy());
-                            if is_proxy {
-                                let arr_val = JsValue::object(array_id);
-                                let len = match interp
-                                    .get_object_property(array_id, "length", &arr_val)
-                                {
-                                    Completion::Normal(v) => {
-                                        v.as_number().map_or(0, |n| n as usize)
-                                    }
-                                    c => return c,
-                                };
-                                if index >= len {
-                                    if let Some(obj) = interp.get_object_cell(this_id) {
-                                        obj.borrow_mut().kind =
-                                            crate::interpreter::types::ObjectKind::Iterator(
-                                                IteratorState::ArrayIterator {
-                                                    array_id,
-                                                    index: len,
-                                                    kind,
-                                                    done: true,
-                                                },
-                                            );
-                                    }
-                                    return Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
-                                    );
-                                }
-                                let idx_str = index.to_string();
-                                let v = match kind {
-                                    IteratorKind::Key => JsValue::number(index as f64),
-                                    IteratorKind::Value => {
-                                        match interp
-                                            .get_object_property(array_id, &idx_str, &arr_val)
-                                        {
-                                            Completion::Normal(v) => v,
-                                            c => return c,
-                                        }
-                                    }
-                                    IteratorKind::KeyValue => {
-                                        let elem = match interp
-                                            .get_object_property(array_id, &idx_str, &arr_val)
-                                        {
-                                            Completion::Normal(v) => v,
-                                            c => return c,
-                                        };
-                                        let pair = interp.create_array(vec![
-                                            JsValue::number(index as f64),
-                                            elem,
-                                        ]);
-                                        if let Some(obj) = interp.get_object_cell(this_id) {
-                                            obj.borrow_mut().kind =
-                                                crate::interpreter::types::ObjectKind::Iterator(
-                                                    IteratorState::ArrayIterator {
-                                                        array_id,
-                                                        index: index + 1,
-                                                        kind,
-                                                        done: false,
-                                                    },
-                                                );
-                                        }
-                                        return Completion::Normal(
-                                            interp.create_iter_result_object(pair, false),
-                                        );
-                                    }
-                                };
-                                if let Some(obj) = interp.get_object_cell(this_id) {
-                                    obj.borrow_mut().kind =
-                                        crate::interpreter::types::ObjectKind::Iterator(
-                                            IteratorState::ArrayIterator {
-                                                array_id,
-                                                index: index + 1,
-                                                kind,
-                                                done: false,
-                                            },
-                                        );
-                                }
-                                return Completion::Normal(
-                                    interp.create_iter_result_object(v, false),
-                                );
-                            }
-                            // §23.1.5.1.1 step 3: TypedArray OOB check
-                            if let Some(arr_obj) = interp.get_object(array_id) {
-                                let borrowed = arr_obj.borrow();
-                                if let Some(ta) = borrowed.typed_array_info()
-                                    && is_typed_array_out_of_bounds(ta)
-                                {
-                                    drop(borrowed);
-                                    if let Some(obj) = interp.get_object_cell(this_id) {
-                                        obj.borrow_mut().kind =
-                                            crate::interpreter::types::ObjectKind::Iterator(
-                                                IteratorState::ArrayIterator {
-                                                    array_id,
-                                                    index,
-                                                    kind,
-                                                    done: true,
-                                                },
-                                            );
-                                    }
-                                    return Completion::Throw(
-                                        interp.create_type_error("TypedArray is out of bounds"),
-                                    );
-                                }
-                            }
-                            let (len, val) = if let Some(arr_obj) = interp.get_object(array_id) {
-                                let borrowed = arr_obj.borrow();
-                                let len = if let Some(ta) = borrowed.typed_array_info() {
-                                    typed_array_length(ta)
-                                } else if let Some(n) = borrowed
-                                    .get_property_value("length")
-                                    .and_then(|v| v.as_number())
-                                {
-                                    n as usize
-                                } else if let Some(elems) = borrowed.array_elements() {
-                                    elems.len()
-                                } else {
-                                    0
-                                };
-                                if index >= len {
-                                    (len, None)
-                                } else {
-                                    let idx_str = index.to_string();
-                                    let has_accessor = borrowed
-                                        .properties
-                                        .get(&idx_str)
-                                        .is_some_and(|d| d.get.is_some());
-                                    let is_hole =
-                                        borrowed.array_elements().is_some_and(|e| index < e.len())
-                                            && !borrowed.properties.contains_key(&idx_str);
-                                    let fast_val = if !has_accessor && !is_hole {
-                                        borrowed
-                                            .array_elements()
-                                            .and_then(|e| e.get(index).cloned())
-                                    } else {
-                                        None
-                                    };
-                                    drop(borrowed);
-                                    let arr_val = JsValue::object(array_id);
-                                    let v = match kind {
-                                        IteratorKind::Key => JsValue::number(index as f64),
-                                        IteratorKind::Value => {
-                                            if let Some(fv) = fast_val {
-                                                fv
-                                            } else {
-                                                match interp.get_object_property(
-                                                    array_id, &idx_str, &arr_val,
-                                                ) {
-                                                    Completion::Normal(v) => v,
-                                                    c => return c,
-                                                }
-                                            }
-                                        }
-                                        IteratorKind::KeyValue => {
-                                            let elem = if let Some(fv) = fast_val {
-                                                fv
-                                            } else {
-                                                match interp.get_object_property(
-                                                    array_id, &idx_str, &arr_val,
-                                                ) {
-                                                    Completion::Normal(v) => v,
-                                                    c => return c,
-                                                }
-                                            };
-                                            let pair = interp.create_array(vec![
-                                                JsValue::number(index as f64),
-                                                elem,
-                                            ]);
-                                            return {
-                                                obj.borrow_mut().kind =
-                                                    crate::interpreter::types::ObjectKind::Iterator(
-                                                        IteratorState::ArrayIterator {
-                                                            array_id,
-                                                            index: index + 1,
-                                                            kind,
-                                                            done: false,
-                                                        },
-                                                    );
-                                                Completion::Normal(
-                                                    interp.create_iter_result_object(pair, false),
-                                                )
-                                            };
-                                        }
-                                    };
-                                    (len, Some(v))
-                                }
-                            } else {
-                                (0, None)
+        self.define_method(arr_iter_proto_id, "next", 0, |interp, this, _args| {
+            if let Some(this_id) = this.as_object_id() {
+                if let Some(obj) = interp.get_object(this_id) {
+                    let state = obj.borrow().iterator_state().cloned();
+                    if let Some(IteratorState::ArrayIterator {
+                        array_id,
+                        index,
+                        kind,
+                        done,
+                    }) = state
+                    {
+                        if done {
+                            return Completion::Normal(
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
+                            );
+                        }
+                        let is_proxy = interp
+                            .get_object_cell(array_id)
+                            .is_some_and(|o| o.borrow().is_proxy());
+                        if is_proxy {
+                            let arr_val = JsValue::object(array_id);
+                            let len = match interp.get_object_property(array_id, "length", &arr_val)
+                            {
+                                Completion::Normal(v) => v.as_number().map_or(0, |n| n as usize),
+                                c => return c,
                             };
-                            match val {
-                                Some(v) => {
-                                    obj.borrow_mut().kind =
-                                        crate::interpreter::types::ObjectKind::Iterator(
-                                            IteratorState::ArrayIterator {
-                                                array_id,
-                                                index: index + 1,
-                                                kind,
-                                                done: false,
-                                            },
-                                        );
-                                    Completion::Normal(interp.create_iter_result_object(v, false))
-                                }
-                                None => {
+                            if index >= len {
+                                if let Some(obj) = interp.get_object_cell(this_id) {
                                     obj.borrow_mut().kind =
                                         crate::interpreter::types::ObjectKind::Iterator(
                                             IteratorState::ArrayIterator {
@@ -1083,25 +889,234 @@ impl Interpreter {
                                                 done: true,
                                             },
                                         );
-                                    Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
-                                    )
                                 }
-                            }
-                        } else if let Some(IteratorState::TypedArrayIterator {
-                            typed_array_id,
-                            index,
-                            kind,
-                            done,
-                        }) = state
-                        {
-                            if done {
                                 return Completion::Normal(
                                     interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
-                            let ta_obj = interp.get_object(typed_array_id);
-                            if ta_obj.is_none() {
+                            let idx_str = index.to_string();
+                            let v = match kind {
+                                IteratorKind::Key => JsValue::number(index as f64),
+                                IteratorKind::Value => {
+                                    match interp.get_object_property(array_id, &idx_str, &arr_val) {
+                                        Completion::Normal(v) => v,
+                                        c => return c,
+                                    }
+                                }
+                                IteratorKind::KeyValue => {
+                                    let elem = match interp
+                                        .get_object_property(array_id, &idx_str, &arr_val)
+                                    {
+                                        Completion::Normal(v) => v,
+                                        c => return c,
+                                    };
+                                    let pair = interp
+                                        .create_array(vec![JsValue::number(index as f64), elem]);
+                                    if let Some(obj) = interp.get_object_cell(this_id) {
+                                        obj.borrow_mut().kind =
+                                            crate::interpreter::types::ObjectKind::Iterator(
+                                                IteratorState::ArrayIterator {
+                                                    array_id,
+                                                    index: index + 1,
+                                                    kind,
+                                                    done: false,
+                                                },
+                                            );
+                                    }
+                                    return Completion::Normal(
+                                        interp.create_iter_result_object(pair, false),
+                                    );
+                                }
+                            };
+                            if let Some(obj) = interp.get_object_cell(this_id) {
+                                obj.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::ArrayIterator {
+                                            array_id,
+                                            index: index + 1,
+                                            kind,
+                                            done: false,
+                                        },
+                                    );
+                            }
+                            return Completion::Normal(interp.create_iter_result_object(v, false));
+                        }
+                        // §23.1.5.1.1 step 3: TypedArray OOB check
+                        if let Some(arr_obj) = interp.get_object(array_id) {
+                            let borrowed = arr_obj.borrow();
+                            if let Some(ta) = borrowed.typed_array_info()
+                                && is_typed_array_out_of_bounds(ta)
+                            {
+                                drop(borrowed);
+                                if let Some(obj) = interp.get_object_cell(this_id) {
+                                    obj.borrow_mut().kind =
+                                        crate::interpreter::types::ObjectKind::Iterator(
+                                            IteratorState::ArrayIterator {
+                                                array_id,
+                                                index,
+                                                kind,
+                                                done: true,
+                                            },
+                                        );
+                                }
+                                return Completion::Throw(
+                                    interp.create_type_error("TypedArray is out of bounds"),
+                                );
+                            }
+                        }
+                        let (len, val) = if let Some(arr_obj) = interp.get_object(array_id) {
+                            let borrowed = arr_obj.borrow();
+                            let len = if let Some(ta) = borrowed.typed_array_info() {
+                                typed_array_length(ta)
+                            } else if let Some(n) = borrowed
+                                .get_property_value("length")
+                                .and_then(|v| v.as_number())
+                            {
+                                n as usize
+                            } else if let Some(elems) = borrowed.array_elements() {
+                                elems.len()
+                            } else {
+                                0
+                            };
+                            if index >= len {
+                                (len, None)
+                            } else {
+                                let idx_str = index.to_string();
+                                let has_accessor = borrowed
+                                    .properties
+                                    .get(&idx_str)
+                                    .is_some_and(|d| d.get.is_some());
+                                let is_hole =
+                                    borrowed.array_elements().is_some_and(|e| index < e.len())
+                                        && !borrowed.properties.contains_key(&idx_str);
+                                let fast_val = if !has_accessor && !is_hole {
+                                    borrowed
+                                        .array_elements()
+                                        .and_then(|e| e.get(index).cloned())
+                                } else {
+                                    None
+                                };
+                                drop(borrowed);
+                                let arr_val = JsValue::object(array_id);
+                                let v = match kind {
+                                    IteratorKind::Key => JsValue::number(index as f64),
+                                    IteratorKind::Value => {
+                                        if let Some(fv) = fast_val {
+                                            fv
+                                        } else {
+                                            match interp
+                                                .get_object_property(array_id, &idx_str, &arr_val)
+                                            {
+                                                Completion::Normal(v) => v,
+                                                c => return c,
+                                            }
+                                        }
+                                    }
+                                    IteratorKind::KeyValue => {
+                                        let elem = if let Some(fv) = fast_val {
+                                            fv
+                                        } else {
+                                            match interp
+                                                .get_object_property(array_id, &idx_str, &arr_val)
+                                            {
+                                                Completion::Normal(v) => v,
+                                                c => return c,
+                                            }
+                                        };
+                                        let pair = interp.create_array(vec![
+                                            JsValue::number(index as f64),
+                                            elem,
+                                        ]);
+                                        return {
+                                            obj.borrow_mut().kind =
+                                                crate::interpreter::types::ObjectKind::Iterator(
+                                                    IteratorState::ArrayIterator {
+                                                        array_id,
+                                                        index: index + 1,
+                                                        kind,
+                                                        done: false,
+                                                    },
+                                                );
+                                            Completion::Normal(
+                                                interp.create_iter_result_object(pair, false),
+                                            )
+                                        };
+                                    }
+                                };
+                                (len, Some(v))
+                            }
+                        } else {
+                            (0, None)
+                        };
+                        match val {
+                            Some(v) => {
+                                obj.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::ArrayIterator {
+                                            array_id,
+                                            index: index + 1,
+                                            kind,
+                                            done: false,
+                                        },
+                                    );
+                                Completion::Normal(interp.create_iter_result_object(v, false))
+                            }
+                            None => {
+                                obj.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::ArrayIterator {
+                                            array_id,
+                                            index: len,
+                                            kind,
+                                            done: true,
+                                        },
+                                    );
+                                Completion::Normal(
+                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
+                                )
+                            }
+                        }
+                    } else if let Some(IteratorState::TypedArrayIterator {
+                        typed_array_id,
+                        index,
+                        kind,
+                        done,
+                    }) = state
+                    {
+                        if done {
+                            return Completion::Normal(
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
+                            );
+                        }
+                        let ta_obj = interp.get_object(typed_array_id);
+                        if ta_obj.is_none() {
+                            obj.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                                IteratorState::TypedArrayIterator {
+                                    typed_array_id,
+                                    index,
+                                    kind,
+                                    done: true,
+                                },
+                            );
+                            return Completion::Normal(
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
+                            );
+                        }
+                        let ta_obj = ta_obj.unwrap();
+                        let ta_info = ta_obj.borrow().typed_array_info().cloned();
+                        if let Some(ref ta) = ta_info {
+                            if ta.is_detached.get() {
+                                return Completion::Throw(
+                                    interp.create_type_error("typed array is detached"),
+                                );
+                            }
+                            if is_typed_array_out_of_bounds(ta) {
+                                return Completion::Throw(
+                                    interp.create_type_error("typed array is out of bounds"),
+                                );
+                            }
+                            let len = typed_array_length(ta);
+                            if index >= len {
                                 obj.borrow_mut().kind =
                                     crate::interpreter::types::ObjectKind::Iterator(
                                         IteratorState::TypedArrayIterator {
@@ -1115,86 +1130,51 @@ impl Interpreter {
                                     interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
-                            let ta_obj = ta_obj.unwrap();
-                            let ta_info = ta_obj.borrow().typed_array_info().cloned();
-                            if let Some(ref ta) = ta_info {
-                                if ta.is_detached.get() {
-                                    return Completion::Throw(
-                                        interp.create_type_error("typed array is detached"),
-                                    );
-                                }
-                                if is_typed_array_out_of_bounds(ta) {
-                                    return Completion::Throw(
-                                        interp.create_type_error("typed array is out of bounds"),
-                                    );
-                                }
-                                let len = typed_array_length(ta);
-                                if index >= len {
+                            let v = match kind {
+                                IteratorKind::Key => JsValue::number(index as f64),
+                                IteratorKind::Value => typed_array_get_index(ta, index),
+                                IteratorKind::KeyValue => {
+                                    let elem = typed_array_get_index(ta, index);
+                                    let pair = interp
+                                        .create_array(vec![JsValue::number(index as f64), elem]);
                                     obj.borrow_mut().kind =
                                         crate::interpreter::types::ObjectKind::Iterator(
                                             IteratorState::TypedArrayIterator {
                                                 typed_array_id,
-                                                index,
+                                                index: index + 1,
                                                 kind,
-                                                done: true,
+                                                done: false,
                                             },
                                         );
                                     return Completion::Normal(
-                                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
+                                        interp.create_iter_result_object(pair, false),
                                     );
                                 }
-                                let v = match kind {
-                                    IteratorKind::Key => JsValue::number(index as f64),
-                                    IteratorKind::Value => typed_array_get_index(ta, index),
-                                    IteratorKind::KeyValue => {
-                                        let elem = typed_array_get_index(ta, index);
-                                        let pair = interp.create_array(vec![
-                                            JsValue::number(index as f64),
-                                            elem,
-                                        ]);
-                                        obj.borrow_mut().kind =
-                                            crate::interpreter::types::ObjectKind::Iterator(
-                                                IteratorState::TypedArrayIterator {
-                                                    typed_array_id,
-                                                    index: index + 1,
-                                                    kind,
-                                                    done: false,
-                                                },
-                                            );
-                                        return Completion::Normal(
-                                            interp.create_iter_result_object(pair, false),
-                                        );
-                                    }
-                                };
-                                obj.borrow_mut().kind =
-                                    crate::interpreter::types::ObjectKind::Iterator(
-                                        IteratorState::TypedArrayIterator {
-                                            typed_array_id,
-                                            index: index + 1,
-                                            kind,
-                                            done: false,
-                                        },
-                                    );
-                                Completion::Normal(interp.create_iter_result_object(v, false))
-                            } else {
-                                Completion::Throw(interp.create_type_error("not a TypedArray"))
-                            }
+                            };
+                            obj.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                                IteratorState::TypedArrayIterator {
+                                    typed_array_id,
+                                    index: index + 1,
+                                    kind,
+                                    done: false,
+                                },
+                            );
+                            Completion::Normal(interp.create_iter_result_object(v, false))
                         } else {
-                            let err = interp.create_type_error("next called on non-array iterator");
-                            Completion::Throw(err)
+                            Completion::Throw(interp.create_type_error("not a TypedArray"))
                         }
                     } else {
-                        Completion::Normal(JsValue::UNDEFINED)
+                        let err = interp.create_type_error("next called on non-array iterator");
+                        Completion::Throw(err)
                     }
                 } else {
-                    let err = interp.create_type_error("next called on non-object");
-                    Completion::Throw(err)
+                    Completion::Normal(JsValue::UNDEFINED)
                 }
-            },
-        ));
-        self.get_object_cell_expect(arr_iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("next".to_string(), arr_iter_next);
+            } else {
+                let err = interp.create_type_error("next called on non-object");
+                Completion::Throw(err)
+            }
+        });
 
         // Set @@toStringTag
         self.define_to_string_tag(arr_iter_proto_id, "Array Iterator");
@@ -1210,76 +1190,64 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "String Iterator".to_string();
 
-        let str_iter_next = self.create_function(JsFunction::native(
-            "next".to_string(),
-            0,
-            |interp, this, _args| {
-                if let Some(this_id) = this.as_object_id() {
-                    if let Some(obj) = interp.get_object_cell(this_id) {
-                        let state = obj.borrow().iterator_state().cloned();
-                        if let Some(IteratorState::StringIterator {
-                            ref string,
-                            position,
-                            done,
-                        }) = state
-                        {
-                            if done || position >= string.code_units.len() {
-                                obj.borrow_mut().kind =
-                                    crate::interpreter::types::ObjectKind::Iterator(
-                                        IteratorState::StringIterator {
-                                            string: string.clone(),
-                                            position,
-                                            done: true,
-                                        },
-                                    );
-                                return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
-                                );
-                            }
-                            let cu = string.code_units[position];
-                            let (result_units, advance) = if (0xD800..=0xDBFF).contains(&cu)
-                                && position + 1 < string.code_units.len()
-                            {
-                                let next_cu = string.code_units[position + 1];
-                                if (0xDC00..=0xDFFF).contains(&next_cu) {
-                                    (vec![cu, next_cu], 2)
-                                } else {
-                                    (vec![cu], 1)
-                                }
-                            } else {
-                                (vec![cu], 1)
-                            };
+        self.define_method(str_iter_proto_id, "next", 0, |interp, this, _args| {
+            if let Some(this_id) = this.as_object_id() {
+                if let Some(obj) = interp.get_object_cell(this_id) {
+                    let state = obj.borrow().iterator_state().cloned();
+                    if let Some(IteratorState::StringIterator {
+                        ref string,
+                        position,
+                        done,
+                    }) = state
+                    {
+                        if done || position >= string.code_units.len() {
                             obj.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                                 IteratorState::StringIterator {
                                     string: string.clone(),
-                                    position: position + advance,
-                                    done: false,
+                                    position,
+                                    done: true,
                                 },
                             );
-                            let result_js_str = JsString::from_vec(result_units);
-                            Completion::Normal(
-                                interp.create_iter_result_object(
-                                    JsValue::string(result_js_str),
-                                    false,
-                                ),
-                            )
-                        } else {
-                            let err =
-                                interp.create_type_error("next called on non-string iterator");
-                            Completion::Throw(err)
+                            return Completion::Normal(
+                                interp.create_iter_result_object(JsValue::UNDEFINED, true),
+                            );
                         }
+                        let cu = string.code_units[position];
+                        let (result_units, advance) = if (0xD800..=0xDBFF).contains(&cu)
+                            && position + 1 < string.code_units.len()
+                        {
+                            let next_cu = string.code_units[position + 1];
+                            if (0xDC00..=0xDFFF).contains(&next_cu) {
+                                (vec![cu, next_cu], 2)
+                            } else {
+                                (vec![cu], 1)
+                            }
+                        } else {
+                            (vec![cu], 1)
+                        };
+                        obj.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                            IteratorState::StringIterator {
+                                string: string.clone(),
+                                position: position + advance,
+                                done: false,
+                            },
+                        );
+                        let result_js_str = JsString::from_vec(result_units);
+                        Completion::Normal(
+                            interp.create_iter_result_object(JsValue::string(result_js_str), false),
+                        )
                     } else {
-                        Completion::Normal(JsValue::UNDEFINED)
+                        let err = interp.create_type_error("next called on non-string iterator");
+                        Completion::Throw(err)
                     }
                 } else {
-                    let err = interp.create_type_error("next called on non-object");
-                    Completion::Throw(err)
+                    Completion::Normal(JsValue::UNDEFINED)
                 }
-            },
-        ));
-        self.get_object_cell_expect(str_iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("next".to_string(), str_iter_next);
+            } else {
+                let err = interp.create_type_error("next called on non-object");
+                Completion::Throw(err)
+            }
+        });
 
         self.define_to_string_tag(str_iter_proto_id, "String Iterator");
 
@@ -1299,130 +1267,112 @@ impl Interpreter {
             .class_name = "Iterator Helper".to_string();
 
         // next() — reads next + gen_state from this object's IterHelperData::Helper
-        let next_fn = self.create_function(JsFunction::native(
-            "next".to_string(),
-            0,
-            |interp, this, args| {
-                let Some(this_id) = this.as_object_id() else {
-                    return Completion::Throw(
-                        interp.create_type_error("Iterator Helper next called on non-object"),
-                    );
-                };
-                let (next_closure, gen_state) = {
-                    let obj = match interp.get_object(this_id) {
-                        Some(o) => o,
-                        None => {
-                            return Completion::Throw(interp.create_type_error(
-                                "Iterator Helper next called on invalid object",
-                            ));
-                        }
-                    };
-                    let b = obj.borrow();
-                    match b.iter_helper() {
-                        Some(crate::interpreter::types::IterHelperData::Helper {
-                            next,
-                            gen_state,
-                            ..
-                        }) => (next.clone(), gen_state.clone()),
-                        _ => {
-                            return Completion::Throw(
-                                interp
-                                    .create_type_error("next method called on incompatible object"),
-                            );
-                        }
+        self.define_method(proto_id, "next", 0, |interp, this, args| {
+            let Some(this_id) = this.as_object_id() else {
+                return Completion::Throw(
+                    interp.create_type_error("Iterator Helper next called on non-object"),
+                );
+            };
+            let (next_closure, gen_state) = {
+                let obj = match interp.get_object(this_id) {
+                    Some(o) => o,
+                    None => {
+                        return Completion::Throw(
+                            interp
+                                .create_type_error("Iterator Helper next called on invalid object"),
+                        );
                     }
                 };
-                let s = gen_state.get();
-                if s == 2 {
-                    return Completion::Throw(
-                        interp.create_type_error("Generator is already running"),
-                    );
+                let b = obj.borrow();
+                match b.iter_helper() {
+                    Some(crate::interpreter::types::IterHelperData::Helper {
+                        next,
+                        gen_state,
+                        ..
+                    }) => (next.clone(), gen_state.clone()),
+                    _ => {
+                        return Completion::Throw(
+                            interp.create_type_error("next method called on incompatible object"),
+                        );
+                    }
                 }
-                if s == 3 {
-                    return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
-                    );
-                }
-                gen_state.set(2);
-                let result = interp.call_function(&next_closure, this, args);
-                let is_done = if let Completion::Normal(ref v) = result {
-                    if let Some(v_id) = v.as_object_id() {
-                        match interp.get_object_property(v_id, "done", v) {
-                            Completion::Normal(d) => d.as_boolean() == Some(true),
-                            _ => false,
-                        }
-                    } else {
-                        false
+            };
+            let s = gen_state.get();
+            if s == 2 {
+                return Completion::Throw(interp.create_type_error("Generator is already running"));
+            }
+            if s == 3 {
+                return Completion::Normal(
+                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
+                );
+            }
+            gen_state.set(2);
+            let result = interp.call_function(&next_closure, this, args);
+            let is_done = if let Completion::Normal(ref v) = result {
+                if let Some(v_id) = v.as_object_id() {
+                    match interp.get_object_property(v_id, "done", v) {
+                        Completion::Normal(d) => d.as_boolean() == Some(true),
+                        _ => false,
                     }
                 } else {
                     false
-                };
-                gen_state.set(if is_done { 3 } else { 1 });
-                result
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_builtin("next".to_string(), next_fn);
+                }
+            } else {
+                false
+            };
+            gen_state.set(if is_done { 3 } else { 1 });
+            result
+        });
 
         // return() — reads return_closure + gen_state from this object's IterHelperData::Helper
-        let return_fn = self.create_function(JsFunction::native(
-            "return".to_string(),
-            0,
-            |interp, this, args| {
-                let Some(this_id) = this.as_object_id() else {
-                    return Completion::Throw(
-                        interp.create_type_error("Iterator Helper return called on non-object"),
-                    );
-                };
-                let (return_closure, gen_state) =
-                    {
-                        let obj = match interp.get_object(this_id) {
-                            Some(o) => o,
-                            None => {
-                                return Completion::Throw(interp.create_type_error(
-                                    "Iterator Helper return called on invalid object",
-                                ));
-                            }
-                        };
-                        let b = obj.borrow();
-                        match b.iter_helper() {
-                            Some(crate::interpreter::types::IterHelperData::Helper {
-                                return_closure,
-                                gen_state,
-                                ..
-                            }) => (return_closure.clone(), gen_state.clone()),
-                            _ => {
-                                return Completion::Throw(interp.create_type_error(
-                                    "return method called on incompatible object",
-                                ));
-                            }
+        self.define_method(proto_id, "return", 0, |interp, this, args| {
+            let Some(this_id) = this.as_object_id() else {
+                return Completion::Throw(
+                    interp.create_type_error("Iterator Helper return called on non-object"),
+                );
+            };
+            let (return_closure, gen_state) = {
+                let obj =
+                    match interp.get_object(this_id) {
+                        Some(o) => o,
+                        None => {
+                            return Completion::Throw(interp.create_type_error(
+                                "Iterator Helper return called on invalid object",
+                            ));
                         }
                     };
-                let s = gen_state.get();
-                if s == 2 {
-                    return Completion::Throw(
-                        interp.create_type_error("Generator is already running"),
-                    );
+                let b = obj.borrow();
+                match b.iter_helper() {
+                    Some(crate::interpreter::types::IterHelperData::Helper {
+                        return_closure,
+                        gen_state,
+                        ..
+                    }) => (return_closure.clone(), gen_state.clone()),
+                    _ => {
+                        return Completion::Throw(
+                            interp.create_type_error("return method called on incompatible object"),
+                        );
+                    }
                 }
-                if s == 3 {
-                    return Completion::Normal(
-                        interp.create_iter_result_object(JsValue::UNDEFINED, true),
-                    );
-                }
-                if s == 0 {
-                    gen_state.set(3);
-                    return interp.call_function(&return_closure, this, args);
-                }
-                gen_state.set(2);
-                let result = interp.call_function(&return_closure, this, args);
+            };
+            let s = gen_state.get();
+            if s == 2 {
+                return Completion::Throw(interp.create_type_error("Generator is already running"));
+            }
+            if s == 3 {
+                return Completion::Normal(
+                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
+                );
+            }
+            if s == 0 {
                 gen_state.set(3);
-                result
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_builtin("return".to_string(), return_fn);
+                return interp.call_function(&return_closure, this, args);
+            }
+            gen_state.set(2);
+            let result = interp.call_function(&return_closure, this, args);
+            gen_state.set(3);
+            result
+        });
 
         // @@iterator returning this
         let iter_self_fn = self.create_function(JsFunction::native(
@@ -1480,345 +1430,293 @@ impl Interpreter {
 
     fn setup_iterator_helper_methods(&mut self, iter_proto_id: u64) {
         // toArray()
-        let to_array_fn = self.create_function(JsFunction::native(
-            "toArray".to_string(),
-            0,
-            |interp, this, _args| {
-                let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
-                    Ok(v) => v,
-                    Err(e) => return Completion::Throw(e),
-                };
-                let mut values = Vec::new();
-                loop {
-                    match interp.iterator_step_direct(&iter, &next_method) {
-                        Ok(Some(result)) => match interp.iterator_value(&result) {
-                            Ok(v) => values.push(v),
-                            Err(e) => {
-                                let _ = iterator_close_getter(interp, &iter);
-                                return Completion::Throw(e);
-                            }
-                        },
-                        Ok(None) => break,
+        self.define_method(iter_proto_id, "toArray", 0, |interp, this, _args| {
+            let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
+                Ok(v) => v,
+                Err(e) => return Completion::Throw(e),
+            };
+            let mut values = Vec::new();
+            loop {
+                match interp.iterator_step_direct(&iter, &next_method) {
+                    Ok(Some(result)) => match interp.iterator_value(&result) {
+                        Ok(v) => values.push(v),
                         Err(e) => {
                             let _ = iterator_close_getter(interp, &iter);
                             return Completion::Throw(e);
                         }
+                    },
+                    Ok(None) => break,
+                    Err(e) => {
+                        let _ = iterator_close_getter(interp, &iter);
+                        return Completion::Throw(e);
                     }
                 }
-                let arr = interp.create_array(values);
-                Completion::Normal(arr)
-            },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("toArray".to_string(), to_array_fn);
+            }
+            let arr = interp.create_array(values);
+            Completion::Normal(arr)
+        });
 
         // forEach(fn)
-        let for_each_fn = self.create_function(JsFunction::native(
-            "forEach".to_string(),
-            1,
-            |interp, this, args| {
-                let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if !callback.as_object_id().is_some_and(|id| {
-                    interp
-                        .get_object_cell(id)
-                        .map(|od| od.borrow().callable.is_some())
-                        .unwrap_or(false)
-                }) {
-                    let _ = iterator_close_getter(interp, this);
-                    let err = interp.create_type_error("callback is not a function");
-                    return Completion::Throw(err);
-                }
-                let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
-                    Ok(v) => v,
+        self.define_method(iter_proto_id, "forEach", 1, |interp, this, args| {
+            let callback = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if !callback.as_object_id().is_some_and(|id| {
+                interp
+                    .get_object_cell(id)
+                    .map(|od| od.borrow().callable.is_some())
+                    .unwrap_or(false)
+            }) {
+                let _ = iterator_close_getter(interp, this);
+                let err = interp.create_type_error("callback is not a function");
+                return Completion::Throw(err);
+            }
+            let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
+                Ok(v) => v,
+                Err(e) => return Completion::Throw(e),
+            };
+            let mut counter = 0.0;
+            loop {
+                match interp.iterator_step_direct(&iter, &next_method) {
+                    Ok(Some(result)) => {
+                        let value = match interp.iterator_value(&result) {
+                            Ok(v) => v,
+                            Err(e) => return Completion::Throw(e),
+                        };
+                        if let Completion::Throw(e) = interp.call_function(
+                            &callback,
+                            &JsValue::UNDEFINED,
+                            &[value, JsValue::number(counter)],
+                        ) {
+                            let _ = iterator_close_getter(interp, &iter);
+                            return Completion::Throw(e);
+                        }
+                        counter += 1.0;
+                    }
+                    Ok(None) => break,
                     Err(e) => return Completion::Throw(e),
-                };
-                let mut counter = 0.0;
-                loop {
-                    match interp.iterator_step_direct(&iter, &next_method) {
-                        Ok(Some(result)) => {
-                            let value = match interp.iterator_value(&result) {
-                                Ok(v) => v,
-                                Err(e) => return Completion::Throw(e),
-                            };
-                            if let Completion::Throw(e) = interp.call_function(
-                                &callback,
-                                &JsValue::UNDEFINED,
-                                &[value, JsValue::number(counter)],
-                            ) {
+                }
+            }
+            Completion::Normal(JsValue::UNDEFINED)
+        });
+
+        // some(predicate)
+        self.define_method(iter_proto_id, "some", 1, |interp, this, args| {
+            let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if !predicate.as_object_id().is_some_and(|id| {
+                interp
+                    .get_object_cell(id)
+                    .map(|od| od.borrow().callable.is_some())
+                    .unwrap_or(false)
+            }) {
+                let _ = iterator_close_getter(interp, this);
+                let err = interp.create_type_error("predicate is not a function");
+                return Completion::Throw(err);
+            }
+            let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
+                Ok(v) => v,
+                Err(e) => return Completion::Throw(e),
+            };
+            let mut counter = 0.0;
+            loop {
+                match interp.iterator_step_direct(&iter, &next_method) {
+                    Ok(Some(result)) => {
+                        let value = match interp.iterator_value(&result) {
+                            Ok(v) => v,
+                            Err(e) => return Completion::Throw(e),
+                        };
+                        match interp.call_function(
+                            &predicate,
+                            &JsValue::UNDEFINED,
+                            &[value, JsValue::number(counter)],
+                        ) {
+                            Completion::Normal(v) if interp.to_boolean_val(&v) => {
+                                // Propagate IteratorClose errors
+                                if let Err(e) = iterator_close_getter(interp, &iter) {
+                                    return Completion::Throw(e);
+                                }
+                                return Completion::Normal(JsValue::TRUE);
+                            }
+                            Completion::Throw(e) => {
+                                let _ =
+                                    iterator_close_with_completion(interp, &iter, Err(e.clone()));
+                                return Completion::Throw(e);
+                            }
+                            _ => {}
+                        }
+                        counter += 1.0;
+                    }
+                    Ok(None) => return Completion::Normal(JsValue::FALSE),
+                    Err(e) => return Completion::Throw(e),
+                }
+            }
+        });
+
+        // every(predicate)
+        self.define_method(iter_proto_id, "every", 1, |interp, this, args| {
+            let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if !predicate.as_object_id().is_some_and(|id| {
+                interp
+                    .get_object_cell(id)
+                    .map(|od| od.borrow().callable.is_some())
+                    .unwrap_or(false)
+            }) {
+                let _ = iterator_close_getter(interp, this);
+                let err = interp.create_type_error("predicate is not a function");
+                return Completion::Throw(err);
+            }
+            let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
+                Ok(v) => v,
+                Err(e) => return Completion::Throw(e),
+            };
+            let mut counter = 0.0;
+            loop {
+                match interp.iterator_step_direct(&iter, &next_method) {
+                    Ok(Some(result)) => {
+                        let value = match interp.iterator_value(&result) {
+                            Ok(v) => v,
+                            Err(e) => return Completion::Throw(e),
+                        };
+                        match interp.call_function(
+                            &predicate,
+                            &JsValue::UNDEFINED,
+                            &[value, JsValue::number(counter)],
+                        ) {
+                            Completion::Normal(v) if !interp.to_boolean_val(&v) => {
+                                if let Err(e) = iterator_close_getter(interp, &iter) {
+                                    return Completion::Throw(e);
+                                }
+                                return Completion::Normal(JsValue::FALSE);
+                            }
+                            Completion::Throw(e) => {
+                                let _ =
+                                    iterator_close_with_completion(interp, &iter, Err(e.clone()));
+                                return Completion::Throw(e);
+                            }
+                            _ => {}
+                        }
+                        counter += 1.0;
+                    }
+                    Ok(None) => return Completion::Normal(JsValue::TRUE),
+                    Err(e) => return Completion::Throw(e),
+                }
+            }
+        });
+
+        // find(predicate)
+        self.define_method(iter_proto_id, "find", 1, |interp, this, args| {
+            let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if !predicate.as_object_id().is_some_and(|id| {
+                interp
+                    .get_object_cell(id)
+                    .map(|od| od.borrow().callable.is_some())
+                    .unwrap_or(false)
+            }) {
+                let _ = iterator_close_getter(interp, this);
+                let err = interp.create_type_error("predicate is not a function");
+                return Completion::Throw(err);
+            }
+            let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
+                Ok(v) => v,
+                Err(e) => return Completion::Throw(e),
+            };
+            let mut counter = 0.0;
+            loop {
+                match interp.iterator_step_direct(&iter, &next_method) {
+                    Ok(Some(result)) => {
+                        let value = match interp.iterator_value(&result) {
+                            Ok(v) => v,
+                            Err(e) => return Completion::Throw(e),
+                        };
+                        match interp.call_function(
+                            &predicate,
+                            &JsValue::UNDEFINED,
+                            &[value.clone(), JsValue::number(counter)],
+                        ) {
+                            Completion::Normal(v) if interp.to_boolean_val(&v) => {
+                                if let Err(e) = iterator_close_getter(interp, &iter) {
+                                    return Completion::Throw(e);
+                                }
+                                return Completion::Normal(value);
+                            }
+                            Completion::Throw(e) => {
+                                let _ =
+                                    iterator_close_with_completion(interp, &iter, Err(e.clone()));
+                                return Completion::Throw(e);
+                            }
+                            _ => {}
+                        }
+                        counter += 1.0;
+                    }
+                    Ok(None) => return Completion::Normal(JsValue::UNDEFINED),
+                    Err(e) => return Completion::Throw(e),
+                }
+            }
+        });
+
+        // reduce(reducer, [initial])
+        self.define_method(iter_proto_id, "reduce", 1, |interp, this, args| {
+            let reducer = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if !reducer.as_object_id().is_some_and(|id| {
+                interp
+                    .get_object_cell(id)
+                    .map(|od| od.borrow().callable.is_some())
+                    .unwrap_or(false)
+            }) {
+                let _ = iterator_close_getter(interp, this);
+                let err = interp.create_type_error("reducer is not a function");
+                return Completion::Throw(err);
+            }
+            let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
+                Ok(v) => v,
+                Err(e) => return Completion::Throw(e),
+            };
+            let mut accumulator;
+            let mut counter;
+            if args.len() >= 2 {
+                accumulator = args[1].clone();
+                counter = 0.0;
+            } else {
+                match interp.iterator_step_direct(&iter, &next_method) {
+                    Ok(Some(result)) => {
+                        accumulator = match interp.iterator_value(&result) {
+                            Ok(v) => v,
+                            Err(e) => return Completion::Throw(e),
+                        };
+                        counter = 1.0;
+                    }
+                    Ok(None) => {
+                        let err = interp
+                            .create_type_error("Reduce of empty iterator with no initial value");
+                        return Completion::Throw(err);
+                    }
+                    Err(e) => return Completion::Throw(e),
+                }
+            }
+            loop {
+                match interp.iterator_step_direct(&iter, &next_method) {
+                    Ok(Some(result)) => {
+                        let value = match interp.iterator_value(&result) {
+                            Ok(v) => v,
+                            Err(e) => return Completion::Throw(e),
+                        };
+                        match interp.call_function(
+                            &reducer,
+                            &JsValue::UNDEFINED,
+                            &[accumulator.clone(), value, JsValue::number(counter)],
+                        ) {
+                            Completion::Normal(v) => accumulator = v,
+                            Completion::Throw(e) => {
                                 let _ = iterator_close_getter(interp, &iter);
                                 return Completion::Throw(e);
                             }
-                            counter += 1.0;
+                            _ => {}
                         }
-                        Ok(None) => break,
-                        Err(e) => return Completion::Throw(e),
+                        counter += 1.0;
                     }
-                }
-                Completion::Normal(JsValue::UNDEFINED)
-            },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("forEach".to_string(), for_each_fn);
-
-        // some(predicate)
-        let some_fn = self.create_function(JsFunction::native(
-            "some".to_string(),
-            1,
-            |interp, this, args| {
-                let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if !predicate.as_object_id().is_some_and(|id| {
-                    interp
-                        .get_object_cell(id)
-                        .map(|od| od.borrow().callable.is_some())
-                        .unwrap_or(false)
-                }) {
-                    let _ = iterator_close_getter(interp, this);
-                    let err = interp.create_type_error("predicate is not a function");
-                    return Completion::Throw(err);
-                }
-                let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
-                    Ok(v) => v,
+                    Ok(None) => return Completion::Normal(accumulator),
                     Err(e) => return Completion::Throw(e),
-                };
-                let mut counter = 0.0;
-                loop {
-                    match interp.iterator_step_direct(&iter, &next_method) {
-                        Ok(Some(result)) => {
-                            let value = match interp.iterator_value(&result) {
-                                Ok(v) => v,
-                                Err(e) => return Completion::Throw(e),
-                            };
-                            match interp.call_function(
-                                &predicate,
-                                &JsValue::UNDEFINED,
-                                &[value, JsValue::number(counter)],
-                            ) {
-                                Completion::Normal(v) if interp.to_boolean_val(&v) => {
-                                    // Propagate IteratorClose errors
-                                    if let Err(e) = iterator_close_getter(interp, &iter) {
-                                        return Completion::Throw(e);
-                                    }
-                                    return Completion::Normal(JsValue::TRUE);
-                                }
-                                Completion::Throw(e) => {
-                                    let _ = iterator_close_with_completion(
-                                        interp,
-                                        &iter,
-                                        Err(e.clone()),
-                                    );
-                                    return Completion::Throw(e);
-                                }
-                                _ => {}
-                            }
-                            counter += 1.0;
-                        }
-                        Ok(None) => return Completion::Normal(JsValue::FALSE),
-                        Err(e) => return Completion::Throw(e),
-                    }
                 }
-            },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("some".to_string(), some_fn);
-
-        // every(predicate)
-        let every_fn = self.create_function(JsFunction::native(
-            "every".to_string(),
-            1,
-            |interp, this, args| {
-                let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if !predicate.as_object_id().is_some_and(|id| {
-                    interp
-                        .get_object_cell(id)
-                        .map(|od| od.borrow().callable.is_some())
-                        .unwrap_or(false)
-                }) {
-                    let _ = iterator_close_getter(interp, this);
-                    let err = interp.create_type_error("predicate is not a function");
-                    return Completion::Throw(err);
-                }
-                let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
-                    Ok(v) => v,
-                    Err(e) => return Completion::Throw(e),
-                };
-                let mut counter = 0.0;
-                loop {
-                    match interp.iterator_step_direct(&iter, &next_method) {
-                        Ok(Some(result)) => {
-                            let value = match interp.iterator_value(&result) {
-                                Ok(v) => v,
-                                Err(e) => return Completion::Throw(e),
-                            };
-                            match interp.call_function(
-                                &predicate,
-                                &JsValue::UNDEFINED,
-                                &[value, JsValue::number(counter)],
-                            ) {
-                                Completion::Normal(v) if !interp.to_boolean_val(&v) => {
-                                    if let Err(e) = iterator_close_getter(interp, &iter) {
-                                        return Completion::Throw(e);
-                                    }
-                                    return Completion::Normal(JsValue::FALSE);
-                                }
-                                Completion::Throw(e) => {
-                                    let _ = iterator_close_with_completion(
-                                        interp,
-                                        &iter,
-                                        Err(e.clone()),
-                                    );
-                                    return Completion::Throw(e);
-                                }
-                                _ => {}
-                            }
-                            counter += 1.0;
-                        }
-                        Ok(None) => return Completion::Normal(JsValue::TRUE),
-                        Err(e) => return Completion::Throw(e),
-                    }
-                }
-            },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("every".to_string(), every_fn);
-
-        // find(predicate)
-        let find_fn = self.create_function(JsFunction::native(
-            "find".to_string(),
-            1,
-            |interp, this, args| {
-                let predicate = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if !predicate.as_object_id().is_some_and(|id| {
-                    interp
-                        .get_object_cell(id)
-                        .map(|od| od.borrow().callable.is_some())
-                        .unwrap_or(false)
-                }) {
-                    let _ = iterator_close_getter(interp, this);
-                    let err = interp.create_type_error("predicate is not a function");
-                    return Completion::Throw(err);
-                }
-                let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
-                    Ok(v) => v,
-                    Err(e) => return Completion::Throw(e),
-                };
-                let mut counter = 0.0;
-                loop {
-                    match interp.iterator_step_direct(&iter, &next_method) {
-                        Ok(Some(result)) => {
-                            let value = match interp.iterator_value(&result) {
-                                Ok(v) => v,
-                                Err(e) => return Completion::Throw(e),
-                            };
-                            match interp.call_function(
-                                &predicate,
-                                &JsValue::UNDEFINED,
-                                &[value.clone(), JsValue::number(counter)],
-                            ) {
-                                Completion::Normal(v) if interp.to_boolean_val(&v) => {
-                                    if let Err(e) = iterator_close_getter(interp, &iter) {
-                                        return Completion::Throw(e);
-                                    }
-                                    return Completion::Normal(value);
-                                }
-                                Completion::Throw(e) => {
-                                    let _ = iterator_close_with_completion(
-                                        interp,
-                                        &iter,
-                                        Err(e.clone()),
-                                    );
-                                    return Completion::Throw(e);
-                                }
-                                _ => {}
-                            }
-                            counter += 1.0;
-                        }
-                        Ok(None) => return Completion::Normal(JsValue::UNDEFINED),
-                        Err(e) => return Completion::Throw(e),
-                    }
-                }
-            },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("find".to_string(), find_fn);
-
-        // reduce(reducer, [initial])
-        let reduce_fn = self.create_function(JsFunction::native(
-            "reduce".to_string(),
-            1,
-            |interp, this, args| {
-                let reducer = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if !reducer.as_object_id().is_some_and(|id| {
-                    interp
-                        .get_object_cell(id)
-                        .map(|od| od.borrow().callable.is_some())
-                        .unwrap_or(false)
-                }) {
-                    let _ = iterator_close_getter(interp, this);
-                    let err = interp.create_type_error("reducer is not a function");
-                    return Completion::Throw(err);
-                }
-                let (iter, next_method) = match get_iterator_direct_getter(interp, this) {
-                    Ok(v) => v,
-                    Err(e) => return Completion::Throw(e),
-                };
-                let mut accumulator;
-                let mut counter;
-                if args.len() >= 2 {
-                    accumulator = args[1].clone();
-                    counter = 0.0;
-                } else {
-                    match interp.iterator_step_direct(&iter, &next_method) {
-                        Ok(Some(result)) => {
-                            accumulator = match interp.iterator_value(&result) {
-                                Ok(v) => v,
-                                Err(e) => return Completion::Throw(e),
-                            };
-                            counter = 1.0;
-                        }
-                        Ok(None) => {
-                            let err = interp.create_type_error(
-                                "Reduce of empty iterator with no initial value",
-                            );
-                            return Completion::Throw(err);
-                        }
-                        Err(e) => return Completion::Throw(e),
-                    }
-                }
-                loop {
-                    match interp.iterator_step_direct(&iter, &next_method) {
-                        Ok(Some(result)) => {
-                            let value = match interp.iterator_value(&result) {
-                                Ok(v) => v,
-                                Err(e) => return Completion::Throw(e),
-                            };
-                            match interp.call_function(
-                                &reducer,
-                                &JsValue::UNDEFINED,
-                                &[accumulator.clone(), value, JsValue::number(counter)],
-                            ) {
-                                Completion::Normal(v) => accumulator = v,
-                                Completion::Throw(e) => {
-                                    let _ = iterator_close_getter(interp, &iter);
-                                    return Completion::Throw(e);
-                                }
-                                _ => {}
-                            }
-                            counter += 1.0;
-                        }
-                        Ok(None) => return Completion::Normal(accumulator),
-                        Err(e) => return Completion::Throw(e),
-                    }
-                }
-            },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("reduce".to_string(), reduce_fn);
+            }
+        });
 
         // Lazy helpers: map, filter, take, drop, flatMap
         self.setup_iterator_lazy_helpers(iter_proto_id);
@@ -1826,8 +1724,9 @@ impl Interpreter {
 
     fn setup_iterator_lazy_helpers(&mut self, iter_proto_id: u64) {
         // map(mapper)
-        let map_fn = self.create_function(JsFunction::native(
-            "map".to_string(),
+        self.define_method(
+            iter_proto_id,
+            "map",
             1,
             |interp, this, args| {
                 // Step 1-2: Require this to be an object
@@ -1954,14 +1853,12 @@ impl Interpreter {
                 }
                 Completion::Normal(helper)
             },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("map".to_string(), map_fn);
+        );
 
         // filter(predicate)
-        let filter_fn = self.create_function(JsFunction::native(
-            "filter".to_string(),
+        self.define_method(
+            iter_proto_id,
+            "filter",
             1,
             |interp, this, args| {
                 if !this.is_object() {
@@ -2096,14 +1993,12 @@ impl Interpreter {
                 }
                 Completion::Normal(helper)
             },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("filter".to_string(), filter_fn);
+        );
 
         // take(limit)
-        let take_fn = self.create_function(JsFunction::native(
-            "take".to_string(),
+        self.define_method(
+            iter_proto_id,
+            "take",
             1,
             |interp, this, args| {
                 // Step 2: If this is not an Object, throw TypeError
@@ -2250,14 +2145,12 @@ impl Interpreter {
                 }
                 Completion::Normal(helper)
             },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("take".to_string(), take_fn);
+        );
 
         // drop(limit)
-        let drop_fn = self.create_function(JsFunction::native(
-            "drop".to_string(),
+        self.define_method(
+            iter_proto_id,
+            "drop",
             1,
             |interp, this, args| {
                 // Step 2: If this is not an Object, throw TypeError
@@ -2415,14 +2308,12 @@ impl Interpreter {
                 }
                 Completion::Normal(helper)
             },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("drop".to_string(), drop_fn);
+        );
 
         // flatMap(mapper)
-        let flat_map_fn = self.create_function(JsFunction::native(
-            "flatMap".to_string(),
+        self.define_method(
+            iter_proto_id,
+            "flatMap",
             1,
             |interp, this, args| {
                 if !this.is_object() {
@@ -2651,10 +2542,7 @@ impl Interpreter {
                 }
                 Completion::Normal(helper)
             },
-        ));
-        self.get_object_cell_expect(iter_proto_id)
-            .borrow_mut()
-            .insert_builtin("flatMap".to_string(), flat_map_fn);
+        );
     }
 
     fn setup_iterator_static_methods(&mut self, iterator_ctor: &JsValue) {
@@ -2665,8 +2553,9 @@ impl Interpreter {
             .borrow_mut()
             .prototype_id = self.realm().iterator_prototype;
 
-        let wrap_next_fn = self.create_function(JsFunction::native(
-            "next".to_string(),
+        self.define_method(
+            wrap_valid_proto_id,
+            "next",
             0,
             move |interp, this, _args| {
                 let Some(this_id) = this.as_object_id() else {
@@ -2693,13 +2582,11 @@ impl Interpreter {
                 };
                 interp.call_function(&next_method, &iter, &[])
             },
-        ));
-        self.get_object_cell_expect(wrap_valid_proto_id)
-            .borrow_mut()
-            .insert_builtin("next".to_string(), wrap_next_fn);
+        );
 
-        let wrap_return_fn = self.create_function(JsFunction::native(
-            "return".to_string(),
+        self.define_method(
+            wrap_valid_proto_id,
+            "return",
             0,
             move |interp, this, _args| {
                 let Some(this_id) = this.as_object_id() else {
@@ -2740,10 +2627,7 @@ impl Interpreter {
                     Completion::Normal(interp.create_iter_result_object(JsValue::UNDEFINED, true))
                 }
             },
-        ));
-        self.get_object_cell_expect(wrap_valid_proto_id)
-            .borrow_mut()
-            .insert_builtin("return".to_string(), wrap_return_fn);
+        );
 
         let wvp_for_from: Option<u64> = Some(wrap_valid_proto_id);
         let iterator_ctor_for_from = iterator_ctor.clone();
@@ -4250,151 +4134,125 @@ impl Interpreter {
 
         // §27.1.2.1 next()
         let sync_for_next = sync_iter.clone();
-        let next_fn = self.create_function(JsFunction::native(
-            "next".to_string(),
-            1,
-            move |interp, _this, args| {
-                let call_args: &[JsValue] = if args.is_empty() {
-                    &[]
-                } else {
-                    std::slice::from_ref(&args[0])
-                };
-                let result = match interp.call_function(&cached_next, &sync_for_next, call_args) {
-                    Completion::Normal(v) if v.is_object() => v,
-                    Completion::Normal(_) => {
-                        let e = interp.create_type_error("Iterator result is not an object");
-                        return interp.create_rejected_promise(e);
-                    }
-                    Completion::Throw(e) => return interp.create_rejected_promise(e),
-                    _ => {
-                        let e = interp.create_type_error("Iterator next failed");
-                        return interp.create_rejected_promise(e);
-                    }
-                };
-                // AsyncFromSyncIteratorContinuation(result, promiseCap, syncIterRec, closeOnRejection=true)
-                interp.async_from_sync_continuation(result, sync_for_next.clone(), true)
-            },
-        ));
-        self.get_object_cell_expect(wrapper_id)
-            .borrow_mut()
-            .insert_builtin("next".to_string(), next_fn);
+        self.define_method(wrapper_id, "next", 1, move |interp, _this, args| {
+            let call_args: &[JsValue] = if args.is_empty() {
+                &[]
+            } else {
+                std::slice::from_ref(&args[0])
+            };
+            let result = match interp.call_function(&cached_next, &sync_for_next, call_args) {
+                Completion::Normal(v) if v.is_object() => v,
+                Completion::Normal(_) => {
+                    let e = interp.create_type_error("Iterator result is not an object");
+                    return interp.create_rejected_promise(e);
+                }
+                Completion::Throw(e) => return interp.create_rejected_promise(e),
+                _ => {
+                    let e = interp.create_type_error("Iterator next failed");
+                    return interp.create_rejected_promise(e);
+                }
+            };
+            // AsyncFromSyncIteratorContinuation(result, promiseCap, syncIterRec, closeOnRejection=true)
+            interp.async_from_sync_continuation(result, sync_for_next.clone(), true)
+        });
 
         // §27.1.2.2 return()
         let sync_for_return = sync_iter.clone();
-        let return_fn = self.create_function(JsFunction::native(
-            "return".to_string(),
-            1,
-            move |interp, _this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let value_present = !args.is_empty();
-                if let Some(sync_id) = sync_for_return.as_object_id() {
-                    // GetMethod(syncIterator, "return")
-                    let ret_fn =
-                        match interp.get_object_property(sync_id, "return", &sync_for_return) {
-                            Completion::Normal(v) if interp.is_callable(&v) => Some(v),
-                            Completion::Throw(e) => return interp.create_rejected_promise(e),
-                            _ => None,
-                        };
-                    if let Some(ret_fn) = ret_fn {
-                        // §27.1.2.2 step 8-9: pass value only if present
-                        let call_args: &[JsValue] = if value_present {
-                            std::slice::from_ref(&value)
-                        } else {
-                            &[]
-                        };
-                        let return_result =
-                            match interp.call_function(&ret_fn, &sync_for_return, call_args) {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => {
-                                    return interp.create_rejected_promise(e);
-                                }
-                                _ => JsValue::UNDEFINED,
-                            };
-                        if !return_result.is_object() {
-                            let e = interp.create_type_error("Iterator result is not an object");
-                            return interp.create_rejected_promise(e);
-                        }
-                        // AsyncFromSyncIteratorContinuation(returnResult, promiseCap, syncIterRec, closeOnRejection=false)
-                        interp.async_from_sync_continuation(
-                            return_result,
-                            sync_for_return.clone(),
-                            false,
-                        )
+        self.define_method(wrapper_id, "return", 1, move |interp, _this, args| {
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let value_present = !args.is_empty();
+            if let Some(sync_id) = sync_for_return.as_object_id() {
+                // GetMethod(syncIterator, "return")
+                let ret_fn = match interp.get_object_property(sync_id, "return", &sync_for_return) {
+                    Completion::Normal(v) if interp.is_callable(&v) => Some(v),
+                    Completion::Throw(e) => return interp.create_rejected_promise(e),
+                    _ => None,
+                };
+                if let Some(ret_fn) = ret_fn {
+                    // §27.1.2.2 step 8-9: pass value only if present
+                    let call_args: &[JsValue] = if value_present {
+                        std::slice::from_ref(&value)
                     } else {
-                        // return is undefined: resolve with {value, done: true}
-                        let iter_result = interp.create_iter_result_object(value, true);
-                        let promise = interp.create_promise_object();
-                        if let Some(promise_id) = promise.as_object_id() {
-                            interp.fulfill_promise(promise_id, iter_result);
-                        }
-                        Completion::Normal(promise)
+                        &[]
+                    };
+                    let return_result =
+                        match interp.call_function(&ret_fn, &sync_for_return, call_args) {
+                            Completion::Normal(v) => v,
+                            Completion::Throw(e) => {
+                                return interp.create_rejected_promise(e);
+                            }
+                            _ => JsValue::UNDEFINED,
+                        };
+                    if !return_result.is_object() {
+                        let e = interp.create_type_error("Iterator result is not an object");
+                        return interp.create_rejected_promise(e);
                     }
+                    // AsyncFromSyncIteratorContinuation(returnResult, promiseCap, syncIterRec, closeOnRejection=false)
+                    interp.async_from_sync_continuation(
+                        return_result,
+                        sync_for_return.clone(),
+                        false,
+                    )
                 } else {
-                    let iter_result = interp.create_iter_result_object(JsValue::UNDEFINED, true);
+                    // return is undefined: resolve with {value, done: true}
+                    let iter_result = interp.create_iter_result_object(value, true);
                     let promise = interp.create_promise_object();
                     if let Some(promise_id) = promise.as_object_id() {
                         interp.fulfill_promise(promise_id, iter_result);
                     }
                     Completion::Normal(promise)
                 }
-            },
-        ));
-        self.get_object_cell_expect(wrapper_id)
-            .borrow_mut()
-            .insert_builtin("return".to_string(), return_fn);
+            } else {
+                let iter_result = interp.create_iter_result_object(JsValue::UNDEFINED, true);
+                let promise = interp.create_promise_object();
+                if let Some(promise_id) = promise.as_object_id() {
+                    interp.fulfill_promise(promise_id, iter_result);
+                }
+                Completion::Normal(promise)
+            }
+        });
 
         // §27.1.2.3 throw()
         let sync_for_throw = sync_iter;
-        let throw_fn = self.create_function(JsFunction::native(
-            "throw".to_string(),
-            1,
-            move |interp, _this, args| {
-                let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                if let Some(sync_id) = sync_for_throw.as_object_id() {
-                    // GetMethod(syncIterator, "throw")
-                    let throw_method =
-                        match interp.get_object_property(sync_id, "throw", &sync_for_throw) {
-                            Completion::Normal(v) if interp.is_callable(&v) => Some(v),
+        self.define_method(wrapper_id, "throw", 1, move |interp, _this, args| {
+            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            if let Some(sync_id) = sync_for_throw.as_object_id() {
+                // GetMethod(syncIterator, "throw")
+                let throw_method =
+                    match interp.get_object_property(sync_id, "throw", &sync_for_throw) {
+                        Completion::Normal(v) if interp.is_callable(&v) => Some(v),
+                        Completion::Throw(e) => return interp.create_rejected_promise(e),
+                        _ => None,
+                    };
+                if let Some(throw_method) = throw_method {
+                    let throw_result =
+                        match interp.call_function(&throw_method, &sync_for_throw, &[value]) {
+                            Completion::Normal(v) => v,
                             Completion::Throw(e) => return interp.create_rejected_promise(e),
-                            _ => None,
+                            _ => JsValue::UNDEFINED,
                         };
-                    if let Some(throw_method) = throw_method {
-                        let throw_result =
-                            match interp.call_function(&throw_method, &sync_for_throw, &[value]) {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => return interp.create_rejected_promise(e),
-                                _ => JsValue::UNDEFINED,
-                            };
-                        if !throw_result.is_object() {
-                            let e = interp.create_type_error("Iterator result is not an object");
-                            return interp.create_rejected_promise(e);
-                        }
-                        // AsyncFromSyncIteratorContinuation(throwResult, promiseCap, syncIterRec, closeOnRejection=true)
-                        interp.async_from_sync_continuation(
-                            throw_result,
-                            sync_for_throw.clone(),
-                            true,
-                        )
-                    } else {
-                        // §27.1.2.3 step 8: throw is undefined
-                        // Close the iterator, then reject with TypeError
-                        let close_err = interp.iterator_close_result(&sync_for_throw);
-                        if let Err(e) = close_err {
-                            return interp.create_rejected_promise(e);
-                        }
-                        let e = interp
-                            .create_type_error("The iterator does not provide a 'throw' method");
-                        interp.create_rejected_promise(e)
+                    if !throw_result.is_object() {
+                        let e = interp.create_type_error("Iterator result is not an object");
+                        return interp.create_rejected_promise(e);
                     }
+                    // AsyncFromSyncIteratorContinuation(throwResult, promiseCap, syncIterRec, closeOnRejection=true)
+                    interp.async_from_sync_continuation(throw_result, sync_for_throw.clone(), true)
                 } else {
-                    let e = interp.create_type_error("Iterator is not an object");
+                    // §27.1.2.3 step 8: throw is undefined
+                    // Close the iterator, then reject with TypeError
+                    let close_err = interp.iterator_close_result(&sync_for_throw);
+                    if let Err(e) = close_err {
+                        return interp.create_rejected_promise(e);
+                    }
+                    let e =
+                        interp.create_type_error("The iterator does not provide a 'throw' method");
                     interp.create_rejected_promise(e)
                 }
-            },
-        ));
-        self.get_object_cell_expect(wrapper_id)
-            .borrow_mut()
-            .insert_builtin("throw".to_string(), throw_fn);
+            } else {
+                let e = interp.create_type_error("Iterator is not an object");
+                interp.create_rejected_promise(e)
+            }
+        });
 
         let id = wrapper_id;
         JsValue::object(id)

--- a/src/interpreter/builtins/promise.rs
+++ b/src/interpreter/builtins/promise.rs
@@ -191,185 +191,162 @@ impl Interpreter {
         self.realm_mut().promise_prototype = Some(proto_id);
 
         // Promise.prototype.then
-        let then_fn = self.create_function(JsFunction::native(
-            "then".to_string(),
-            2,
-            |interp, this, args| {
-                let on_fulfilled = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let on_rejected = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
-                interp.promise_then(this, &on_fulfilled, &on_rejected)
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_builtin("then".to_string(), then_fn);
+        self.define_method(proto_id, "then", 2, |interp, this, args| {
+            let on_fulfilled = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let on_rejected = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+            interp.promise_then(this, &on_fulfilled, &on_rejected)
+        });
 
         // Promise.prototype.catch — spec 27.2.5.1
-        let catch_fn = self.create_function(JsFunction::native(
-            "catch".to_string(),
-            1,
-            |interp, this, args| {
-                let on_rejected = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                // Spec 27.2.5.1: Return ? Invoke(this, "then", « undefined, onRejected »).
-                // Invoke calls GetV(V, P) which calls ToObject(V).
-                let obj = match interp.to_object(this) {
-                    Completion::Normal(v) => v,
-                    Completion::Throw(e) => return Completion::Throw(e),
-                    _ => return Completion::Normal(JsValue::UNDEFINED),
-                };
-                let obj_id = obj.as_object_id().unwrap_or_default();
-                let then_method = match interp.get_object_property(obj_id, "then", &obj) {
-                    Completion::Normal(v) => v,
-                    Completion::Throw(e) => return Completion::Throw(e),
-                    _ => JsValue::UNDEFINED,
-                };
-                interp.call_function(&then_method, this, &[JsValue::UNDEFINED, on_rejected])
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_builtin("catch".to_string(), catch_fn);
+        self.define_method(proto_id, "catch", 1, |interp, this, args| {
+            let on_rejected = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            // Spec 27.2.5.1: Return ? Invoke(this, "then", « undefined, onRejected »).
+            // Invoke calls GetV(V, P) which calls ToObject(V).
+            let obj = match interp.to_object(this) {
+                Completion::Normal(v) => v,
+                Completion::Throw(e) => return Completion::Throw(e),
+                _ => return Completion::Normal(JsValue::UNDEFINED),
+            };
+            let obj_id = obj.as_object_id().unwrap_or_default();
+            let then_method = match interp.get_object_property(obj_id, "then", &obj) {
+                Completion::Normal(v) => v,
+                Completion::Throw(e) => return Completion::Throw(e),
+                _ => JsValue::UNDEFINED,
+            };
+            interp.call_function(&then_method, this, &[JsValue::UNDEFINED, on_rejected])
+        });
 
         // Promise.prototype.finally — spec 27.2.5.3
-        let finally_fn = self.create_function(JsFunction::native(
-            "finally".to_string(),
-            1,
-            |interp, this, args| {
-                // Step 1-2: Let promise be the this value. If not Object, throw TypeError.
-                let Some(promise_id) = this.as_object_id() else {
-                    return Completion::Throw(
-                        interp.create_type_error("Promise.prototype.finally called on non-object"),
-                    );
-                };
+        self.define_method(proto_id, "finally", 1, |interp, this, args| {
+            // Step 1-2: Let promise be the this value. If not Object, throw TypeError.
+            let Some(promise_id) = this.as_object_id() else {
+                return Completion::Throw(
+                    interp.create_type_error("Promise.prototype.finally called on non-object"),
+                );
+            };
 
-                // Step 3: Let C = ? SpeciesConstructor(promise, %Promise%).
-                let promise_ctor = interp
-                    .get_global_var("Promise")
-                    .unwrap_or(JsValue::UNDEFINED);
-                let c = match interp.species_constructor(this, &promise_ctor) {
-                    Ok(c) => c,
-                    Err(e) => return Completion::Throw(e),
-                };
+            // Step 3: Let C = ? SpeciesConstructor(promise, %Promise%).
+            let promise_ctor = interp
+                .get_global_var("Promise")
+                .unwrap_or(JsValue::UNDEFINED);
+            let c = match interp.species_constructor(this, &promise_ctor) {
+                Ok(c) => c,
+                Err(e) => return Completion::Throw(e),
+            };
 
-                let on_finally = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+            let on_finally = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
 
-                // Steps 5-6: Create thenFinally and catchFinally
-                let (then_finally, catch_finally) = if !interp.is_callable(&on_finally) {
-                    // Step 5: If IsCallable(onFinally) is false, pass through
-                    (on_finally.clone(), on_finally)
-                } else {
-                    // Step 6a: thenFinally closure
-                    let on_finally_clone = on_finally.clone();
-                    let c_clone = c.clone();
-                    let then_finally = interp.create_function(JsFunction::native(
-                        "".to_string(),
-                        1,
-                        move |interp, _this, args| {
-                            let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                            // Step 6a.i: Let result = ? Call(onFinally, undefined).
-                            let result =
-                                interp.call_function(&on_finally_clone, &JsValue::UNDEFINED, &[]);
-                            match result {
-                                Completion::Throw(e) => Completion::Throw(e),
-                                Completion::Normal(r) => {
-                                    // Step 6a.ii: Let promise = ? PromiseResolve(C, result).
-                                    let p = match interp
-                                        .promise_resolve_with_constructor(&c_clone, &r)
-                                    {
-                                        Ok(p) => p,
-                                        Err(e) => return Completion::Throw(e),
-                                    };
-                                    // Step 6a.iii-iv: valueThunk that returns value
-                                    let value_clone = value.clone();
-                                    let return_fn = interp.create_function(JsFunction::native(
-                                        "".to_string(),
-                                        0,
-                                        move |_interp, _this, _args| {
-                                            Completion::Normal(value_clone.clone())
-                                        },
-                                    ));
-                                    interp.pin_native_root(&return_fn, &value);
-                                    // Step 6a.v: Return ? Invoke(promise, "then", « valueThunk »).
-                                    let p_id = p.as_object_id().unwrap_or_default();
-                                    let then_method =
-                                        match interp.get_object_property(p_id, "then", &p) {
-                                            Completion::Normal(v) => v,
-                                            Completion::Throw(e) => return Completion::Throw(e),
-                                            _ => JsValue::UNDEFINED,
-                                        };
-                                    interp.call_function(&then_method, &p, &[return_fn])
-                                }
-                                _ => Completion::Normal(JsValue::UNDEFINED),
+            // Steps 5-6: Create thenFinally and catchFinally
+            let (then_finally, catch_finally) = if !interp.is_callable(&on_finally) {
+                // Step 5: If IsCallable(onFinally) is false, pass through
+                (on_finally.clone(), on_finally)
+            } else {
+                // Step 6a: thenFinally closure
+                let on_finally_clone = on_finally.clone();
+                let c_clone = c.clone();
+                let then_finally = interp.create_function(JsFunction::native(
+                    "".to_string(),
+                    1,
+                    move |interp, _this, args| {
+                        let value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                        // Step 6a.i: Let result = ? Call(onFinally, undefined).
+                        let result =
+                            interp.call_function(&on_finally_clone, &JsValue::UNDEFINED, &[]);
+                        match result {
+                            Completion::Throw(e) => Completion::Throw(e),
+                            Completion::Normal(r) => {
+                                // Step 6a.ii: Let promise = ? PromiseResolve(C, result).
+                                let p = match interp.promise_resolve_with_constructor(&c_clone, &r)
+                                {
+                                    Ok(p) => p,
+                                    Err(e) => return Completion::Throw(e),
+                                };
+                                // Step 6a.iii-iv: valueThunk that returns value
+                                let value_clone = value.clone();
+                                let return_fn = interp.create_function(JsFunction::native(
+                                    "".to_string(),
+                                    0,
+                                    move |_interp, _this, _args| {
+                                        Completion::Normal(value_clone.clone())
+                                    },
+                                ));
+                                interp.pin_native_root(&return_fn, &value);
+                                // Step 6a.v: Return ? Invoke(promise, "then", « valueThunk »).
+                                let p_id = p.as_object_id().unwrap_or_default();
+                                let then_method = match interp.get_object_property(p_id, "then", &p)
+                                {
+                                    Completion::Normal(v) => v,
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    _ => JsValue::UNDEFINED,
+                                };
+                                interp.call_function(&then_method, &p, &[return_fn])
                             }
-                        },
-                    ));
+                            _ => Completion::Normal(JsValue::UNDEFINED),
+                        }
+                    },
+                ));
 
-                    // Step 6c: catchFinally closure
-                    let on_finally_clone2 = on_finally.clone();
-                    let c_clone2 = c.clone();
-                    let catch_finally = interp.create_function(JsFunction::native(
-                        "".to_string(),
-                        1,
-                        move |interp, _this, args| {
-                            let reason = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                            // Step 6c.i: Let result = ? Call(onFinally, undefined).
-                            let result =
-                                interp.call_function(&on_finally_clone2, &JsValue::UNDEFINED, &[]);
-                            match result {
-                                Completion::Throw(e) => Completion::Throw(e),
-                                Completion::Normal(r) => {
-                                    // Step 6c.ii: Let promise = ? PromiseResolve(C, result).
-                                    let p = match interp
-                                        .promise_resolve_with_constructor(&c_clone2, &r)
-                                    {
-                                        Ok(p) => p,
-                                        Err(e) => return Completion::Throw(e),
-                                    };
-                                    // Step 6c.iii-iv: thrower that throws reason
-                                    let reason_clone = reason.clone();
-                                    let throw_fn = interp.create_function(JsFunction::native(
-                                        "".to_string(),
-                                        0,
-                                        move |_interp, _this, _args| {
-                                            Completion::Throw(reason_clone.clone())
-                                        },
-                                    ));
-                                    interp.pin_native_root(&throw_fn, &reason);
-                                    // Step 6c.v: Return ? Invoke(promise, "then", « thrower »).
-                                    let p_id = p.as_object_id().unwrap_or_default();
-                                    let then_method =
-                                        match interp.get_object_property(p_id, "then", &p) {
-                                            Completion::Normal(v) => v,
-                                            Completion::Throw(e) => return Completion::Throw(e),
-                                            _ => JsValue::UNDEFINED,
-                                        };
-                                    interp.call_function(&then_method, &p, &[throw_fn])
-                                }
-                                _ => Completion::Normal(JsValue::UNDEFINED),
+                // Step 6c: catchFinally closure
+                let on_finally_clone2 = on_finally.clone();
+                let c_clone2 = c.clone();
+                let catch_finally = interp.create_function(JsFunction::native(
+                    "".to_string(),
+                    1,
+                    move |interp, _this, args| {
+                        let reason = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                        // Step 6c.i: Let result = ? Call(onFinally, undefined).
+                        let result =
+                            interp.call_function(&on_finally_clone2, &JsValue::UNDEFINED, &[]);
+                        match result {
+                            Completion::Throw(e) => Completion::Throw(e),
+                            Completion::Normal(r) => {
+                                // Step 6c.ii: Let promise = ? PromiseResolve(C, result).
+                                let p = match interp.promise_resolve_with_constructor(&c_clone2, &r)
+                                {
+                                    Ok(p) => p,
+                                    Err(e) => return Completion::Throw(e),
+                                };
+                                // Step 6c.iii-iv: thrower that throws reason
+                                let reason_clone = reason.clone();
+                                let throw_fn = interp.create_function(JsFunction::native(
+                                    "".to_string(),
+                                    0,
+                                    move |_interp, _this, _args| {
+                                        Completion::Throw(reason_clone.clone())
+                                    },
+                                ));
+                                interp.pin_native_root(&throw_fn, &reason);
+                                // Step 6c.v: Return ? Invoke(promise, "then", « thrower »).
+                                let p_id = p.as_object_id().unwrap_or_default();
+                                let then_method = match interp.get_object_property(p_id, "then", &p)
+                                {
+                                    Completion::Normal(v) => v,
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    _ => JsValue::UNDEFINED,
+                                };
+                                interp.call_function(&then_method, &p, &[throw_fn])
                             }
-                        },
-                    ));
+                            _ => Completion::Normal(JsValue::UNDEFINED),
+                        }
+                    },
+                ));
 
-                    interp.pin_native_root(&then_finally, &on_finally);
-                    interp.pin_native_root(&then_finally, &c);
-                    interp.pin_native_root(&catch_finally, &on_finally);
-                    interp.pin_native_root(&catch_finally, &c);
+                interp.pin_native_root(&then_finally, &on_finally);
+                interp.pin_native_root(&then_finally, &c);
+                interp.pin_native_root(&catch_finally, &on_finally);
+                interp.pin_native_root(&catch_finally, &c);
 
-                    (then_finally, catch_finally)
-                };
+                (then_finally, catch_finally)
+            };
 
-                // Step 7: Return ? Invoke(promise, "then", « thenFinally, catchFinally »).
-                let then_method = match interp.get_object_property(promise_id, "then", this) {
-                    Completion::Normal(v) => v,
-                    Completion::Throw(e) => return Completion::Throw(e),
-                    _ => JsValue::UNDEFINED,
-                };
-                interp.call_function(&then_method, this, &[then_finally, catch_finally])
-            },
-        ));
-        self.get_object_cell_expect(proto_id)
-            .borrow_mut()
-            .insert_builtin("finally".to_string(), finally_fn);
+            // Step 7: Return ? Invoke(promise, "then", « thenFinally, catchFinally »).
+            let then_method = match interp.get_object_property(promise_id, "then", this) {
+                Completion::Normal(v) => v,
+                Completion::Throw(e) => return Completion::Throw(e),
+                _ => JsValue::UNDEFINED,
+            };
+            interp.call_function(&then_method, this, &[then_finally, catch_finally])
+        });
 
         // @@toStringTag
         self.define_to_string_tag(proto_id, "Promise");

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3754,3 +3754,125 @@ mod node_host_tests {
         assert_eq!(global_string(&interp, "after"), "no");
     }
 }
+
+// Spec-derived property-descriptor invariants for the builtin methods installed
+// by iterators.rs, promise.rs and disposable.rs. Every built-in method must be
+// a `{ writable: true, enumerable: false, configurable: true }` own property
+// whose function object carries `name`/`length` own props that are
+// `{ writable: false, enumerable: false, configurable: true }` (ECMAScript
+// §10.2.9 SetFunctionName / §10.2.10 SetFunctionLength, §20 built-in intro).
+// Expected `name`/`length` values are the reference values reported by Node
+// (v26), an independent source of truth — not read off jsse's implementation.
+// These pin the observable shape so the define_method adoption refactor is
+// verifiably behavior-preserving.
+mod builtin_method_descriptors {
+    use super::run_script;
+
+    // JS helpers shared by every descriptor check. `checkMethod` returns the
+    // function object so aliased-symbol checks can assert value identity.
+    const PRELUDE: &str = r#"
+        function _attrs(d) { return [d.writable, d.enumerable, d.configurable]; }
+        function checkMethod(obj, objName, key, expName, expLen) {
+            var d = Object.getOwnPropertyDescriptor(obj, key);
+            if (!d) throw new Error(objName + "." + String(key) + " missing");
+            var a = _attrs(d);
+            if (!(a[0] === true && a[1] === false && a[2] === true))
+                throw new Error(objName + "." + String(key) + " method attrs " + a);
+            var f = d.value;
+            if (typeof f !== "function")
+                throw new Error(objName + "." + String(key) + " value not a function");
+            var nd = Object.getOwnPropertyDescriptor(f, "name");
+            var na = _attrs(nd);
+            if (!(na[0] === false && na[1] === false && na[2] === true))
+                throw new Error(objName + "." + String(key) + " name attrs " + na);
+            if (nd.value !== expName)
+                throw new Error(objName + "." + String(key) + " name " + nd.value + " != " + expName);
+            var ld = Object.getOwnPropertyDescriptor(f, "length");
+            var la = _attrs(ld);
+            if (!(la[0] === false && la[1] === false && la[2] === true))
+                throw new Error(objName + "." + String(key) + " length attrs " + la);
+            if (ld.value !== expLen)
+                throw new Error(objName + "." + String(key) + " length " + ld.value + " != " + expLen);
+            return f;
+        }
+        // A symbol-keyed method that must be the *same* function object as a
+        // named data-key method (e.g. @@dispose === dispose), same attrs.
+        function checkAlias(obj, objName, symKey, dataKey) {
+            var d = Object.getOwnPropertyDescriptor(obj, symKey);
+            if (!d) throw new Error(objName + " @@" + " alias missing");
+            var a = _attrs(d);
+            if (!(a[0] === true && a[1] === false && a[2] === true))
+                throw new Error(objName + " alias attrs " + a);
+            if (d.value !== obj[dataKey])
+                throw new Error(objName + " alias not same object as " + dataKey);
+        }
+    "#;
+
+    fn run_checks(checks: &str) {
+        run_script(&format!("{PRELUDE}\n{checks}"));
+    }
+
+    #[test]
+    fn promise_builtin_method_descriptors() {
+        run_checks(
+            r#"
+            var P = Promise.prototype;
+            checkMethod(P, "Promise.prototype", "then", "then", 2);
+            checkMethod(P, "Promise.prototype", "catch", "catch", 1);
+            checkMethod(P, "Promise.prototype", "finally", "finally", 1);
+            checkMethod(Promise, "Promise", "resolve", "resolve", 1);
+            checkMethod(Promise, "Promise", "reject", "reject", 1);
+            checkMethod(Promise, "Promise", "all", "all", 1);
+            checkMethod(Promise, "Promise", "allSettled", "allSettled", 1);
+            checkMethod(Promise, "Promise", "race", "race", 1);
+            checkMethod(Promise, "Promise", "any", "any", 1);
+            checkMethod(Promise, "Promise", "withResolvers", "withResolvers", 0);
+        "#,
+        );
+    }
+
+    #[test]
+    fn iterator_helper_builtin_method_descriptors() {
+        run_checks(
+            r#"
+            var I = Iterator.prototype;
+            checkMethod(I, "Iterator.prototype", "map", "map", 1);
+            checkMethod(I, "Iterator.prototype", "filter", "filter", 1);
+            checkMethod(I, "Iterator.prototype", "take", "take", 1);
+            checkMethod(I, "Iterator.prototype", "drop", "drop", 1);
+            checkMethod(I, "Iterator.prototype", "flatMap", "flatMap", 1);
+            checkMethod(I, "Iterator.prototype", "toArray", "toArray", 0);
+            checkMethod(I, "Iterator.prototype", "forEach", "forEach", 1);
+            checkMethod(I, "Iterator.prototype", "some", "some", 1);
+            checkMethod(I, "Iterator.prototype", "every", "every", 1);
+            checkMethod(I, "Iterator.prototype", "find", "find", 1);
+            checkMethod(I, "Iterator.prototype", "reduce", "reduce", 1);
+            checkMethod(Iterator, "Iterator", "from", "from", 1);
+            checkMethod(Iterator, "Iterator", "concat", "concat", 0);
+        "#,
+        );
+    }
+
+    #[test]
+    fn disposable_stack_builtin_method_descriptors() {
+        run_checks(
+            r#"
+            var D = DisposableStack.prototype;
+            checkMethod(D, "DisposableStack.prototype", "dispose", "dispose", 0);
+            checkMethod(D, "DisposableStack.prototype", "use", "use", 1);
+            checkMethod(D, "DisposableStack.prototype", "adopt", "adopt", 2);
+            checkMethod(D, "DisposableStack.prototype", "defer", "defer", 1);
+            checkMethod(D, "DisposableStack.prototype", "move", "move", 0);
+            checkAlias(D, "DisposableStack.prototype", Symbol.dispose, "dispose");
+
+            var A = AsyncDisposableStack.prototype;
+            checkMethod(A, "AsyncDisposableStack.prototype", "disposeAsync", "disposeAsync", 0);
+            checkMethod(A, "AsyncDisposableStack.prototype", "use", "use", 1);
+            checkMethod(A, "AsyncDisposableStack.prototype", "adopt", "adopt", 2);
+            checkMethod(A, "AsyncDisposableStack.prototype", "defer", "defer", 1);
+            checkMethod(A, "AsyncDisposableStack.prototype", "move", "move", 0);
+            checkAlias(A, "AsyncDisposableStack.prototype", Symbol.asyncDispose, "disposeAsync");
+        "#,
+        );
+    }
+}


### PR DESCRIPTION
## Refactoring goal

Deepen the **builtin-install seam**. Three install helpers already exist in `src/interpreter/mod.rs` — `define_method`, `define_getter`, `define_to_string_tag` — whose doc-comments state they exist to replace "the two-step `create_function` + `insert_builtin` dance repeated at every builtin call site." But `define_method` was adopted at only ~37% of cleanly-eligible sites; the rest hand-rolled the dance and **wrote each method name twice** (once in `JsFunction::native("x", …)`, once in `insert_builtin("x", …)`) — a latent desync hazard between a function's `.name` and its property key.

This PR adopts `define_method` across a bounded, cohesive slice — the iteration/async-protocol builtins:

```
let use_fn = self.create_function(JsFunction::native(     ->   self.define_method(ds_proto_id, "use", 1,
    "use".to_string(), 1, |i, this, args| { … },          ->       |i, this, args| { … });
));                                                        ->   // name + length + {W:true,E:false,C:true}
self.get_object_cell_expect(ds_proto_id)                  ->   // applied in ONE place; drift impossible.
    .borrow_mut().insert_builtin("use".to_string(), use_fn);
```

**32 conversions:** `iterators.rs` (20) + `disposable.rs` (9) + `promise.rs` (3).

## Why this is behavior-preserving

`insert_builtin` already emits `PropertyDescriptor::data(value, /*writable*/ true, /*enumerable*/ false, /*configurable*/ true)` — the *exact* descriptor `define_method` installs (it calls `insert_builtin` internally). No `define_method` signature change was made. The transform only paired hand-rolled installs whose `native(...)` name literal and `insert_builtin(...)` key literal matched, so no `.name` or key could change. Sites that install on a pre-borrowed cell handle (Promise's static methods on `func_obj`) or mint per-call/wrapper closures don't fit `define_method`'s `target_id` interface and are intentionally left untouched.

## Tests that validate it

New `builtin_method_descriptors` tests in `src/interpreter/tests.rs` pin the spec invariant for every built-in method in the slice, via `Object.getOwnPropertyDescriptor`:

- methods are `{ writable: true, enumerable: false, configurable: true }`;
- their `name`/`length` own props are `{ writable: false, enumerable: false, configurable: true }`, with the exact `name`/`length` values;
- `@@dispose` / `@@asyncDispose` are the *same function object* as `dispose` / `disposeAsync`.

Expected values were taken from **Node v26** (an independent source of truth), not read off jsse's implementation, so the assertions are not tautological. They were written and run **before** the refactor (all green — establishing the behavior-preservation baseline) and stay green **after**. Because the refactor is behavior-preserving there is no red→green phase; the tests are a pinned invariant, and were confirmed capable of failing (flipping one expected `length` turns the suite red).

## Validation

- `./scripts/lint.sh` — rustfmt + `clippy -D warnings`: clean
- `cargo test --bin jsse` — **544 passed** (incl. 3 new descriptor tests)
- Full **test262**: `99568 / 99568` pass, **0 regressions**, 0 failures (baseline `origin/main:test262-pass.txt`).

> The runner reports `New passes: 323`. That is **not** produced by this change — a name/length/attribute-identical transform cannot newly pass any test. It reflects baseline staleness: per the project layout, `test262-pass.txt` is **not rewritten by default** (only rolled forward with `--update-baseline`, typically on `main`), so the recorded baseline lags the actual passing state as feature PRs land. The behavior-preservation guarantee is `regressions: 0`.

## Audit context

Produced by the `improve-codebase-architecture` skill; implemented following the `tdd` skill's rules (spec-derived tests first, at the public `Object.getOwnPropertyDescriptor` seam). Candidates surfaced, in priority order:

1. **Builtin-install seam adoption** — *this PR* (Strong; deep, high-leverage, mechanically verifiable).
2. **OrdinarySet property-write cluster** (`eval_assign` ↔ `eval_logical_assign` + 3 divergent prototype-chain walks) — highest deletion-test value but needs a dedicated test-first pass; filed as #482.
3. Generator state write-back boilerplate (~1,850 lines); 4. RequireInternalSlot/`this`-unwrap divergence; 5. `try_completion!`/`try_result!` macros trapped in `temporal/duration.rs` — recorded for future passes.

A self-contained HTML report was generated at `/tmp/architecture-review-20260824-013250.html` (not auto-opened — headless run).