### PR TITLE
refactor(interpreter): unify property assignment writes

### DIFF
--- a/docs/specs/2026-08-24-ordinary-set-property-write-design.md
+++ b/docs/specs/2026-08-24-ordinary-set-property-write-design.md
@@ -38,6 +38,10 @@ differ, but their reached write must not.
 the canonical `[[Set]]` module. Its implementation dispatches module namespace,
 Proxy, TypedArray, Array length, accessors, receiver descriptors, and ordinary
 prototype recursion and returns the specification's Boolean success result.
+An internal outcome-preserving variant additionally records when the operation
+itself performed an own data-property write on the receiver. This path fact
+cannot be reconstructed from the descriptor after `[[Set]]`, because a setter
+or Proxy trap can redefine the property before returning.
 
 `eval.rs::set_object_with_key(base, key, value, strict)` is the existing
 ordinary-member `PutValue` adapter. It preserves the original base as receiver,
@@ -68,12 +72,16 @@ this seam and reimplement parts of `[[Set]]`.
 ## Design
 
 Add one private receiver-aware `PutValue` adapter in `eval.rs` with the logical
-interface `(base object id, key, value, receiver, strict) -> Result<bool,
-JsValue>`. It calls `set_object_property` exactly once, returns the success bit
-for the one caller that mirrors successful global-object writes, and translates
-a false result into the existing strict assignment diagnostic. The interface
-keeps strictness outside the object internal method, matching the specification:
-`[[Set]]` returns a Boolean; `PutValue` decides whether false throws.
+interface `(base object id, key, value, receiver, strict) ->
+Result<SetOutcome, JsValue>`. `SetOutcome` distinguishes rejection, success
+without a receiver data write, and a successful own data write on a particular
+receiver. The adapter calls the canonical property module exactly once, uses
+the success bit for strict assignment diagnostics, and lets the one caller that
+mirrors global object-record writes require the matching receiver-write
+outcome. Existing property callers retain a Boolean compatibility wrapper. The
+interface keeps strictness outside the object internal method, matching the
+specification: `[[Set]]` returns a Boolean; `PutValue` decides whether false
+throws.
 
 `set_object_with_key` remains the ordinary-member adapter. It captures the
 original value as receiver, boxes a primitive base, and delegates to the new
@@ -104,6 +112,12 @@ remain inside the canonical implementation. A thrown trap, setter, coercion,
 or exotic operation propagates unchanged. A false result is silent for sloppy
 References and becomes a `TypeError` for strict References.
 
+The internal outcome is selected at the branch that actually handles the set
+and is preserved through prototype recursion. Successful setters and Proxy
+traps do not report a receiver data write, even if their user code leaves a
+data descriptor behind. This keeps the evaluator's global-binding bridge from
+copying the assignment RHS over a value chosen by user code.
+
 When prototype recursion reaches the synthetic writable descriptor and the
 receiver is a module namespace exotic object, canonical `OrdinarySet` performs
 the receiver's `[[GetOwnProperty]]`-equivalent deferred-evaluation/TDZ check
@@ -128,6 +142,8 @@ Characterize behaviour through executable JavaScript, the public seam:
 - a deferred module namespace used as a super-property receiver;
 - primitive member References, especially logical assignment, retaining the
   primitive receiver;
+- own and inherited global setters, including a setter that replaces itself
+  with a data property before returning, not being mistaken for a data write;
 - the simple, compound, and logical assignment forms that reach `PutValue`.
 
 Run the custom characterization tests, the relevant test262 assignment,

--- a/docs/specs/2026-08-24-ordinary-set-property-write-design.md
+++ b/docs/specs/2026-08-24-ordinary-set-property-write-design.md
@@ -1,0 +1,136 @@
+# OrdinarySet property-write consolidation design
+
+## Goal
+
+Consolidate ordinary property assignment in the evaluator behind one deep
+module so simple, compound, logical, update, destructuring, bytecode, and
+`super` writes cannot drift in descriptor, proxy, prototype-chain, receiver,
+Array-length, or strict-mode behaviour.
+
+This is a behaviour-preserving refactor except where characterization exposes
+an existing contradiction with the ECMAScript algorithms. Such contradictions
+are corrected to the pinned specification and covered at the JavaScript
+execution seam.
+
+## Specification constraints
+
+`PutValue` (§6.2.5.6) first applies `ToObject` to a property Reference's base,
+then calls that object's `[[Set]]` with `GetThisValue(reference)` as the
+receiver. For an ordinary member Reference the receiver is the original base,
+including when that base is primitive. For a Super Reference the base is the
+super base while the receiver is the actual `this` value. A rejected `[[Set]]`
+throws only for a strict Reference.
+
+`OrdinarySet` and `OrdinarySetWithOwnDescriptor` (§10.1.9) own the descriptor
+lookup, prototype recursion, receiver-own-descriptor checks, property creation,
+and inherited accessor invocation. Each prototype is entered through its own
+`[[Set]]`, so Proxy and other exotic dispatch remains observable. Array
+`length` writes must reach `ArraySetLength`; the assignment expression still
+returns the uncoerced right-hand value.
+
+Simple, compound, and logical assignment (§13.15) all finish with `PutValue`
+on the captured left Reference. Their read/short-circuit/arithmetic timing may
+differ, but their reached write must not.
+
+## Existing seam
+
+`property.rs::set_object_property(base_id, key, value, receiver)` is already
+the canonical `[[Set]]` module. Its implementation dispatches module namespace,
+Proxy, TypedArray, Array length, accessors, receiver descriptors, and ordinary
+prototype recursion and returns the specification's Boolean success result.
+
+`eval.rs::set_object_with_key(base, key, value, strict)` is the existing
+ordinary-member `PutValue` adapter. It preserves the original base as receiver,
+boxes only the `[[Set]]` holder, converts a false result to a strict-mode
+`TypeError`, and is already shared by update, destructuring, and bytecode
+writes. The remaining assignment dispatchers and `super_set_property` bypass
+this seam and reimplement parts of `[[Set]]`.
+
+## Approaches considered
+
+1. **Route every remaining write into the existing canonical `[[Set]]`
+   module.** Selected. Add a receiver-aware evaluator adapter over
+   `set_object_property`, let `set_object_with_key` use it, and reduce
+   `super_set_property` to the same adapter with a distinct base and receiver.
+   Replace the simple/compound and logical member write-back blocks with
+   `set_object_with_key`. This maximizes locality without creating a competing
+   implementation.
+2. **Add a new `ordinary_set` implementation in `eval.rs`.** Rejected because
+   `property.rs` already owns the internal-method implementation. A second
+   module would merely move, rather than remove, the semantic duplication and
+   would leave Reflect/builtin callers on a separate implementation.
+3. **Introduce a first-class Reference Record and rewrite all assignment
+   evaluation around it.** This could eventually reduce duplicated evaluation
+   order code, but expands the change into identifier environments, private
+   references, destructuring, and bytecode. It is not required to delete the
+   property-write cluster and has a much larger regression surface.
+
+## Design
+
+Add one private receiver-aware `PutValue` adapter in `eval.rs` with the logical
+interface `(base object id, key, value, receiver, strict) -> Result<bool,
+JsValue>`. It calls `set_object_property` exactly once, returns the success bit
+for the one caller that mirrors successful global-object writes, and translates
+a false result into the existing strict assignment diagnostic. The interface
+keeps strictness outside the object internal method, matching the specification:
+`[[Set]]` returns a Boolean; `PutValue` decides whether false throws.
+
+`set_object_with_key` remains the ordinary-member adapter. It captures the
+original value as receiver, boxes a primitive base, and delegates to the new
+receiver-aware adapter. `super_set_property` delegates with the super base as
+holder and actual `this` as receiver, returning the assigned value after a
+successful or sloppy rejected write.
+
+The public member arms of `eval_assign` and `eval_logical_assign` retain their
+current left-reference capture, read, right-hand evaluation, short-circuit,
+and compound-operation order. Only the terminal write-back is replaced. The
+dense ordinary-Array indexed-write optimization may remain as a guarded fast
+path because it is an implementation of the same successful observable
+outcome and explicitly bails for descriptors, prototypes, proxies, holes,
+non-extensibility, and non-writable length. All slow paths cross the canonical
+seam.
+
+Private fields intentionally remain on `PrivateSet`; they are not ordinary
+properties and have brand/accessor semantics unrelated to `OrdinarySet`.
+`apply_compound_assign` also remains a value-computation module: its member
+callers perform the unified write after it returns.
+
+## Error handling and observable order
+
+No caller probes descriptors before calling `[[Set]]`. Proxy traps therefore
+run once and in prototype order, inherited setters receive the Reference's
+receiver, and receiver `[[GetOwnProperty]]`/`[[DefineOwnProperty]]` operations
+remain inside the canonical implementation. A thrown trap, setter, coercion,
+or exotic operation propagates unchanged. A false result is silent for sloppy
+References and becomes a `TypeError` for strict References.
+
+When prototype recursion reaches the synthetic writable descriptor and the
+receiver is a module namespace exotic object, canonical `OrdinarySet` performs
+the receiver's `[[GetOwnProperty]]`-equivalent deferred-evaluation/TDZ check
+before returning false. This behaviour previously lived only in the open-coded
+super path.
+
+The assigned expression result is always the computed right-hand value, not an
+Array length value after coercion. Existing caller-side GC rooting remains in
+place around assignment paths that already protect a transient base across
+computed key evaluation, getters, right-hand evaluation, and write-back.
+
+## Verification
+
+Characterize behaviour through executable JavaScript, the public seam:
+
+- a Proxy in the prototype chain, including trap receiver and false-result
+  strict/sloppy handling;
+- inherited non-writable data properties in strict and sloppy code;
+- inherited setters and receiver identity;
+- `ArraySetLength` effects while assignment returns the uncoerced RHS;
+- super-property writes with a distinct holder and receiver;
+- a deferred module namespace used as a super-property receiver;
+- primitive member References, especially logical assignment, retaining the
+  primitive receiver;
+- the simple, compound, and logical assignment forms that reach `PutValue`.
+
+Run the custom characterization tests, the relevant test262 assignment,
+logical-assignment, update, super, Reflect.set, and Proxy/set areas, then the
+repository's complete formatting, lint, release build/test, and full test262
+quality gate. The refactor must not change the baseline pass count.

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2752,31 +2752,6 @@ impl Interpreter {
                             Completion::Throw(e) => return Err(e),
                             _ => return Ok(()),
                         };
-                        // Fast path: non-negative integer index on typed array
-                        if let Some(index) = v.as_number()
-                            && let Some(o) = (obj_val)
-                                .as_object_id()
-                                .map(|id| crate::types::JsObject { id })
-                            && let Some(obj) = self.get_object(o.id)
-                            && obj.borrow().typed_array_info().is_some()
-                        {
-                            let obj_ref = obj.borrow();
-                            let ta = obj_ref.typed_array_info().unwrap();
-                            if is_valid_integer_index(ta, index) {
-                                let is_bigint = ta.kind.is_bigint();
-                                let ta_clone = ta.clone();
-                                drop(obj_ref);
-                                let num_val = if is_bigint {
-                                    self.to_bigint_value(&value)?
-                                } else {
-                                    JsValue::number(self.to_number_value(&value)?)
-                                };
-                                typed_array_set_index(&ta_clone, index as usize, &num_val);
-                                return Ok(());
-                            }
-                            // Invalid index (e.g. -0, NaN, fractional) — fall through
-                            // to to_property_key which may canonicalize the key
-                        }
                         self.to_property_key(&v)?
                     }
                     MemberProperty::Private(_) => unreachable!(),
@@ -2791,82 +2766,8 @@ impl Interpreter {
                         }
                     )));
                 }
-                if let Some(o) = (obj_val)
-                    .as_object_id()
-                    .map(|id| crate::types::JsObject { id })
-                    && let Some(obj) = self.get_object(o.id)
-                {
-                    // TypedArray [[Set]]
-                    let is_ta = obj.borrow().typed_array_info().is_some();
-                    if is_ta && let Some(index) = canonical_numeric_index_string(&key) {
-                        let is_bigint = obj
-                            .borrow()
-                            .typed_array_info()
-                            .map(|ta| ta.kind.is_bigint())
-                            .unwrap_or(false);
-                        let num_val = if is_bigint {
-                            self.to_bigint_value(&value)?
-                        } else {
-                            JsValue::number(self.to_number_value(&value)?)
-                        };
-                        let obj_ref = obj.borrow();
-                        let ta = obj_ref.typed_array_info().unwrap();
-                        if is_valid_integer_index(ta, index) {
-                            let ta_clone = ta.clone();
-                            drop(obj_ref);
-                            typed_array_set_index(&ta_clone, index as usize, &num_val);
-                        }
-                        return Ok(());
-                    }
-                    // Check own setter
-                    let desc = obj.borrow().get_own_property_full(&key);
-                    if let Some(ref d) = desc
-                        && let Some(ref setter) = d.set
-                        && !(setter).is_undefined()
-                    {
-                        let setter = setter.clone();
-                        let this = obj_val.clone();
-                        return match self.call_function(
-                            &setter,
-                            &this,
-                            std::slice::from_ref(&value),
-                        ) {
-                            Completion::Throw(e) => Err(e),
-                            _ => Ok(()),
-                        };
-                    }
-                    // OrdinarySet: walk prototype chain for setters
-                    if !obj.borrow().has_own_property(&key) {
-                        let mut proto_opt = obj.borrow().prototype_id;
-                        while let Some(proto_id) = proto_opt {
-                            let inherited = self.get_property_descriptor_on_id(proto_id, &key);
-                            if let Some(ref inherited_desc) = inherited {
-                                if inherited_desc.is_accessor_descriptor() {
-                                    if let Some(ref setter) = inherited_desc.set
-                                        && !(setter).is_undefined()
-                                    {
-                                        let setter = setter.clone();
-                                        let this = obj_val.clone();
-                                        return match self.call_function(
-                                            &setter,
-                                            &this,
-                                            std::slice::from_ref(&value),
-                                        ) {
-                                            Completion::Throw(e) => Err(e),
-                                            _ => Ok(()),
-                                        };
-                                    }
-                                    return Ok(());
-                                }
-                                break;
-                            }
-                            proto_opt = self.get_object_cell_expect(proto_id).borrow().prototype_id;
-                        }
-                    }
-                    self.gc_write_barrier_value(&obj, &value);
-                    obj.borrow_mut_untracked().set_property_value(&key, value);
-                }
-                Ok(())
+                let strict = env.borrow().strict;
+                self.set_object_with_key(obj_val, &key, value, strict)
             }
             _ => Ok(()),
         }
@@ -3245,19 +3146,19 @@ impl Interpreter {
                             key
                         )));
                     }
