### PR TITLE
refactor(modules): centralize loading around module keys

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,10 @@ _Avoid_: cache header, IC metadata.
 The runtime cache of IC slot values for a Body, keyed by the Body's identity and shared by all closures of that Body.
 _Avoid_: cache table, IC map.
 
+**Module Key**:
+The canonical host identity of a resolved ECMAScript module, whether it is backed by a file or supplied directly by the host.
+_Avoid_: module path, registry path
+
 **Seam**:
 A place where one module's interface ends and another's begins. In JSSE, the seams between the AST, the inline-cache system, and the interpreter are intentionally narrow: the AST carries site identifiers, the runtime carries slot values, and the interpreter maps one to the other.
 _Avoid_: boundary, layer.

--- a/docs/specs/2026-08-24-module-loading-dispatch-and-key-design.md
+++ b/docs/specs/2026-08-24-module-loading-dispatch-and-key-design.md
@@ -1,0 +1,82 @@
+# Module loading dispatch and key design
+
+## Context
+
+JSSE's host resolvers currently return `PathBuf` for both real files and the
+host-provided `<module source>` module. Loader callers then repeat type and
+evaluation-mode dispatch, while every filesystem operation must remember that
+one registry "path" is not a file. The host-loading requirements in
+`HostLoadImportedModule` permit normalization and require repeated equivalent
+requests to return the same Module Record, so the normalized host identity is
+the stable concept the registry must represent.
+
+This is a structural refactor. It must preserve the existing module behavior
+and the current module-error caching rules.
+
+## Approaches considered
+
+1. Wrap only the `HashMap` key in a newtype and convert from `PathBuf` at the
+   registry helpers. This is the smallest diff, but it leaves filesystem
+   sentinel checks and canonicalization discipline spread across the graph.
+   Deleting the wrapper would not make complexity reappear at callers, so the
+   module would remain shallow.
+2. Represent module identity as `enum ModuleKey { File(PathBuf), ModuleSource }`.
+   This makes file access exhaustive, but adds a variant-oriented interface for
+   the only host module and conflicts with the issue's explicit newtype choice.
+3. Return an opaque `ModuleKey(PathBuf)` from host resolution, propagate it
+   through the module graph, and make one loader dispatcher the only seam that
+   converts file-backed keys to `&Path`. This gives callers the most leverage
+   and concentrates host-key knowledge in one implementation. This is the
+   selected approach.
+
+## Design
+
+`ModuleKey` is cloneable, hashable, comparable, and debuggable, but does not
+implement `Deref<Target = Path>` or a total raw-path accessor. Its total
+canonicalization operation preserves a host key and canonicalizes a file key,
+falling back to the unresolved file path exactly as today. Its file accessor
+returns `Option<&Path>`, forcing a caller to handle host identity before doing
+filesystem I/O. Display remains available for diagnostics.
+
+Both host-specifier resolution paths produce `ModuleKey`. Registry entries,
+`LoadedModule` relationships, module namespace metadata, export-resolution
+visited sets, DFS stacks, and async-module graph bookkeeping carry the same
+type. Entry-point file paths are normalized into a Module Key before registry
+insertion. General script file paths remain ordinary paths until they take
+part in module resolution.
+
+`load_module_for_type(key, import_type, mode)` is the loading interface.
+`mode` distinguishes eager evaluation from deferred loading. For the host key,
+the dispatcher returns the one host Module Record for untyped requests and
+constructs the shared `TypeError` for text/bytes requests. For a file key, it
+dispatches text, bytes, eager source-text/JSON, or deferred source-text/JSON
+loading. The lower loaders accept only `&Path`, so the host key cannot reach a
+file read. Existing callers retain their own module-error caching because typed
+synthetic-module failures do not use that cache.
+
+Source-phase loading stays shallow for ordinary Source Text Modules. Resolution
+returns their Module Key but does not read, link, or evaluate the target. When
+the resolved key names the host module, the source-phase helper goes through
+the same typed loader dispatcher and reads `[[ModuleSource]]` from the returned
+record. Thus the dispatcher owns the typed host rejection without making source
+phase load real files.
+
+## Failure handling
+
+Resolver errors and filesystem/parse/link/evaluation errors retain their
+current JavaScript values and timing. `load_module` continues to balance the
+static-load-depth counter around every result. Eager and deferred callers keep
+their existing `cache_module_error` decisions. No new fallback from a host key
+to the filesystem is permitted.
+
+## Verification
+
+- Add focused Rust tests for total Module Key canonicalization and for the
+  dispatcher rejecting typed host requests in eager and deferred modes.
+- Keep the child-process regression where a real `<module source>` file cannot
+  capture the host key, updating its explanation to the type-enforced model.
+- Run custom tests and targeted test262 areas for dynamic import, import
+  attributes, import defer, source-phase import, and module code.
+- Run formatting, Clippy, release build/tests, and the full test262 suite
+  against the `origin/main` baseline without rewriting it.
+- Update `README.md` only if the full pass count changes.