+                    let final_val = if op == AssignOp::Assign {
+                        rval
+                    } else {
+                        match self.apply_compound_assign(op, lval_for_compound.unwrap(), rval) {
+                            Completion::Normal(v) => v,
+                            other => return other,
+                        }
+                    };
                     if let Some(o) = (obj_val)
                         .as_object_id()
                         .map(|id| crate::types::JsObject { id })
                         && let Some(obj) = self.get_object(o.id)
                     {
-                        let final_val = if op == AssignOp::Assign {
-                            rval
-                        } else {
-                            match self.apply_compound_assign(op, lval_for_compound.unwrap(), rval) {
-                                Completion::Normal(v) => v,
-                                other => return other,
-                            }
-                        };
                         // Fast path for dense ordinary Array indexed writes: in-bounds
                         // overwrite or append-at-end directly into the backing Vec,
                         // bypassing the setter/prototype/Set machinery. Bails to the
@@ -3358,294 +3259,25 @@ impl Interpreter {
                                 // inherited index): fall through to the slow path.
                             }
                         }
-                        // Proxy set trap
-                        if obj.borrow().is_proxy() || obj.borrow().is_proxy_revoked() {
-                            let receiver = obj_val.clone();
-                            match self.proxy_set(o.id, &key, final_val.clone(), &receiver) {
-                                Ok(success) => {
-                                    if !success && env.borrow().strict {
-                                        return Completion::Throw(self.create_type_error(
-                                            &format!("Cannot assign to read only property '{key}'"),
-                                        ));
-                                    }
-                                    return Completion::Normal(final_val);
-                                }
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        }
-                        // Module namespace [[Set]] always returns false (§10.4.6.5)
-                        if obj.borrow().module_namespace().is_some() {
-                            if env.borrow().strict {
-                                return Completion::Throw(self.create_type_error(&format!(
-                                "Cannot assign to read only property '{key}' of object '[object Module]'"
-                            )));
-                            }
-                            return Completion::Normal(final_val);
-                        }
-                        // Check for setter — only own properties (prototype chain walked below with proxy support)
-                        let desc = obj.borrow().get_own_property_full(&key);
-                        if let Some(ref d) = desc
-                            && let Some(ref setter) = d.set
-                            && !(setter).is_undefined()
-                        {
-                            let setter = setter.clone();
-                            let this = obj_val.clone();
-                            return match self.call_function(
-                                &setter,
-                                &this,
-                                std::slice::from_ref(&final_val),
-                            ) {
-                                Completion::Normal(_) => Completion::Normal(final_val),
-                                other => other,
-                            };
-                        }
-                        if desc
-                            .as_ref()
-                            .map(|d| d.is_accessor_descriptor())
-                            .unwrap_or(false)
-                        {
-                            if env.borrow().strict {
-                                return Completion::Throw(self.create_type_error(&format!(
-                                    "Cannot set property '{key}' which has only a getter"
-                                )));
-                            }
-                            return Completion::Normal(final_val);
-                        }
-                        // TypedArray [[Set]]: ToNumber/ToBigInt before index check
-                        {
-                            let is_ta = obj.borrow().typed_array_info().is_some();
-                            if is_ta && let Some(index) = canonical_numeric_index_string(&key) {
-                                let is_bigint = obj
-                                    .borrow()
-                                    .typed_array_info()
-                                    .map(|ta| ta.kind.is_bigint())
-                                    .unwrap_or(false);
-                                // Convert value first (may throw)
-                                let num_val = if is_bigint {
-                                    match self.to_bigint_value(&final_val) {
-                                        Ok(v) => v,
-                                        Err(e) => return Completion::Throw(e),
-                                    }
-                                } else {
-                                    match self.to_number_value(&final_val) {
-                                        Ok(n) => JsValue::number(n),
-                                        Err(e) => return Completion::Throw(e),
-                                    }
-                                };
-                                let obj_ref = obj.borrow();
-                                let ta = obj_ref.typed_array_info().unwrap();
-                                if is_valid_integer_index(ta, index) {
-                                    let ta_clone = ta.clone();
-                                    drop(obj_ref);
-                                    typed_array_set_index(&ta_clone, index as usize, &num_val);
-                                }
-                                return Completion::Normal(final_val);
-                            }
-                        }
-                        // OrdinarySet (§10.1.9.2): if no own property, walk prototype chain
-                        if !obj.borrow().has_own_property(&key) {
-                            let mut proto_opt = obj.borrow().prototype_id;
-                            while let Some(proto_rc) = proto_opt {
-                                let proto_id = proto_rc;
-                                // TypedArray [[Set]] §10.4.5.5: canonical numeric index in TA prototype
-                                {
-                                    let proto_borrow =
-                                        self.get_object_cell_expect(proto_rc).borrow();
-                                    if let Some(ta) = proto_borrow.typed_array_info()
-                                        && let Some(index) = canonical_numeric_index_string(&key)
-                                        && !is_valid_integer_index(ta, index)
-                                    {
-                                        return Completion::Normal(final_val);
-                                    }
-                                    // Valid index: fall through to data descriptor path below
-                                }
-                                if self.has_proxy_in_prototype_chain(proto_id) {
-                                    let receiver = obj_val.clone();
-                                    match self.proxy_set(
-                                        proto_id,
-                                        &key,
-                                        final_val.clone(),
-                                        &receiver,
-                                    ) {
-                                        Ok(success) => {
-                                            if !success && env.borrow().strict {
-                                                return Completion::Throw(self.create_type_error(
-                                                &format!(
-                                                    "Cannot assign to read only property '{key}'"
-                                                ),
-                                            ));
-                                            }
-                                            return Completion::Normal(final_val);
-                                        }
-                                        Err(e) => return Completion::Throw(e),
-                                    }
-                                }
-                                let proto_id = proto_rc;
-                                let inherited = self.get_property_descriptor_on_id(proto_id, &key);
-                                if let Some(ref inherited_desc) = inherited {
-                                    if inherited_desc.is_data_descriptor() {
-                                        if inherited_desc.writable == Some(false) {
-                                            if env.borrow().strict {
-                                                return Completion::Throw(self.create_type_error(
-                                                &format!(
-                                                    "Cannot assign to read only property '{key}' of object '#<Object>'"
-                                                ),
-                                            ));
-                                            }
-                                            return Completion::Normal(final_val);
-                                        }
-                                        break;
-                                    }
-                                    if inherited_desc.is_accessor_descriptor() {
-                                        if let Some(ref setter) = inherited_desc.set
-                                            && !(setter).is_undefined()
-                                        {
-                                            let setter = setter.clone();
-                                            let this = obj_val.clone();
-                                            return match self.call_function(
-                                                &setter,
-                                                &this,
-                                                std::slice::from_ref(&final_val),
-                                            ) {
-                                                Completion::Normal(_) => {
-                                                    Completion::Normal(final_val)
-                                                }
-                                                other => other,
-                                            };
-                                        }
-                                        if env.borrow().strict {
-                                            return Completion::Throw(self.create_type_error(
-                                            &format!(
-                                                "Cannot set property '{key}' which has only a getter"
-                                            ),
-                                        ));
-                                        }
-                                        return Completion::Normal(final_val);
-                                    }
-                                    break;
-                                }
-                                proto_opt =
-                                    self.get_object_cell_expect(proto_rc).borrow().prototype_id;
-                            }
-                        }
-                        // ArraySetLength §10.4.2.4 via [[Set]]
-                        if key.eq_str("length") && obj.borrow().class_name == "Array" {
-                            let desc = PropertyDescriptor {
-                                value: Some(final_val.clone()),
-                                writable: None,
-                                enumerable: None,
-                                configurable: None,
-                                get: None,
-                                set: None,
-                            };
-                            match self.array_set_length(o.id as usize, desc) {
-                                Ok(success) => {
-                                    if !success && env.borrow().strict {
-                                        return Completion::Throw(self.create_type_error(
-                                            "Cannot assign to read only property 'length'",
-                                        ));
-                                    }
-                                    let obj_rc = self.get_object_cell(o.id).unwrap();
-                                    let len_val = obj_rc
-                                        .borrow()
-                                        .properties
-                                        .get("length")
-                                        .and_then(|d| d.value.clone())
-                                        .unwrap_or(JsValue::number(0.0));
-                                    return Completion::Normal(len_val);
-                                }
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        }
-                        self.gc_write_barrier_value(&obj, &final_val);
-                        let success = obj
-                            .borrow_mut_untracked()
-                            .set_property_value(&key, final_val.clone());
-                        if !success && env.borrow().strict {
-                            return Completion::Throw(self.create_type_error(&format!(
-                                "Cannot assign to read only property '{key}'"
-                            )));
-                        }
-                        if success && let Some(key) = key.as_str() {
-                            self.sync_global_object_binding(o.id, key, &final_val);
-                        }
-                        return Completion::Normal(final_val);
                     }
-                    // Primitive base: ToObject(base).[[Set]](key, val, primitiveBase)
-                    // Per §6.2.5.6 PutValue + §10.1.9.2 OrdinarySet:
-                    // The receiver is the original primitive. If a setter exists in
-                    // the prototype chain, call it. Otherwise [[Set]] returns false
-                    // (can't create own property on primitive receiver), so strict
-                    // mode throws TypeError and sloppy silently returns.
-                    let final_val = if op == AssignOp::Assign {
-                        rval
-                    } else {
-                        match self.apply_compound_assign(op, lval_for_compound.unwrap(), rval) {
-                            Completion::Normal(v) => v,
-                            other => return other,
-                        }
-                    };
                     let strict = env.borrow().strict;
-                    let wrapper = match self.to_object(&obj_val) {
-                        Completion::Normal(v) => v,
-                        Completion::Throw(e) => return Completion::Throw(e),
-                        _ => return Completion::Normal(final_val),
+                    let succeeded = match self.set_object_with_key_result(
+                        obj_val.clone(),
+                        &key,
+                        final_val.clone(),
+                        false,
+                    ) {
+                        Ok(succeeded) => succeeded,
+                        Err(e) => return Completion::Throw(e),
                     };
-                    if let Some(o) = (wrapper)
-                        .as_object_id()
-                        .map(|id| crate::types::JsObject { id })
-                    {
-                        // Walk prototype chain looking for setter or proxy set trap
-                        let desc = self.get_property_descriptor_on_id(o.id, &key);
-                        if let Some(ref d) = desc
-                            && let Some(ref setter) = d.set
-                            && !(setter).is_undefined()
-                        {
-                            let setter = setter.clone();
-                            return match self.call_function(
-                                &setter,
-                                &obj_val,
-                                std::slice::from_ref(&final_val),
-                            ) {
-                                Completion::Normal(_) => Completion::Normal(final_val),
-                                other => other,
-                            };
-                        }
-                        // Check for proxy in prototype chain
-                        if let Some(obj) = self.get_object_cell(o.id) {
-                            let mut proto_opt = obj.borrow().prototype_id;
-                            while let Some(proto_rc) = proto_opt {
-                                let proto_id = proto_rc;
-                                if self.get_proxy_info(proto_id).is_some() {
-                                    match self.proxy_set(
-                                        proto_id,
-                                        &key,
-                                        final_val.clone(),
-                                        &obj_val,
-                                    ) {
-                                        Ok(success) => {
-                                            if !success && strict {
-                                                return Completion::Throw(self.create_type_error(
-                                                &format!(
-                                                    "Cannot create property '{key}' on {obj_val}"
-                                                ),
-                                            ));
-                                            }
-                                            return Completion::Normal(final_val);
-                                        }
-                                        Err(e) => return Completion::Throw(e),
-                                    }
-                                }
-                                proto_opt =
-                                    self.get_object_cell_expect(proto_rc).borrow().prototype_id;
-                            }
-                        }
+                    if !succeeded && strict {
+                        return Completion::Throw(self.member_assignment_error(&obj_val, &key));
                     }
-                    // No setter found — [[Set]] returns false for primitive receiver
-                    if strict {
-                        return Completion::Throw(self.create_type_error(&format!(
-                            "Cannot create property '{key}' on {obj_val}"
-                        )));
+                    if succeeded
+                        && let Some(obj_id) = obj_val.as_object_id()
+                        && let Some(key) = key.as_str()
+                    {
+                        self.sync_global_object_binding(obj_id, key, &final_val);
                     }
                     Completion::Normal(final_val)
                 })();
@@ -3932,111 +3564,11 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                // Write back (boxed_obj is already the ToObject result)
-                if let Some(o) = (boxed_obj)
-                    .as_object_id()
-                    .map(|id| crate::types::JsObject { id })
-                    && let Some(obj) = self.get_object_cell(o.id)
+                let strict = env.borrow().strict;
+                if let Err(e) =
+                    self.set_object_with_key(obj_val.clone(), &key, rval.clone(), strict)
                 {
-                    if obj.borrow().is_proxy() || obj.borrow().is_proxy_revoked() {
-                        let receiver = boxed_obj.clone();
-                        match self.proxy_set(o.id, &key, rval.clone(), &receiver) {
-                            Ok(success) => {
-                                if !success && env.borrow().strict {
-                                    return Completion::Throw(self.create_type_error(&format!(
-                                        "Cannot assign to read only property '{key}'"
-                                    )));
-                                }
-                                return Completion::Normal(rval);
-                            }
-                            Err(e) => return Completion::Throw(e),
-                        }
-                    }
-                    let desc = self.get_property_descriptor_on_id(o.id, &key);
-                    if let Some(ref d) = desc
-                        && let Some(ref setter) = d.set
-                        && !(setter).is_undefined()
-                    {
-                        let setter = setter.clone();
-                        let this = boxed_obj.clone();
-                        return match self.call_function(&setter, &this, std::slice::from_ref(&rval))
-                        {
-                            Completion::Normal(_) => Completion::Normal(rval),
-                            other => other,
-                        };
-                    }
-                    if desc
-                        .as_ref()
-                        .map(|d| d.is_accessor_descriptor())
-                        .unwrap_or(false)
-                    {
-                        if env.borrow().strict {
-                            return Completion::Throw(self.create_type_error(&format!(
-                                "Cannot set property '{key}' which has only a getter"
-                            )));
-                        }
-                        return Completion::Normal(rval);
-                    }
-                    if !obj.borrow().has_own_property(&key) {
-                        let proto = obj.borrow().prototype_id;
-                        if let Some(proto_rc) = proto {
-                            let proto_id = proto_rc;
-                            if self.has_proxy_in_prototype_chain(proto_id) {
-                                let receiver = boxed_obj.clone();
-                                match self.proxy_set(proto_id, &key, rval.clone(), &receiver) {
-                                    Ok(success) => {
-                                        if !success && env.borrow().strict {
-                                            return Completion::Throw(self.create_type_error(
-                                                &format!(
-                                                    "Cannot assign to read only property '{key}'"
-                                                ),
-                                            ));
-                                        }
-                                        return Completion::Normal(rval);
-                                    }
-                                    Err(e) => return Completion::Throw(e),
-                                }
-                            }
-                        }
-                    }
-                    // ArraySetLength §10.4.2.4 via [[Set]]
-                    if key.eq_str("length") && obj.borrow().class_name == "Array" {
-                        let desc = PropertyDescriptor {
-                            value: Some(rval.clone()),
-                            writable: None,
-                            enumerable: None,
-                            configurable: None,
-                            get: None,
-                            set: None,
-                        };
-                        match self.array_set_length(o.id as usize, desc) {
-                            Ok(success) => {
-                                if !success && env.borrow().strict {
-                                    return Completion::Throw(self.create_type_error(
-                                        "Cannot assign to read only property 'length'",
-                                    ));
-                                }
-                                let obj_rc = self.get_object_cell(o.id).unwrap();
-                                let len_val = obj_rc
-                                    .borrow()
-                                    .properties
-                                    .get("length")
-                                    .and_then(|d| d.value.clone())
-                                    .unwrap_or(JsValue::number(0.0));
-                                return Completion::Normal(len_val);
-                            }
-                            Err(e) => return Completion::Throw(e),
-                        }
-                    }
-                    self.gc_write_barrier_value(obj, &rval);
-                    let success = obj
-                        .borrow_mut_untracked()
-                        .set_property_value(&key, rval.clone());
-                    if !success && env.borrow().strict {
-                        return Completion::Throw(self.create_type_error(&format!(
-                            "Cannot assign to read only property '{key}'"
-                        )));
-                    }
+                    return Completion::Throw(e);
                 }
                 Completion::Normal(rval)
             }
@@ -4171,7 +3703,17 @@ impl Interpreter {
         val: JsValue,
         strict: bool,
     ) -> Result<(), JsValue> {
-        let key = key.to_js_property_key();
+        self.set_object_with_key_result(obj_val, key, val, strict)
+            .map(|_| ())
+    }
+
+    fn set_object_with_key_result<K: PropertyKeyLike + ?Sized>(
+        &mut self,
+        obj_val: JsValue,
+        key: &K,
+        val: JsValue,
+        strict: bool,
+    ) -> Result<bool, JsValue> {
         // §6.2.5.6 PutValue: [[Set]] is invoked on ToObject(base), but the
         // receiver argument stays the original base value. For a primitive
         // base that means the receiver is never an object, so OrdinarySet's
@@ -4183,7 +3725,7 @@ impl Interpreter {
             match self.to_object(&obj_val) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => return Ok(()),
+                _ => return Ok(true),
             }
         } else {
             obj_val
@@ -4193,18 +3735,34 @@ impl Interpreter {
             .as_object_id()
             .map(|id| crate::types::JsObject { id })
         else {
-            return Ok(());
+            return Ok(true);
         };
-        let obj_id = o.id;
+        self.put_value_to_property(o.id, key, val, &receiver, strict)
+    }
+
+    /// Property-Reference branch of §6.2.5.6 PutValue after ToObject and
+    /// ToPropertyKey have identified the [[Set]] holder and property key.
+    ///
+    /// `receiver` is GetThisValue(reference): the original base for an
+    /// ordinary member Reference and the actual `this` for a Super Reference.
+    fn put_value_to_property<K: PropertyKeyLike + ?Sized>(
+        &mut self,
+        base_id: u64,
+        key: &K,
+        val: JsValue,
+        receiver: &JsValue,
+        strict: bool,
+    ) -> Result<bool, JsValue> {
+        let key = key.to_js_property_key();
         // Delegate to the canonical [[Set]] entry point: proxy `set` trap,
         // module-namespace reject, TypedArray integer-index set, accessor
         // setters, and the OrdinarySet prototype-chain walk all live in
         // `property.rs`.
-        let success = self.set_object_property(obj_id, &key, val, &receiver)?;
+        let success = self.set_object_property(base_id, &key, val, receiver)?;
         if !success && strict {
-            return Err(self.read_only_assignment_error(obj_id, &key));
+            return Err(self.read_only_assignment_error(base_id, &key));
         }
-        Ok(())
+        Ok(success)
     }
 
     /// Builds the strict-mode TypeError for a rejected [[Set]] on `obj_id`,
@@ -4235,6 +3793,38 @@ impl Interpreter {
             ));
         }
         self.create_type_error(&format!("Cannot assign to read only property '{key}'"))