--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -8052,21 +8052,27 @@ impl Interpreter {
                 let old_realm = interp.current_realm_id;
                 interp.current_realm_id = eval_realm_id;
 
-                let module_path =
-                    match interp.resolve_module_specifier(&specifier, referrer.as_deref()) {
-                        Ok(p) => p,
-                        Err(_) => {
-                            interp.current_realm_id = old_realm;
-                            let err = interp.create_error_in_realm(
-                                caller_realm_id,
-                                "TypeError",
-                                "ShadowRealm importValue: cannot resolve module",
-                            );
-                            return interp.create_rejected_promise(err);
-                        }
-                    };
+                let module_path = match interp.resolve_module_specifier(
+                    &specifier,
+                    referrer.as_ref().and_then(ModuleKey::file_path),
+                ) {
+                    Ok(p) => p,
+                    Err(_) => {
+                        interp.current_realm_id = old_realm;
+                        let err = interp.create_error_in_realm(
+                            caller_realm_id,
+                            "TypeError",
+                            "ShadowRealm importValue: cannot resolve module",
+                        );
+                        return interp.create_rejected_promise(err);
+                    }
+                };
 
-                let module = match interp.load_module(&module_path) {
+                let module = match interp.load_module_for_type(
+                    &module_path,
+                    None,
+                    super::ModuleLoadMode::Evaluate,
+                ) {
                     Ok(m) => m,
                     Err(_) => {
                         interp.current_realm_id = old_realm;
@@ -8078,7 +8084,7 @@ impl Interpreter {
                         return interp.create_rejected_promise(err);
                     }
                 };
-                let resolved_canon = Interpreter::canonicalize_module_path(&module_path);
+                let resolved_canon = module_path.canonicalize();
                 let mut stack = vec![];
                 if interp
                     .inner_module_evaluation(&resolved_canon, &mut stack, 0)

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1162,7 +1162,7 @@ impl Interpreter {
                 let module_path =
                     Environment::find_module_path(env).or_else(|| self.current_module_path.clone());
                 if let Some(ref path) = module_path {
-                    let canon = path.canonicalize().unwrap_or_else(|_| path.clone());
+                    let canon = path.canonicalize();
                     if let Some(module) = self.module_registry_get(&canon)
                         && let Some(ref cached) = module.borrow().cached_import_meta
                     {
@@ -1173,7 +1173,7 @@ impl Interpreter {
                 self.get_object_cell_expect(meta_id)
                     .borrow_mut()
                     .prototype_id = None;
-                if let Some(ref path) = module_path {
+                if let Some(path) = module_path.as_ref().and_then(ModuleKey::file_path) {
                     let url = format!("file://{}", path.display());
                     self.get_object_cell_expect(meta_id)
                         .borrow_mut()
@@ -1190,7 +1190,7 @@ impl Interpreter {
                 let id = meta_id;
                 let meta_val = JsValue::object(id);
                 if let Some(ref path) = module_path {
-                    let canon = path.canonicalize().unwrap_or_else(|_| path.clone());
+                    let canon = path.canonicalize();
                     if let Some(module) = self.module_registry_get(&canon) {
                         module.borrow_mut().cached_import_meta = Some(meta_val.clone());
                     }
@@ -1236,23 +1236,20 @@ impl Interpreter {
                 // import.defer() loads module without evaluation, returns deferred namespace
                 // but eagerly evaluates async transitive deps (spec ContinueDynamicImport step 25)
                 let module_path = self.current_module_path.clone();
-                let resolved = match self.resolve_module_specifier(&source, module_path.as_deref())
-                {
+                let resolved = match self.resolve_module_specifier(
+                    &source,
+                    module_path.as_ref().and_then(ModuleKey::file_path),
+                ) {
                     Ok(r) => r,
                     Err(e) => return self.create_rejected_promise(e),
                 };
-                // The synthetic Module Source module has no text or bytes in any
-                // phase, so a typed request must be refused here too, exactly as
-                // import() and import.source() refuse it.
-                if let Some(itype) = defer_import_type
-                    && Self::is_module_source_path(&resolved)
-                {
-                    let err = self.module_source_type_error(itype);
-                    return self.create_rejected_promise(err);
-                }
-                match self.load_module_no_eval(&resolved) {
+                match self.load_module_for_type(
+                    &resolved,
+                    defer_import_type,
+                    super::ModuleLoadMode::Defer,
+                ) {
                     Ok(module) => {
-                        let resolved_canon = Self::canonicalize_module_path(&resolved);
+                        let resolved_canon = resolved.canonicalize();
                         self.evaluate_async_transitive_deps(&resolved_canon);
                         self.drain_microtasks();
                         let ns = self.create_deferred_module_namespace(&module);
@@ -1284,7 +1281,7 @@ impl Interpreter {
                 let referrer = self.current_module_path.clone();
                 match self.resolve_source_phase_target(
                     &source,
-                    referrer.as_deref(),
+                    referrer.as_ref().and_then(ModuleKey::file_path),
                     source_import_type,
                 ) {
                     Ok((_, Some(ms))) => self.create_resolved_promise(ms),

--- a/src/interpreter/eval/modules.rs
+++ b/src/interpreter/eval/modules.rs
@@ -7,7 +7,7 @@ impl Interpreter {
         &mut self,
         binding_name: &str,
         env: &crate::interpreter::types::EnvRef,
-        module_path: Option<&std::path::Path>,
+        module_path: Option<&ModuleKey>,
         original_key: &str,
     ) -> Result<JsValue, JsValue> {
         self.resolve_module_export_value_inner(
@@ -23,12 +23,12 @@ impl Interpreter {
         &mut self,
         binding_name: &str,
         env: &crate::interpreter::types::EnvRef,
-        module_path: Option<&std::path::Path>,
+        module_path: Option<&ModuleKey>,
         original_key: &str,
-        visited: &mut HashSet<(std::path::PathBuf, String)>,
+        visited: &mut HashSet<(ModuleKey, String)>,
     ) -> Result<JsValue, JsValue> {
         if let Some(mp) = module_path {
-            let key = (mp.to_path_buf(), binding_name.to_string());
+            let key = (mp.clone(), binding_name.to_string());
             if visited.contains(&key) {
                 return Err(self.create_reference_error(&format!(
                     "Cannot access '{}' before initialization",
@@ -58,8 +58,9 @@ impl Interpreter {
                 let source = &rest[..colon_idx];
                 let export_name = &rest[colon_idx + 1..];
                 if let Some(mp) = module_path
-                    && let Ok(resolved) = self.resolve_module_specifier(source, Some(mp))
-                    && let Ok(source_mod) = self.load_module(&resolved)
+                    && let Ok(resolved) = self.resolve_module_specifier(source, mp.file_path())
+                    && let Ok(source_mod) =
+                        self.load_module_for_type(&resolved, None, super::ModuleLoadMode::Evaluate)
                 {
                     let source_ref = source_mod.borrow();
                     let source_env = source_ref.env.clone();
@@ -140,8 +141,12 @@ impl Interpreter {
                         let export_name = &rest[colon_idx + 1..];
                         if let Some(ref module_path) = ns_data.module_path
                             && let Ok(resolved) =
-                                self.resolve_module_specifier(source, Some(module_path))
-                            && let Ok(source_mod) = self.load_module(&resolved)
+                                self.resolve_module_specifier(source, module_path.file_path())
+                            && let Ok(source_mod) = self.load_module_for_type(
+                                &resolved,
+                                None,
+                                super::ModuleLoadMode::Evaluate,
+                            )
                         {
                             let source_ref = source_mod.borrow();
                             if let Some(binding) = source_ref.export_bindings.get(export_name) {
@@ -397,20 +402,22 @@ impl Interpreter {
         specifier: &str,
         import_type: Option<super::ImportModuleType>,
     ) -> Completion {
-        let resolved =
-            match self.resolve_module_specifier(specifier, self.current_module_path.as_deref()) {
-                Ok(p) => p,
-                Err(e) => {
-                    return self.create_rejected_promise(e);
-                }
-            };
+        let resolved = match self.resolve_module_specifier(
+            specifier,
+            self.current_module_path
+                .as_ref()
+                .and_then(ModuleKey::file_path),
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                return self.create_rejected_promise(e);
+            }
+        };
 
         // Text/bytes synthetic modules: load and resolve immediately
-        if let Some(ref itype) = import_type {
-            let module = match itype {
-                super::ImportModuleType::Text => self.load_text_module(&resolved),
-                super::ImportModuleType::Bytes => self.load_bytes_module(&resolved),
-            };
+        if import_type.is_some() {
+            let module =
+                self.load_module_for_type(&resolved, import_type, super::ModuleLoadMode::Evaluate);
             return match module {
                 Ok(m) => {
                     let ns = self.create_module_namespace(&m);
@@ -422,13 +429,14 @@ impl Interpreter {
 
         // If we're NOT inside a static module load, load synchronously
         if self.static_module_load_depth == 0 {
-            let module = match self.load_module(&resolved) {
-                Ok(m) => m,
-                Err(e) => {
-                    return self.create_rejected_promise(e);
-                }
-            };
-            let resolved_canon = Interpreter::canonicalize_module_path(&resolved);
+            let module =
+                match self.load_module_for_type(&resolved, None, super::ModuleLoadMode::Evaluate) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        return self.create_rejected_promise(e);
+                    }
+                };
+            let resolved_canon = resolved.canonicalize();
             let mut stack = vec![];
             if let Err(ref e) = self.inner_module_evaluation(&resolved_canon, &mut stack, 0) {
                 for m_path in &stack {
@@ -459,9 +467,13 @@ impl Interpreter {
         self.scheduler.enqueue_microtask((
             vec![promise_root, resolve_root.clone(), reject_root.clone()],
             Box::new(move |interp: &mut Interpreter| {
-                match interp.load_module(&resolved_path) {
+                match interp.load_module_for_type(
+                    &resolved_path,
+                    None,
+                    super::ModuleLoadMode::Evaluate,
+                ) {
                     Ok(m) => {
-                        let resolved_canon = Interpreter::canonicalize_module_path(&resolved_path);
+                        let resolved_canon = resolved_path.canonicalize();
                         let mut stack = vec![];
                         if let Err(ref e) =
                             interp.inner_module_evaluation(&resolved_canon, &mut stack, 0)
@@ -553,7 +565,7 @@ impl Interpreter {
             let m = module.borrow();
             m.cycle_root
                 .clone()
-                .unwrap_or_else(|| Interpreter::canonicalize_module_path(&m.path))
+                .unwrap_or_else(|| m.path.canonicalize())
         };
         let root_module = self
             .module_registry_get(&root_path)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -43,7 +43,7 @@ mod scheduler;
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum ImportModuleType {
     Text,
     Bytes,
@@ -76,6 +76,62 @@ fn import_module_type(attrs: &[(String, String)]) -> Option<ImportModuleType> {
         .and_then(|(_, value)| ImportModuleType::from_attr_value(value))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ModuleLoadMode {
+    Evaluate,
+    Defer,
+}
+
+/// Canonical host identity for a resolved module.
+///
+/// Most keys name files, but the host-provided `<module source>` record does
+/// not. Deliberately do not implement `Deref<Target = Path>`: callers must
+/// prove that a key is file-backed before crossing into filesystem code.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct ModuleKey(PathBuf);
+
+impl ModuleKey {
+    fn for_file(path: PathBuf) -> Self {
+        Self(path).canonicalize()
+    }
+
+    fn module_source() -> Self {
+        Self(PathBuf::from(MODULE_SOURCE_SPECIFIER))
+    }
+
+    fn is_module_source(&self) -> bool {
+        self.0 == Path::new(MODULE_SOURCE_SPECIFIER)
+    }
+
+    /// Return the backing file path, or `None` for a host-provided module.
+    fn file_path(&self) -> Option<&Path> {
+        (!self.is_module_source()).then_some(self.0.as_path())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.as_os_str().is_empty()
+    }
+
+    fn display(&self) -> std::path::Display<'_> {
+        self.0.display()
+    }
+
+    /// Canonicalize every Module Key without interpreting a host key as a
+    /// filesystem path. Missing files retain their resolved fallback spelling.
+    fn canonicalize(&self) -> Self {
+        if self.is_module_source() || self.0.as_os_str().is_empty() {
+            return self.clone();
+        }
+        Self(self.0.canonicalize().unwrap_or_else(|_| self.0.clone()))
+    }
+}
+
+impl std::fmt::Display for ModuleKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.display().fmt(f)
+    }
+}
+
 pub(crate) struct Interpreter {
     pub(crate) realms: Vec<Realm>,
     pub(crate) current_realm_id: usize,
@@ -99,9 +155,9 @@ pub(crate) struct Interpreter {
     pub(crate) generator_inline_iters: FxHashMap<u64, Vec<JsValue>>,
     pub(crate) scheduler: scheduler::JobScheduler,
     cached_has_instance_key: Option<JsPropertyKey>,
-    module_registry: HashMap<(usize, PathBuf), Rc<RefCell<LoadedModule>>>,
-    synthetic_module_registry: HashMap<(PathBuf, ImportModuleType), Rc<RefCell<LoadedModule>>>,
-    current_module_path: Option<PathBuf>,
+    module_registry: HashMap<(usize, ModuleKey), Rc<RefCell<LoadedModule>>>,
+    synthetic_module_registry: HashMap<(ModuleKey, ImportModuleType), Rc<RefCell<LoadedModule>>>,
+    current_module_path: Option<ModuleKey>,
     loading_deferred: bool,
     last_call_had_explicit_return: bool,
     last_call_this_value: Option<JsValue>,
@@ -139,7 +195,7 @@ pub(crate) struct Interpreter {
     pub(crate) pending_async_dispose_await: bool,
     pub(crate) static_module_load_depth: u32,
     module_async_evaluation_count: u64,
-    module_async_info: FxHashMap<u64, PathBuf>,
+    module_async_info: FxHashMap<u64, ModuleKey>,
     pub(crate) with_scope_depth: u32,
     pub(crate) has_ever_entered_with: bool,
     /// IC hit counter for Phase-2 telemetry/tests. Issue #71. Cell so the
@@ -323,7 +379,7 @@ pub(crate) enum AsyncGenRequestKind {
 }
 
 pub(crate) struct LoadedModule {
-    pub path: PathBuf,
+    pub path: ModuleKey,
     pub env: EnvRef,
     pub exports: HashMap<String, JsValue>,
     pub export_bindings: HashMap<String, String>, // export_name -> binding_name
@@ -331,8 +387,8 @@ pub(crate) struct LoadedModule {
     pub cached_deferred_namespace: Option<JsValue>, // cached deferred namespace (separate from eager)
     pub cached_import_meta: Option<JsValue>,        // cached import.meta object per §16.2.1.5.2
     pub error: Option<JsValue>,                     // if module evaluation threw, the error
-    pub namespace_imports: HashMap<String, PathBuf>, // local_name -> source module path (for `import * as ns`)
-    pub source_imports: HashMap<String, PathBuf>, // local_name -> source-phase target path (for `import source X`)
+    pub namespace_imports: HashMap<String, ModuleKey>, // local_name -> source module (for `import * as ns`)
+    pub source_imports: HashMap<String, ModuleKey>, // local_name -> source-phase target (for `import source X`)
     pub module_source: Option<JsValue>, // [[ModuleSource]]: source-phase representation (empty for Source Text Modules)
     pub star_export_sources: Vec<String>, // source specifiers from `export * from '...'`
     pub evaluated: bool,
@@ -342,8 +398,8 @@ pub(crate) struct LoadedModule {
     pub program_ast: Option<crate::ast::Program>,
     pub async_evaluation_order: Option<u64>,
     pub pending_async_dependencies: u32,
-    pub async_parent_modules: Vec<PathBuf>,
-    pub cycle_root: Option<PathBuf>,
+    pub async_parent_modules: Vec<ModuleKey>,
+    pub cycle_root: Option<ModuleKey>,
     pub top_level_capability: Option<(JsValue, JsValue, JsValue)>,
     pub dfs_index: Option<u32>,
     pub dfs_ancestor_index: Option<u32>,
@@ -923,9 +979,9 @@ impl Interpreter {
     /// `MODULE_SOURCE_SPECIFIER` resolves to, in every import phase. Its
     /// `[[ModuleSource]]` is a fresh %AbstractModuleSource% instance; it exposes
     /// no bindings.
-    fn get_or_create_module_source_module(&mut self) -> Rc<RefCell<LoadedModule>> {
-        let sentinel = PathBuf::from(MODULE_SOURCE_SPECIFIER);
-        if let Some(existing) = self.module_registry_get(&sentinel) {
+    fn get_or_create_module_source_module(&mut self, key: &ModuleKey) -> Rc<RefCell<LoadedModule>> {
+        debug_assert!(key.is_module_source());
+        if let Some(existing) = self.module_registry_get(key) {
             return existing;
         }
 
@@ -943,7 +999,7 @@ impl Interpreter {
         let module_env = Environment::new_function_scope(Some(self.realm().global_env.clone()));
         module_env.borrow_mut().strict = true;
         let module = Rc::new(RefCell::new(LoadedModule {
-            path: sentinel.clone(),
+            path: key.clone(),
             env: module_env,
             exports: HashMap::new(),
             export_bindings: HashMap::new(),
@@ -968,7 +1024,7 @@ impl Interpreter {
             dfs_index: None,
             dfs_ancestor_index: None,
         }));
-        self.module_registry_insert(sentinel, module.clone());
+        self.module_registry_insert(key.clone(), module.clone());
         module
     }
 
@@ -997,39 +1053,15 @@ impl Interpreter {
         specifier: &str,
         referrer: Option<&Path>,
         import_type: Option<ImportModuleType>,
-    ) -> Result<(PathBuf, Option<JsValue>), JsValue> {
+    ) -> Result<(ModuleKey, Option<JsValue>), JsValue> {
         let resolved = self.resolve_module_specifier(specifier, referrer)?;
-        if Self::is_module_source_path(&resolved) {
-            if let Some(itype) = import_type {
-                return Err(self.module_source_type_error(itype));
-            }
-            let module = self.load_module(&resolved)?;
+        if resolved.is_module_source() {
+            let module =
+                self.load_module_for_type(&resolved, import_type, ModuleLoadMode::Evaluate)?;
             let module_source = module.borrow().module_source.clone();
             return Ok((resolved, module_source));
         }
         Ok((resolved, None))
-    }
-
-    /// Whether `path` is the module-registry key of the synthetic
-    /// `<module source>` host module rather than a filesystem path.
-    fn is_module_source_path(path: &Path) -> bool {
-        path == Path::new(MODULE_SOURCE_SPECIFIER)
-    }
-
-    /// Canonicalize a module *target* path, leaving the synthetic
-    /// `<module source>` key untouched.
-    ///
-    /// The key is a bare relative path, so a plain `canonicalize()` succeeds
-    /// whenever the process happens to run in a directory holding a real entry of
-    /// that name — silently rebinding the specifier to that file's registry slot.
-    /// Every site that canonicalizes a path which may have come from
-    /// `resolve_module_specifier` goes through here, so the key also keeps
-    /// resolving to the synthetic record rather than missing the registry.
-    fn canonicalize_module_path(path: &Path) -> PathBuf {
-        if Self::is_module_source_path(path) {
-            return path.to_path_buf();
-        }
-        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
     }
 
     /// The host has no text or bytes to hand back for a Module Source module, in
@@ -1040,6 +1072,32 @@ impl Interpreter {
             "Module '{MODULE_SOURCE_SPECIFIER}' has no {} representation",
             itype.attr_value()
         ))
+    }
+
+    /// Load a resolved module request through the one host/type/mode dispatch
+    /// seam. File-only loaders sit behind this method, so the host-provided
+    /// `<module source>` key can never reach a filesystem read.
+    fn load_module_for_type(
+        &mut self,
+        key: &ModuleKey,
+        import_type: Option<ImportModuleType>,
+        mode: ModuleLoadMode,
+    ) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        let Some(path) = key.file_path() else {
+            return match import_type {
+                Some(itype) => Err(self.module_source_type_error(itype)),
+                None => Ok(self.get_or_create_module_source_module(key)),
+            };
+        };
+
+        match import_type {
+            Some(ImportModuleType::Text) => self.load_text_module(key, path),
+            Some(ImportModuleType::Bytes) => self.load_bytes_module(key, path),
+            None => match mode {
+                ModuleLoadMode::Evaluate => self.load_module(key, path),
+                ModuleLoadMode::Defer => self.load_module_no_eval(key, path),
+            },
+        }
     }
 
     pub(crate) fn gc_root_value(&mut self, val: &JsValue) {
@@ -1967,7 +2025,7 @@ impl Interpreter {
         match program.source_type {
             SourceType::Script => {
                 let prev = self.current_module_path.take();
-                self.current_module_path = Some(path.to_path_buf());
+                self.current_module_path = Some(ModuleKey::for_file(path.to_path_buf()));
                 let global = self.realm().global_env.clone();
                 if program.body_is_strict {
                     global.borrow_mut().strict = true;
@@ -1984,13 +2042,14 @@ impl Interpreter {
                 r
             }
             SourceType::Module => {
-                let r = self.run_module(program, Some(path.to_path_buf()));
+                let module_key = ModuleKey::for_file(path.to_path_buf());
+                let r = self.run_module(program, Some(module_key.clone()));
                 if let Completion::Exit(code) = &r {
                     self.pending_exit = Some(*code);
                 }
                 // Keep path set during microtask draining so async callbacks can use relative imports
                 let prev = self.current_module_path.take();
-                self.current_module_path = Some(path.to_path_buf());
+                self.current_module_path = Some(module_key);
                 self.drain_microtasks_until_idle();
                 self.current_module_path = prev;
                 r
@@ -1998,18 +2057,18 @@ impl Interpreter {
         }
     }
 
-    pub(crate) fn module_registry_get(&self, path: &Path) -> Option<Rc<RefCell<LoadedModule>>> {
+    pub(crate) fn module_registry_get(&self, key: &ModuleKey) -> Option<Rc<RefCell<LoadedModule>>> {
         self.module_registry
-            .get(&(self.current_realm_id, path.to_path_buf()))
+            .get(&(self.current_realm_id, key.clone()))
             .cloned()
     }
 
-    fn module_registry_insert(&mut self, path: PathBuf, module: Rc<RefCell<LoadedModule>>) {
+    fn module_registry_insert(&mut self, key: ModuleKey, module: Rc<RefCell<LoadedModule>>) {
         self.module_registry
-            .insert((self.current_realm_id, path), module);
+            .insert((self.current_realm_id, key), module);
     }
 
-    fn run_module(&mut self, program: &Program, module_path: Option<PathBuf>) -> Completion {
+    fn run_module(&mut self, program: &Program, module_path: Option<ModuleKey>) -> Completion {
         let prev_module_path = self.current_module_path.take();
         self.current_module_path = module_path.clone();
 
@@ -2022,9 +2081,8 @@ impl Interpreter {
 
         // Register entry-point module in registry to handle self-imports
         let canon_path_entry = module_path
-            .as_ref()
-            .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
-            .unwrap_or_default();
+            .clone()
+            .unwrap_or_else(|| ModuleKey::for_file(PathBuf::new()));
         let has_tla_entry = Self::module_has_tla(program);
         let loaded_module = Rc::new(RefCell::new(LoadedModule {
             path: canon_path_entry.clone(),
@@ -2052,9 +2110,8 @@ impl Interpreter {
             dfs_index: None,
             dfs_ancestor_index: None,
         }));
-        if let Some(ref path) = module_path {
-            let canon_path = path.canonicalize().unwrap_or_else(|_| path.clone());
-            self.module_registry_insert(canon_path, loaded_module.clone());
+        if let Some(ref key) = module_path {
+            self.module_registry_insert(key.clone(), loaded_module.clone());
         }
         // Note: is_evaluating is managed by inner_module_evaluation
 
@@ -2129,34 +2186,21 @@ impl Interpreter {
             };
             if let Some(spec) = specifier {
                 let module_path = self.current_module_path.clone();
-                if let Ok(resolved) = self.resolve_module_specifier(spec, module_path.as_deref()) {
-                    match import_type {
-                        Some(ImportModuleType::Text) => {
-                            if let Err(e) = self.load_text_module(&resolved) {
-                                self.current_module_path = prev_module_path;
-                                return Completion::Throw(e);
-                            }
+                if let Ok(resolved) = self.resolve_module_specifier(
+                    spec,
+                    module_path.as_ref().and_then(ModuleKey::file_path),
+                ) {
+                    let mode = if is_deferred {
+                        ModuleLoadMode::Defer
+                    } else {
+                        ModuleLoadMode::Evaluate
+                    };
+                    if let Err(e) = self.load_module_for_type(&resolved, import_type, mode) {
+                        if import_type.is_none() {
+                            Self::cache_module_error(&loaded_module, &e);
                         }
-                        Some(ImportModuleType::Bytes) => {
-                            if let Err(e) = self.load_bytes_module(&resolved) {
-                                self.current_module_path = prev_module_path;
-                                return Completion::Throw(e);
-                            }
-                        }
-                        None if is_deferred => {
-                            if let Err(e) = self.load_module_no_eval(&resolved) {
-                                Self::cache_module_error(&loaded_module, &e);
-                                self.current_module_path = prev_module_path;
-                                return Completion::Throw(e);
-                            }
-                        }
-                        None => {
-                            if let Err(e) = self.load_module(&resolved) {
-                                Self::cache_module_error(&loaded_module, &e);
-                                self.current_module_path = prev_module_path;
-                                return Completion::Throw(e);
-                            }
-                        }
+                        self.current_module_path = prev_module_path;
+                        return Completion::Throw(e);
                     }
                 }
             }
@@ -2187,14 +2231,15 @@ impl Interpreter {
         }
 
         // Validate named re-exports (export { x } from './mod')
-        if let Some(ref canon_path) = module_path {
+        if module_path.is_some() {
             for item in &program.module_items {
                 if let ModuleItem::ExportDeclaration(ExportDeclaration::Named {
                     specifiers,
                     source: Some(source),
                     ..
                 }) = item
-                    && let Err(e) = self.validate_named_reexports(canon_path, source, specifiers)
+                    && let Err(e) =
+                        self.validate_named_reexports(&canon_path_entry, source, specifiers)
                 {
                     Self::cache_module_error(&loaded_module, &e);
                     self.current_module_path = prev_module_path;
@@ -2249,14 +2294,16 @@ impl Interpreter {
             return self.process_source_phase_import(local, &import.source, itype, env);
         }
 
-        let resolved = self.resolve_module_specifier(&import.source, module_path.as_deref())?;
+        let resolved = self.resolve_module_specifier(
+            &import.source,
+            module_path.as_ref().and_then(ModuleKey::file_path),
+        )?;
 
         let itype = import_module_type(&import.attributes);
 
         // Text/bytes imports use synthetic module registry
         if let Some(ref it) = itype {
-            let canon = Self::canonicalize_module_path(&resolved);
-            let key = (canon, it.clone());
+            let key = (resolved.clone(), *it);
             let loaded = self
                 .synthetic_module_registry
                 .get(&key)
@@ -2298,9 +2345,9 @@ impl Interpreter {
         // For deferred imports or when loading in deferred context,
         // use load_module_no_eval to avoid premature evaluation
         let loaded = if is_deferred || self.loading_deferred {
-            self.load_module_no_eval(&resolved)?
+            self.load_module_for_type(&resolved, None, ModuleLoadMode::Defer)?
         } else {
-            self.load_module(&resolved)?
+            self.load_module_for_type(&resolved, None, ModuleLoadMode::Evaluate)?
         };
 
         for spec in &import.specifiers {
@@ -2316,7 +2363,7 @@ impl Interpreter {
                     env.borrow_mut().declare(local, BindingKind::Const);
                     env.borrow_mut().initialize_binding(local, ns);
                     if let Some(ref mp) = self.current_module_path {
-                        let canon = mp.canonicalize().unwrap_or_else(|_| mp.clone());
+                        let canon = mp.canonicalize();
                         if let Some(current_mod) = self.module_registry_get(&canon) {
                             current_mod
                                 .borrow_mut()
@@ -2366,8 +2413,11 @@ impl Interpreter {
         env: &EnvRef,
     ) -> Result<(), JsValue> {
         let referrer = self.current_module_path.clone();
-        let (target_path, module_source) =
-            self.resolve_source_phase_target(specifier, referrer.as_deref(), import_type)?;
+        let (target_path, module_source) = self.resolve_source_phase_target(
+            specifier,
+            referrer.as_ref().and_then(ModuleKey::file_path),
+            import_type,
+        )?;
 
         let Some(module_source) = module_source else {
             return Err(self.create_error(
@@ -2382,7 +2432,7 @@ impl Interpreter {
         // Record the source-phase target so `export { X }` re-exports resolve
         // to the same ResolvedBinding { [[Module]], [[BindingName]]: ~source~ }.
         if let Some(ref mp) = referrer {
-            let canon = mp.canonicalize().unwrap_or_else(|_| mp.clone());
+            let canon = mp.canonicalize();
             if let Some(current_mod) = self.module_registry_get(&canon) {
                 current_mod
                     .borrow_mut()
@@ -2398,7 +2448,7 @@ impl Interpreter {
         local: &str,
         imported: &str,
         loaded: &Rc<RefCell<LoadedModule>>,
-        resolved: &Path,
+        resolved: &ModuleKey,
         env: &EnvRef,
     ) -> Result<(), JsValue> {
         let binding_info = loaded.borrow().export_bindings.get(imported).cloned();
@@ -2480,8 +2530,11 @@ impl Interpreter {
         module: &Rc<RefCell<LoadedModule>>,
     ) -> Result<(), JsValue> {
         let module_path = self.current_module_path.clone();
-        let resolved = self.resolve_module_specifier(source, module_path.as_deref())?;
-        let source_module = self.load_module(&resolved)?;
+        let resolved = self.resolve_module_specifier(
+            source,
+            module_path.as_ref().and_then(ModuleKey::file_path),
+        )?;
+        let source_module = self.load_module_for_type(&resolved, None, ModuleLoadMode::Evaluate)?;
 
         if let Some(name) = exported_as {
             // export * as ns from './mod' - create namespace object
@@ -2522,15 +2575,17 @@ impl Interpreter {
                                 UseNew,
                                 Ambiguous,
                             }
-                            let decision = if let Some(ref mp) = module_path {
+                            let decision = if let Some(ref module_key) = module_path {
                                 let mut v1 = HashSet::new();
-                                let r1 = self.resolve_export_binding(mp, &export_name, &mut v1);
+                                let r1 =
+                                    self.resolve_export_binding(module_key, &export_name, &mut v1);
                                 module
                                     .borrow_mut()
                                     .export_bindings
                                     .insert(export_name.clone(), new_reexport.clone());
                                 let mut v2 = HashSet::new();
-                                let r2 = self.resolve_export_binding(mp, &export_name, &mut v2);
+                                let r2 =
+                                    self.resolve_export_binding(module_key, &export_name, &mut v2);
                                 module
                                     .borrow_mut()
                                     .export_bindings
@@ -2601,11 +2656,11 @@ impl Interpreter {
         &self,
         specifier: &str,
         referrer: Option<&Path>,
-    ) -> Result<PathBuf, JsValue> {
+    ) -> Result<ModuleKey, JsValue> {
         // Host-provided synthetic module. Resolved here rather than in the
         // source-phase path so that every phase names the same Module Record.
         if specifier == MODULE_SOURCE_SPECIFIER {
-            return Ok(PathBuf::from(MODULE_SOURCE_SPECIFIER));
+            return Ok(ModuleKey::module_source());
         }
 
         // Relative paths: ./ or ../
@@ -2614,7 +2669,7 @@ impl Interpreter {
                 let base = referrer.parent().unwrap_or(Path::new("."));
                 let resolved = base.join(specifier);
                 if resolved.exists() {
-                    return Ok(resolved.canonicalize().unwrap_or(resolved));
+                    return Ok(ModuleKey::for_file(resolved));
                 }
                 return Err(JsValue::string(JsString::from_str(&format!(
                     "Cannot find module '{}'",
@@ -2630,7 +2685,7 @@ impl Interpreter {
         // Absolute paths
         let path = Path::new(specifier);
         if path.is_absolute() && path.exists() {
-            return Ok(path.to_path_buf());
+            return Ok(ModuleKey::for_file(path.to_path_buf()));
         }
 
         // Bare specifiers not supported
@@ -2644,19 +2699,23 @@ impl Interpreter {
         module.borrow_mut().error = Some(err.clone());
     }
 
-    fn load_module(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+    fn load_module(
+        &mut self,
+        key: &ModuleKey,
+        path: &Path,
+    ) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
         self.static_module_load_depth += 1;
-        let result = self.load_module_inner(path);
+        let result = self.load_module_inner(key, path);
         self.static_module_load_depth -= 1;
         result
     }
 
-    fn load_module_inner(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
-        if Self::is_module_source_path(path) {
-            return Ok(self.get_or_create_module_source_module());
-        }
-
-        let canon_path = Self::canonicalize_module_path(path);
+    fn load_module_inner(
+        &mut self,
+        key: &ModuleKey,
+        path: &Path,
+    ) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        let canon_path = key.clone();
 
         // Check if module is already loaded
         if let Some(existing) = self.module_registry_get(&canon_path) {
@@ -2870,7 +2929,7 @@ impl Interpreter {
             // targets like `<do not resolve>` — must surface unresolvable
             // specifier errors here.
             if let Some(spec) = specifier
-                && let Err(e) = self.resolve_module_specifier(spec, Some(&canon_path))
+                && let Err(e) = self.resolve_module_specifier(spec, Some(path))
             {
                 Self::cache_module_error(&loaded_module, &e);
                 self.current_module_path = prev_path;
@@ -2910,24 +2969,21 @@ impl Interpreter {
             };
             if let Some(spec) = specifier {
                 let module_path = self.current_module_path.clone();
-                if let Ok(resolved) = self.resolve_module_specifier(spec, module_path.as_deref()) {
-                    match itype {
-                        Some(ImportModuleType::Text) => {
-                            self.load_text_module(&resolved)?;
+                if let Ok(resolved) = self.resolve_module_specifier(
+                    spec,
+                    module_path.as_ref().and_then(ModuleKey::file_path),
+                ) {
+                    let mode = if is_deferred {
+                        ModuleLoadMode::Defer
+                    } else {
+                        ModuleLoadMode::Evaluate
+                    };
+                    if let Err(e) = self.load_module_for_type(&resolved, itype, mode) {
+                        if itype.is_none() && !is_deferred {
+                            Self::cache_module_error(&loaded_module, &e);
+                            self.current_module_path = prev_path;
                         }
-                        Some(ImportModuleType::Bytes) => {
-                            self.load_bytes_module(&resolved)?;
-                        }
-                        None if is_deferred => {
-                            self.load_module_no_eval(&resolved)?;
-                        }
-                        None => {
-                            if let Err(e) = self.load_module(&resolved) {
-                                Self::cache_module_error(&loaded_module, &e);
-                                self.current_module_path = prev_path;
-                                return Err(e);
-                            }
-                        }
+                        return Err(e);
                     }
                 }
             }
@@ -2983,12 +3039,12 @@ impl Interpreter {
 
     /// Load a module without evaluating it (for deferred imports).
     /// Parses, links, resolves exports, but does NOT execute the module body.
-    fn load_module_no_eval(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
-        if Self::is_module_source_path(path) {
-            return Ok(self.get_or_create_module_source_module());
-        }
-
-        let canon_path = Self::canonicalize_module_path(path);
+    fn load_module_no_eval(
+        &mut self,
+        key: &ModuleKey,
+        path: &Path,
+    ) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        let canon_path = key.clone();
 
         if let Some(existing) = self.module_registry_get(&canon_path) {
             // Propagate parse/link errors (module never finished loading) eagerly.
@@ -3007,7 +3063,7 @@ impl Interpreter {
 
         // JSON modules are always fully evaluated
         if path.extension().and_then(|e| e.to_str()) == Some("json") {
-            return self.load_module(path);
+            return self.load_module(key, path);
         }
 
         let source = std::fs::read_to_string(path).map_err(|e| {
@@ -3143,12 +3199,11 @@ impl Interpreter {
             };
             if let Some(spec) = specifier {
                 let module_path = self.current_module_path.clone();
-                if let Ok(resolved) = self.resolve_module_specifier(spec, module_path.as_deref()) {
-                    let result = match itype {
-                        Some(ImportModuleType::Text) => self.load_text_module(&resolved),
-                        Some(ImportModuleType::Bytes) => self.load_bytes_module(&resolved),
-                        None => self.load_module_no_eval(&resolved),
-                    };
+                if let Ok(resolved) = self.resolve_module_specifier(
+                    spec,
+                    module_path.as_ref().and_then(ModuleKey::file_path),
+                ) {
+                    let result = self.load_module_for_type(&resolved, itype, ModuleLoadMode::Defer);
                     if let Err(e) = result {
                         Self::cache_module_error(&loaded_module, &e);
                         self.current_module_path = prev_path;
@@ -3212,7 +3267,7 @@ impl Interpreter {
 
     fn create_synthetic_default_module(
         &mut self,
-        canon_path: PathBuf,
+        canon_path: ModuleKey,
         value: JsValue,
     ) -> Rc<RefCell<LoadedModule>> {
         let module_env = Environment::new_function_scope(Some(self.realm().global_env.clone()));
@@ -3259,11 +3314,12 @@ impl Interpreter {
         }))
     }
 
-    fn load_text_module(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
-        if Self::is_module_source_path(path) {
-            return Err(self.module_source_type_error(ImportModuleType::Text));
-        }
-        let canon = Self::canonicalize_module_path(path);
+    fn load_text_module(
+        &mut self,
+        key: &ModuleKey,
+        path: &Path,
+    ) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        let canon = key.clone();
         let key = (canon.clone(), ImportModuleType::Text);
         if let Some(existing) = self.synthetic_module_registry.get(&key) {
             return Ok(existing.clone());
@@ -3281,11 +3337,12 @@ impl Interpreter {
         Ok(module)
     }
 
-    fn load_bytes_module(&mut self, path: &Path) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
-        if Self::is_module_source_path(path) {
-            return Err(self.module_source_type_error(ImportModuleType::Bytes));
-        }
-        let canon = Self::canonicalize_module_path(path);
+    fn load_bytes_module(
+        &mut self,
+        key: &ModuleKey,
+        path: &Path,
+    ) -> Result<Rc<RefCell<LoadedModule>>, JsValue> {
+        let canon = key.clone();
         let key = (canon.clone(), ImportModuleType::Bytes);
         if let Some(existing) = self.synthetic_module_registry.get(&key) {
             return Ok(existing.clone());
@@ -3346,7 +3403,7 @@ impl Interpreter {
     }
 
     /// Execute a module's body synchronously (no DFS into dependencies).
-    fn execute_module_body_sync(&mut self, module_path: &Path) -> Result<(), JsValue> {
+    fn execute_module_body_sync(&mut self, module_path: &ModuleKey) -> Result<(), JsValue> {
         let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return Ok(()),
@@ -3357,7 +3414,7 @@ impl Interpreter {
         };
         let module_env = module.borrow().env.clone();
         let prev_path = self.current_module_path.take();
-        self.current_module_path = Some(module_path.to_path_buf());
+        self.current_module_path = Some(module_path.clone());
         self.static_module_load_depth += 1;
 
         let prev_ic_handle = self.current_ic_handle;
@@ -3396,7 +3453,7 @@ impl Interpreter {
         }
     }
 
-    fn collect_all_exports(&mut self, module_path: &Path) {
+    fn collect_all_exports(&mut self, module_path: &ModuleKey) {
         let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return,
@@ -3407,7 +3464,7 @@ impl Interpreter {
         };
         let module_env = module.borrow().env.clone();
         let prev_path = self.current_module_path.take();
-        self.current_module_path = Some(module_path.to_path_buf());
+        self.current_module_path = Some(module_path.clone());
         for item in &program.module_items {
             if let ModuleItem::ExportDeclaration(export) = item {
                 self.collect_exports(export, &module_env, &module);
@@ -3449,7 +3506,7 @@ impl Interpreter {
         stmts
     }
 
-    fn execute_async_module(&mut self, module_path: &Path) {
+    fn execute_async_module(&mut self, module_path: &ModuleKey) {
         let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return,
@@ -3479,15 +3536,15 @@ impl Interpreter {
                 module_env.borrow_mut().declare(&lv.name, bk);
             }
         }
-        let path_for_resolve = module_path.to_path_buf();
-        let path_for_reject = module_path.to_path_buf();
+        let key_for_resolve = module_path.clone();
+        let key_for_reject = module_path.clone();
         let resolve_fn = self.create_function(JsFunction::native(
             "asyncModuleResolve".to_string(),
             0,
             move |interp, _this, _args| {
                 let prev = interp.current_module_path.take();
-                interp.current_module_path = Some(path_for_resolve.clone());
-                interp.async_module_execution_fulfilled(&path_for_resolve.clone());
+                interp.current_module_path = Some(key_for_resolve.clone());
+                interp.async_module_execution_fulfilled(&key_for_resolve);
                 interp.current_module_path = prev;
                 Completion::Normal(JsValue::UNDEFINED)
             },
@@ -3497,13 +3554,12 @@ impl Interpreter {
             1,
             move |interp, _this, args| {
                 let error = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                interp.async_module_execution_rejected(&path_for_reject.clone(), &error);
+                interp.async_module_execution_rejected(&key_for_reject, &error);
                 Completion::Normal(JsValue::UNDEFINED)
             },
         ));
         let async_id = self.scheduler.alloc_async_function_id();
-        self.module_async_info
-            .insert(async_id, module_path.to_path_buf());
+        self.module_async_info.insert(async_id, module_path.clone());
         self.scheduler.insert_async_function_state(
             async_id,
             AsyncFunctionState {
@@ -3519,11 +3575,11 @@ impl Interpreter {
                 reject_fn,
                 for_of_stack: vec![],
                 for_of_iter_env: None,
-                module_path: Some(module_path.to_path_buf()),
+                module_path: Some(module_path.clone()),
             },
         );
         let prev_path = self.current_module_path.take();
-        self.current_module_path = Some(module_path.to_path_buf());
+        self.current_module_path = Some(module_path.clone());
         self.static_module_load_depth += 1;
         // Module top-level `await` (issue #242): this driver returns `()`, so a
         // `__host_exit` from top-level module code is recorded in the terminal
@@ -3539,11 +3595,11 @@ impl Interpreter {
 
     fn inner_module_evaluation(
         &mut self,
-        module_path: &Path,
-        stack: &mut Vec<PathBuf>,
+        module_path: &ModuleKey,
+        stack: &mut Vec<ModuleKey>,
         index: u32,
     ) -> Result<u32, JsValue> {
-        let canon = Self::canonicalize_module_path(module_path);
+        let canon = module_path.canonicalize();
         let module = match self.module_registry_get(&canon) {
             Some(m) => m,
             None => return Ok(index),
@@ -3573,7 +3629,7 @@ impl Interpreter {
 
         // Build evaluationList per spec §16.2.1.5.3.1 step 7
         let dep_paths = self.get_module_dep_paths(&canon);
-        let mut evaluation_list: Vec<PathBuf> = Vec::new();
+        let mut evaluation_list: Vec<ModuleKey> = Vec::new();
         for (dep_canon, is_deferred) in &dep_paths {
             if *is_deferred {
                 let mut to_eval = Vec::new();
@@ -3670,7 +3726,7 @@ impl Interpreter {
         Ok(idx)
     }
 
-    fn get_module_dep_paths(&self, canon_path: &Path) -> Vec<(PathBuf, bool)> {
+    fn get_module_dep_paths(&self, canon_path: &ModuleKey) -> Vec<(ModuleKey, bool)> {
         let module = match self.module_registry_get(canon_path) {
             Some(m) => m,
             None => return Vec::new(),
@@ -3703,7 +3759,8 @@ impl Interpreter {
                 _ => (None, false),
             };
             if let Some(spec) = specifier
-                && let Ok(resolved) = self.resolve_module_specifier_pure(spec, Some(canon_path))
+                && let Ok(resolved) =
+                    self.resolve_module_specifier_pure(spec, canon_path.file_path())
             {
                 deps.push((resolved, is_deferred));
             }
@@ -3711,7 +3768,7 @@ impl Interpreter {
         deps
     }
 
-    fn gather_available_ancestors(&mut self, module_path: &Path) -> Vec<PathBuf> {
+    fn gather_available_ancestors(&mut self, module_path: &ModuleKey) -> Vec<ModuleKey> {
         let parents = match self.module_registry_get(module_path) {
             Some(m) => m.borrow().async_parent_modules.clone(),
             None => return Vec::new(),
@@ -3741,7 +3798,7 @@ impl Interpreter {
         result
     }
 
-    fn async_module_execution_rejected(&mut self, module_path: &Path, error: &JsValue) {
+    fn async_module_execution_rejected(&mut self, module_path: &ModuleKey, error: &JsValue) {
         let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return,
@@ -3764,7 +3821,7 @@ impl Interpreter {
         }
     }
 
-    fn async_module_execution_fulfilled(&mut self, module_path: &Path) {
+    fn async_module_execution_fulfilled(&mut self, module_path: &ModuleKey) {
         let module = match self.module_registry_get(module_path) {
             Some(m) => m,
             None => return,
@@ -3984,7 +4041,7 @@ impl Interpreter {
     }
 
     /// Eagerly evaluate async transitive dependencies of a deferred module
-    fn evaluate_async_transitive_deps(&mut self, deferred_path: &Path) {
+    fn evaluate_async_transitive_deps(&mut self, deferred_path: &ModuleKey) {
         let mut to_eval = Vec::new();
         let mut seen = HashSet::new();
         self.gather_async_transitive_deps(deferred_path, &mut to_eval, &mut seen);
@@ -4001,11 +4058,11 @@ impl Interpreter {
 
     fn gather_async_transitive_deps(
         &self,
-        module_path: &Path,
-        result: &mut Vec<PathBuf>,
-        seen: &mut HashSet<PathBuf>,
+        module_path: &ModuleKey,
+        result: &mut Vec<ModuleKey>,
+        seen: &mut HashSet<ModuleKey>,
     ) {
-        let canon = Self::canonicalize_module_path(module_path);
+        let canon = module_path.canonicalize();
         if !seen.insert(canon.clone()) {
             return;
         }
@@ -4049,7 +4106,8 @@ impl Interpreter {
                     _ => None,
                 };
                 if let Some(spec) = specifier
-                    && let Ok(resolved) = self.resolve_module_specifier_pure(spec, Some(&canon))
+                    && let Ok(resolved) =
+                        self.resolve_module_specifier_pure(spec, canon.file_path())
                 {
                     self.gather_async_transitive_deps(&resolved, result, seen);
                 }
@@ -4062,34 +4120,34 @@ impl Interpreter {
         &self,
         specifier: &str,
         referrer: Option<&Path>,
-    ) -> Result<PathBuf, JsValue> {
+    ) -> Result<ModuleKey, JsValue> {
         if specifier == MODULE_SOURCE_SPECIFIER {
-            return Ok(PathBuf::from(MODULE_SOURCE_SPECIFIER));
+            return Ok(ModuleKey::module_source());
         }
         if specifier.starts_with("./") || specifier.starts_with("../") || specifier.starts_with('/')
         {
             let base = referrer.and_then(|r| r.parent()).unwrap_or(Path::new("."));
             let resolved = base.join(specifier);
             if resolved.exists() {
-                return Ok(resolved.canonicalize().unwrap_or(resolved));
+                return Ok(ModuleKey::for_file(resolved));
             }
             // Try .js extension
             let with_js = resolved.with_extension("js");
             if with_js.exists() {
-                return Ok(with_js.canonicalize().unwrap_or(with_js));
+                return Ok(ModuleKey::for_file(with_js));
             }
             // Try /index.js
             let index = resolved.join("index.js");
             if index.exists() {
-                return Ok(index.canonicalize().unwrap_or(index));
+                return Ok(ModuleKey::for_file(index));
             }
         }
         Err(JsValue::UNDEFINED)
     }
 
     /// Check if a module and all its transitive deps are ready for synchronous execution
-    fn ready_for_sync_execution(&self, path: &Path, seen: &mut HashSet<PathBuf>) -> bool {
-        let canon = Self::canonicalize_module_path(path);
+    fn ready_for_sync_execution(&self, path: &ModuleKey, seen: &mut HashSet<ModuleKey>) -> bool {
+        let canon = path.canonicalize();
         if !seen.insert(canon.clone()) {
             return true; // cycle — spec says return true
         }
@@ -4131,7 +4189,8 @@ impl Interpreter {
                     _ => None,
                 };
                 if let Some(spec) = specifier
-                    && let Ok(resolved) = self.resolve_module_specifier_pure(spec, Some(&canon))
+                    && let Ok(resolved) =
+                        self.resolve_module_specifier_pure(spec, canon.file_path())
                     && !self.ready_for_sync_execution(&resolved, seen)
                 {
                     return false;
@@ -4144,11 +4203,11 @@ impl Interpreter {
 
     fn validate_named_reexports(
         &mut self,
-        current_module: &Path,
+        current_module: &ModuleKey,
         source: &str,
         specifiers: &[ExportSpecifier],
     ) -> Result<(), JsValue> {
-        let resolved = self.resolve_module_specifier(source, Some(current_module))?;
+        let resolved = self.resolve_module_specifier(source, current_module.file_path())?;
 
         for spec in specifiers {
             let mut visited = HashSet::new();
@@ -4161,11 +4220,11 @@ impl Interpreter {
     /// Returns (source_env, binding_name) for creating indirect import bindings.
     fn resolve_export_binding(
         &mut self,
-        module_path: &Path,
+        module_path: &ModuleKey,
         export_name: &str,
-        visited: &mut HashSet<(PathBuf, String)>,
+        visited: &mut HashSet<(ModuleKey, String)>,
     ) -> Result<(EnvRef, String), JsValue> {
-        let canon_path = Self::canonicalize_module_path(module_path);
+        let canon_path = module_path.canonicalize();
         let key = (canon_path.clone(), export_name.to_string());
 
         if visited.contains(&key) {
@@ -4176,7 +4235,7 @@ impl Interpreter {
         }
         visited.insert(key);
 
-        let module = self.load_module(&canon_path)?;
+        let module = self.load_module_for_type(&canon_path, None, ModuleLoadMode::Evaluate)?;
 
         let reexport_info = {
             let module_ref = module.borrow();
@@ -4197,8 +4256,9 @@ impl Interpreter {
                     let ns_source = ns_source.to_string();
                     drop(module_ref);
                     if let Ok(resolved) =
-                        self.resolve_module_specifier(&ns_source, Some(&canon_path))
-                        && let Ok(ns_mod) = self.load_module(&resolved)
+                        self.resolve_module_specifier(&ns_source, canon_path.file_path())
+                        && let Ok(ns_mod) =
+                            self.load_module_for_type(&resolved, None, ModuleLoadMode::Evaluate)
                     {
                         return Ok((ns_mod.borrow().env.clone(), "*namespace*".to_string()));
                     }
@@ -4221,7 +4281,8 @@ impl Interpreter {
                     drop(module_ref);
                     // Namespace import (import * as foo) resolves to the source module
                     if let Some(ns_path) = ns_path
-                        && let Ok(ns_mod) = self.load_module(&ns_path)
+                        && let Ok(ns_mod) =
+                            self.load_module_for_type(&ns_path, None, ModuleLoadMode::Evaluate)
                     {
                         return Ok((ns_mod.borrow().env.clone(), "*namespace*".to_string()));
                     }
@@ -4231,7 +4292,8 @@ impl Interpreter {
                     // re-exports of the same `<module source>` therefore compare
                     // equal (same target env + "*source*"), so are unambiguous.
                     if let Some(source_path) = source_path
-                        && let Ok(source_mod) = self.load_module(&source_path)
+                        && let Ok(source_mod) =
+                            self.load_module_for_type(&source_path, None, ModuleLoadMode::Evaluate)
                     {
                         return Ok((source_mod.borrow().env.clone(), "*source*".to_string()));
                     }
@@ -4250,7 +4312,8 @@ impl Interpreter {
         };
 
         if let Some((source_specifier, source_export)) = reexport_info {
-            let resolved = self.resolve_module_specifier(&source_specifier, Some(&canon_path))?;
+            let resolved =
+                self.resolve_module_specifier(&source_specifier, canon_path.file_path())?;
             return self.resolve_export_binding(&resolved, &source_export, visited);
         }
 
@@ -4266,11 +4329,11 @@ impl Interpreter {
 
     fn resolve_export(
         &mut self,
-        module_path: &Path,
+        module_path: &ModuleKey,
         export_name: &str,
-        visited: &mut HashSet<(PathBuf, String)>,
+        visited: &mut HashSet<(ModuleKey, String)>,
     ) -> Result<(), JsValue> {
-        let canon_path = Self::canonicalize_module_path(module_path);
+        let canon_path = module_path.canonicalize();
         let key = (canon_path.clone(), export_name.to_string());
 
         // §16.2.1.6.3 step 2: circular reference → return null (not resolved)
@@ -4287,7 +4350,7 @@ impl Interpreter {
         visited.insert(key);
 
         // Load the module if not already loaded
-        let module = self.load_module(&canon_path)?;
+        let module = self.load_module_for_type(&canon_path, None, ModuleLoadMode::Evaluate)?;
 
         // Check if this export is a local binding or a re-export (steps 4-5)
         let (reexport_info, star_sources) = {
@@ -4326,7 +4389,8 @@ impl Interpreter {
 
         // Step 5: follow indirect re-exports
         if let Some((source_specifier, source_export)) = reexport_info {
-            let resolved = self.resolve_module_specifier(&source_specifier, Some(&canon_path))?;
+            let resolved =
+                self.resolve_module_specifier(&source_specifier, canon_path.file_path())?;
             return self.resolve_export(&resolved, &source_export, visited);
         }
 
@@ -4344,9 +4408,9 @@ impl Interpreter {
 
         // §16.2.1.6.3 step 8: check star re-exports
         let mut found_in_star = false;
-        let mut first_star_source: Option<PathBuf> = None;
+        let mut first_star_source: Option<ModuleKey> = None;
         for star_source in &star_sources {
-            let resolved = self.resolve_module_specifier(star_source, Some(&canon_path))?;
+            let resolved = self.resolve_module_specifier(star_source, canon_path.file_path())?;
             let mut v2 = visited.clone();
             if self.resolve_export(&resolved, export_name, &mut v2).is_ok() {
                 if found_in_star {
@@ -4421,8 +4485,11 @@ impl Interpreter {
                 if let Some(src) = source {
                     // Re-export: get values from source module
                     let module_path = self.current_module_path.clone();
-                    if let Ok(resolved) = self.resolve_module_specifier(src, module_path.as_deref())
-                        && let Ok(source_mod) = self.load_module(&resolved)
+                    if let Ok(resolved) = self.resolve_module_specifier(
+                        src,
+                        module_path.as_ref().and_then(ModuleKey::file_path),
+                    ) && let Ok(source_mod) =
+                        self.load_module_for_type(&resolved, None, ModuleLoadMode::Evaluate)
                     {
                         let source_exports = source_mod.borrow().exports.clone();
                         for spec in specifiers {
@@ -4580,7 +4647,7 @@ impl Interpreter {
             let module_ref = module.borrow();
             let env = module_ref.env.clone();
             let export_bindings = module_ref.export_bindings.clone();
-            let module_path = if module_ref.path.as_os_str().is_empty() {
+            let module_path = if module_ref.path.is_empty() {
                 None
             } else {
                 Some(module_ref.path.clone())
@@ -4662,7 +4729,7 @@ impl Interpreter {
             let module_ref = module.borrow();
             let env = module_ref.env.clone();
             let export_bindings = module_ref.export_bindings.clone();
-            let module_path = if module_ref.path.as_os_str().is_empty() {
+            let module_path = if module_ref.path.is_empty() {
                 None
             } else {
                 Some(module_ref.path.clone())

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -244,7 +244,7 @@ impl Interpreter {
                     match self.resolve_module_export_value(
                         binding_name,
                         &ns_data.env,
-                        module_path.as_deref(),
+                        module_path.as_ref(),
                         key_str,
                     ) {
                         Ok(val) => return Completion::Normal(val),

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -717,6 +717,57 @@ fn module_cycle_preserves_live_bindings_and_reuses_registry_entries() {
 }
 
 #[test]
+fn module_key_canonicalization_distinguishes_host_identity_from_a_real_file() {
+    let dir = temp_case_dir("module-key");
+    let file_path = write_case_file(&dir, MODULE_SOURCE_SPECIFIER, "export const value = 1;");
+
+    let host_key = ModuleKey::module_source();
+    assert!(host_key.is_module_source());
+    assert!(host_key.file_path().is_none());
+    assert_eq!(host_key.canonicalize(), host_key);
+
+    let file_key = ModuleKey::for_file(file_path.clone());
+    assert!(!file_key.is_module_source());
+    assert_eq!(file_key.file_path(), Some(file_path.as_path()));
+    assert_eq!(file_key.canonicalize(), file_key);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn module_loader_dispatch_owns_host_type_and_mode_handling() {
+    let mut interp = Interpreter::new();
+    let key = interp
+        .resolve_module_specifier(MODULE_SOURCE_SPECIFIER, None)
+        .expect("host module should resolve");
+
+    let eager = interp
+        .load_module_for_type(&key, None, ModuleLoadMode::Evaluate)
+        .expect("untyped eager host module should load");
+    let deferred = interp
+        .load_module_for_type(&key, None, ModuleLoadMode::Defer)
+        .expect("untyped deferred host module should load");
+    assert!(Rc::ptr_eq(&eager, &deferred));
+
+    for import_type in [ImportModuleType::Text, ImportModuleType::Bytes] {
+        let mut messages = Vec::new();
+        for mode in [ModuleLoadMode::Evaluate, ModuleLoadMode::Defer] {
+            let error = match interp.load_module_for_type(&key, Some(import_type), mode) {
+                Ok(_) => panic!("typed host module request unexpectedly loaded"),
+                Err(error) => error,
+            };
+            let message = interp.format_value(&error);
+            assert!(
+                message.starts_with("TypeError:"),
+                "unexpected error: {message}"
+            );
+            messages.push(message);
+        }
+        assert_eq!(messages[0], messages[1]);
+    }
+}
+
+#[test]
 fn module_top_level_call_and_member_evaluate() {
     let dir = temp_case_dir("module-ic-fallback");
     let main_path = write_case_file(
@@ -909,11 +960,11 @@ fn transitive_module_import_link_error_aborts_parent_before_evaluation() {
     assert!(err.contains("nonExistent"), "unexpected error: {err}");
     assert!(interp.get_global_var_ref("marker").is_none());
 
-    let broken_canon = broken_path.canonicalize().unwrap_or(broken_path.clone());
+    let broken_key = ModuleKey::for_file(broken_path.clone());
     let realm_id = interp.current_realm_id;
     let cached = interp
         .module_registry
-        .get(&(realm_id, broken_canon))
+        .get(&(realm_id, broken_key))
         .expect("broken module registry entry")
         .borrow()
         .error
@@ -1342,9 +1393,9 @@ fn gc_keeps_module_exports_alive_until_registry_entry_is_removed() {
     let main_path = write_case_file(&dir, "main.js", r#"export const obj = { marker: 1 };"#);
 
     let mut interp = run_module_with_path(&fs::read_to_string(&main_path).unwrap(), &main_path);
-    let canon = main_path.canonicalize().unwrap_or(main_path.clone());
+    let module_key = ModuleKey::for_file(main_path.clone());
     let realm_id = interp.current_realm_id;
-    let key = (realm_id, canon.clone());
+    let key = (realm_id, module_key);
     let module = interp
         .module_registry
         .get(&key)

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -319,7 +319,7 @@ pub(crate) struct AsyncFunctionState {
     pub reject_fn: JsValue,
     pub for_of_stack: Vec<(String, usize, usize)>,
     pub for_of_iter_env: Option<EnvRef>,
-    pub module_path: Option<std::path::PathBuf>,
+    pub module_path: Option<super::ModuleKey>,
 }
 
 #[derive(Debug, Clone)]
@@ -702,7 +702,7 @@ pub(crate) struct Environment {
     // §9.1.1.5.5 CreateImportBinding: indirect bindings for module imports
     pub(crate) indirect_bindings: Option<HashMap<String, (EnvRef, String)>>,
     // Module path for import.meta resolution (§16.2.1.5.2 GetActiveScriptOrModule)
-    pub(crate) module_path: Option<std::path::PathBuf>,
+    pub(crate) module_path: Option<super::ModuleKey>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -850,7 +850,7 @@ impl Environment {
         self.module_path = None;
     }
 
-    pub(crate) fn find_module_path(env: &EnvRef) -> Option<std::path::PathBuf> {
+    pub(crate) fn find_module_path(env: &EnvRef) -> Option<super::ModuleKey> {
         if let Some(ref mp) = env.borrow().module_path {
             return Some(mp.clone());
         }
@@ -1680,7 +1680,7 @@ pub(crate) struct ModuleNamespaceData {
     pub env: EnvRef,
     pub export_names: Vec<String>,
     pub export_to_binding: HashMap<String, String>,
-    pub module_path: Option<std::path::PathBuf>,
+    pub module_path: Option<super::ModuleKey>,
     pub deferred: bool,
 }
 

--- a/tests/module_source_host_specifier.rs
+++ b/tests/module_source_host_specifier.rs
@@ -1,11 +1,10 @@
 //! The `<module source>` host specifier must not be capturable by a real
 //! filesystem entry of the same name (jsse#222 review finding).
 //!
-//! Its module-registry key is a bare relative path, so any `canonicalize()` on
-//! it succeeds whenever jsse runs in a directory holding an entry called
-//! `<module source>` — rebinding the specifier to that file's registry slot.
-//! This lives in `tests/` rather than `test262-extra/` because the condition is
-//! the *process working directory*, which only a spawned child can control.
+//! The registry now uses an opaque Module Key whose total canonicalization
+//! preserves host identity and exposes a filesystem path only for file-backed
+//! modules. This child-process regression keeps the original collision
+//! scenario covered because the condition is the process working directory.
 
 use std::fs;
 use std::process::Command;
@@ -85,12 +84,8 @@ if (Object.keys(ns).length !== 0) throw new Error('namespace leaked: ' + Object.
 if (Object.keys(dyn).length !== 0) throw new Error('dynamic namespace leaked');
 if (ns !== dyn) throw new Error('phases disagree on the record');
 
-// import.defer and ShadowRealm.prototype.importValue canonicalize the resolved
-// path themselves. These two are a canary, not a regression guard: the record is
-// already evaluated with no exports and no async dependencies, so a misdirected
-// registry lookup misses and no-ops, and reverting either site to a raw
-// canonicalize() still passes (verified). They start discriminating the moment
-// the synthetic record gains exports or async dependencies.
+// import.defer and ShadowRealm.prototype.importValue exercise downstream
+// Module Key consumers as well as the static and ordinary dynamic forms above.
 const deferred = await import.defer('<module source>');
 if (Object.keys(deferred).length !== 0) {
   throw new Error('deferred namespace leaked: ' + Object.keys(deferred));


### PR DESCRIPTION
## Summary

- route static, dynamic, deferred, typed, and source-phase module requests through one loader dispatcher
- key module registries and graph state with an opaque `ModuleKey`, exposing a filesystem path only after proving the module is file-backed
- preserve loader-specific error caching while adding canonicalization, dispatch, and working-directory collision regressions
- document the module identity seam in the domain glossary and design notes

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py` (12/12)
- targeted module/import test262 coverage (2,043/2,043)
- full test262 suite (99,568/99,568; zero regressions)

Closes #479