+    }
+
+    /// Preserve the host-compatible diagnostics historically produced by the
+    /// plain member-assignment dispatcher after canonical [[Set]] rejects.
+    /// The rejection itself and all observable descriptor/proxy work have
+    /// already happened inside `property.rs`; this only formats the TypeError.
+    fn member_assignment_error(&mut self, base: &JsValue, key: &JsPropertyKey) -> JsValue {
+        let Some(obj_id) = base.as_object_id() else {
+            return self.create_type_error(&format!("Cannot create property '{key}' on {base}"));
+        };
+        let Some(cell) = self.get_object_cell(obj_id) else {
+            return self.create_type_error(&format!("Cannot assign to read only property '{key}'"));
+        };
+        if cell.borrow().module_namespace().is_some() {
+            return self.create_type_error(&format!(
+                "Cannot assign to read only property '{key}' of object '[object Module]'"
+            ));
+        }
+        let is_proxy = cell.borrow().is_proxy() || cell.borrow().is_proxy_revoked();
+        let has_own = cell.borrow().has_own_property(key);
+        if !is_proxy
+            && !has_own
+            && !self.has_proxy_in_prototype_chain(obj_id)
+            && self
+                .get_property_descriptor_on_id(obj_id, key)
+                .is_some_and(|desc| desc.is_data_descriptor() && desc.writable == Some(false))
+        {
+            return self.create_type_error(&format!(
+                "Cannot assign to read only property '{key}' of object '#<Object>'"
+            ));
+        }
+        self.read_only_assignment_error(obj_id, key)
     }
 
     fn set_member_property(
@@ -8361,8 +7951,7 @@ impl Interpreter {
         None
     }
 
-    /// OrdinarySet (§10.1.9) starting at `base_id` with a separate `receiver`.
-    /// Used for super property assignment: `super[key] = val`.
+    /// PutValue for a Super Reference, whose [[Set]] holder and receiver differ.
     fn super_set_property<K: PropertyKeyLike + ?Sized>(
         &mut self,
         base_id: u64,
@@ -8371,126 +7960,9 @@ impl Interpreter {
         receiver: &JsValue,
         strict: bool,
     ) -> Completion {
-        let key = key.to_js_property_key();
-        // Find the property descriptor starting from base_id, walking prototype chain.
-        // If we encounter a Proxy, delegate to proxy_set.
-        let mut current_id = Some(base_id);
-        let mut desc: Option<PropertyDescriptor> = None;
-        while let Some(id) = current_id {
-            if self.get_proxy_info(id).is_some() {
-                match self.proxy_set(id, &key, val.clone(), receiver) {
-                    Ok(success) => {
-                        if !success && strict {
-                            return Completion::Throw(self.create_type_error(&format!(
-                                "Cannot set property '{key}' on proxy"
-                            )));
-                        }
-                        return Completion::Normal(val);
-                    }
-                    Err(e) => return Completion::Throw(e),
-                }
-            }
-            if let Some(obj) = self.get_object_cell(id) {
-                desc = obj.borrow().get_own_property_full(&key);
-                if desc.is_some() {
-                    break;
-                }
-                current_id = obj.borrow().prototype_id.as_ref().copied();
-            } else {
-                break;
-            }
-        }
-
-        match &desc {
-            Some(d) if d.is_accessor_descriptor() => {
-                if let Some(ref setter) = d.set
-                    && !(setter).is_undefined()
-                {
-                    let setter = setter.clone();
-                    let recv = receiver.clone();
-                    return match self.call_function(&setter, &recv, std::slice::from_ref(&val)) {
-                        Completion::Normal(_) => Completion::Normal(val),
-                        other => other,
-                    };
-                }
-                if strict {
-                    return Completion::Throw(self.create_type_error(&format!(
-                        "Cannot set property '{key}' which has only a getter"
-                    )));
-                }
-                Completion::Normal(val)
-            }
-            Some(d) if d.is_data_descriptor() && d.writable == Some(false) => {
-                if strict {
-                    return Completion::Throw(self.create_type_error(&format!(
-                        "Cannot assign to read only property '{key}'"
-                    )));
-                }
-                Completion::Normal(val)
-            }
-            _ => {
-                // §10.1.9.2 OrdinarySetWithOwnDescriptor: set on Receiver
-                if let Some(o) = (receiver)
-                    .as_object_id()
-                    .map(|id| crate::types::JsObject { id })
-                    && let Some(obj) = self.get_object_cell(o.id)
-                {
-                    // Module namespace exotic receiver (§10.4.6):
-                    // OrdinarySetWithOwnDescriptor calls Receiver.[[GetOwnProperty]] before
-                    // attempting [[DefineOwnProperty]]. For a module namespace, that
-                    // [[GetOwnProperty]] (a) triggers deferred-module evaluation for
-                    // non-symbol-like keys, and (b) throws ReferenceError if the export
-                    // binding is uninitialized (TDZ). After both checks pass, [[Set]]
-                    // returns false (TypeError in strict).
-                    let is_ns = obj.borrow().module_namespace().is_some();
-                    if is_ns {
-                        if let Err(e) = self.check_namespace_tdz(o.id, &key) {
-                            return Completion::Throw(e);
-                        }
-                        if strict {
-                            return Completion::Throw(self.create_type_error(&format!(
-                                "Cannot assign to read only property '{key}' of module namespace"
-                            )));
-                        }
-                        return Completion::Normal(val);
-                    }
-                    let existing = obj.borrow().get_own_property_full(&key);
-                    match &existing {
-                        Some(ed) if ed.is_accessor_descriptor() => {
-                            if strict {
-                                return Completion::Throw(
-                                    self.create_type_error(&format!("Cannot set property '{key}'")),
-                                );
-                            }
-                            return Completion::Normal(val);
-                        }
-                        Some(ed) if ed.writable == Some(false) => {
-                            if strict {
-                                return Completion::Throw(self.create_type_error(&format!(
-                                    "Cannot assign to read only property '{key}'"
-                                )));
-                            }
-                            return Completion::Normal(val);
-                        }
-                        Some(_) => {
-                            let _ = obj.borrow_mut().set_property_value(&key, val.clone());
-                        }
-                        None => {
-                            // CreateDataProperty: checks extensibility
-                            if !obj.borrow().extensible {
-                                if strict {
-                                    return Completion::Throw(self.create_type_error(&format!(
-                                        "Cannot add property '{key}', object is not extensible"
-                                    )));
-                                }
-                                return Completion::Normal(val);
-                            }
-                            let _ = obj.borrow_mut().set_property_value(&key, val.clone());
-                        }
-                    }
-                }
-                Completion::Normal(val)
-            }
+        match self.put_value_to_property(base_id, key, val.clone(), receiver, strict) {
+            Ok(_) => Completion::Normal(val),
+            Err(e) => Completion::Throw(e),
         }
     }
 

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -2744,30 +2744,42 @@ impl Interpreter {
                 if let MemberProperty::Private(name) = prop {
                     return self.set_private_field(&obj_val, name, value, env);
                 }
-                let key = match prop {
-                    MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
-                    MemberProperty::Computed(cexpr) => {
-                        let v = match self.eval_expr(cexpr, env) {
-                            Completion::Normal(v) => v,
-                            Completion::Throw(e) => return Err(e),
-                            _ => return Ok(()),
-                        };
-                        self.to_property_key(&v)?
-                    }
-                    MemberProperty::Private(_) => unreachable!(),
-                };
-                if obj_val.is_null() || obj_val.is_undefined() {
-                    return Err(self.create_type_error(&format!(
-                        "Cannot set properties of {} (setting '{key}')",
-                        if obj_val.is_null() {
-                            "null"
-                        } else {
-                            "undefined"
+                // The base Reference and the value being written must survive
+                // the computed-key evaluation (arbitrary user code, plus
+                // ToPropertyKey) and PutValue. Both can reach a GC safepoint
+                // while these exist only as Rust locals, invisible to the
+                // tracing collector.
+                let gc_frame = self.gc_root_frame();
+                self.gc_root_value(&obj_val);
+                self.gc_root_value(&value);
+                let result = (|| {
+                    let key = match prop {
+                        MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
+                        MemberProperty::Computed(cexpr) => {
+                            let v = match self.eval_expr(cexpr, env) {
+                                Completion::Normal(v) => v,
+                                Completion::Throw(e) => return Err(e),
+                                _ => return Ok(()),
+                            };
+                            self.to_property_key(&v)?
                         }
-                    )));
-                }
-                let strict = env.borrow().strict;
-                self.set_object_with_key(obj_val, &key, value, strict)
+                        MemberProperty::Private(_) => unreachable!(),
+                    };
+                    if obj_val.is_null() || obj_val.is_undefined() {
+                        return Err(self.create_type_error(&format!(
+                            "Cannot set properties of {} (setting '{key}')",
+                            if obj_val.is_null() {
+                                "null"
+                            } else {
+                                "undefined"
+                            }
+                        )));
+                    }
+                    let strict = env.borrow().strict;
+                    self.set_object_with_key(obj_val, &key, value, strict)
+                })();
+                self.gc_unroot_frame(gc_frame);
+                result
             }
             _ => Ok(()),
         }
@@ -3273,11 +3285,25 @@ impl Interpreter {
                     if !succeeded && strict {
                         return Completion::Throw(self.member_assignment_error(&obj_val, &key));
                     }
+                    // Mirror the write into the matching global environment
+                    // binding only when [[Set]] actually stored `final_val` as
+                    // an own data property of the base. An accessor, a Proxy
+                    // trap, or an inherited setter can store something else (or
+                    // nothing), and copying the RHS into the binding would
+                    // desynchronise the global lexical scope from the object.
                     if succeeded
                         && let Some(obj_id) = obj_val.as_object_id()
-                        && let Some(key) = key.as_str()
+                        && let Some(key_str) = key.as_str()
+                        && self.is_realm_global_object(obj_id)
+                        && self.get_object_cell(obj_id).is_some_and(|cell| {
+                            let b = cell.borrow();
+                            !b.is_proxy()
+                                && !b.is_proxy_revoked()
+                                && b.get_own_property(&key)
+                                    .is_some_and(|d| d.is_data_descriptor())
+                        })
                     {
-                        self.sync_global_object_binding(obj_id, key, &final_val);
+                        self.sync_global_object_binding(obj_id, key_str, &final_val);
                     }
                     Completion::Normal(final_val)
                 })();
@@ -3446,6 +3472,14 @@ impl Interpreter {
                 if matches!(obj_expr.as_ref(), Expression::Super)
                     && !matches!(prop, MemberProperty::Private(_))
                 {
+                    // §13.3.7.3 step 2: GetThisEnvironment().GetThisBinding()
+                    // runs before the key expression and throws for an
+                    // uninitialized `this` in a derived constructor.
+                    if Self::this_is_in_tdz(env) {
+                        return Completion::Throw(self.create_reference_error(
+                            "Must call super constructor in derived class before accessing 'this' or returning from derived constructor",
+                        ));
+                    }
                     let this_val = env.borrow().get("this").unwrap_or(JsValue::UNDEFINED);
                     let raw_key = match prop {
                         MemberProperty::Dot(name) => {
@@ -3495,82 +3529,99 @@ impl Interpreter {
                     Completion::Normal(v) => v,
                     other => return other,
                 };
-                // Evaluate key expression (but defer ToPropertyKey for null/undefined base)
-                let key_expr_val = match prop {
-                    MemberProperty::Computed(expr) => {
-                        let v = match self.eval_expr(expr, env) {
+                // The base Reference — and, for a primitive base, the ToObject
+                // wrapper GetValue and PutValue share — must survive the
+                // computed-key evaluation, the getter, the right-hand side, and
+                // the write-back. Each of those can hit a GC safepoint while
+                // these values exist only as Rust locals, invisible to the
+                // tracing collector.
+                let gc_frame = self.gc_root_frame();
+                self.gc_root_value(&obj_val);
+                let result = (|| {
+                    // Evaluate key expression (but defer ToPropertyKey for null/undefined base)
+                    let key_expr_val = match prop {
+                        MemberProperty::Computed(expr) => {
+                            let v = match self.eval_expr(expr, env) {
+                                Completion::Normal(v) => v,
+                                other => return other,
+                            };
+                            Some(v)
+                        }
+                        _ => None,
+                    };
+                    // GetValue: ToObject(base) first, then ToPropertyKey
+                    let (boxed_obj, key) = if obj_val.is_object() {
+                        let key = match prop {
+                            MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
+                            MemberProperty::Computed(_) => {
+                                match self.to_property_key(key_expr_val.as_ref().unwrap()) {
+                                    Ok(s) => s,
+                                    Err(e) => return Completion::Throw(e),
+                                }
+                            }
+                            MemberProperty::Private(_) => unreachable!(),
+                        };
+                        (obj_val.clone(), key)
+                    } else {
+                        let boxed = match self.to_object(&obj_val) {
+                            Completion::Normal(v) => v,
+                            Completion::Throw(e) => return Completion::Throw(e),
+                            _ => return Completion::Normal(JsValue::UNDEFINED),
+                        };
+                        self.gc_root_value(&boxed);
+                        let key = match prop {
+                            MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
+                            MemberProperty::Computed(_) => {
+                                match self.to_property_key(key_expr_val.as_ref().unwrap()) {
+                                    Ok(s) => s,
+                                    Err(e) => return Completion::Throw(e),
+                                }
+                            }
+                            MemberProperty::Private(_) => unreachable!(),
+                        };
+                        (boxed, key)
+                    };
+                    let base_id = boxed_obj.as_object_id();
+                    let lval = if let Some(base_id) = base_id {
+                        match self.get_object_property(base_id, &key, &obj_val) {
                             Completion::Normal(v) => v,
                             other => return other,
-                        };
-                        Some(v)
+                        }
+                    } else {
+                        JsValue::UNDEFINED
+                    };
+                    let should_assign = match op {
+                        AssignOp::LogicalAndAssign => self.to_boolean_val(&lval),
+                        AssignOp::LogicalOrAssign => !self.to_boolean_val(&lval),
+                        AssignOp::NullishAssign => lval.is_null() || lval.is_undefined(),
+                        _ => unreachable!(),
+                    };
+                    if !should_assign {
+                        return Completion::Normal(lval);
                     }
-                    _ => None,
-                };
-                // GetValue: ToObject(base) first, then ToPropertyKey
-                let (boxed_obj, key) = if let Some(_o) = (obj_val)
-                    .as_object_id()
-                    .map(|id| crate::types::JsObject { id })
-                {
-                    let key = match prop {
-                        MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
-                        MemberProperty::Computed(_) => {
-                            match self.to_property_key(key_expr_val.as_ref().unwrap()) {
-                                Ok(s) => s,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        }
-                        MemberProperty::Private(_) => unreachable!(),
-                    };
-                    (obj_val.clone(), key)
-                } else {
-                    let boxed = match self.to_object(&obj_val) {
-                        Completion::Normal(v) => v,
-                        Completion::Throw(e) => return Completion::Throw(e),
-                        _ => return Completion::Normal(JsValue::UNDEFINED),
-                    };
-                    let key = match prop {
-                        MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
-                        MemberProperty::Computed(_) => {
-                            match self.to_property_key(key_expr_val.as_ref().unwrap()) {
-                                Ok(s) => s,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        }
-                        MemberProperty::Private(_) => unreachable!(),
-                    };
-                    (boxed, key)
-                };
-                let lval = if let Some(o) = (boxed_obj)
-                    .as_object_id()
-                    .map(|id| crate::types::JsObject { id })
-                {
-                    match self.get_object_property(o.id, &key, &obj_val) {
+                    let rval = match self.eval_expr(right, env) {
                         Completion::Normal(v) => v,
                         other => return other,
+                    };
+                    // §6.2.5.6 PutValue: [[Set]] runs on ToObject(base) with the
+                    // original base as receiver. `boxed_obj` already is that
+                    // ToObject result, so reuse it instead of boxing again.
+                    let strict = env.borrow().strict;
+                    if let Some(base_id) = base_id
+                        && let Err(e) = self.put_value_to_property(
+                            base_id,
+                            &key,
+                            rval.clone(),
+                            &obj_val,
+                            strict,
+                        )
+                    {
+                        return Completion::Throw(e);
                     }
-                } else {
-                    JsValue::UNDEFINED
-                };
-                let should_assign = match op {
-                    AssignOp::LogicalAndAssign => self.to_boolean_val(&lval),
-                    AssignOp::LogicalOrAssign => !self.to_boolean_val(&lval),
-                    AssignOp::NullishAssign => lval.is_null() || lval.is_undefined(),
-                    _ => unreachable!(),
-                };
-                if !should_assign {
-                    return Completion::Normal(lval);
-                }
-                let rval = match self.eval_expr(right, env) {
-                    Completion::Normal(v) => v,
-                    other => return other,
-                };
-                let strict = env.borrow().strict;
-                if let Err(e) =
-                    self.set_object_with_key(obj_val.clone(), &key, rval.clone(), strict)
-                {
-                    return Completion::Throw(e);
-                }
-                Completion::Normal(rval)
+                    Completion::Normal(rval)
+                })();
+                self.gc_unroot_frame(gc_frame);
+                result
             }
             Expression::Sequence(exprs)
                 if exprs.len() == 1 && matches!(&exprs[0], Expression::Identifier(_)) =>
@@ -3760,6 +3811,14 @@ impl Interpreter {
         // `property.rs`.
         let success = self.set_object_property(base_id, &key, val, receiver)?;
         if !success && strict {
+            // A non-object receiver never rejects because of a read-only
+            // property: OrdinarySet bails at "Receiver is not an Object", and
+            // `base_id` is only the throwaway ToObject wrapper, so describing
+            // its descriptors would be misleading.
+            if !receiver.is_object() {
+                return Err(self
+                    .create_type_error(&format!("Cannot create property '{key}' on {receiver}")));
+            }
             return Err(self.read_only_assignment_error(base_id, &key));
         }
         Ok(success)
@@ -3970,22 +4029,34 @@ impl Interpreter {
             return self.set_private_field(&obj_val, name, val, env);
         }
 
-        let key = match prop {
-            MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
-            MemberProperty::Computed(expr) => {
-                let v = match self.eval_expr(expr, env) {
-                    Completion::Normal(v) => v,
-                    Completion::Throw(e) => return Err(e),
-                    _ => return Ok(()),
-                };
-                self.to_property_key(&v)?
-            }
-            MemberProperty::Private(_) => unreachable!(),
-        };
+        // The base Reference and the value being written must survive the
+        // computed-key evaluation (arbitrary user code, plus ToPropertyKey) and
+        // PutValue. Both can reach a GC safepoint while these exist only as
+        // Rust locals, invisible to the tracing collector.
+        let gc_frame = self.gc_root_frame();
+        self.gc_root_value(&obj_val);
+        self.gc_root_value(&val);
+        let result = (|| {
+            let key = match prop {
+                MemberProperty::Dot(name) => JsPropertyKey::from(name.clone()),
+                MemberProperty::Computed(expr) => {
+                    let v = match self.eval_expr(expr, env) {
+                        Completion::Normal(v) => v,
+                        Completion::Throw(e) => return Err(e),
+                        _ => return Ok(()),
+                    };
+                    self.to_property_key(&v)?
+                }
+                MemberProperty::Private(_) => unreachable!(),
+            };
 
-        let strict = env.borrow().strict;
-        self.set_object_with_key(obj_val, &key, val, strict)
+            let strict = env.borrow().strict;
+            self.set_object_with_key(obj_val, &key, val, strict)
+        })();
+        self.gc_unroot_frame(gc_frame);
+        result
     }
+
     pub(crate) fn assign_to_for_pattern(
         &mut self,
         pat: &crate::ast::Pattern,
@@ -7647,6 +7718,14 @@ impl Interpreter {
             Ok(()) => Completion::Normal(value),
             Err(_) => Completion::Throw(self.create_type_error("Assignment to constant variable.")),
         }
+    }
+
+    /// Whether `obj_id` is some realm's global object — the only case in which
+    /// a property write has a global environment binding to mirror.
+    fn is_realm_global_object(&self, obj_id: u64) -> bool {
+        self.realms
+            .iter()
+            .any(|realm| realm.global_object == Some(obj_id))
     }
 
     /// Sync a property set on an object to the corresponding global env binding,

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ast::{CallSiteId, PropSiteId};
+use crate::interpreter::property::SetOutcome;
 
 mod access;
 mod generator_runtime;
@@ -3281,7 +3282,7 @@ impl Interpreter {
                         }
                     }
                     let strict = env.borrow().strict;
-                    let succeeded = match self.set_object_with_key_result(
+                    let set_outcome = match self.set_object_with_key_result(
                         obj_val.clone(),
                         &key,
                         final_val.clone(),
@@ -3290,15 +3291,15 @@ impl Interpreter {
                         Ok(succeeded) => succeeded,
                         Err(e) => return Completion::Throw(e),
                     };
-                    if !succeeded && strict {
+                    if !set_outcome.succeeded() && strict {
                         return Completion::Throw(self.member_assignment_error(&obj_val, &key));
                     }
                     // The realm test comes before `as_str`, which validates the
                     // whole key as UTF-8: it is both cheaper and false for
                     // essentially every write in a real program.
-                    if succeeded
-                        && let Some(obj_id) = obj_val.as_object_id()
-                        && self.write_mirrors_global_binding(obj_id, &key)
+                    if let Some(obj_id) = obj_val.as_object_id()
+                        && set_outcome.wrote_own_data_property_on(obj_id)
+                        && self.is_realm_global_object(obj_id)
                         && let Some(key_str) = key.as_str()
                     {
                         self.sync_global_object_binding(obj_id, key_str, &final_val);
@@ -3762,7 +3763,7 @@ impl Interpreter {
         key: &K,
         val: JsValue,
         strict: bool,
-    ) -> Result<bool, JsValue> {
+    ) -> Result<SetOutcome, JsValue> {
         // §6.2.5.6 PutValue: [[Set]] is invoked on ToObject(base), but the
         // receiver argument stays the original base value. For a primitive
         // base that means the receiver is never an object, so OrdinarySet's
@@ -3778,14 +3779,14 @@ impl Interpreter {
             match self.to_object(&obj_val) {
                 Completion::Normal(v) => v,
                 Completion::Throw(e) => return Err(e),
-                _ => return Ok(true),
+                _ => return Ok(SetOutcome::Succeeded),
             }
         } else {
             obj_val
         };
 
         let Some(base_id) = obj_val.as_object_id() else {
-            return Ok(true);
+            return Ok(SetOutcome::Succeeded);
         };
         self.put_value_to_property(base_id, key, val, &receiver, strict)
     }
@@ -3802,15 +3803,15 @@ impl Interpreter {
         val: JsValue,
         receiver: &JsValue,
         strict: bool,
-    ) -> Result<bool, JsValue> {
+    ) -> Result<SetOutcome, JsValue> {
         // Delegate to the canonical [[Set]] entry point: proxy `set` trap,
         // module-namespace reject, TypedArray integer-index set, accessor
         // setters, and the OrdinarySet prototype-chain walk all live in
         // `property.rs`. It is generic over the key, so only the error path
         // below needs an owned `JsPropertyKey` — converting here would allocate
         // on every write reached with a `&str` key.
-        let success = self.set_object_property(base_id, key, val, receiver)?;
-        if !success && strict {
+        let outcome = self.set_object_property_with_outcome(base_id, key, val, receiver)?;
+        if !outcome.succeeded() && strict {
             let key = key.to_js_property_key();
             // A non-object receiver never rejects because of a read-only
             // property: OrdinarySet bails at "Receiver is not an Object", and
@@ -3821,7 +3822,7 @@ impl Interpreter {
             }
             return Err(self.read_only_assignment_error(base_id, &key));
         }
-        Ok(success)
+        Ok(outcome)
     }
 
     /// The strict-mode TypeError for a [[Set]] rejected at OrdinarySet's
@@ -7749,26 +7750,12 @@ impl Interpreter {
         }
     }
 
-    /// Whether a just-succeeded [[Set]] of `key` on `obj_id` is one the global
-    /// environment must mirror: `obj_id` has to be some realm's global object
-    /// (the only case with a binding to mirror at all), and [[Set]] has to have
-    /// left the right-hand value there as an own data property. An accessor, a
-    /// Proxy trap, or an inherited setter can store something else — or nothing
-    /// — and copying the RHS into the binding would desynchronise the global
-    /// lexical scope from the object.
-    ///
-    /// The realm test is first: it is the cheap, highly selective one.
-    fn write_mirrors_global_binding(&self, obj_id: u64, key: &JsPropertyKey) -> bool {
+    /// Whether `obj_id` is some realm's global object — the only case in which
+    /// a property write has a global environment binding to mirror.
+    fn is_realm_global_object(&self, obj_id: u64) -> bool {
         self.realms
             .iter()
             .any(|realm| realm.global_object == Some(obj_id))
-            && self.get_object_cell(obj_id).is_some_and(|cell| {
-                let b = cell.borrow();
-                !b.is_proxy()
-                    && !b.is_proxy_revoked()
-                    && b.get_own_property(key)
-                        .is_some_and(|d| d.is_data_descriptor())
-            })
     }
 
     /// Sync a property set on an object to the corresponding global env binding,

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -27,6 +27,17 @@ pub(super) enum IdentifierRef {
     SpecificEnv(EnvRef),
 }
 
+/// The state a rejected-[[Set]] diagnostic is chosen from, gathered once by
+/// `Interpreter::set_rejection_facts`. `[[Set]]` has already decided and
+/// discarded its reason by the time a message is needed, so the assignment
+/// paths re-derive it here rather than each walking the prototype chain again.
+struct SetRejection {
+    is_module_namespace: bool,
+    has_own: bool,
+    /// `None` when the lookup was skipped because a proxy is involved.
+    desc: Option<PropertyDescriptor>,
+}
+
 /// Pre-evaluated lref for destructuring assignment targets.
 /// ToPropertyKey is deferred to PutValue time per spec §13.15.5.
 enum DestructLRef {
@@ -3166,110 +3177,107 @@ impl Interpreter {
                             other => return other,
                         }
                     };
-                    if let Some(o) = (obj_val)
-                        .as_object_id()
-                        .map(|id| crate::types::JsObject { id })
-                        && let Some(obj) = self.get_object(o.id)
+                    // Fast path for dense ordinary Array indexed writes: in-bounds
+                    // overwrite or append-at-end directly into the backing Vec,
+                    // bypassing the setter/prototype/Set machinery. Bails to the
+                    // slow path on holes, length mismatch, frozen/sealed/non-
+                    // -writable-length, non-extensible, proxies, or shadowed
+                    // indices so strict-throw and exotic behaviour stay correct.
+                    //
+                    // NB: in this engine `JsValue::UNDEFINED` in `array_elements`
+                    // (with no `properties` entry) is the HOLE sentinel (see
+                    // `has_own_property`/`get_own_property_full`). The fast path
+                    // therefore must not (a) treat an `Undefined` slot as a live
+                    // element to overwrite, nor (b) store `undefined` as a present
+                    // element without the `properties` presence marker the slow
+                    // path adds — doing either materialises/leaves a hole with the
+                    // wrong own-property state. Both cases bail to the slow path.
+                    //
+                    // The key and value tests gate the arena lookup: both are
+                    // pure and allocation-free, so a non-index write never pays
+                    // for an object handle it would immediately drop.
+                    if !(final_val).is_undefined()
+                        && let Some(idx_u32) = parse_array_index(&key)
+                        && let Some(obj_id) = obj_val.as_object_id()
+                        && let Some(obj) = self.get_object(obj_id)
                     {
-                        // Fast path for dense ordinary Array indexed writes: in-bounds
-                        // overwrite or append-at-end directly into the backing Vec,
-                        // bypassing the setter/prototype/Set machinery. Bails to the
-                        // slow path on holes, length mismatch, frozen/sealed/non-
-                        // -writable-length, non-extensible, proxies, or shadowed
-                        // indices so strict-throw and exotic behaviour stay correct.
-                        //
-                        // NB: in this engine `JsValue::UNDEFINED` in `array_elements`
-                        // (with no `properties` entry) is the HOLE sentinel (see
-                        // `has_own_property`/`get_own_property_full`). The fast path
-                        // therefore must not (a) treat an `Undefined` slot as a live
-                        // element to overwrite, nor (b) store `undefined` as a present
-                        // element without the `properties` presence marker the slow
-                        // path adds — doing either materialises/leaves a hole with the
-                        // wrong own-property state. Both cases bail to the slow path.
-                        if let Some(idx_u32) = parse_array_index(&key)
-                            && !(final_val).is_undefined()
-                        {
-                            let fast = {
-                                let b = obj.borrow();
-                                if b.class_name == "Array"
-                                    && !b.is_proxy()
-                                    && b.array_elements().is_some()
-                                    && !b.properties.contains_key(&key)
-                                {
-                                    let elems = b.array_elements().unwrap();
-                                    let elems_len = elems.len();
-                                    let idx = idx_u32 as usize;
-                                    // Overwrite is only sound on a genuinely live slot
-                                    // (not the hole sentinel).
-                                    let slot_is_hole =
-                                        idx < elems_len && (elems[idx]).is_undefined();
-                                    let len_desc = b.properties.get("length");
-                                    let cur_len = len_desc
-                                        .and_then(|d| d.value.as_ref())
-                                        .and_then(|v| (v).as_number().map(|n| n as u32))
-                                        .unwrap_or(0);
-                                    let length_writable = len_desc
-                                        .map(|d| d.writable != Some(false))
-                                        .unwrap_or(false);
-                                    Some((
-                                        elems_len,
-                                        cur_len,
-                                        length_writable,
-                                        b.extensible,
-                                        slot_is_hole,
-                                        b.prototype_id,
-                                    ))
-                                } else {
-                                    None
-                                }
-                            };
-                            if let Some((
-                                elems_len,
-                                cur_len,
-                                length_writable,
-                                extensible,
-                                slot_is_hole,
-                                proto_id,
-                            )) = fast
+                        let fast = {
+                            let b = obj.borrow();
+                            if b.class_name == "Array"
+                                && !b.is_proxy()
+                                && b.array_elements().is_some()
+                                && !b.properties.contains_key(&key)
                             {
+                                let elems = b.array_elements().unwrap();
+                                let elems_len = elems.len();
                                 let idx = idx_u32 as usize;
-                                if idx < elems_len && !slot_is_hole {
-                                    // In-bounds overwrite of a live slot: no length /
-                                    // extensible / shape / prototype involvement.
-                                    obj.borrow_mut().array_elements_mut().unwrap()[idx] =
-                                        final_val.clone();
-                                    return Completion::Normal(final_val);
-                                } else if idx == elems_len
-                                && idx_u32 >= cur_len
-                                && cur_len as usize == elems_len
-                                && extensible
-                                && length_writable
-                                && idx_u32 < 0xFFFF_FFFF
-                                // OrdinarySet walks the prototype chain when the
-                                // receiver has no own property for this index.
-                                // If the index ToString is inherited (setter or
-                                // data), or a Proxy sits anywhere in the chain,
-                                // we must honour the proto via the slow path's
-                                // OrdinarySet/proxy_set — a bare Proxy exposes no
-                                // own descriptor here, so check it explicitly.
-                                && !proto_id.is_some_and(|pid| {
-                                    self.has_proxy_in_prototype_chain(pid)
-                                        || self.get_property_descriptor_on_id(pid, &key).is_some()
-                                }) {
-                                    // Append at end: push and bump length + shape.
-                                    let mut b = obj.borrow_mut();
-                                    b.array_elements_mut().unwrap().push(final_val.clone());
-                                    if let Some(len_desc) = b.properties.get_mut("length") {
-                                        len_desc.value =
-                                            Some(JsValue::number((idx_u32 + 1) as f64));
-                                    }
-                                    b.shape_id = crate::interpreter::types::fresh_shape_id();
-                                    return Completion::Normal(final_val);
-                                }
-                                // Otherwise (hole creation/overwrite, length mismatch,
-                                // frozen/sealed/non-writable-length, non-extensible,
-                                // inherited index): fall through to the slow path.
+                                // Overwrite is only sound on a genuinely live slot
+                                // (not the hole sentinel).
+                                let slot_is_hole = idx < elems_len && (elems[idx]).is_undefined();
+                                let len_desc = b.properties.get("length");
+                                let cur_len = len_desc
+                                    .and_then(|d| d.value.as_ref())
+                                    .and_then(|v| (v).as_number().map(|n| n as u32))
+                                    .unwrap_or(0);
+                                let length_writable =
+                                    len_desc.map(|d| d.writable != Some(false)).unwrap_or(false);
+                                Some((
+                                    elems_len,
+                                    cur_len,
+                                    length_writable,
+                                    b.extensible,
+                                    slot_is_hole,
+                                    b.prototype_id,
+                                ))
+                            } else {
+                                None
                             }
+                        };
+                        if let Some((
+                            elems_len,
+                            cur_len,
+                            length_writable,
+                            extensible,
+                            slot_is_hole,
+                            proto_id,
+                        )) = fast
+                        {
+                            let idx = idx_u32 as usize;
+                            if idx < elems_len && !slot_is_hole {
+                                // In-bounds overwrite of a live slot: no length /
+                                // extensible / shape / prototype involvement.
+                                obj.borrow_mut().array_elements_mut().unwrap()[idx] =
+                                    final_val.clone();
+                                return Completion::Normal(final_val);
+                            } else if idx == elems_len
+                            && idx_u32 >= cur_len
+                            && cur_len as usize == elems_len
+                            && extensible
+                            && length_writable
+                            && idx_u32 < 0xFFFF_FFFF
+                            // OrdinarySet walks the prototype chain when the
+                            // receiver has no own property for this index.
+                            // If the index ToString is inherited (setter or
+                            // data), or a Proxy sits anywhere in the chain,
+                            // we must honour the proto via the slow path's
+                            // OrdinarySet/proxy_set — a bare Proxy exposes no
+                            // own descriptor here, so check it explicitly.
+                            && !proto_id.is_some_and(|pid| {
+                                self.has_proxy_in_prototype_chain(pid)
+                                    || self.get_property_descriptor_on_id(pid, &key).is_some()
+                            }) {
+                                // Append at end: push and bump length + shape.
+                                let mut b = obj.borrow_mut();
+                                b.array_elements_mut().unwrap().push(final_val.clone());
+                                if let Some(len_desc) = b.properties.get_mut("length") {
+                                    len_desc.value = Some(JsValue::number((idx_u32 + 1) as f64));
+                                }
+                                b.shape_id = crate::interpreter::types::fresh_shape_id();
+                                return Completion::Normal(final_val);
+                            }
+                            // Otherwise (hole creation/overwrite, length mismatch,
+                            // frozen/sealed/non-writable-length, non-extensible,
+                            // inherited index): fall through to the slow path.
                         }
                     }
                     let strict = env.borrow().strict;
@@ -3285,23 +3293,13 @@ impl Interpreter {
                     if !succeeded && strict {
                         return Completion::Throw(self.member_assignment_error(&obj_val, &key));
                     }
-                    // Mirror the write into the matching global environment
-                    // binding only when [[Set]] actually stored `final_val` as
-                    // an own data property of the base. An accessor, a Proxy
-                    // trap, or an inherited setter can store something else (or
-                    // nothing), and copying the RHS into the binding would
-                    // desynchronise the global lexical scope from the object.
+                    // The realm test comes before `as_str`, which validates the
+                    // whole key as UTF-8: it is both cheaper and false for
+                    // essentially every write in a real program.
                     if succeeded
                         && let Some(obj_id) = obj_val.as_object_id()
+                        && self.write_mirrors_global_binding(obj_id, &key)
                         && let Some(key_str) = key.as_str()
-                        && self.is_realm_global_object(obj_id)
-                        && self.get_object_cell(obj_id).is_some_and(|cell| {
-                            let b = cell.borrow();
-                            !b.is_proxy()
-                                && !b.is_proxy_revoked()
-                                && b.get_own_property(&key)
-                                    .is_some_and(|d| d.is_data_descriptor())
-                        })
                     {
                         self.sync_global_object_binding(obj_id, key_str, &final_val);
                     }
@@ -3771,7 +3769,11 @@ impl Interpreter {
         // "Receiver is not an Object" rejection (§10.1.9.2 step 3) applies —
         // capture it before boxing, not after.
         let receiver = obj_val.clone();
-        // Auto-box primitives for property access.
+        // Auto-box primitives for property access. The two bail-outs below
+        // yield `true` in the sense of "no rejection to report" — [[Set]] never
+        // ran, so there is nothing for a strict caller to throw about. Neither
+        // is reachable today: `to_object` on a non-object always completes
+        // normally with an object.
         let obj_val = if !(obj_val).is_object() {
             match self.to_object(&obj_val) {
                 Completion::Normal(v) => v,
@@ -3782,13 +3784,10 @@ impl Interpreter {
             obj_val
         };
 
-        let Some(o) = (obj_val)
-            .as_object_id()
-            .map(|id| crate::types::JsObject { id })
-        else {
+        let Some(base_id) = obj_val.as_object_id() else {
             return Ok(true);
         };
-        self.put_value_to_property(o.id, key, val, &receiver, strict)
+        self.put_value_to_property(base_id, key, val, &receiver, strict)
     }
 
     /// Property-Reference branch of §6.2.5.6 PutValue after ToObject and
@@ -3804,24 +3803,32 @@ impl Interpreter {
         receiver: &JsValue,
         strict: bool,
     ) -> Result<bool, JsValue> {
-        let key = key.to_js_property_key();
         // Delegate to the canonical [[Set]] entry point: proxy `set` trap,
         // module-namespace reject, TypedArray integer-index set, accessor
         // setters, and the OrdinarySet prototype-chain walk all live in
-        // `property.rs`.
-        let success = self.set_object_property(base_id, &key, val, receiver)?;
+        // `property.rs`. It is generic over the key, so only the error path
+        // below needs an owned `JsPropertyKey` — converting here would allocate
+        // on every write reached with a `&str` key.
+        let success = self.set_object_property(base_id, key, val, receiver)?;
         if !success && strict {
+            let key = key.to_js_property_key();
             // A non-object receiver never rejects because of a read-only
             // property: OrdinarySet bails at "Receiver is not an Object", and
             // `base_id` is only the throwaway ToObject wrapper, so describing
             // its descriptors would be misleading.
             if !receiver.is_object() {
-                return Err(self
-                    .create_type_error(&format!("Cannot create property '{key}' on {receiver}")));
+                return Err(self.non_object_receiver_error(receiver, &key));
             }
             return Err(self.read_only_assignment_error(base_id, &key));
         }
         Ok(success)
+    }
+
+    /// The strict-mode TypeError for a [[Set]] rejected at OrdinarySet's
+    /// "Receiver is not an Object" step (§10.1.9.2 step 3): no own property can
+    /// be created on a primitive, so the write simply cannot land.
+    fn non_object_receiver_error(&mut self, receiver: &JsValue, key: &JsPropertyKey) -> JsValue {
+        self.create_type_error(&format!("Cannot create property '{key}' on {receiver}"))
     }
 
     /// Builds the strict-mode TypeError for a rejected [[Set]] on `obj_id`,
@@ -3831,27 +3838,53 @@ impl Interpreter {
     /// is skipped when a proxy sits on the object or its prototype chain, so no
     /// trap is re-invoked on the error path.
     fn read_only_assignment_error(&mut self, obj_id: u64, key: &JsPropertyKey) -> JsValue {
-        let Some(cell) = self.get_object_cell(obj_id) else {
-            return self.create_type_error(&format!("Cannot assign to read only property '{key}'"));
+        let facts = self.set_rejection_facts(obj_id, key);
+        self.read_only_assignment_error_from(facts.as_ref(), key)
+    }
+
+    /// Reads, exactly once, every fact the two rejection formatters below
+    /// select a message from. Returns `None` when `obj_id` names no live
+    /// object, which both formatters report as the undecorated message.
+    ///
+    /// `desc` is deliberately left `None` when a proxy sits on the object or
+    /// its prototype chain, so no trap is re-invoked on the error path.
+    fn set_rejection_facts(&mut self, obj_id: u64, key: &JsPropertyKey) -> Option<SetRejection> {
+        let cell = self.get_object_cell(obj_id)?;
+        let (is_module_namespace, is_proxy, has_own) = {
+            let b = cell.borrow();
+            (
+                b.module_namespace().is_some(),
+                b.is_proxy() || b.is_proxy_revoked(),
+                b.has_own_property(key),
+            )
         };
-        let is_module_ns = cell.borrow().module_namespace().is_some();
-        let is_proxy = cell.borrow().is_proxy() || cell.borrow().is_proxy_revoked();
-        if is_module_ns {
-            return self.create_type_error(&format!(
+        let desc = if is_proxy || self.has_proxy_in_prototype_chain(obj_id) {
+            None
+        } else {
+            self.get_property_descriptor_on_id(obj_id, key)
+        };
+        Some(SetRejection {
+            is_module_namespace,
+            has_own,
+            desc,
+        })
+    }
+
+    fn read_only_assignment_error_from(
+        &mut self,
+        facts: Option<&SetRejection>,
+        key: &JsPropertyKey,
+    ) -> JsValue {
+        match facts {
+            Some(f) if f.is_module_namespace => self.create_type_error(&format!(
                 "Cannot assign to read only property '{key}' of module namespace"
-            ));
+            )),
+            Some(f) if f.desc.as_ref().is_some_and(|d| d.is_accessor_descriptor()) => self
+                .create_type_error(&format!(
+                    "Cannot set property '{key}' which has only a getter"
+                )),
+            _ => self.create_type_error(&format!("Cannot assign to read only property '{key}'")),
         }
-        if !is_proxy
-            && !self.has_proxy_in_prototype_chain(obj_id)
-            && self
-                .get_property_descriptor_on_id(obj_id, key)
-                .is_some_and(|d| d.is_accessor_descriptor())
-        {
-            return self.create_type_error(&format!(
-                "Cannot set property '{key}' which has only a getter"
-            ));
-        }
-        self.create_type_error(&format!("Cannot assign to read only property '{key}'"))
     }
 
     /// Preserve the host-compatible diagnostics historically produced by the
@@ -3860,30 +3893,26 @@ impl Interpreter {
     /// already happened inside `property.rs`; this only formats the TypeError.
     fn member_assignment_error(&mut self, base: &JsValue, key: &JsPropertyKey) -> JsValue {
         let Some(obj_id) = base.as_object_id() else {
-            return self.create_type_error(&format!("Cannot create property '{key}' on {base}"));
+            return self.non_object_receiver_error(base, key);
         };
-        let Some(cell) = self.get_object_cell(obj_id) else {
-            return self.create_type_error(&format!("Cannot assign to read only property '{key}'"));
-        };
-        if cell.borrow().module_namespace().is_some() {
-            return self.create_type_error(&format!(
-                "Cannot assign to read only property '{key}' of object '[object Module]'"
-            ));
+        let facts = self.set_rejection_facts(obj_id, key);
+        if let Some(f) = &facts {
+            if f.is_module_namespace {
+                return self.create_type_error(&format!(
+                    "Cannot assign to read only property '{key}' of object '[object Module]'"
+                ));
+            }
+            if !f.has_own
+                && f.desc
+                    .as_ref()
+                    .is_some_and(|d| d.is_data_descriptor() && d.writable == Some(false))
+            {
+                return self.create_type_error(&format!(
+                    "Cannot assign to read only property '{key}' of object '#<Object>'"
+                ));
+            }
         }
-        let is_proxy = cell.borrow().is_proxy() || cell.borrow().is_proxy_revoked();
-        let has_own = cell.borrow().has_own_property(key);
-        if !is_proxy
-            && !has_own
-            && !self.has_proxy_in_prototype_chain(obj_id)
-            && self
-                .get_property_descriptor_on_id(obj_id, key)
-                .is_some_and(|desc| desc.is_data_descriptor() && desc.writable == Some(false))
-        {
-            return self.create_type_error(&format!(
-                "Cannot assign to read only property '{key}' of object '#<Object>'"
-            ));
-        }
-        self.read_only_assignment_error(obj_id, key)
+        self.read_only_assignment_error_from(facts.as_ref(), key)
     }
 
     fn set_member_property(
@@ -7720,12 +7749,26 @@ impl Interpreter {
         }
     }
 
-    /// Whether `obj_id` is some realm's global object — the only case in which
-    /// a property write has a global environment binding to mirror.
-    fn is_realm_global_object(&self, obj_id: u64) -> bool {
+    /// Whether a just-succeeded [[Set]] of `key` on `obj_id` is one the global
+    /// environment must mirror: `obj_id` has to be some realm's global object
+    /// (the only case with a binding to mirror at all), and [[Set]] has to have
+    /// left the right-hand value there as an own data property. An accessor, a
+    /// Proxy trap, or an inherited setter can store something else — or nothing
+    /// — and copying the RHS into the binding would desynchronise the global
+    /// lexical scope from the object.
+    ///
+    /// The realm test is first: it is the cheap, highly selective one.
+    fn write_mirrors_global_binding(&self, obj_id: u64, key: &JsPropertyKey) -> bool {
         self.realms
             .iter()
             .any(|realm| realm.global_object == Some(obj_id))
+            && self.get_object_cell(obj_id).is_some_and(|cell| {
+                let b = cell.borrow();
+                !b.is_proxy()
+                    && !b.is_proxy_revoked()
+                    && b.get_own_property(key)
+                        .is_some_and(|d| d.is_data_descriptor())
+            })
     }
 
     /// Sync a property set on an object to the corresponding global env binding,

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -1,4 +1,40 @@
 use super::*;
+
+/// The observable result of [[Set]] plus the internal write-path fact needed
+/// by the evaluator's global object-record bridge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SetOutcome {
+    Rejected,
+    Succeeded,
+    OwnDataWrite(u64),
+}
+
+impl SetOutcome {
+    pub(crate) fn succeeded(self) -> bool {
+        !matches!(self, Self::Rejected)
+    }
+
+    fn from_success(succeeded: bool) -> Self {
+        if succeeded {
+            Self::Succeeded
+        } else {
+            Self::Rejected
+        }
+    }
+
+    fn from_own_data_write(receiver_id: u64, succeeded: bool) -> Self {
+        if succeeded {
+            Self::OwnDataWrite(receiver_id)
+        } else {
+            Self::Rejected
+        }
+    }
+
+    pub(crate) fn wrote_own_data_property_on(self, receiver_id: u64) -> bool {
+        self == Self::OwnDataWrite(receiver_id)
+    }
+}
+
 impl Interpreter {
     /// Canonical [[Set]] entry point (§10.1.9 OrdinarySet + exotic dispatch).
     /// Handles proxy `set` trap, TypedArray integer-index element set,
@@ -13,15 +49,31 @@ impl Interpreter {
         value: JsValue,
         receiver: &JsValue,
     ) -> Result<bool, JsValue> {
+        self.set_object_property_with_outcome(obj_id, key, value, receiver)
+            .map(SetOutcome::succeeded)
+    }
+
+    /// Canonical [[Set]] entry point retaining whether the operation itself
+    /// reached a successful own data-property write on the Receiver. A plain
+    /// Boolean cannot distinguish that path from a successful setter or Proxy
+    /// trap, and inspecting the descriptor after user code returns is racy with
+    /// a setter that redefines the property.
+    pub(crate) fn set_object_property_with_outcome<K: PropertyKeyLike + ?Sized>(
+        &mut self,
+        obj_id: u64,
+        key: &K,
+        value: JsValue,
+        receiver: &JsValue,
+    ) -> Result<SetOutcome, JsValue> {
         // Module namespace exotic [[Set]] (§10.4.6.9) always rejects the set,
         // even though exported bindings have writable own data descriptors.
         if self
             .get_object_cell(obj_id)
             .is_some_and(|obj| obj.borrow().module_namespace().is_some())
         {
-            return Ok(false);
+            return Ok(SetOutcome::Rejected);
         }
-        self.proxy_set(obj_id, key, value, receiver)
+        self.proxy_set_with_outcome(obj_id, key, value, receiver)
     }
 
     /// Canonical [[DefineOwnProperty]] entry point.
@@ -697,6 +749,17 @@ impl Interpreter {
         value: JsValue,
         receiver: &JsValue,
     ) -> Result<bool, JsValue> {
+        self.proxy_set_with_outcome(obj_id, key, value, receiver)
+            .map(SetOutcome::succeeded)
+    }
+
+    fn proxy_set_with_outcome<K: PropertyKeyLike + ?Sized>(
+        &mut self,
+        obj_id: u64,
+        key: &K,
+        value: JsValue,
+        receiver: &JsValue,
+    ) -> Result<SetOutcome, JsValue> {
         if self.get_proxy_info(obj_id).is_some() {
             let target_val = self.get_proxy_target_val(obj_id);
             let key_val = self.symbol_key_to_jsvalue(key);
@@ -734,16 +797,16 @@ impl Interpreter {
                                 }
                             }
                         }
-                        Ok(true)
+                        Ok(SetOutcome::Succeeded)
                     } else {
-                        Ok(false)
+                        Ok(SetOutcome::Rejected)
                     }
                 }
                 Ok(None) => {
                     if let Some(target_id) = target_val.as_object_id() {
-                        return self.proxy_set(target_id, key, value, receiver);
+                        return self.proxy_set_with_outcome(target_id, key, value, receiver);
                     }
-                    Ok(false)
+                    Ok(SetOutcome::Rejected)
                 }
                 Err(e) => Err(e),
             }
@@ -771,7 +834,7 @@ impl Interpreter {
                         drop(obj_ref);
                         typed_array_set_index(&ta_clone, index as usize, &num_val);
                     }
-                    return Ok(true);
+                    return Ok(SetOutcome::Succeeded);
                 } else {
                     // Different receiver: if invalid index return true without coercing
                     let valid = {
@@ -780,7 +843,7 @@ impl Interpreter {
                         is_valid_integer_index(ta, index)
                     };
                     if !valid {
-                        return Ok(true);
+                        return Ok(SetOutcome::Succeeded);
                     }
                     // Valid index, different receiver: fall through to OrdinarySet below
                     // OrdinarySet will find writable data descriptor from TypedArray [[GetOwnProperty]],
@@ -797,16 +860,16 @@ impl Interpreter {
                     {
                         let setter = setter.clone();
                         match self.call_function(&setter, receiver, &[value]) {
-                            Completion::Normal(_) => return Ok(true),
+                            Completion::Normal(_) => return Ok(SetOutcome::Succeeded),
                             Completion::Throw(e) => return Err(e),
-                            _ => return Ok(true),
+                            _ => return Ok(SetOutcome::Succeeded),
                         }
                     }
-                    return Ok(false);
+                    return Ok(SetOutcome::Rejected);
                 }
                 // Data descriptor
                 if desc.writable == Some(false) {
-                    return Ok(false);
+                    return Ok(SetOutcome::Rejected);
                 }
                 // OrdinarySetWithOwnDescriptor step 3.c: use Receiver.[[GetOwnProperty]] / [[DefineOwnProperty]]
                 let recv_id = receiver.as_object_id();
@@ -838,13 +901,21 @@ impl Interpreter {
                             get: None,
                             set: None,
                         };
-                        return self.array_set_length(obj_id as usize, val_desc);
+                        return self
+                            .array_set_length(obj_id as usize, val_desc)
+                            .map(|succeeded| SetOutcome::from_own_data_write(obj_id, succeeded));
                     }
                     self.gc_write_barrier_value(&obj, &value);
-                    return Ok(obj.borrow_mut_untracked().set_property_value(key, value));
+                    let succeeded = obj.borrow_mut_untracked().set_property_value(key, value);
+                    return Ok(SetOutcome::from_own_data_write(obj_id, succeeded));
                 }
                 // Receiver differs: call Receiver.[[GetOwnProperty]](P) and [[DefineOwnProperty]]
                 if let Some(rid) = recv_id {
+                    let receiver_uses_proxy_define =
+                        self.get_object_cell(rid).is_some_and(|cell| {
+                            let b = cell.borrow();
+                            b.is_proxy() || b.is_proxy_revoked()
+                        });
                     let existing = self.proxy_get_own_property_descriptor(rid, key)?;
                     if existing.is_undefined() {
                         // CreateDataProperty(Receiver, P, V)
@@ -857,23 +928,28 @@ impl Interpreter {
                             set: None,
                         };
                         let desc_val = self.from_property_descriptor(&desc);
-                        return self.proxy_define_own_property(
+                        let succeeded = self.proxy_define_own_property(
                             rid,
                             key.to_js_property_key(),
                             &desc_val,
-                        );
+                        )?;
+                        return Ok(if receiver_uses_proxy_define {
+                            SetOutcome::from_success(succeeded)
+                        } else {
+                            SetOutcome::from_own_data_write(rid, succeeded)
+                        });
                     } else {
                         // existingDescriptor found: check accessor or non-writable
                         let existing_desc = match self.to_property_descriptor(&existing) {
                             Ok(d) => d,
                             Err(Some(e)) => return Err(e),
-                            Err(None) => return Ok(false),
+                            Err(None) => return Ok(SetOutcome::Rejected),
                         };
                         if existing_desc.is_accessor_descriptor() {
-                            return Ok(false);
+                            return Ok(SetOutcome::Rejected);
                         }
                         if existing_desc.writable == Some(false) {
-                            return Ok(false);
+                            return Ok(SetOutcome::Rejected);
                         }
                         // [[DefineOwnProperty]](P, {Value: V})
                         let val_desc = crate::interpreter::types::PropertyDescriptor {
@@ -885,24 +961,29 @@ impl Interpreter {
                             set: None,
                         };
                         let desc_val = self.from_property_descriptor(&val_desc);
-                        return self.proxy_define_own_property(
+                        let succeeded = self.proxy_define_own_property(
                             rid,
                             key.to_js_property_key(),
                             &desc_val,
-                        );
+                        )?;
+                        return Ok(if receiver_uses_proxy_define {
+                            SetOutcome::from_success(succeeded)
+                        } else {
+                            SetOutcome::from_own_data_write(rid, succeeded)
+                        });
                     }
                 }
                 // Receiver is not an Object: [[Set]] must return false, never
                 // fall back to writing the property onto `obj` itself — `obj`
                 // may be a shared prototype reached by walking up from the
                 // (non-object) receiver's own [[Prototype]] chain.
-                return Ok(false);
+                return Ok(SetOutcome::Rejected);
             }
             // No own property, walk prototype chain
             let proto = obj.borrow().prototype_id;
             if let Some(proto_rc) = proto {
                 let proto_id = proto_rc;
-                return self.proxy_set(proto_id, key, value, receiver);
+                return self.proxy_set_with_outcome(proto_id, key, value, receiver);
             }
             // No prototype: OrdinarySetWithOwnDescriptor with synthetic {writable:true,...} ownDesc.
             // Per spec step 1.c.i + 2.c: call Receiver.[[GetOwnProperty]](P) then act on result.
@@ -923,7 +1004,7 @@ impl Interpreter {
                 // necessarily rejects the new data property.
                 if is_module_namespace_recv {
                     self.check_namespace_tdz(recv_id, key)?;
-                    return Ok(false);
+                    return Ok(SetOutcome::Rejected);
                 }
                 if is_proxy_recv {
                     let existing = self.proxy_get_own_property_descriptor(recv_id, key)?;
@@ -938,22 +1019,23 @@ impl Interpreter {
                             set: None,
                         };
                         let desc_val = self.from_property_descriptor(&create_desc);
-                        return self.proxy_define_own_property(
+                        let succeeded = self.proxy_define_own_property(
                             recv_id,
                             key.to_js_property_key(),
                             &desc_val,
-                        );
+                        )?;
+                        return Ok(SetOutcome::from_success(succeeded));
                     } else {
                         let existing_desc = match self.to_property_descriptor(&existing) {
                             Ok(d) => d,
                             Err(Some(e)) => return Err(e),
-                            Err(None) => return Ok(false),
+                            Err(None) => return Ok(SetOutcome::Rejected),
                         };
                         if existing_desc.is_accessor_descriptor() {
-                            return Ok(false);
+                            return Ok(SetOutcome::Rejected);
                         }
                         if existing_desc.writable == Some(false) {
-                            return Ok(false);
+                            return Ok(SetOutcome::Rejected);
                         }
                         let val_desc = crate::interpreter::types::PropertyDescriptor {
                             value: Some(value),
@@ -964,25 +1046,27 @@ impl Interpreter {
                             set: None,
                         };
                         let desc_val = self.from_property_descriptor(&val_desc);
-                        return self.proxy_define_own_property(
+                        let succeeded = self.proxy_define_own_property(
                             recv_id,
                             key.to_js_property_key(),
                             &desc_val,
-                        );
+                        )?;
+                        return Ok(SetOutcome::from_success(succeeded));
                     }
                 }
                 if let Some(recv_obj) = self.get_object_cell(recv_id) {
                     self.gc_write_barrier_value(recv_obj, &value);
-                    return Ok(recv_obj
+                    let succeeded = recv_obj
                         .borrow_mut_untracked()
-                        .set_property_value(key, value));
+                        .set_property_value(key, value);
+                    return Ok(SetOutcome::from_own_data_write(recv_id, succeeded));
                 }
             }
             // Receiver is not an Object (or resolved to no live object): [[Set]]
             // must return false, never fall back to writing onto `obj` itself.
-            Ok(false)
+            Ok(SetOutcome::Rejected)
         } else {
-            Ok(false)
+            Ok(SetOutcome::Rejected)
         }
     }
 

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -907,6 +907,16 @@ impl Interpreter {
             // No prototype: OrdinarySetWithOwnDescriptor with synthetic {writable:true,...} ownDesc.
             // Per spec step 1.c.i + 2.c: call Receiver.[[GetOwnProperty]](P) then act on result.
             if let Some(recv_id) = receiver.as_object_id() {
+                // Module namespace exotic [[GetOwnProperty]] triggers deferred
+                // evaluation / TDZ checks before its [[DefineOwnProperty]]
+                // necessarily rejects the new data property.
+                let is_module_namespace_recv = self
+                    .get_object_cell(recv_id)
+                    .is_some_and(|o| o.borrow().module_namespace().is_some());
+                if is_module_namespace_recv {
+                    self.check_namespace_tdz(recv_id, key)?;
+                    return Ok(false);
+                }
                 let is_proxy_recv = self
                     .get_object_cell(recv_id)
                     .is_some_and(|o| o.borrow().is_proxy() || o.borrow().is_proxy_revoked());

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -907,19 +907,24 @@ impl Interpreter {
             // No prototype: OrdinarySetWithOwnDescriptor with synthetic {writable:true,...} ownDesc.
             // Per spec step 1.c.i + 2.c: call Receiver.[[GetOwnProperty]](P) then act on result.
             if let Some(recv_id) = receiver.as_object_id() {
+                // Which exotic [[GetOwnProperty]]/[[DefineOwnProperty]] the
+                // receiver has, read in one borrow that ends before the
+                // `&mut self` calls below.
+                let (is_module_namespace_recv, is_proxy_recv) =
+                    self.get_object_cell(recv_id).map_or((false, false), |o| {
+                        let b = o.borrow();
+                        (
+                            b.module_namespace().is_some(),
+                            b.is_proxy() || b.is_proxy_revoked(),
+                        )
+                    });
                 // Module namespace exotic [[GetOwnProperty]] triggers deferred
                 // evaluation / TDZ checks before its [[DefineOwnProperty]]
                 // necessarily rejects the new data property.
-                let is_module_namespace_recv = self
-                    .get_object_cell(recv_id)
-                    .is_some_and(|o| o.borrow().module_namespace().is_some());
                 if is_module_namespace_recv {
                     self.check_namespace_tdz(recv_id, key)?;
                     return Ok(false);
                 }
-                let is_proxy_recv = self
-                    .get_object_cell(recv_id)
-                    .is_some_and(|o| o.borrow().is_proxy() || o.borrow().is_proxy_revoked());
                 if is_proxy_recv {
                     let existing = self.proxy_get_own_property_descriptor(recv_id, key)?;
                     if existing.is_undefined() {

--- a/test262-extra/GC-assignment-target-base-rooting.js
+++ b/test262-extra/GC-assignment-target-base-rooting.js
@@ -1,0 +1,87 @@
+// Every assignment form that captures a member Reference keeps that
+// Reference's base (and, for a primitive base, its ToObject result) alive
+// while the remaining steps run user code. Losing the base turns PutValue into
+// a silent no-op instead of reaching the inherited setter.
+//
+// Spec: ECMAScript 2026,
+//   sec-assignment-operators-runtime-semantics-evaluation (logical assignment
+//   evaluates the RHS after capturing the left Reference),
+//   sec-runtime-semantics-forin-div-ofbodyevaluation (the loop target
+//   Reference is evaluated, then PutValue is performed with the next value).
+
+function allocatingRhs() {
+  var values = [];
+  for (var i = 0; i < 20000; i++) {
+    values.push({ index: i });
+  }
+  return 42;
+}
+
+function allocatingKey() {
+  var values = [];
+  for (var i = 0; i < 20000; i++) {
+    values.push({ index: i });
+  }
+  return "value";
+}
+
+// Logical assignment: the base is captured, the getter short-circuits to
+// "assign", then the allocating RHS runs before the write-back.
+var logicalObserved;
+var logicalPrototype = {
+  get value() {
+    return 0;
+  },
+  set value(v) {
+    logicalObserved = v;
+  },
+};
+Object.create(logicalPrototype).value ||= allocatingRhs();
+if (logicalObserved !== 42) {
+  throw new Test262Error("logical assignment base was not preserved across RHS evaluation");
+}
+
+// Logical assignment on a primitive base: PutValue's receiver is the primitive
+// and the [[Set]] holder is the ToObject wrapper, so the wrapper must survive
+// the RHS too.
+var primitiveObserved;
+Object.defineProperty(Number.prototype, "gcRootingProbe", {
+  configurable: true,
+  set: function (v) {
+    primitiveObserved = v;
+  },
+});
+(7).gcRootingProbe ||= allocatingRhs();
+delete Number.prototype.gcRootingProbe;
+if (primitiveObserved !== 42) {
+  throw new Test262Error("primitive-base logical assignment lost its ToObject wrapper");
+}
+
+// for-of member target: the base is evaluated before the allocating computed
+// key expression.
+var loopObserved;
+var loopPrototype = {
+  set value(v) {
+    loopObserved = v;
+  },
+};
+for (Object.create(loopPrototype)[allocatingKey()] of [7]) {
+  // The member target is written before the (empty) body runs.
+}
+if (loopObserved !== 7) {
+  throw new Test262Error("for-of member target base was not preserved across key evaluation");
+}
+
+// for-in member target takes the same PutValue path.
+var forInObserved;
+var forInPrototype = {
+  set value(v) {
+    forInObserved = v;
+  },
+};
+for (Object.create(forInPrototype)[allocatingKey()] in { a: 1 }) {
+  // The member target is written before the (empty) body runs.
+}
+if (forInObserved !== "a") {
+  throw new Test262Error("for-in member target base was not preserved across key evaluation");
+}

--- a/test262-extra/OrdinarySet-module-namespace-receiver-dep.mjs
+++ b/test262-extra/OrdinarySet-module-namespace-receiver-dep.mjs
@@ -1,0 +1,1 @@
+export var initialized = "initialized";

--- a/test262-extra/OrdinarySet-module-namespace-receiver.js
+++ b/test262-extra/OrdinarySet-module-namespace-receiver.js
@@ -1,0 +1,69 @@
+/*---
+description: >
+  OrdinarySetWithOwnDescriptor consults the Receiver's [[GetOwnProperty]] and
+  [[DefineOwnProperty]], so a module namespace exotic object used as the
+  receiver of a super-property write rejects the write instead of gaining an
+  own property.
+info: |
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  3. If IsDataDescriptor(ownDesc) is true, then
+    b. If Receiver is not an Object, return false.
+    c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
+    d. If existingDescriptor is not undefined, then
+      iv. Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
+    e. Else, return ? CreateDataProperty(Receiver, P, V).
+
+  Module Namespace Exotic Objects [[DefineOwnProperty]] ( P, Desc )
+    2. Let current be ! O.[[GetOwnProperty]](P).
+    3. If current is undefined, return false.
+    8. If Desc has a [[Value]] field, return
+       SameValue(Desc.[[Value]], current.[[Value]]).
+
+  A key that is not an export is rejected by step 3; an exported key reaches
+  step 8 and is rejected because the written value differs from the binding's
+  current value.
+
+  PutValue ( V, W ) converts the false result into a TypeError because module
+  code is always strict.
+esid: sec-ordinarysetwithowndescriptor
+flags: [module]
+---*/
+
+import * as ns from "./OrdinarySet-module-namespace-receiver-dep.mjs";
+
+// The home object's prototype is the [[Set]] holder; `this` is the receiver.
+// A null-prototype holder makes OrdinarySet reach the synthetic writable
+// ownDesc, which is the branch that must consult the receiver.
+var holder = {
+  writeNewKey(value) {
+    super.notAnExport = value;
+  },
+  writeExportedKey(value) {
+    super.initialized = value;
+  },
+};
+Object.setPrototypeOf(holder, Object.create(null));
+
+assert.throws(
+  TypeError,
+  function () {
+    holder.writeNewKey.call(ns, 1);
+  },
+  "a new key on a module namespace receiver rejects"
+);
+
+assert.throws(
+  TypeError,
+  function () {
+    holder.writeExportedKey.call(ns, 1);
+  },
+  "an exported key on a module namespace receiver rejects"
+);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(ns, "notAnExport"),
+  false,
+  "the rejected write created no own property on the namespace"
+);
+assert.sameValue(ns.initialized, "initialized", "the exported binding is unchanged");

--- a/test262-extra/ordinary-set-assignment-cluster.js
+++ b/test262-extra/ordinary-set-assignment-cluster.js
@@ -1,0 +1,278 @@
+/*---
+description: >
+  Simple, compound, logical, and super property writes share OrdinarySet's
+  prototype, descriptor, Proxy, receiver, and strict-rejection semantics.
+info: |
+  OrdinarySet and OrdinarySetWithOwnDescriptor (sec-ordinaryset and
+  sec-ordinarysetwithowndescriptor) recurse through the holder's prototype
+  [[Set]], reject inherited non-writable data descriptors, and call inherited
+  setters with the original Reference receiver. PutValue (sec-putvalue)
+  converts a false [[Set]] result to TypeError only for strict References.
+esid: sec-ordinaryset
+flags: [noStrict]
+features: [Proxy, logical-assignment-operators]
+---*/
+
+var proxyTarget = {
+  compound: 2,
+  logical: 0,
+};
+var proxyCalls = [];
+var proxyPrototype = new Proxy(proxyTarget, {
+  set: function (target, key, value, receiver) {
+    proxyCalls.push({ key: key, value: value, receiver: receiver });
+    return true;
+  },
+});
+var proxyReceiver = Object.create(proxyPrototype);
+
+assert.sameValue((proxyReceiver.simple = 4), 4, "simple Proxy-chain assignment result");
+assert.sameValue((proxyReceiver.compound += 3), 5, "compound Proxy-chain assignment result");
+assert.sameValue((proxyReceiver.logical ||= 6), 6, "logical Proxy-chain assignment result");
+assert.sameValue(proxyCalls.length, 3, "each reached write invokes the Proxy set trap once");
+assert.sameValue(proxyCalls[0].key, "simple", "simple key");
+assert.sameValue(proxyCalls[0].value, 4, "simple value");
+assert.sameValue(proxyCalls[1].key, "compound", "compound key");
+assert.sameValue(proxyCalls[1].value, 5, "compound value");
+assert.sameValue(proxyCalls[2].key, "logical", "logical key");
+assert.sameValue(proxyCalls[2].value, 6, "logical value");
+for (var proxyIndex = 0; proxyIndex < proxyCalls.length; proxyIndex += 1) {
+  assert.sameValue(proxyCalls[proxyIndex].receiver, proxyReceiver, "Proxy receiver is the LHS base");
+}
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(proxyReceiver, "simple"),
+  false,
+  "a handled Proxy write does not create a receiver property"
+);
+
+var rejectingPrototype = new Proxy(
+  { compound: 1, logical: 0 },
+  {
+    set: function () {
+      return false;
+    },
+  }
+);
+
+var sloppyProxyReceiver = Object.create(rejectingPrototype);
+assert.sameValue((sloppyProxyReceiver.simple = 2), 2, "sloppy rejected simple write returns RHS");
+assert.sameValue((sloppyProxyReceiver.compound += 2), 3, "sloppy rejected compound write returns result");
+assert.sameValue((sloppyProxyReceiver.logical ||= 4), 4, "sloppy rejected logical write returns RHS");
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(sloppyProxyReceiver, "simple"),
+  false,
+  "sloppy false Proxy result is silent and creates no property"
+);
+
+assert.throws(TypeError, function () {
+  "use strict";
+  var receiver = Object.create(rejectingPrototype);
+  receiver.simple = 2;
+});
+assert.throws(TypeError, function () {
+  "use strict";
+  var receiver = Object.create(rejectingPrototype);
+  receiver.compound += 2;
+});
+assert.throws(TypeError, function () {
+  "use strict";
+  var receiver = Object.create(rejectingPrototype);
+  receiver.logical ||= 4;
+});
+
+var readOnlyPrototype = {};
+Object.defineProperty(readOnlyPrototype, "simple", {
+  value: 1,
+  writable: false,
+  configurable: true,
+});
+Object.defineProperty(readOnlyPrototype, "compound", {
+  value: 1,
+  writable: false,
+  configurable: true,
+});
+Object.defineProperty(readOnlyPrototype, "logical", {
+  value: 0,
+  writable: false,
+  configurable: true,
+});
+
+var sloppyReadOnlyReceiver = Object.create(readOnlyPrototype);
+assert.sameValue((sloppyReadOnlyReceiver.simple = 2), 2, "sloppy inherited read-only simple result");
+assert.sameValue((sloppyReadOnlyReceiver.compound += 2), 3, "sloppy inherited read-only compound result");
+assert.sameValue((sloppyReadOnlyReceiver.logical ||= 4), 4, "sloppy inherited read-only logical result");
+assert.sameValue(sloppyReadOnlyReceiver.simple, 1, "simple inherited value is unchanged");
+assert.sameValue(sloppyReadOnlyReceiver.compound, 1, "compound inherited value is unchanged");
+assert.sameValue(sloppyReadOnlyReceiver.logical, 0, "logical inherited value is unchanged");
+
+assert.throws(TypeError, function () {
+  "use strict";
+  var receiver = Object.create(readOnlyPrototype);
+  receiver.simple = 2;
+});
+assert.throws(TypeError, function () {
+  "use strict";
+  var receiver = Object.create(readOnlyPrototype);
+  receiver.compound += 2;
+});
+assert.throws(TypeError, function () {
+  "use strict";
+  var receiver = Object.create(readOnlyPrototype);
+  receiver.logical ||= 4;
+});
+
+var setterCalls = [];
+var setterPrototype = {};
+Object.defineProperty(setterPrototype, "simple", {
+  configurable: true,
+  set: function (value) {
+    setterCalls.push({ key: "simple", value: value, receiver: this });
+  },
+});
+Object.defineProperty(setterPrototype, "compound", {
+  configurable: true,
+  get: function () {
+    return 2;
+  },
+  set: function (value) {
+    setterCalls.push({ key: "compound", value: value, receiver: this });
+  },
+});
+Object.defineProperty(setterPrototype, "logical", {
+  configurable: true,
+  get: function () {
+    return 0;
+  },
+  set: function (value) {
+    setterCalls.push({ key: "logical", value: value, receiver: this });
+  },
+});
+var setterReceiver = Object.create(setterPrototype);
+
+assert.sameValue((setterReceiver.simple = 4), 4, "inherited simple setter result");
+assert.sameValue((setterReceiver.compound += 3), 5, "inherited compound setter result");
+assert.sameValue((setterReceiver.logical ||= 6), 6, "inherited logical setter result");
+assert.sameValue(setterCalls.length, 3, "each inherited setter is called once");
+for (var setterIndex = 0; setterIndex < setterCalls.length; setterIndex += 1) {
+  assert.sameValue(setterCalls[setterIndex].receiver, setterReceiver, "setter receiver is the LHS base");
+}
+assert.sameValue(setterCalls[0].value, 4, "simple setter value");
+assert.sameValue(setterCalls[1].value, 5, "compound setter value");
+assert.sameValue(setterCalls[2].value, 6, "logical setter value");
+
+var loopSetterReceiver;
+var loopSetterValue;
+var loopSetterPrototype = {};
+Object.defineProperty(loopSetterPrototype, "value", {
+  configurable: true,
+  set: function (value) {
+    loopSetterReceiver = this;
+    loopSetterValue = value;
+  },
+});
+var loopReceiver = Object.create(loopSetterPrototype);
+for (loopReceiver.value of [8]) {
+  // Assignment to the member target happens before the loop body.
+}
+assert.sameValue(loopSetterReceiver, loopReceiver, "for-of member target preserves its receiver");
+assert.sameValue(loopSetterValue, 8, "for-of member target invokes the inherited setter");
+
+var loopProxyCalls = 0;
+var loopProxyReceiver;
+var loopProxyPrototype = new Proxy({}, {
+  set: function (target, key, value, receiver) {
+    loopProxyCalls += 1;
+    loopProxyReceiver = receiver;
+    assert.sameValue(key, "value", "for-of Proxy key");
+    assert.sameValue(value, 9, "for-of Proxy value");
+    return true;
+  },
+});
+var loopProxyBase = Object.create(loopProxyPrototype);
+for (loopProxyBase.value of [9]) {
+  // Assignment to the member target happens before the loop body.
+}
+assert.sameValue(loopProxyCalls, 1, "for-of member target invokes a prototype Proxy once");
+assert.sameValue(loopProxyReceiver, loopProxyBase, "for-of Proxy receives the LHS base");
+
+var superCalls = [];
+class SuperBase {}
+Object.defineProperty(SuperBase.prototype, "simple", {
+  configurable: true,
+  set: function (value) {
+    superCalls.push({ key: "simple", value: value, receiver: this });
+  },
+});
+Object.defineProperty(SuperBase.prototype, "compound", {
+  configurable: true,
+  get: function () {
+    return 2;
+  },
+  set: function (value) {
+    superCalls.push({ key: "compound", value: value, receiver: this });
+  },
+});
+Object.defineProperty(SuperBase.prototype, "logical", {
+  configurable: true,
+  get: function () {
+    return 0;
+  },
+  set: function (value) {
+    superCalls.push({ key: "logical", value: value, receiver: this });
+  },
+});
+Object.defineProperty(SuperBase.prototype, "fixed", {
+  configurable: true,
+  value: 1,
+  writable: false,
+});
+
+class SuperDerived extends SuperBase {
+  writeSimple(value) {
+    return (super.simple = value);
+  }
+  writeCompound(value) {
+    return (super.compound += value);
+  }
+  writeLogical(value) {
+    return (super.logical ||= value);
+  }
+  writeFixed(value) {
+    return (super.fixed = value);
+  }
+}
+
+var superReceiver = new SuperDerived();
+assert.sameValue(superReceiver.writeSimple(4), 4, "super simple result");
+assert.sameValue(superReceiver.writeCompound(3), 5, "super compound result");
+assert.sameValue(superReceiver.writeLogical(6), 6, "super logical result");
+assert.sameValue(superCalls.length, 3, "each super setter is called once");
+for (var superIndex = 0; superIndex < superCalls.length; superIndex += 1) {
+  assert.sameValue(superCalls[superIndex].receiver, superReceiver, "super setter receives actual this");
+}
+assert.throws(TypeError, function () {
+  superReceiver.writeFixed(2);
+});
+assert.sameValue(superReceiver.fixed, 1, "rejected super write leaves inherited data unchanged");
+
+var superProxyCalls = 0;
+var superProxyReceiver;
+var superProxyPrototype = new Proxy({}, {
+  set: function (target, key, value, receiver) {
+    superProxyCalls += 1;
+    superProxyReceiver = receiver;
+    assert.sameValue(key, "value", "super Proxy key");
+    assert.sameValue(value, 10, "super Proxy value");
+    return true;
+  },
+});
+class SuperProxyHolder {
+  write(value) {
+    return (super.value = value);
+  }
+}
+Object.setPrototypeOf(SuperProxyHolder.prototype, superProxyPrototype);
+var superProxyBase = new SuperProxyHolder();
+assert.sameValue(superProxyBase.write(10), 10, "super Proxy assignment result");
+assert.sameValue(superProxyCalls, 1, "super write invokes a prototype Proxy once");
+assert.sameValue(superProxyReceiver, superProxyBase, "super Proxy receives actual this");

--- a/test262-extra/ordinary-set-assignment-writeback.js
+++ b/test262-extra/ordinary-set-assignment-writeback.js
@@ -1,0 +1,69 @@
+/*---
+description: >
+  Assignment forms that reach PutValue share the same OrdinarySet semantics,
+  including ArraySetLength effects without replacing the assignment
+  expression's result with the coerced length.
+info: |
+  PutValue (sec-putvalue) calls the base object's [[Set]] with the Reference's
+  receiver and ignores the Boolean result unless a strict Reference needs to
+  throw. Assignment evaluation
+  (sec-assignment-operators-runtime-semantics-evaluation) returns the computed
+  right-hand value after PutValue. ArraySetLength may coerce that value for the
+  stored length, but does not change the assignment expression result.
+esid: sec-assignment-operators-runtime-semantics-evaluation
+---*/
+
+var simpleArray = [1, 2, 3];
+var simpleRhs = {
+  valueOf: function () {
+    return 1;
+  },
+};
+var simpleResult = (simpleArray.length = simpleRhs);
+
+assert.sameValue(simpleResult, simpleRhs, "simple assignment returns its uncoerced RHS");
+assert.sameValue(simpleArray.length, 1, "simple assignment still runs ArraySetLength");
+assert.sameValue(simpleArray[1], undefined, "ArraySetLength removes truncated elements");
+
+var logicalArray = [1, 2, 3];
+var logicalRhs = {
+  valueOf: function () {
+    return 1;
+  },
+};
+var logicalResult = (logicalArray.length &&= logicalRhs);
+
+assert.sameValue(logicalResult, logicalRhs, "logical assignment returns its uncoerced RHS");
+assert.sameValue(logicalArray.length, 1, "logical assignment still runs ArraySetLength");
+assert.sameValue(logicalArray[1], undefined, "logical ArraySetLength removes truncated elements");
+
+var compoundArray = [1, 2, 3];
+var compoundResult = (compoundArray.length -= 1);
+
+assert.sameValue(compoundResult, 2, "compound assignment returns its computed value");
+assert.sameValue(compoundArray.length, 2, "compound assignment still runs ArraySetLength");
+assert.sameValue(compoundArray[2], undefined, "compound ArraySetLength removes truncated elements");
+
+var setterReceiver;
+Object.defineProperty(Number.prototype, "ordinarySetReceiverProbe", {
+  configurable: true,
+  get: function () {
+    return 0;
+  },
+  set: function (value) {
+    "use strict";
+    setterReceiver = this;
+    assert.sameValue(value, 9, "the inherited setter receives the logical RHS");
+  },
+});
+
+var primitiveBase = 7;
+var primitiveResult = (primitiveBase.ordinarySetReceiverProbe ||= 9);
+
+assert.sameValue(primitiveResult, 9, "primitive logical assignment returns its RHS");
+assert.sameValue(
+  setterReceiver,
+  primitiveBase,
+  "PutValue passes the original primitive as the inherited setter receiver"
+);
+delete Number.prototype.ordinarySetReceiverProbe;

--- a/test262-extra/ordinary-set-global-binding-sync.js
+++ b/test262-extra/ordinary-set-global-binding-sync.js
@@ -1,0 +1,89 @@
+/*---
+description: >
+  A successful setter call is not an OrdinarySet data-property write and must
+  not mirror the assignment value into a same-named global lexical binding.
+info: |
+  OrdinarySetWithOwnDescriptor (sec-ordinarysetwithowndescriptor) returns true
+  both after Receiver.[[DefineOwnProperty]] writes a data property and after an
+  accessor setter is called. A setter can also change the property's descriptor
+  before it returns, so the resulting descriptor does not identify which path
+  handled the assignment.
+esid: sec-ordinarysetwithowndescriptor
+---*/
+
+let noOpSetterLexical = 0;
+Object.defineProperty(globalThis, "noOpSetterLexical", {
+  configurable: true,
+  set: function () {},
+});
+
+globalThis.noOpSetterLexical = 7;
+
+assert.sameValue(
+  noOpSetterLexical,
+  0,
+  "a no-op setter must not mirror its argument into the lexical binding"
+);
+delete globalThis.noOpSetterLexical;
+
+let redefiningSetterLexical = 0;
+Object.defineProperty(globalThis, "redefiningSetterLexical", {
+  configurable: true,
+  set: function () {
+    Object.defineProperty(globalThis, "redefiningSetterLexical", {
+      configurable: true,
+      value: 99,
+      writable: true,
+    });
+  },
+});
+
+globalThis.redefiningSetterLexical = 7;
+
+assert.sameValue(
+  redefiningSetterLexical,
+  0,
+  "a setter that installs a data property must not mirror its argument"
+);
+assert.sameValue(
+  globalThis.redefiningSetterLexical,
+  99,
+  "the setter's own data-property value is preserved"
+);
+delete globalThis.redefiningSetterLexical;
+
+let inheritedSetterLexical = 0;
+Object.defineProperty(Object.prototype, "inheritedSetterLexical", {
+  configurable: true,
+  set: function () {
+    Object.defineProperty(this, "inheritedSetterLexical", {
+      configurable: true,
+      value: 99,
+      writable: true,
+    });
+  },
+});
+
+globalThis.inheritedSetterLexical = 7;
+
+assert.sameValue(
+  inheritedSetterLexical,
+  0,
+  "an inherited setter must retain its no-data-write outcome through prototype recursion"
+);
+assert.sameValue(
+  globalThis.inheritedSetterLexical,
+  99,
+  "the inherited setter's own data-property value is preserved"
+);
+delete globalThis.inheritedSetterLexical;
+delete Object.prototype.inheritedSetterLexical;
+
+var ordinaryDataWriteBinding = 0;
+globalThis.ordinaryDataWriteBinding = 7;
+
+assert.sameValue(
+  ordinaryDataWriteBinding,
+  7,
+  "an actual own data-property write still mirrors the global object binding"
+);

--- a/test262-extra/super-logical-assignment-this-tdz.js
+++ b/test262-extra/super-logical-assignment-this-tdz.js
@@ -1,0 +1,97 @@
+/*---
+description: >
+  A super-property logical assignment performs GetThisBinding before evaluating
+  its key expression, so an uninitialized `this` throws ReferenceError just as
+  it does for simple and compound super assignment.
+info: |
+  MakeSuperPropertyReference ( actualThis, propertyKey, strict )
+
+  Runtime Semantics: Evaluation
+    SuperProperty : super [ Expression ]
+    1. Let env be GetThisEnvironment().
+    2. Let actualThis be ? env.GetThisBinding().
+
+  Function Environment Records GetThisBinding ( )
+    1. Assert: envRec.[[ThisBindingStatus]] is not lexical.
+    2. If envRec.[[ThisBindingStatus]] is uninitialized, throw a ReferenceError
+       exception.
+esid: sec-super-keyword-runtime-semantics-evaluation
+features: [logical-assignment-operators]
+---*/
+
+class Base {}
+
+var keyEvaluated = false;
+function trackedKey() {
+  keyEvaluated = true;
+  return "value";
+}
+
+assert.throws(
+  ReferenceError,
+  function () {
+    new (class extends Base {
+      constructor() {
+        super.value ??= 1;
+        super();
+      }
+    })();
+  },
+  "super.value ??= throws before `this` is initialized"
+);
+
+assert.throws(
+  ReferenceError,
+  function () {
+    new (class extends Base {
+      constructor() {
+        super.value ||= 1;
+        super();
+      }
+    })();
+  },
+  "super.value ||= throws before `this` is initialized"
+);
+
+assert.throws(
+  ReferenceError,
+  function () {
+    new (class extends Base {
+      constructor() {
+        super[trackedKey()] &&= 1;
+        super();
+      }
+    })();
+  },
+  "super[key] &&= throws before `this` is initialized"
+);
+
+assert.sameValue(
+  keyEvaluated,
+  false,
+  "GetThisBinding runs before the super key expression is evaluated"
+);
+
+assert.throws(
+  ReferenceError,
+  function () {
+    new (class extends Base {
+      constructor() {
+        super.value = 1;
+        super();
+      }
+    })();
+  },
+  "simple super assignment already threw for an uninitialized `this`"
+);
+
+var afterSuper;
+class Derived extends Base {
+  constructor() {
+    super();
+    super.value ??= 5;
+    afterSuper = this.value;
+  }
+}
+new Derived();
+assert.sameValue(afterSuper, 5, "the same form succeeds once `this` is initialized");


### PR DESCRIPTION
## Summary

- route simple, compound, logical, loop-target, and super property writes through the existing canonical `property.rs` `[[Set]]` module
- preserve primitive/super receivers, strict diagnostics, proxy sequencing, ArraySetLength results, and deferred module-namespace receiver checks
- add spec-derived characterization for proxies in prototype chains, inherited descriptors/setters, strict/sloppy rejection, Array length, primitive receivers, loop targets, and super writes
- document the deep-module seam and rejected alternatives

The issue suggested extracting a new `ordinary_set` module in `eval.rs`. Since `property.rs::set_object_property` already implements canonical `[[Set]]`, this PR reuses that deeper existing seam instead of introducing a competing implementation. The evaluator keeps only the `PutValue` strictness/diagnostic adapter.

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- custom tests: 12/12
- test262-extra: 158/158
- targeted assignment/super/for-in/for-of/Reflect.set/Proxy.set/Array.length: 3,742/3,742
- full test262: 99,568/99,568 (100.00%, zero regressions)

Closes #482
