### PR TITLE
fix(node-shim): avoid invoking user code during inspect

### DIFF
--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -96,9 +96,12 @@ skipped for Array exotic objects: `ArrayCreate` and
 `[[BooleanData]]`, `[[BigIntData]]` or `[[SymbolData]]`, and every probe would
 only throw and be caught. The Error prototype-chain classification is *not*
 skipped, so `Reflect.construct(Array, [1, 2], Error)` still renders `[Error]`
-and an array whose chain contains a revoked Proxy still throws. Slot-bearing
-prototype objects retain cross-realm recognition where the built-in exposes
-such a slot.
+and an array whose chain contains a revoked Proxy still throws. Only the exact
+captured intrinsic prototype identifies a built-in family. An arbitrary boxed
+instance carries the same internal slot as its family's intrinsic prototype,
+so accepting any slot-bearing chain node would misclassify values that Node
+renders generically. The shim has no unforgeable, trap-free way to recognize a
+foreign realm's intrinsic prototype, so such chains also take the generic path.
 RegExps are formatted from the captured `source` and individual flag accessors;
 using the captured `RegExp.prototype.toString` would still perform ordinary
 `source` and `flags` gets and could invoke replacement accessors. Normal boxed
@@ -141,6 +144,10 @@ are accepted, not bugs:
   "user-defined", `convS` coerces the original value, so a `toString`/
   `@@toPrimitive` hook — including a Proxy `get` trap — does run, as it does on
   Node.
+- A built-in whose chain contains a foreign-realm intrinsic prototype renders
+  generically. Distinguishing that prototype from an arbitrary same-family
+  instance would require either forgeable JavaScript heuristics or more native
+  metadata; the shim chooses conservative generic rendering.
 
 The no-`--node` fallback cannot read `[[ProxyTarget]]`, so reflection there
 still dispatches handler traps *and* cannot see through a Proxy to the internal
@@ -159,8 +166,10 @@ nested Proxies, a Proxy in the prototype chain rather than as the inspected
 value, Error accessors, sparse arrays with inherited accessors, reparented
 RegExps with throwing `source`/`flags` getters, and replacement accessors on
 `RegExp.prototype`. Ordinary- and null-prototype cases cover Error, Date,
-RegExp, and every boxed primitive; a proxied replacement prototype verifies the
-classifier itself dispatches no handler trap.
+RegExp, and every boxed primitive. Same-family instances used as prototype
+objects verify they do not impersonate the captured intrinsic prototype; a
+proxied replacement prototype verifies the classifier itself dispatches no
+handler trap.
 Trap/getter counters prove the JSSE shim invokes none of them **for those
 cases**; the counters are evidence for the enumerated shapes, not a blanket
 proof, and the `%s` `toString`/`@@toPrimitive` presence reads noted above remain

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -1,0 +1,81 @@
+# Proxy- and Accessor-Safe Node Shim Inspection
+
+## Context
+
+`scripts/node-shim.js` implements the best-effort `util.inspect` used by the
+Node-compatible library harness. Descriptor-based member rendering already
+avoids ordinary getters, but reflection on a Proxy still invokes its traps.
+Array length, sparse holes, and Error formatting also retain direct property
+reads that can invoke user code.
+
+ECMAScript requires `Object.getPrototypeOf`, `Object.keys`, and
+`Object.getOwnPropertyDescriptor` to dispatch through a Proxy's corresponding
+internal methods. `Array.isArray` is different: `IsArray` unwraps Proxy targets
+through internal slots without calling a handler trap. Consequently, a
+pure-JavaScript formatter cannot both recognize and inspect arbitrary Proxies
+without invoking traps.
+
+## Approaches considered
+
+1. Catch reflection failures and render an opaque object. This prevents a
+   throwing trap from escaping, but the trap still runs and can mutate state,
+   so it does not satisfy the acceptance criterion.
+2. Move the complete formatter into Rust. This provides safe access to all
+   metadata, but duplicates the existing JavaScript formatting policy and
+   substantially expands the native host surface.
+3. Add a single, `--node`-gated Proxy-target metadata hook, then retain the
+   formatter in JavaScript. The shim captures the hook before library code can
+   replace it, recursively unwraps Proxies before reflection, and handles
+   revoked Proxies as an opaque terminal value. This is the selected approach.
+
+## Design
+
+The Node host floor exposes `__host_proxy_target(value)` only when `--node` is
+enabled. It returns:
+
+- `undefined` when `value` is not a Proxy;
+- the active Proxy's target object without consulting the handler; or
+- `null` for a revoked Proxy.
+
+The shim captures this function with its other host primordials. At the start
+of object/function rendering it repeatedly unwraps active Proxies, returns
+`<Revoked Proxy>` for revoked ones, and only then performs type classification,
+descriptor lookup, enumeration, or prototype traversal. This mirrors the
+metadata access Node's native inspector has while keeping the hook too narrow
+to encode presentation policy.
+
+Array rendering obtains `length` from the unwrapped array's own data descriptor
+and renders missing descriptors as collapsed `<N empty item(s)>` entries. It
+never falls back to indexed property access, so inherited accessors are not
+observed.
+
+Error rendering uses data descriptors for `stack`, `name`, and `message`.
+Accessor descriptors shadow inherited values but are never called. The normal
+JSSE Error prototype stack accessor is therefore skipped, while its data-valued
+name and the instance's data-valued message still produce a readable
+`[Error: message]` fallback.
+
+Constructor and function names are read from data descriptors. Prototype
+metadata traversal unwraps a Proxy before inspecting it. Primitive Symbol
+formatting uses the captured intrinsic rather than a mutable prototype method.
+
+## Failure behavior and fallback
+
+The production library harness always uses `--node`, so Proxy metadata is
+available on the path covered by the acceptance criterion. The documented
+plain-jsse fallback has no native capability to identify a Proxy; reflection
+there remains best-effort and catches exotic failures where possible.
+
+## Validation
+
+The cross-engine node-shim self-test covers array-target Proxies, throwing
+`getPrototypeOf`/`ownKeys`/`getOwnPropertyDescriptor`/`get` traps, revoked and
+nested Proxies, Error accessors, and sparse arrays with inherited accessors.
+Trap/getter counters prove the JSSE shim invokes none of them; Node runs the
+same structural cases as the reference implementation. Rust host-floor tests
+verify the hook is gated, non-enumerable, unwraps without traps, and identifies
+revoked Proxies.
+
+Because this is a flag-gated harness feature rather than ECMAScript behavior,
+there is no targeted test262 area and no pass-count change expected. The full
+test262 suite remains the regression gate.

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -89,8 +89,16 @@ avoid, so the shorter prefix is accepted.
 Built-in presentation combines an internal-slot probe with a trap-free
 prototype-chain classifier. Reparenting a genuine Date, RegExp, or boxed
 primitive to an ordinary object selects the generic descriptor path; a direct
-null prototype receives Node's family-specific marker. Slot-bearing prototype
-objects retain cross-realm recognition where the built-in exposes such a slot.
+null prototype receives Node's family-specific marker. The slot probes are
+skipped for Array exotic objects: `ArrayCreate` and
+`OrdinaryCreateFromConstructor` are disjoint, so an array can carry none of
+`[[RegExpMatcher]]`, `[[DateValue]]`, `[[NumberData]]`, `[[StringData]]`,
+`[[BooleanData]]`, `[[BigIntData]]` or `[[SymbolData]]`, and every probe would
+only throw and be caught. The Error prototype-chain classification is *not*
+skipped, so `Reflect.construct(Array, [1, 2], Error)` still renders `[Error]`
+and an array whose chain contains a revoked Proxy still throws. Slot-bearing
+prototype objects retain cross-realm recognition where the built-in exposes
+such a slot.
 RegExps are formatted from the captured `source` and individual flag accessors;
 using the captured `RegExp.prototype.toString` would still perform ordinary
 `source` and `flags` gets and could invoke replacement accessors. Normal boxed

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -74,10 +74,17 @@ A candidate `constructor` is rejected when its own `prototype` is the value
 being inspected. Node's `getConstructorName` accepts a constructor only when
 the value is an *instance* of it, and a constructor's own `prototype` object
 never is, so every intrinsic prototype renders as a plain `{}` — matching Node
-for `Date.prototype`, `Error.prototype`, `RegExp.prototype` and any user
-class's `prototype`, not just the three legacy wrapper prototypes. An object
-that merely *inherits* from an intrinsic prototype is unaffected:
+for `Date.prototype`, `Error.prototype`, `RegExp.prototype` and a base class's
+`prototype`, not just the three legacy wrapper prototypes. An object that
+merely *inherits* from an intrinsic prototype is unaffected:
 `Object.create(RegExp.prototype)` still renders `RegExp {}`.
+
+Rejection is where the shim stops, whereas Node keeps walking the chain for
+another accepted constructor. A *derived* class's prototype is the visible
+difference: Node renders `class B extends A {}`'s `B.prototype` as `A {}`,
+because `B.prototype instanceof A` holds one hop up, while the shim renders
+`{}`. Reproducing that needs the `instanceof` call this design exists to
+avoid, so the shorter prefix is accepted.
 
 Built-in presentation combines an internal-slot probe with a trap-free
 prototype-chain classifier. Reparenting a genuine Date, RegExp, or boxed

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -70,6 +70,15 @@ metadata traversal unwraps a Proxy at every hop before inspecting it. Primitive
 Symbol formatting uses the captured intrinsic rather than a mutable prototype
 method.
 
+A candidate `constructor` is rejected when its own `prototype` is the value
+being inspected. Node's `getConstructorName` accepts a constructor only when
+the value is an *instance* of it, and a constructor's own `prototype` object
+never is, so every intrinsic prototype renders as a plain `{}` — matching Node
+for `Date.prototype`, `Error.prototype`, `RegExp.prototype` and any user
+class's `prototype`, not just the three legacy wrapper prototypes. An object
+that merely *inherits* from an intrinsic prototype is unaffected:
+`Object.create(RegExp.prototype)` still renders `RegExp {}`.
+
 Built-in presentation combines an internal-slot probe with a trap-free
 prototype-chain classifier. Reparenting a genuine Date, RegExp, or boxed
 primitive to an ordinary object selects the generic descriptor path; a direct

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -99,6 +99,27 @@ available on the path covered by the acceptance criterion. The documented
 plain-jsse fallback has no native capability to identify a Proxy; reflection
 there remains best-effort and catches exotic failures where possible.
 
+## Deliberate divergences from Node
+
+Node reaches a few of its outputs by invoking exactly the user code this design
+exists to avoid, so refusing to call it necessarily changes the rendering. These
+are accepted, not bugs:
+
+- A function whose `name` is an accessor renders `[Function (anonymous)]`;
+  Node reports `[Function: Dyn]` because it calls the getter. `functionName`
+  reads an own *data* descriptor only.
+- An Error whose `message` has been replaced by an object renders `[Error]`;
+  Node renders `[Error: [object Object]]` by invoking the object's `toString`.
+  A `null` or falsy `message` still renders as Node does (`[Error: null]`).
+- The `%s` path only classifies trap-free. Once classification answers
+  "user-defined", `convS` coerces the original value, so a `toString`/
+  `@@toPrimitive` hook — including a Proxy `get` trap — does run, as it does on
+  Node.
+
+The no-`--node` fallback cannot read `[[ProxyTarget]]`, so reflection there
+still dispatches handler traps; its rendering matches the `--node` path but its
+trap counts do not.
+
 ## Validation
 
 The cross-engine node-shim self-test covers array-target Proxies, throwing

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -37,8 +37,11 @@ enabled. It returns:
 - the active Proxy's target object without consulting the handler; or
 - `null` for a revoked Proxy.
 
-The shim captures this function with its other host primordials. At the start
-of object/function rendering it repeatedly unwraps active Proxies, returns
+The shim captures this function with its other host primordials, then
+immediately deletes the configurable global binding so subsequently evaluated
+library code cannot observe or call the Proxy-target seam. The closure retains
+the only reference needed by the formatter. At the start of object/function
+rendering it repeatedly unwraps active Proxies, returns
 `<Revoked Proxy>` for revoked ones, and only then performs type classification,
 descriptor lookup, enumeration, or prototype traversal. This mirrors the
 metadata access Node's native inspector has while keeping the hook too narrow
@@ -53,7 +56,10 @@ Error rendering uses data descriptors for `stack`, `name`, and `message`.
 Accessor descriptors shadow inherited values but are never called. The normal
 JSSE Error prototype stack accessor is therefore skipped, while its data-valued
 name and the instance's data-valued message still produce a readable
-`[Error: message]` fallback.
+`[Error: message]` fallback. A raw `stack` value is tested for truthiness before
+safe primitive stringification, preserving the fallback for `0`, `-0`, `0n`,
+`false`, and `NaN`. `null` remains a safely stringifiable primitive for `name`
+and `message`, despite JavaScript's historical `typeof null === "object"` result.
 
 Constructor and function names are read from data descriptors. Prototype
 metadata traversal unwraps a Proxy at every hop before inspecting it. Primitive
@@ -87,10 +93,19 @@ value, Error accessors, and sparse arrays with inherited accessors.
 Trap/getter counters prove the JSSE shim invokes none of them **for those
 cases**; the counters are evidence for the enumerated shapes, not a blanket
 proof, and the `%s` `toString`/`@@toPrimitive` presence reads noted above remain
-a known uncovered remainder. Node runs the
-same structural cases as the reference implementation. Rust host-floor tests
+a known uncovered remainder. The nested-Proxy rendering assertion runs only on
+JSSE because Node 24 and Node 26 differ in how many Proxy layers their native
+inspectors unwrap; the Node branch emits the same successful assertion line so
+the cross-check count and stdout stay identical. Node runs the other structural
+cases as the reference implementation. Rust host-floor tests
 verify the hook is gated, non-enumerable, unwraps without traps, and identifies
-revoked Proxies.
+revoked Proxies. The JavaScript self-test additionally verifies the captured
+hook is no longer globally reachable once the shim has initialized.
+
+String escaping continues to use captured `String.prototype.split` with
+primitive string separators. ECMAScript only consults `%Symbol.split%` when the
+separator is an Object, and JSSE implements the same object-only guard, so a
+library assignment to `String.prototype[Symbol.split]` cannot run on this path.
 
 Because this is a flag-gated harness feature rather than ECMAScript behavior,
 there is no targeted test262 area and no pass-count change expected. The full

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -60,20 +60,26 @@ name and the instance's data-valued message still produce a readable
 safe primitive stringification, preserving the fallback for `0`, `-0`, `0n`,
 `false`, and `NaN`. `null` remains a safely stringifiable primitive for `name`
 and `message`, despite JavaScript's historical `typeof null === "object"` result.
+Error presentation is gated by the same trap-free prototype classification as
+the other built-ins: reparenting a genuine Error to an ordinary object selects
+generic rendering, while a direct null prototype receives the explicit
+`[Error: null prototype]` marker.
 
 Constructor and function names are read from data descriptors. Prototype
 metadata traversal unwraps a Proxy at every hop before inspecting it. Primitive
 Symbol formatting uses the captured intrinsic rather than a mutable prototype
 method.
 
-RegExp rendering first probes the captured intrinsic `source` getter to verify
-the internal slot, then classifies the prototype chain without `instanceof` or
-ordinary property reads. An ordinary-object-reparented RegExp stays on the
-generic descriptor path, while a null-prototype RegExp receives Node's explicit
-`[RegExp: null prototype]` marker. Ordinary and cross-realm RegExps are formatted
-from the captured `source` and individual flag accessors; using the captured
-`RegExp.prototype.toString` would still perform ordinary `source` and `flags`
-gets and could invoke replacement accessors.
+Built-in presentation combines an internal-slot probe with a trap-free
+prototype-chain classifier. Reparenting a genuine Date, RegExp, or boxed
+primitive to an ordinary object selects the generic descriptor path; a direct
+null prototype receives Node's family-specific marker. Slot-bearing prototype
+objects retain cross-realm recognition where the built-in exposes such a slot.
+RegExps are formatted from the captured `source` and individual flag accessors;
+using the captured `RegExp.prototype.toString` would still perform ordinary
+`source` and `flags` gets and could invoke replacement accessors. Normal boxed
+BigInt/Symbol chains retain their existing `@@hasInstance`-sensitive shape after
+the trap-free presentation classification succeeds.
 
 `util.format`'s `%s` classification walk (`hasBuiltInToString`) decides whether
 a value carries a user-defined coercion hook or routes to `inspect`. It unwraps
@@ -100,7 +106,9 @@ The cross-engine node-shim self-test covers array-target Proxies, throwing
 nested Proxies, a Proxy in the prototype chain rather than as the inspected
 value, Error accessors, sparse arrays with inherited accessors, reparented
 RegExps with throwing `source`/`flags` getters, and replacement accessors on
-`RegExp.prototype`.
+`RegExp.prototype`. Ordinary- and null-prototype cases cover Error, Date,
+RegExp, and every boxed primitive; a proxied replacement prototype verifies the
+classifier itself dispatches no handler trap.
 Trap/getter counters prove the JSSE shim invokes none of them **for those
 cases**; the counters are evidence for the enumerated shapes, not a blanket
 proof, and the `%s` `toString`/`@@toPrimitive` presence reads noted above remain

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -56,8 +56,20 @@ name and the instance's data-valued message still produce a readable
 `[Error: message]` fallback.
 
 Constructor and function names are read from data descriptors. Prototype
-metadata traversal unwraps a Proxy before inspecting it. Primitive Symbol
-formatting uses the captured intrinsic rather than a mutable prototype method.
+metadata traversal unwraps a Proxy at every hop before inspecting it. Primitive
+Symbol formatting uses the captured intrinsic rather than a mutable prototype
+method.
+
+`util.format`'s `%s` classification walk (`hasBuiltInToString`) decides whether
+a value carries a user-defined coercion hook or routes to `inspect`. It unwraps
+the value and then each prototype it visits, so a Proxy anywhere in the chain
+runs no `getPrototypeOf`/`getOwnPropertyDescriptor` trap. This is a deliberate
+divergence: Node *would* fire that trap, so a `--node` cross-check difference on
+a prototype-chain Proxy is expected rather than a regression. The initial
+`toString`/`@@toPrimitive` presence checks on that path are still ordinary
+property reads, so a proxied prototype can observe those two gets; closing that
+remainder requires changing the classification to descriptor lookups, which
+would alter which values Node-compatibly route to `inspect`, and is left out.
 
 ## Failure behavior and fallback
 
@@ -70,8 +82,12 @@ there remains best-effort and catches exotic failures where possible.
 
 The cross-engine node-shim self-test covers array-target Proxies, throwing
 `getPrototypeOf`/`ownKeys`/`getOwnPropertyDescriptor`/`get` traps, revoked and
-nested Proxies, Error accessors, and sparse arrays with inherited accessors.
-Trap/getter counters prove the JSSE shim invokes none of them; Node runs the
+nested Proxies, a Proxy in the prototype chain rather than as the inspected
+value, Error accessors, and sparse arrays with inherited accessors.
+Trap/getter counters prove the JSSE shim invokes none of them **for those
+cases**; the counters are evidence for the enumerated shapes, not a blanket
+proof, and the `%s` `toString`/`@@toPrimitive` presence reads noted above remain
+a known uncovered remainder. Node runs the
 same structural cases as the reference implementation. Rust host-floor tests
 verify the hook is gated, non-enumerable, unwraps without traps, and identifies
 revoked Proxies.

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -108,17 +108,24 @@ are accepted, not bugs:
 - A function whose `name` is an accessor renders `[Function (anonymous)]`;
   Node reports `[Function: Dyn]` because it calls the getter. `functionName`
   reads an own *data* descriptor only.
-- An Error whose `message` has been replaced by an object renders `[Error]`;
-  Node renders `[Error: [object Object]]` by invoking the object's `toString`.
-  A `null` or falsy `message` still renders as Node does (`[Error: null]`).
+- An Error whose `message` has been replaced by an object renders `[Error]`,
+  dropping the message. Node invokes the object's `toString` and folds the
+  result into the rendering (`Error: [object Object]`, followed by the stack);
+  jsse on `main` produced `[Error: [object Object]]`. A `null` or falsy
+  `message` still renders as Node does (`[Error: null]`).
 - The `%s` path only classifies trap-free. Once classification answers
   "user-defined", `convS` coerces the original value, so a `toString`/
   `@@toPrimitive` hook — including a Proxy `get` trap — does run, as it does on
   Node.
 
 The no-`--node` fallback cannot read `[[ProxyTarget]]`, so reflection there
-still dispatches handler traps; its rendering matches the `--node` path but its
-trap counts do not.
+still dispatches handler traps *and* cannot see through a Proxy to the internal
+slot behind it. Its renderings therefore diverge from the `--node` path
+wherever a Proxy is involved: a Proxy-wrapped built-in falls back to the
+generic object shape (`Date {}`, `RegExp {}`, `Number {}` rather than the ISO
+string, `/x/g`, `[Number: 5]`), and a revoked Proxy throws out of `inspect`
+instead of rendering `<Revoked Proxy>`. Non-Proxy values render identically on
+both paths.
 
 ## Validation
 

--- a/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
+++ b/docs/specs/2026-08-24-node-shim-safe-inspect-design.md
@@ -66,6 +66,15 @@ metadata traversal unwraps a Proxy at every hop before inspecting it. Primitive
 Symbol formatting uses the captured intrinsic rather than a mutable prototype
 method.
 
+RegExp rendering first probes the captured intrinsic `source` getter to verify
+the internal slot, then classifies the prototype chain without `instanceof` or
+ordinary property reads. An ordinary-object-reparented RegExp stays on the
+generic descriptor path, while a null-prototype RegExp receives Node's explicit
+`[RegExp: null prototype]` marker. Ordinary and cross-realm RegExps are formatted
+from the captured `source` and individual flag accessors; using the captured
+`RegExp.prototype.toString` would still perform ordinary `source` and `flags`
+gets and could invoke replacement accessors.
+
 `util.format`'s `%s` classification walk (`hasBuiltInToString`) decides whether
 a value carries a user-defined coercion hook or routes to `inspect`. It unwraps
 the value and then each prototype it visits, so a Proxy anywhere in the chain
@@ -89,7 +98,9 @@ there remains best-effort and catches exotic failures where possible.
 The cross-engine node-shim self-test covers array-target Proxies, throwing
 `getPrototypeOf`/`ownKeys`/`getOwnPropertyDescriptor`/`get` traps, revoked and
 nested Proxies, a Proxy in the prototype chain rather than as the inspected
-value, Error accessors, and sparse arrays with inherited accessors.
+value, Error accessors, sparse arrays with inherited accessors, reparented
+RegExps with throwing `source`/`flags` getters, and replacement accessors on
+`RegExp.prototype`.
 Trap/getter counters prove the JSSE shim invokes none of them **for those
 cases**; the counters are evidence for the enumerated shapes, not a blanket
 proof, and the `%s` `toString`/`@@toPrimitive` presence reads noted above remain

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,14 +43,15 @@ checks on jsse.
 
 The shim's readable-output layer (`process`, the full `console` method set, and
 the `util.format` / `util.inspect` core they share) is built on top of the
-flag-gated Rust "syscall floor" (issue #229): `__host_write` (byte-accurate fd
-I/O), `__host_hrtime` (monotonic clock), and `__host_exit` (real process exit).
-The runner therefore invokes **jsse with `--node`** so those primitives exist
-(never Node — it has no such flag and doesn't need one). The shim is guarded to
-be a complete no-op on real Node, where `process`, the full `console`, and
-`require('util')` already exist; that inertness is what lets the identical bundle
-run on Node as the reference oracle. When the floor is absent (jsse without
-`--node`) each surface degrades to a pure-JS fallback.
+flag-gated Rust host floor (issue #229): `__host_write` (byte-accurate fd I/O),
+`__host_hrtime` (monotonic clock), `__host_exit` (real process exit), and
+`__host_proxy_target` (trap-free Proxy metadata for inspection). The runner
+therefore invokes **jsse with `--node`** so those primitives exist (never Node —
+it has no such flag and doesn't need one). The shim is guarded to be a complete
+no-op on real Node, where `process`, the full `console`, and `require('util')`
+already exist; that inertness is what lets the identical bundle run on Node as
+the reference oracle. When the floor is absent (jsse without `--node`) each
+surface degrades to a pure-JS fallback.
 
 ## Running
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,8 +50,10 @@ therefore invokes **jsse with `--node`** so those primitives exist (never Node â
 it has no such flag and doesn't need one). The shim is guarded to be a complete
 no-op on real Node, where `process`, the full `console`, and `require('util')`
 already exist; that inertness is what lets the identical bundle run on Node as
-the reference oracle. When the floor is absent (jsse without `--node`) each
-surface degrades to a pure-JS fallback.
+the reference oracle. The shim captures `__host_proxy_target` and immediately
+removes its configurable global binding, keeping the Proxy abstraction bypass
+private from subsequently evaluated library code. When the floor is absent
+(jsse without `--node`) each surface degrades to a pure-JS fallback.
 
 ## Running
 

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -88,6 +88,7 @@
   var arrayIndexOf = functionCall.bind(arrayConstructor.prototype.indexOf);
   var arrayIsArray = arrayConstructor.isArray;
   var arrayJoin = functionCall.bind(arrayConstructor.prototype.join);
+  var arrayPush = functionCall.bind(arrayConstructor.prototype.push);
   var objectGetOwnPropertyDescriptor =
     objectConstructor.getOwnPropertyDescriptor;
   var objectGetPrototypeOf = objectConstructor.getPrototypeOf;
@@ -155,22 +156,16 @@
   }
 
   // `desc` is always FromPropertyDescriptor output — an ordinary object whose
-  // fields are own data properties — so an own-property check is enough to keep
-  // a polluted `Object.prototype.get`/`set`/`value` out of the result.
-  function descriptorField(desc, key) {
-    if (!desc) return undefined;
-    return objectHasOwnProperty(desc, key) ? desc[key] : undefined;
+  // fields are own data properties — so an own-property check keeps a polluted
+  // `Object.prototype.value` out of the result. That output is always either a
+  // data descriptor (own `value`) or an accessor one (own `get`/`set`), never
+  // both and never neither, so probing `value` alone discriminates the two.
+  function isDataDescriptor(desc) {
+    return !!desc && objectHasOwnProperty(desc, "value");
   }
 
   function dataDescriptorValue(desc) {
-    if (!desc) return undefined;
-    if (
-      descriptorField(desc, "get") !== undefined ||
-      descriptorField(desc, "set") !== undefined
-    ) {
-      return undefined;
-    }
-    return descriptorField(desc, "value");
+    return isDataDescriptor(desc) ? desc.value : undefined;
   }
 
   function findPropertyDescriptor(v, key) {
@@ -190,6 +185,17 @@
     return null;
   }
 
+  // A function's `name` read from its own data descriptor only, so neither an
+  // accessor `name` nor a Proxy get trap is observed. Returns "" when absent.
+  function functionName(fn) {
+    var name = dataDescriptorValue(objectGetOwnPropertyDescriptor(fn, "name"));
+    return typeof name === "string" ? name : "";
+  }
+
+  function emptyItems(count) {
+    return "<" + count + " empty item" + (count === 1 ? "" : "s") + ">";
+  }
+
   function primitiveString(value, fallback) {
     var type = typeof value;
     if (type === "object" || type === "function" || type === "undefined") {
@@ -207,15 +213,12 @@
   // object costs a single trap-free [[GetPrototypeOf]].
   function inheritsErrorPrototype(v) {
     try {
-      var current = objectGetPrototypeOf(v);
+      // `unwrapProxy` is already fully recursive and maps a revoked Proxy to
+      // null, which the loop condition treats as the end of the chain.
+      var current = unwrapProxy(objectGetPrototypeOf(v));
       while (current !== null && current !== objectPrototype) {
         if (current === errorPrototype) return true;
-        var target = unwrapProxy(current);
-        if (target !== current) {
-          current = target;
-          continue;
-        }
-        current = objectGetPrototypeOf(current);
+        current = unwrapProxy(objectGetPrototypeOf(current));
       }
     } catch (e) {
       // The no-host fallback cannot unwrap an exotic chain; leave it opaque.
@@ -250,14 +253,8 @@
       }
 
       if (t === "function") {
-        var name = dataDescriptorValue(
-          objectGetOwnPropertyDescriptor(v, "name")
-        );
-        return (
-          "[Function" +
-          (typeof name === "string" && name ? ": " + name : " (anonymous)") +
-          "]"
-        );
+        var name = functionName(v);
+        return "[Function" + (name ? ": " + name : " (anonymous)") + "]";
       }
 
       // Objects.
@@ -332,16 +329,16 @@
     }
 
     function renderDescriptor(desc, depth) {
-      var getter = descriptorField(desc, "get");
-      var setter = descriptorField(desc, "set");
-      if (getter !== undefined || setter !== undefined) {
-        return getter
-          ? setter
+      // Not a data descriptor => an accessor one, whose `get`/`set` are own
+      // data properties that are undefined-or-callable.
+      if (desc && !isDataDescriptor(desc)) {
+        return desc.get
+          ? desc.set
             ? "[Getter/Setter]"
             : "[Getter]"
           : "[Setter]";
       }
-      return render(descriptorField(desc, "value"), depth - 1);
+      return render(dataDescriptorValue(desc), depth - 1);
     }
 
     // Array length and elements are read from own descriptors on the unwrapped
@@ -353,48 +350,43 @@
       );
       if (typeof length !== "number" || length <= 0) return "[]";
 
-      var body = "";
-      var hasPart = false;
+      // Collect into a local array and join once. Accumulating with `+=`
+      // instead is superlinear here: JsString is a flat buffer with no rope
+      // representation, so each concat copies the whole prefix.
+      var parts = [];
       var holes = 0;
-
-      function append(part) {
-        if (hasPart) body += ", ";
-        body += part;
-        hasPart = true;
-      }
-
-      function flushHoles() {
-        if (!holes) return;
-        append("<" + holes + " empty item" + (holes === 1 ? "" : "s") + ">");
-        holes = 0;
-      }
 
       for (var i = 0; i < length; i++) {
         var desc = objectGetOwnPropertyDescriptor(v, i);
         if (!desc) {
           holes++;
-        } else {
-          flushHoles();
-          append(renderDescriptor(desc, depth));
+          continue;
         }
+        if (holes) {
+          arrayPush(parts, emptyItems(holes));
+          holes = 0;
+        }
+        arrayPush(parts, renderDescriptor(desc, depth));
       }
-      flushHoles();
-      return hasPart ? "[ " + body + " ]" : "[]";
+      if (holes) arrayPush(parts, emptyItems(holes));
+      // `length > 0` guarantees the loop ran, so every index became either an
+      // element or a hole, and `parts` cannot be empty.
+      return "[ " + arrayJoin(parts, ", ") + " ]";
+    }
+
+    function errorField(v, key, fallback) {
+      return primitiveString(
+        dataDescriptorValue(findPropertyDescriptor(v, key)),
+        fallback
+      );
     }
 
     function renderError(v) {
-      var stackDesc = findPropertyDescriptor(v, "stack");
-      var stack = primitiveString(dataDescriptorValue(stackDesc), "");
+      var stack = errorField(v, "stack", "");
       if (stack) return stack;
 
-      var name = primitiveString(
-        dataDescriptorValue(findPropertyDescriptor(v, "name")),
-        "Error"
-      );
-      var message = primitiveString(
-        dataDescriptorValue(findPropertyDescriptor(v, "message")),
-        ""
-      );
+      var name = errorField(v, "name", "Error");
+      var message = errorField(v, "message", "");
       var text = !name ? message : !message ? name : name + ": " + message;
       return "[" + text + "]";
     }
@@ -421,12 +413,8 @@
         // leading space).
         ctor = unwrapProxy(ctor);
         if (typeof ctor !== "function") return "";
-        var name = dataDescriptorValue(
-          objectGetOwnPropertyDescriptor(ctor, "name")
-        );
-        return typeof name === "string" && name && name !== "Object"
-          ? name + " "
-          : "";
+        var name = functionName(ctor);
+        return name && name !== "Object" ? name + " " : "";
       } catch (e) {
         return "";
       }
@@ -535,10 +523,15 @@
       return false;
     }
 
+    // Unwrap at every hop, not just at the top: a Proxy anywhere in the chain
+    // would otherwise run its getPrototypeOf/getOwnPropertyDescriptor traps
+    // during a diagnostic print. This is a deliberate divergence — Node *would*
+    // fire the trap here — so a `--node` cross-check difference on a
+    // prototype-chain Proxy is expected, not a regression.
     var pointer = value;
     try {
       do {
-        pointer = objectGetPrototypeOf(pointer);
+        pointer = unwrapProxy(objectGetPrototypeOf(pointer));
       } while (
         pointer !== null &&
         !hasOwnToString(pointer, "toString") &&
@@ -827,7 +820,7 @@
   function writeLine(stream, args) {
     var line = format.apply(null, args);
     if (groupIndent) {
-      line = groupIndent + line.replace(/\n/g, "\n" + groupIndent);
+      line = groupIndent + replaceAll(line, "\n", "\n" + groupIndent);
     }
     stream.write(line + "\n");
   }

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -101,6 +101,9 @@
   var objectIs = objectConstructor.is;
   var objectKeys = objectConstructor.keys;
   var objectPrototype = objectConstructor.prototype;
+  var numberPrototype = numberConstructor.prototype;
+  var stringPrototype = stringConstructor.prototype;
+  var booleanPrototype = booleanConstructor.prototype;
   var numberIsNaN = numberConstructor.isNaN;
   var dateGetTime = functionCall.bind(dateConstructor.prototype.getTime);
   var dateToISOString = functionCall.bind(
@@ -199,6 +202,12 @@
     return "<" + count + " empty item" + (count === 1 ? "" : "s") + ">";
   }
 
+  function isLegacyWrapperPrototype(v) {
+    return (
+      v === numberPrototype || v === stringPrototype || v === booleanPrototype
+    );
+  }
+
   function primitiveString(value, fallback) {
     var type = typeof value;
     if (
@@ -280,11 +289,16 @@
       if (boxed) {
         return numberIsNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);
       }
-      boxed = tryApplyIntrinsic(numberValueOf, v);
+      // These three intrinsic prototypes carry the same internal slots as
+      // their boxed instances, but Node deliberately presents the prototype
+      // singletons as ordinary objects. Exact identity guards keep genuine
+      // wrappers (including cross-realm/reparented ones) on the slot path.
+      var legacyWrapperPrototype = isLegacyWrapperPrototype(v);
+      boxed = legacyWrapperPrototype ? null : tryApplyIntrinsic(numberValueOf, v);
       if (boxed) return "[Number: " + render(boxed.value, depth) + "]";
-      boxed = tryApplyIntrinsic(stringValueOf, v);
+      boxed = legacyWrapperPrototype ? null : tryApplyIntrinsic(stringValueOf, v);
       if (boxed) return "[String: " + render(boxed.value, depth) + "]";
-      boxed = tryApplyIntrinsic(booleanValueOf, v);
+      boxed = legacyWrapperPrototype ? null : tryApplyIntrinsic(booleanValueOf, v);
       if (boxed) return "[Boolean: " + render(boxed.value, depth) + "]";
       boxed = tryApplyIntrinsic(bigintValueOf, v);
       if (boxed) {
@@ -409,6 +423,9 @@
     // data descriptors only, and treat any exotic-trap throw as "no prefix".
     function constructorName(v) {
       try {
+        // Match Node's ordinary-object presentation for these intrinsic
+        // prototype singletons instead of emitting `Number {}` and friends.
+        if (isLegacyWrapperPrototype(v)) return "";
         var ctor;
         var own = objectGetOwnPropertyDescriptor(v, "constructor");
         if (own) {

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -45,13 +45,22 @@
   // heuristics, `<ref *N>` back-references, hidden keys, getters, Map/Set
   // internals — a bottomless pit); it only needs to be correct on depth,
   // cycles, and the common types.
+  // `String.prototype.replace` with a RegExp dispatches through
+  // `RegExp.prototype[@@replace]`, which reads `rx.exec` — a bundled library
+  // that monkey-patches `RegExp.prototype.exec` would therefore run during a
+  // diagnostic print. Split/join on a plain string separator is equivalent and
+  // touches no user-replaceable hook.
+  function replaceAll(s, needle, replacement) {
+    return arrayJoin(stringSplit(s, needle), replacement);
+  }
+
   function quoteString(s) {
     s = stringConstructor(s);
     return (
       "'" +
-      stringReplace(
-        stringReplace(stringReplace(s, /\\/g, "\\\\"), /'/g, "\\'"),
-        /\n/g,
+      replaceAll(
+        replaceAll(replaceAll(s, "\\", "\\\\"), "'", "\\'"),
+        "\n",
         "\\n"
       ) +
       "'"
@@ -59,7 +68,7 @@
   }
 
   function isIdentifierKey(k) {
-    return regexpTest(/^[A-Za-z_$][A-Za-z0-9_$]*$/, k);
+    return regexpExec(identifierKeyPattern, k) !== null;
   }
 
   // Capture uncurried intrinsics before bundled library code runs. Node's
@@ -82,21 +91,27 @@
   var objectGetOwnPropertyDescriptor =
     objectConstructor.getOwnPropertyDescriptor;
   var objectGetPrototypeOf = objectConstructor.getPrototypeOf;
+  var objectHasOwnProperty = functionCall.bind(
+    objectConstructor.prototype.hasOwnProperty
+  );
   var objectIs = objectConstructor.is;
   var objectKeys = objectConstructor.keys;
+  var objectPrototype = objectConstructor.prototype;
   var numberIsNaN = numberConstructor.isNaN;
   var dateGetTime = functionCall.bind(dateConstructor.prototype.getTime);
   var dateToISOString = functionCall.bind(
     dateConstructor.prototype.toISOString
   );
   var errorIsError = errorConstructor.isError;
+  var errorPrototype = errorConstructor.prototype;
   var regexpGetSource = functionCall.bind(
     objectGetOwnPropertyDescriptor(regexpConstructor.prototype, "source").get
   );
   var regexpToString = functionCall.bind(
     regexpConstructor.prototype.toString
   );
-  var regexpTest = functionCall.bind(regexpConstructor.prototype.test);
+  var regexpExec = functionCall.bind(regexpConstructor.prototype.exec);
+  var identifierKeyPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
   var numberValueOf = functionCall.bind(numberConstructor.prototype.valueOf);
   var stringValueOf = functionCall.bind(stringConstructor.prototype.valueOf);
   var booleanValueOf = functionCall.bind(
@@ -106,7 +121,7 @@
   var symbolToString = functionCall.bind(
     symbolConstructor.prototype.toString
   );
-  var stringReplace = functionCall.bind(stringConstructor.prototype.replace);
+  var stringSplit = functionCall.bind(stringConstructor.prototype.split);
 
   function tryApplyIntrinsic(intrinsic, value) {
     try {
@@ -124,6 +139,88 @@
     } catch (e) {
       return false;
     }
+  }
+
+  // Walk a Proxy chain down to its non-Proxy target without dispatching to any
+  // handler. Returns the value unchanged when it is not a Proxy (or when the
+  // host floor is absent) and null for a revoked Proxy.
+  function unwrapProxy(v) {
+    if (!hostProxyTarget) return v;
+    while (true) {
+      var target = hostProxyTarget(v);
+      if (target === undefined) return v;
+      if (target === null) return null;
+      v = target;
+    }
+  }
+
+  // `desc` is always FromPropertyDescriptor output — an ordinary object whose
+  // fields are own data properties — so an own-property check is enough to keep
+  // a polluted `Object.prototype.get`/`set`/`value` out of the result.
+  function descriptorField(desc, key) {
+    if (!desc) return undefined;
+    return objectHasOwnProperty(desc, key) ? desc[key] : undefined;
+  }
+
+  function dataDescriptorValue(desc) {
+    if (!desc) return undefined;
+    if (
+      descriptorField(desc, "get") !== undefined ||
+      descriptorField(desc, "set") !== undefined
+    ) {
+      return undefined;
+    }
+    return descriptorField(desc, "value");
+  }
+
+  function findPropertyDescriptor(v, key) {
+    try {
+      var current = v;
+      while (current !== null) {
+        current = unwrapProxy(current);
+        if (current === null) return null;
+        var desc = objectGetOwnPropertyDescriptor(current, key);
+        if (desc) return desc;
+        current = objectGetPrototypeOf(current);
+      }
+    } catch (e) {
+      // The pure-JS no-host fallback cannot unwrap exotic objects. A failed
+      // metadata walk degrades to the caller's default instead of escaping.
+    }
+    return null;
+  }
+
+  function primitiveString(value, fallback) {
+    var type = typeof value;
+    if (type === "object" || type === "function" || type === "undefined") {
+      return fallback;
+    }
+    return type === "symbol" ? symbolToString(value) : stringConstructor(value);
+  }
+
+  // Node's isError is `isNativeError(e) || e instanceof Error`, so a plain
+  // object that merely inherits Error.prototype still renders as an error. The
+  // `instanceof` half is OrdinaryHasInstance, which would dispatch to a
+  // getPrototypeOf trap for a Proxy anywhere in the chain — unwrap at every
+  // step instead so no handler ever runs. %Object.prototype% terminates the
+  // walk: nothing below it can reach Error.prototype, so the common plain
+  // object costs a single trap-free [[GetPrototypeOf]].
+  function inheritsErrorPrototype(v) {
+    try {
+      var current = objectGetPrototypeOf(v);
+      while (current !== null && current !== objectPrototype) {
+        if (current === errorPrototype) return true;
+        var target = unwrapProxy(current);
+        if (target !== current) {
+          current = target;
+          continue;
+        }
+        current = objectGetPrototypeOf(current);
+      }
+    } catch (e) {
+      // The no-host fallback cannot unwrap an exotic chain; leave it opaque.
+    }
+    return false;
   }
 
   function inspect(value, opts) {
@@ -165,9 +262,15 @@
 
       // Objects.
       if (arrayIndexOf(seen, v) !== -1) return "[Circular *1]";
-      if (errorIsError(v)) return renderError(v);
+      if (errorIsError(v) || inheritsErrorPrototype(v)) return renderError(v);
       var boxed;
-      boxed = tryApplyIntrinsic(regexpGetSource, v);
+      // `get RegExp.prototype.source` uniquely does NOT throw for
+      // %RegExp.prototype% (it answers "(?:)"), so the slot probe alone would
+      // misreport the prototype itself as a RegExp.
+      boxed =
+        v === regexpConstructor.prototype
+          ? null
+          : tryApplyIntrinsic(regexpGetSource, v);
       if (boxed) return regexpToString(v);
       boxed = tryApplyIntrinsic(dateGetTime, v);
       if (boxed) {
@@ -204,12 +307,18 @@
         if (arrayIsArray(v)) {
           out = renderArray(v, depth);
         } else {
+          // Own properties are rendered from their descriptors WITHOUT
+          // invoking accessors — Node's util.inspect shows [Getter]/[Setter]
+          // rather than calling the getter, so a throwing or side-effecting
+          // accessor cannot make a diagnostic print throw/mutate under jsse
+          // where it would not under Node.
           var keys = objectKeys(v);
           var parts = [];
           for (var j = 0; j < keys.length; j++) {
             var k = keys[j];
             var label = isIdentifierKey(k) ? k : quoteString(k);
-            parts.push(label + ": " + renderMember(v, k, depth));
+            var memberDesc = objectGetOwnPropertyDescriptor(v, k);
+            parts.push(label + ": " + renderDescriptor(memberDesc, depth));
           }
           var ctorName = constructorName(v);
           out = parts.length
@@ -220,33 +329,6 @@
         seen.pop();
       }
       return out;
-    }
-
-    function unwrapProxy(v) {
-      if (!hostProxyTarget) return v;
-      while (true) {
-        var target = hostProxyTarget(v);
-        if (target === undefined) return v;
-        if (target === null) return null;
-        v = target;
-      }
-    }
-
-    function descriptorField(desc, key) {
-      if (!desc) return undefined;
-      var field = objectGetOwnPropertyDescriptor(desc, key);
-      return field ? field.value : undefined;
-    }
-
-    function dataDescriptorValue(desc) {
-      if (!desc) return undefined;
-      if (
-        descriptorField(desc, "get") !== undefined ||
-        descriptorField(desc, "set") !== undefined
-      ) {
-        return undefined;
-      }
-      return descriptorField(desc, "value");
     }
 
     function renderDescriptor(desc, depth) {
@@ -260,16 +342,6 @@
           : "[Setter]";
       }
       return render(descriptorField(desc, "value"), depth - 1);
-    }
-
-    // Render one own property/element WITHOUT invoking accessors — Node's
-    // util.inspect shows [Getter]/[Setter] rather than calling the getter, so a
-    // throwing or side-effecting accessor (object property or array element)
-    // cannot make a diagnostic print throw/mutate under jsse where it would not
-    // under Node.
-    function renderMember(container, key, depth) {
-      var desc = objectGetOwnPropertyDescriptor(container, key);
-      return desc ? renderDescriptor(desc, depth) : "undefined";
     }
 
     // Array length and elements are read from own descriptors on the unwrapped
@@ -310,31 +382,6 @@
       return hasPart ? "[ " + body + " ]" : "[]";
     }
 
-    function findPropertyDescriptor(v, key) {
-      try {
-        var current = v;
-        while (current !== null) {
-          current = unwrapProxy(current);
-          if (current === null) return null;
-          var desc = objectGetOwnPropertyDescriptor(current, key);
-          if (desc) return desc;
-          current = objectGetPrototypeOf(current);
-        }
-      } catch (e) {
-        // The pure-JS no-host fallback cannot unwrap exotic objects. A failed
-        // metadata walk degrades to the caller's default instead of escaping.
-      }
-      return null;
-    }
-
-    function primitiveString(value, fallback) {
-      var type = typeof value;
-      if (type === "object" || type === "function" || type === "undefined") {
-        return fallback;
-      }
-      return type === "symbol" ? symbolToString(value) : stringConstructor(value);
-    }
-
     function renderError(v) {
       var stackDesc = findPropertyDescriptor(v, "stack");
       var stack = primitiveString(dataDescriptorValue(stackDesc), "");
@@ -363,19 +410,23 @@
         if (own) {
           ctor = dataDescriptorValue(own);
         } else {
-          var proto = objectGetPrototypeOf(v);
-          proto = proto === null ? null : unwrapProxy(proto);
+          var proto = unwrapProxy(objectGetPrototypeOf(v));
           var pd = proto
             ? objectGetOwnPropertyDescriptor(proto, "constructor")
             : null;
           if (pd) ctor = dataDescriptorValue(pd);
         }
-        if (typeof ctor !== "object" && typeof ctor !== "function") return "";
+        // Node's getConstructorName only accepts a callable `constructor` with
+        // a non-empty name; anything else yields no prefix at all (never a bare
+        // leading space).
         ctor = unwrapProxy(ctor);
-        var name = ctor
-          ? dataDescriptorValue(objectGetOwnPropertyDescriptor(ctor, "name"))
-          : undefined;
-        return typeof name === "string" && name !== "Object" ? name + " " : "";
+        if (typeof ctor !== "function") return "";
+        var name = dataDescriptorValue(
+          objectGetOwnPropertyDescriptor(ctor, "name")
+        );
+        return typeof name === "string" && name && name !== "Object"
+          ? name + " "
+          : "";
       } catch (e) {
         return "";
       }
@@ -449,9 +500,6 @@
     }
     return names;
   })();
-  var objectHasOwnProperty = functionCall.bind(
-    objectConstructor.prototype.hasOwnProperty
-  );
   var symbolToPrimitive = symbolConstructor.toPrimitive;
 
   function hasOwnProperty(value, key) {
@@ -468,6 +516,12 @@
   function hasBuiltInToString(value) {
     var hasOwnToString = hasOwnProperty;
     var hasOwnToPrimitive = hasOwnProperty;
+
+    // Node reads [[ProxyTarget]] here before touching a single property, so a
+    // Proxy's get trap never runs for `%s`. Do the same via the host floor; a
+    // revoked Proxy has no coercion hook at all, so it routes to inspect.
+    value = unwrapProxy(value);
+    if (value === null) return true;
 
     if (typeof value.toString !== "function") {
       if (typeof value[symbolToPrimitive] !== "function") return true;
@@ -491,14 +545,14 @@
         !hasOwnToPrimitive(pointer, symbolToPrimitive)
       );
     } catch (e) {
-      // Node can unwrap proxies without invoking their prototype traps. The
-      // pure-JS shim cannot, so a failed owner walk uses ordinary coercion.
+      // Without the host floor the shim cannot unwrap an exotic object, so a
+      // failed owner walk falls back to ordinary coercion.
       return false;
     }
 
-    // A callable hook visible through a Proxy get trap may not have an owner in
-    // the reported prototype chain. Node can unwrap proxies internally; the
-    // pure-JS shim cannot, so treat that hook as user-defined.
+    // A callable hook with no owner in the reported prototype chain (only
+    // reachable on the no-host fallback, where a Proxy stays opaque) is treated
+    // as user-defined.
     if (pointer === null) return false;
 
     var descriptor = objectGetOwnPropertyDescriptor(pointer, "constructor");

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -242,13 +242,10 @@
   // Classify a built-in's presentation from trap-free prototype metadata. A
   // genuine built-in can be reparented while retaining its internal slot, but
   // Node renders it generically unless its prototype chain still identifies
-  // that built-in family. Slot-bearing prototype objects also recognize the
-  // corresponding chain from another realm without invoking @@hasInstance.
-  function builtinPrototypeKind(
-    startPrototype,
-    intrinsicPrototype,
-    prototypeProbe
-  ) {
+  // that built-in family. Only the captured intrinsic prototype is decisive:
+  // an arbitrary same-family instance carries the same slot, so probing chain
+  // nodes would let it impersonate the intrinsic prototype.
+  function builtinPrototypeKind(startPrototype, intrinsicPrototype) {
     var current = startPrototype;
     if (current === UNKNOWN_PROTOTYPE) return "ordinary";
     if (current === REVOKED_PROXY) return "revoked";
@@ -257,12 +254,7 @@
       var hops = MAX_PROTOTYPE_HOPS;
       while (current !== null && current !== objectPrototype && hops-- > 0) {
         if (current === REVOKED_PROXY) return "revoked";
-        if (
-          current === intrinsicPrototype ||
-          (prototypeProbe && tryApplyIntrinsic(prototypeProbe, current))
-        ) {
-          return "builtin";
-        }
+        if (current === intrinsicPrototype) return "builtin";
         current = unwrapProxy(objectGetPrototypeOf(current));
       }
     } catch (e) {
@@ -466,7 +458,7 @@
         // report it too — but only this one throws. It must therefore stay
         // ahead of them all, and outside the `isArr` guard, so an array whose
         // chain contains a revoked Proxy still throws.
-        var errorKind = builtinPrototypeKind(prototype, errorPrototype, null);
+        var errorKind = builtinPrototypeKind(prototype, errorPrototype);
         if (errorKind === "revoked") {
           throw new typeErrorConstructor(
             "Cannot perform 'get' on a proxy that has been revoked"
@@ -502,11 +494,7 @@
             ? null
             : tryApplyIntrinsic(regexpGetSource, v);
         if (boxed) {
-          var regexpKind = builtinPrototypeKind(
-            prototype,
-            regexpPrototype,
-            regexpGetSource
-          );
+          var regexpKind = builtinPrototypeKind(prototype, regexpPrototype);
           if (regexpKind === "builtin") return formatRegExp(v, boxed.value);
           if (regexpKind === "null") {
             return "[RegExp: null prototype] " + formatRegExp(v, boxed.value);
@@ -517,11 +505,7 @@
           var dateText = numberIsNaN(boxed.value)
             ? "Invalid Date"
             : dateToISOString(v);
-          var dateKind = builtinPrototypeKind(
-            prototype,
-            datePrototype,
-            dateGetTime
-          );
+          var dateKind = builtinPrototypeKind(prototype, datePrototype);
           if (dateKind === "builtin") return dateText;
           if (dateKind === "null") {
             return "[Date: null prototype] " + dateText;
@@ -534,8 +518,7 @@
           var wrapperText = render(boxed.value, depth);
           var wrapperKind = builtinPrototypeKind(
             prototype,
-            wrapper.prototype,
-            wrapper.probe
+            wrapper.prototype
           );
           if (wrapperKind === "builtin") {
             return "[" + wrapper.label + ": " + wrapperText + "]";
@@ -551,8 +534,7 @@
           var bigintText = render(boxed.value, depth);
           var bigintKind = builtinPrototypeKind(
             prototype,
-            bigintPrototype,
-            bigintValueOf
+            bigintPrototype
           );
           if (bigintKind === "null") {
             return "[BigInt (null prototype): " + bigintText + "]";
@@ -571,8 +553,7 @@
         if (boxed) {
           var symbolKind = builtinPrototypeKind(
             prototype,
-            symbolPrototype,
-            symbolToString
+            symbolPrototype
           );
           if (symbolKind === "null") {
             return "[Symbol (null prototype): " + boxed.value + "]";

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -7,10 +7,11 @@
 //
 // The readable-output layer (process, the full console method set, and the
 // util.format / util.inspect core they share) is built on top of the flag-gated
-// Rust "syscall floor" (issue #229): __host_write (byte-accurate fd I/O),
-// __host_hrtime (monotonic clock), and __host_exit (real process exit). The
-// harness runs jsse with `--node` so those primitives exist; when they are
-// absent (jsse without --node) each surface degrades to a pure-JS fallback.
+// Rust host floor (issue #229): __host_write (byte-accurate fd I/O),
+// __host_hrtime (monotonic clock), __host_exit (real process exit), and
+// __host_proxy_target (trap-free Proxy metadata). The harness runs jsse with
+// `--node` so those primitives exist; when they are absent (jsse without
+// --node) each surface degrades to a pure-JS fallback.
 //
 // Everything below is skipped on real Node, where `process`, the full
 // `console`, and `require('util')` already exist. That inertness is what lets
@@ -30,6 +31,8 @@
   var hostWrite = typeof __host_write !== "undefined" ? __host_write : null;
   var hostHrtime = typeof __host_hrtime !== "undefined" ? __host_hrtime : null;
   var hostExit = typeof __host_exit !== "undefined" ? __host_exit : null;
+  var hostProxyTarget =
+    typeof __host_proxy_target !== "undefined" ? __host_proxy_target : null;
   var fallbackConsoleLog = console.log;
 
   var NS_PER_SEC = 1000000000;
@@ -73,9 +76,6 @@
   var regexpConstructor = RegExp;
   var stringConstructor = String;
   var symbolConstructor = Symbol;
-  var functionHasInstance = functionCall.bind(
-    Function.prototype[symbolConstructor.hasInstance]
-  );
   var arrayIndexOf = functionCall.bind(arrayConstructor.prototype.indexOf);
   var arrayIsArray = arrayConstructor.isArray;
   var arrayJoin = functionCall.bind(arrayConstructor.prototype.join);
@@ -84,13 +84,12 @@
   var objectGetPrototypeOf = objectConstructor.getPrototypeOf;
   var objectIs = objectConstructor.is;
   var objectKeys = objectConstructor.keys;
-  var objectToString = functionCall.bind(objectConstructor.prototype.toString);
   var numberIsNaN = numberConstructor.isNaN;
   var dateGetTime = functionCall.bind(dateConstructor.prototype.getTime);
   var dateToISOString = functionCall.bind(
     dateConstructor.prototype.toISOString
   );
-  var errorToString = functionCall.bind(errorConstructor.prototype.toString);
+  var errorIsError = errorConstructor.isError;
   var regexpGetSource = functionCall.bind(
     objectGetOwnPropertyDescriptor(regexpConstructor.prototype, "source").get
   );
@@ -113,8 +112,8 @@
     try {
       return { value: intrinsic(value) };
     } catch (e) {
-      // `instanceof` also accepts objects that merely inherit a built-in
-      // prototype. Only a genuine instance has the corresponding internal slot.
+      // An object can inherit a built-in prototype without carrying the
+      // corresponding internal slot. The intrinsic slot probe rejects it.
       return null;
     }
   }
@@ -140,70 +139,61 @@
       if (t === "number") return objectIs(v, -0) ? "-0" : stringConstructor(v);
       if (t === "bigint") return stringConstructor(v) + "n";
       if (t === "boolean") return stringConstructor(v);
-      if (t === "symbol") return v.toString();
+      if (t === "symbol") return symbolToString(v);
+
+      // Node's native inspector can read [[ProxyTarget]] without dispatching
+      // through the handler. The --node host floor exposes that one piece of
+      // metadata so the JS shim can do the same before any instanceof,
+      // reflection, property access, or enumeration. Nested Proxies are
+      // unwrapped recursively; a revoked Proxy is an opaque terminal value.
+      if (t === "object" || t === "function") {
+        v = unwrapProxy(v);
+        if (v === null) return "<Revoked Proxy>";
+        t = typeof v;
+      }
+
       if (t === "function") {
-        return "[Function" + (v.name ? ": " + v.name : " (anonymous)") + "]";
+        var name = dataDescriptorValue(
+          objectGetOwnPropertyDescriptor(v, "name")
+        );
+        return (
+          "[Function" +
+          (typeof name === "string" && name ? ": " + name : " (anonymous)") +
+          "]"
+        );
       }
 
       // Objects.
       if (arrayIndexOf(seen, v) !== -1) return "[Circular *1]";
-      if (functionHasInstance(errorConstructor, v)) {
-        var stack;
-        try {
-          stack = v.stack;
-        } catch (e) {
-          // Node ignores a throwing stack getter and renders the intrinsic
-          // Error string as a stackless error.
-        }
-        if (stack) return stringConstructor(stack);
-        try {
-          return "[" + errorToString(v) + "]";
-        } catch (e) {
-          return objectToString(v);
-        }
-      }
+      if (errorIsError(v)) return renderError(v);
       var boxed;
-      if (functionHasInstance(regexpConstructor, v)) {
-        boxed = tryApplyIntrinsic(regexpGetSource, v);
-        if (boxed) return regexpToString(v);
+      boxed = tryApplyIntrinsic(regexpGetSource, v);
+      if (boxed) return regexpToString(v);
+      boxed = tryApplyIntrinsic(dateGetTime, v);
+      if (boxed) {
+        return numberIsNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);
       }
-      if (functionHasInstance(dateConstructor, v)) {
-        boxed = tryApplyIntrinsic(dateGetTime, v);
-        if (boxed) {
-          return numberIsNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);
-        }
+      boxed = tryApplyIntrinsic(numberValueOf, v);
+      if (boxed) return "[Number: " + render(boxed.value, depth) + "]";
+      boxed = tryApplyIntrinsic(stringValueOf, v);
+      if (boxed) return "[String: " + render(boxed.value, depth) + "]";
+      boxed = tryApplyIntrinsic(booleanValueOf, v);
+      if (boxed) return "[Boolean: " + render(boxed.value, depth) + "]";
+      boxed = tryApplyIntrinsic(bigintValueOf, v);
+      if (boxed) {
+        // Unlike the older wrappers above, Node's boxed BigInt/Symbol
+        // rendering intentionally observes a constructor's current
+        // @@hasInstance result. A false or throwing hook selects its generic
+        // object shape, but must not intercept the internal-slot probe.
+        return tryInstanceOf(v, bigintConstructor)
+          ? "[BigInt: " + render(boxed.value, depth) + "]"
+          : "Object [BigInt] {}";
       }
-      if (functionHasInstance(numberConstructor, v)) {
-        boxed = tryApplyIntrinsic(numberValueOf, v);
-        if (boxed) return "[Number: " + render(boxed.value, depth) + "]";
-      }
-      if (functionHasInstance(stringConstructor, v)) {
-        boxed = tryApplyIntrinsic(stringValueOf, v);
-        if (boxed) return "[String: " + render(boxed.value, depth) + "]";
-      }
-      if (functionHasInstance(booleanConstructor, v)) {
-        boxed = tryApplyIntrinsic(booleanValueOf, v);
-        if (boxed) return "[Boolean: " + render(boxed.value, depth) + "]";
-      }
-      if (functionHasInstance(bigintConstructor, v)) {
-        boxed = tryApplyIntrinsic(bigintValueOf, v);
-        if (boxed) {
-          // Unlike the older wrappers above, Node's boxed BigInt/Symbol
-          // rendering intentionally observes a constructor's current
-          // @@hasInstance result. A false or throwing hook selects its generic
-          // object shape, but must not intercept the internal-slot probe.
-          return tryInstanceOf(v, bigintConstructor)
-            ? "[BigInt: " + render(boxed.value, depth) + "]"
-            : "Object [BigInt] {}";
-        }
-      }
-      if (functionHasInstance(symbolConstructor, v)) {
-        boxed = tryApplyIntrinsic(symbolToString, v);
-        if (boxed) {
-          return tryInstanceOf(v, symbolConstructor)
-            ? "[Symbol: " + boxed.value + "]"
-            : "Object [Symbol] {}";
-        }
+      boxed = tryApplyIntrinsic(symbolToString, v);
+      if (boxed) {
+        return tryInstanceOf(v, symbolConstructor)
+          ? "[Symbol: " + boxed.value + "]"
+          : "Object [Symbol] {}";
       }
 
       if (depth < 0) return arrayIsArray(v) ? "[Array]" : "[Object]";
@@ -212,9 +202,7 @@
       var out;
       try {
         if (arrayIsArray(v)) {
-          var items = [];
-          for (var i = 0; i < v.length; i++) items.push(renderMember(v, i, depth));
-          out = items.length ? "[ " + arrayJoin(items, ", ") + " ]" : "[]";
+          out = renderArray(v, depth);
         } else {
           var keys = objectKeys(v);
           var parts = [];
@@ -234,6 +222,46 @@
       return out;
     }
 
+    function unwrapProxy(v) {
+      if (!hostProxyTarget) return v;
+      while (true) {
+        var target = hostProxyTarget(v);
+        if (target === undefined) return v;
+        if (target === null) return null;
+        v = target;
+      }
+    }
+
+    function descriptorField(desc, key) {
+      if (!desc) return undefined;
+      var field = objectGetOwnPropertyDescriptor(desc, key);
+      return field ? field.value : undefined;
+    }
+
+    function dataDescriptorValue(desc) {
+      if (!desc) return undefined;
+      if (
+        descriptorField(desc, "get") !== undefined ||
+        descriptorField(desc, "set") !== undefined
+      ) {
+        return undefined;
+      }
+      return descriptorField(desc, "value");
+    }
+
+    function renderDescriptor(desc, depth) {
+      var getter = descriptorField(desc, "get");
+      var setter = descriptorField(desc, "set");
+      if (getter !== undefined || setter !== undefined) {
+        return getter
+          ? setter
+            ? "[Getter/Setter]"
+            : "[Getter]"
+          : "[Setter]";
+      }
+      return render(descriptorField(desc, "value"), depth - 1);
+    }
+
     // Render one own property/element WITHOUT invoking accessors — Node's
     // util.inspect shows [Getter]/[Setter] rather than calling the getter, so a
     // throwing or side-effecting accessor (object property or array element)
@@ -241,10 +269,87 @@
     // under Node.
     function renderMember(container, key, depth) {
       var desc = objectGetOwnPropertyDescriptor(container, key);
-      if (desc && (desc.get || desc.set)) {
-        return desc.get ? (desc.set ? "[Getter/Setter]" : "[Getter]") : "[Setter]";
+      return desc ? renderDescriptor(desc, depth) : "undefined";
+    }
+
+    // Array length and elements are read from own descriptors on the unwrapped
+    // target. A missing descriptor is a hole, never an invitation to read
+    // through Array.prototype (which could invoke an inherited getter).
+    function renderArray(v, depth) {
+      var length = dataDescriptorValue(
+        objectGetOwnPropertyDescriptor(v, "length")
+      );
+      if (typeof length !== "number" || length <= 0) return "[]";
+
+      var body = "";
+      var hasPart = false;
+      var holes = 0;
+
+      function append(part) {
+        if (hasPart) body += ", ";
+        body += part;
+        hasPart = true;
       }
-      return render(desc ? desc.value : container[key], depth - 1);
+
+      function flushHoles() {
+        if (!holes) return;
+        append("<" + holes + " empty item" + (holes === 1 ? "" : "s") + ">");
+        holes = 0;
+      }
+
+      for (var i = 0; i < length; i++) {
+        var desc = objectGetOwnPropertyDescriptor(v, i);
+        if (!desc) {
+          holes++;
+        } else {
+          flushHoles();
+          append(renderDescriptor(desc, depth));
+        }
+      }
+      flushHoles();
+      return hasPart ? "[ " + body + " ]" : "[]";
+    }
+
+    function findPropertyDescriptor(v, key) {
+      try {
+        var current = v;
+        while (current !== null) {
+          current = unwrapProxy(current);
+          if (current === null) return null;
+          var desc = objectGetOwnPropertyDescriptor(current, key);
+          if (desc) return desc;
+          current = objectGetPrototypeOf(current);
+        }
+      } catch (e) {
+        // The pure-JS no-host fallback cannot unwrap exotic objects. A failed
+        // metadata walk degrades to the caller's default instead of escaping.
+      }
+      return null;
+    }
+
+    function primitiveString(value, fallback) {
+      var type = typeof value;
+      if (type === "object" || type === "function" || type === "undefined") {
+        return fallback;
+      }
+      return type === "symbol" ? symbolToString(value) : stringConstructor(value);
+    }
+
+    function renderError(v) {
+      var stackDesc = findPropertyDescriptor(v, "stack");
+      var stack = primitiveString(dataDescriptorValue(stackDesc), "");
+      if (stack) return stack;
+
+      var name = primitiveString(
+        dataDescriptorValue(findPropertyDescriptor(v, "name")),
+        "Error"
+      );
+      var message = primitiveString(
+        dataDescriptorValue(findPropertyDescriptor(v, "message")),
+        ""
+      );
+      var text = !name ? message : !message ? name : name + ": " + message;
+      return "[" + text + "]";
     }
 
     // Derive the "ClassName " prefix without a plain `v.constructor` get, which
@@ -256,15 +361,21 @@
         var ctor;
         var own = objectGetOwnPropertyDescriptor(v, "constructor");
         if (own) {
-          if (!own.get && !own.set) ctor = own.value;
+          ctor = dataDescriptorValue(own);
         } else {
           var proto = objectGetPrototypeOf(v);
+          proto = proto === null ? null : unwrapProxy(proto);
           var pd = proto
             ? objectGetOwnPropertyDescriptor(proto, "constructor")
             : null;
-          if (pd && !pd.get && !pd.set) ctor = pd.value;
+          if (pd) ctor = dataDescriptorValue(pd);
         }
-        return ctor && ctor.name && ctor.name !== "Object" ? ctor.name + " " : "";
+        if (typeof ctor !== "object" && typeof ctor !== "function") return "";
+        ctor = unwrapProxy(ctor);
+        var name = ctor
+          ? dataDescriptorValue(objectGetOwnPropertyDescriptor(ctor, "name"))
+          : undefined;
+        return typeof name === "string" && name !== "Object" ? name + " " : "";
       } catch (e) {
         return "";
       }

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -101,9 +101,12 @@
   var objectIs = objectConstructor.is;
   var objectKeys = objectConstructor.keys;
   var objectPrototype = objectConstructor.prototype;
+  var bigintPrototype = bigintConstructor.prototype;
+  var booleanPrototype = booleanConstructor.prototype;
+  var datePrototype = dateConstructor.prototype;
   var numberPrototype = numberConstructor.prototype;
   var stringPrototype = stringConstructor.prototype;
-  var booleanPrototype = booleanConstructor.prototype;
+  var symbolPrototype = symbolConstructor.prototype;
   var numberIsNaN = numberConstructor.isNaN;
   var dateGetTime = functionCall.bind(dateConstructor.prototype.getTime);
   var dateToISOString = functionCall.bind(
@@ -183,22 +186,21 @@
     return "/" + source + "/" + flags;
   }
 
-  // Classify a RegExp's presentation from trap-free prototype metadata. A
-  // genuine RegExp can be reparented to an ordinary object while retaining its
-  // internal slot; Node renders that as an ordinary object, not by performing
-  // `source`/`flags` gets through the replacement prototype. A RegExp object in
-  // the chain also recognizes a foreign realm's %RegExp.prototype% without an
-  // `instanceof` or @@hasInstance call.
-  function regexpPrototypeKind(value) {
+  // Classify a built-in's presentation from trap-free prototype metadata. A
+  // genuine built-in can be reparented while retaining its internal slot, but
+  // Node renders it generically unless its prototype chain still identifies
+  // that built-in family. Slot-bearing prototype objects also recognize the
+  // corresponding chain from another realm without invoking @@hasInstance.
+  function builtinPrototypeKind(value, intrinsicPrototype, prototypeProbe) {
     try {
       var current = unwrapProxy(objectGetPrototypeOf(value));
       if (current === null) return "null";
-      while (current !== null) {
+      while (current !== null && current !== objectPrototype) {
         if (
-          current === regexpPrototype ||
-          tryApplyIntrinsic(regexpGetSource, current)
+          current === intrinsicPrototype ||
+          (prototypeProbe && tryApplyIntrinsic(prototypeProbe, current))
         ) {
-          return "regexp";
+          return "builtin";
         }
         current = unwrapProxy(objectGetPrototypeOf(current));
       }
@@ -280,28 +282,6 @@
     return type === "symbol" ? symbolToString(value) : stringConstructor(value);
   }
 
-  // Node's isError is `isNativeError(e) || e instanceof Error`, so a plain
-  // object that merely inherits Error.prototype still renders as an error. The
-  // `instanceof` half is OrdinaryHasInstance, which would dispatch to a
-  // getPrototypeOf trap for a Proxy anywhere in the chain — unwrap at every
-  // step instead so no handler ever runs. %Object.prototype% terminates the
-  // walk: nothing below it can reach Error.prototype, so the common plain
-  // object costs a single trap-free [[GetPrototypeOf]].
-  function inheritsErrorPrototype(v) {
-    try {
-      // `unwrapProxy` is already fully recursive and maps a revoked Proxy to
-      // null, which the loop condition treats as the end of the chain.
-      var current = unwrapProxy(objectGetPrototypeOf(v));
-      while (current !== null && current !== objectPrototype) {
-        if (current === errorPrototype) return true;
-        current = unwrapProxy(objectGetPrototypeOf(current));
-      }
-    } catch (e) {
-      // The no-host fallback cannot unwrap an exotic chain; leave it opaque.
-    }
-    return false;
-  }
-
   function inspect(value, opts) {
     opts = opts || {};
     var maxDepth = typeof opts.depth === "number" ? opts.depth : 2;
@@ -335,7 +315,11 @@
 
       // Objects.
       if (arrayIndexOf(seen, v) !== -1) return "[Circular *1]";
-      if (errorIsError(v) || inheritsErrorPrototype(v)) return renderError(v);
+      var errorKind = builtinPrototypeKind(v, errorPrototype, null);
+      if (errorKind === "builtin") return renderError(v);
+      if (errorKind === "null" && errorIsError(v)) {
+        return renderNullPrototypeError(v);
+      }
       var boxed;
       // `get RegExp.prototype.source` uniquely does NOT throw for
       // %RegExp.prototype% (it answers "(?:)"), so the slot probe alone would
@@ -348,38 +332,102 @@
           ? null
           : tryApplyIntrinsic(regexpGetSource, v);
       if (boxed) {
-        var regexpKind = regexpPrototypeKind(v);
-        if (regexpKind === "regexp") return formatRegExp(v, boxed.value);
+        var regexpKind = builtinPrototypeKind(
+          v,
+          regexpPrototype,
+          regexpGetSource
+        );
+        if (regexpKind === "builtin") return formatRegExp(v, boxed.value);
         if (regexpKind === "null") {
           return "[RegExp: null prototype] " + formatRegExp(v, boxed.value);
         }
       }
       boxed = tryApplyIntrinsic(dateGetTime, v);
       if (boxed) {
-        return numberIsNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);
+        var dateText = numberIsNaN(boxed.value)
+          ? "Invalid Date"
+          : dateToISOString(v);
+        var dateKind = builtinPrototypeKind(v, datePrototype, dateGetTime);
+        if (dateKind === "builtin") return dateText;
+        if (dateKind === "null") {
+          return "[Date: null prototype] " + dateText;
+        }
       }
-      // These three intrinsic prototypes carry the same internal slots as
-      // their boxed instances, but Node deliberately presents the prototype
-      // singletons as ordinary objects. Exact identity guards keep genuine
-      // wrappers (including cross-realm/reparented ones) on the slot path.
-      var legacyWrapperPrototype = isLegacyWrapperPrototype(v);
-      boxed = legacyWrapperPrototype ? null : tryApplyIntrinsic(numberValueOf, v);
-      if (boxed) return "[Number: " + render(boxed.value, depth) + "]";
-      boxed = legacyWrapperPrototype ? null : tryApplyIntrinsic(stringValueOf, v);
-      if (boxed) return "[String: " + render(boxed.value, depth) + "]";
-      boxed = legacyWrapperPrototype ? null : tryApplyIntrinsic(booleanValueOf, v);
-      if (boxed) return "[Boolean: " + render(boxed.value, depth) + "]";
+      boxed = tryApplyIntrinsic(numberValueOf, v);
+      if (boxed) {
+        var numberText = render(boxed.value, depth);
+        var numberKind = builtinPrototypeKind(
+          v,
+          numberPrototype,
+          numberValueOf
+        );
+        if (numberKind === "builtin") return "[Number: " + numberText + "]";
+        if (numberKind === "null") {
+          return "[Number (null prototype): " + numberText + "]";
+        }
+      }
+      boxed = tryApplyIntrinsic(stringValueOf, v);
+      if (boxed) {
+        var stringText = render(boxed.value, depth);
+        var stringKind = builtinPrototypeKind(
+          v,
+          stringPrototype,
+          stringValueOf
+        );
+        if (stringKind === "builtin") return "[String: " + stringText + "]";
+        if (stringKind === "null") {
+          return "[String (null prototype): " + stringText + "]";
+        }
+      }
+      boxed = tryApplyIntrinsic(booleanValueOf, v);
+      if (boxed) {
+        var booleanText = render(boxed.value, depth);
+        var booleanKind = builtinPrototypeKind(
+          v,
+          booleanPrototype,
+          booleanValueOf
+        );
+        if (booleanKind === "builtin") {
+          return "[Boolean: " + booleanText + "]";
+        }
+        if (booleanKind === "null") {
+          return "[Boolean (null prototype): " + booleanText + "]";
+        }
+      }
       boxed = tryApplyIntrinsic(bigintValueOf, v);
+      if (boxed) {
+        var bigintText = render(boxed.value, depth);
+        var bigintKind = builtinPrototypeKind(
+          v,
+          bigintPrototype,
+          bigintValueOf
+        );
+        if (bigintKind === "null") {
+          return "[BigInt (null prototype): " + bigintText + "]";
+        }
+        if (bigintKind !== "builtin") boxed = null;
+      }
       if (boxed) {
         // Unlike the older wrappers above, Node's boxed BigInt/Symbol
         // rendering intentionally observes a constructor's current
         // @@hasInstance result. A false or throwing hook selects its generic
         // object shape, but must not intercept the internal-slot probe.
         return tryInstanceOf(v, bigintConstructor)
-          ? "[BigInt: " + render(boxed.value, depth) + "]"
+          ? "[BigInt: " + bigintText + "]"
           : "Object [BigInt] {}";
       }
       boxed = tryApplyIntrinsic(symbolToString, v);
+      if (boxed) {
+        var symbolKind = builtinPrototypeKind(
+          v,
+          symbolPrototype,
+          symbolToString
+        );
+        if (symbolKind === "null") {
+          return "[Symbol (null prototype): " + boxed.value + "]";
+        }
+        if (symbolKind !== "builtin") boxed = null;
+      }
       if (boxed) {
         return tryInstanceOf(v, symbolConstructor)
           ? "[Symbol: " + boxed.value + "]"
@@ -484,6 +532,14 @@
       var message = errorField(v, "message", "");
       var text = !name ? message : !message ? name : name + ": " + message;
       return "[" + text + "]";
+    }
+
+    function renderNullPrototypeError(v) {
+      var name = errorField(v, "name", "Error") || "Error";
+      var message = errorField(v, "message", "");
+      return (
+        "[" + name + ": null prototype]" + (message ? ": " + message : "")
+      );
     }
 
     // Derive the "ClassName " prefix without a plain `v.constructor` get, which

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -143,7 +143,13 @@
     objectGetOwnPropertyDescriptor(regexpPrototype, "sticky").get
   );
   var regexpExec = functionCall.bind(regexpConstructor.prototype.exec);
+  var arrayPop = functionCall.bind(arrayConstructor.prototype.pop);
+  var stringCharCodeAt = functionCall.bind(
+    stringConstructor.prototype.charCodeAt
+  );
+  var stringSlice = functionCall.bind(stringConstructor.prototype.slice);
   var identifierKeyPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+  var circularMessagePattern = /circular/i;
   var numberValueOf = functionCall.bind(numberConstructor.prototype.valueOf);
   var stringValueOf = functionCall.bind(stringConstructor.prototype.valueOf);
   var booleanValueOf = functionCall.bind(
@@ -186,16 +192,46 @@
     return "/" + source + "/" + flags;
   }
 
+  // Prototype chains are acyclic in practice, but a Proxy defeats
+  // OrdinarySetPrototypeOf's cycle check, so every walk below is bounded.
+  var MAX_PROTOTYPE_HOPS = 1000;
+
+  // Sentinel for a [[Prototype]] read that threw — an exotic object in the
+  // no-host fallback. Distinct from every value a real chain can hold.
+  var UNKNOWN_PROTOTYPE = {};
+
+  // The unwrapped [[Prototype]] of `v`. Read once per value and threaded into
+  // every builtinPrototypeKind() call below, so classifying eight built-in
+  // families costs one metadata read rather than eight — and, in the no-host
+  // fallback where `v` may still be a Proxy, one getPrototypeOf trap.
+  function prototypeOf(v) {
+    try {
+      return unwrapProxy(objectGetPrototypeOf(v));
+    } catch (e) {
+      return UNKNOWN_PROTOTYPE;
+    }
+  }
+
   // Classify a built-in's presentation from trap-free prototype metadata. A
   // genuine built-in can be reparented while retaining its internal slot, but
   // Node renders it generically unless its prototype chain still identifies
   // that built-in family. Slot-bearing prototype objects also recognize the
   // corresponding chain from another realm without invoking @@hasInstance.
-  function builtinPrototypeKind(value, intrinsicPrototype, prototypeProbe) {
+  function builtinPrototypeKind(
+    value,
+    intrinsicPrototype,
+    prototypeProbe,
+    startPrototype
+  ) {
+    // [[Prototype]] is always an object or null, never undefined, so undefined
+    // unambiguously means "not supplied".
+    var current =
+      startPrototype === undefined ? prototypeOf(value) : startPrototype;
+    if (current === UNKNOWN_PROTOTYPE) return "ordinary";
+    if (current === null) return "null";
     try {
-      var current = unwrapProxy(objectGetPrototypeOf(value));
-      if (current === null) return "null";
-      while (current !== null && current !== objectPrototype) {
+      var hops = MAX_PROTOTYPE_HOPS;
+      while (current !== null && current !== objectPrototype && hops-- > 0) {
         if (
           current === intrinsicPrototype ||
           (prototypeProbe && tryApplyIntrinsic(prototypeProbe, current))
@@ -239,7 +275,8 @@
   function findPropertyDescriptor(v, key) {
     try {
       var current = v;
-      while (current !== null) {
+      var hops = MAX_PROTOTYPE_HOPS;
+      while (current !== null && hops-- > 0) {
         current = unwrapProxy(current);
         if (current === null) return null;
         var desc = objectGetOwnPropertyDescriptor(current, key);
@@ -315,128 +352,146 @@
 
       // Objects.
       if (arrayIndexOf(seen, v) !== -1) return "[Circular *1]";
-      var errorKind = builtinPrototypeKind(v, errorPrototype, null);
-      if (errorKind === "builtin") return renderError(v);
-      if (errorKind === "null" && errorIsError(v)) {
-        return renderNullPrototypeError(v);
-      }
-      var boxed;
-      // `get RegExp.prototype.source` uniquely does NOT throw for
-      // %RegExp.prototype% (it answers "(?:)"), so the slot probe alone would
-      // misreport the prototype itself as a RegExp. After detecting a genuine
-      // RegExp, classify its prototype chain before presentation: a reparented
-      // RegExp must not dispatch ordinary `source`/`flags` gets through a user
-      // object. Compose the standard rendering from captured slot getters.
-      boxed =
-        v === regexpPrototype
-          ? null
-          : tryApplyIntrinsic(regexpGetSource, v);
-      if (boxed) {
-        var regexpKind = builtinPrototypeKind(
-          v,
-          regexpPrototype,
-          regexpGetSource
-        );
-        if (regexpKind === "builtin") return formatRegExp(v, boxed.value);
-        if (regexpKind === "null") {
-          return "[RegExp: null prototype] " + formatRegExp(v, boxed.value);
+      // Every builtinPrototypeKind() answer for a direct child of
+      // %Object.prototype% is "ordinary" — its walk body never runs — so the
+      // whole built-in classification below (seven throwing slot probes and
+      // eight chain walks) is pure waste for the commonest object shape.
+      var prototype = prototypeOf(v);
+      if (prototype !== objectPrototype) {
+        var errorKind = builtinPrototypeKind(v, errorPrototype, null, prototype);
+        if (errorKind === "builtin") return renderError(v);
+        if (errorKind === "null" && errorIsError && errorIsError(v)) {
+          return renderNullPrototypeError(v);
         }
-      }
-      boxed = tryApplyIntrinsic(dateGetTime, v);
-      if (boxed) {
-        var dateText = numberIsNaN(boxed.value)
-          ? "Invalid Date"
-          : dateToISOString(v);
-        var dateKind = builtinPrototypeKind(v, datePrototype, dateGetTime);
-        if (dateKind === "builtin") return dateText;
-        if (dateKind === "null") {
-          return "[Date: null prototype] " + dateText;
+        var boxed;
+        // `get RegExp.prototype.source` uniquely does NOT throw for
+        // %RegExp.prototype% (it answers "(?:)"), so the slot probe alone would
+        // misreport the prototype itself as a RegExp. After detecting a genuine
+        // RegExp, classify its prototype chain before presentation: a reparented
+        // RegExp must not dispatch ordinary `source`/`flags` gets through a user
+        // object. Compose the standard rendering from captured slot getters.
+        boxed =
+          v === regexpPrototype
+            ? null
+            : tryApplyIntrinsic(regexpGetSource, v);
+        if (boxed) {
+          var regexpKind = builtinPrototypeKind(
+            v,
+            regexpPrototype,
+            regexpGetSource,
+            prototype
+          );
+          if (regexpKind === "builtin") return formatRegExp(v, boxed.value);
+          if (regexpKind === "null") {
+            return "[RegExp: null prototype] " + formatRegExp(v, boxed.value);
+          }
         }
-      }
-      boxed = tryApplyIntrinsic(numberValueOf, v);
-      if (boxed) {
-        var numberText = render(boxed.value, depth);
-        var numberKind = builtinPrototypeKind(
-          v,
-          numberPrototype,
-          numberValueOf
-        );
-        if (numberKind === "builtin") return "[Number: " + numberText + "]";
-        if (numberKind === "null") {
-          return "[Number (null prototype): " + numberText + "]";
+        boxed = tryApplyIntrinsic(dateGetTime, v);
+        if (boxed) {
+          var dateText = numberIsNaN(boxed.value)
+            ? "Invalid Date"
+            : dateToISOString(v);
+          var dateKind = builtinPrototypeKind(
+            v,
+            datePrototype,
+            dateGetTime,
+            prototype
+          );
+          if (dateKind === "builtin") return dateText;
+          if (dateKind === "null") {
+            return "[Date: null prototype] " + dateText;
+          }
         }
-      }
-      boxed = tryApplyIntrinsic(stringValueOf, v);
-      if (boxed) {
-        var stringText = render(boxed.value, depth);
-        var stringKind = builtinPrototypeKind(
-          v,
-          stringPrototype,
-          stringValueOf
-        );
-        if (stringKind === "builtin") return "[String: " + stringText + "]";
-        if (stringKind === "null") {
-          return "[String (null prototype): " + stringText + "]";
+        boxed = tryApplyIntrinsic(numberValueOf, v);
+        if (boxed) {
+          var numberText = render(boxed.value, depth);
+          var numberKind = builtinPrototypeKind(
+            v,
+            numberPrototype,
+            numberValueOf,
+            prototype
+          );
+          if (numberKind === "builtin") return "[Number: " + numberText + "]";
+          if (numberKind === "null") {
+            return "[Number (null prototype): " + numberText + "]";
+          }
         }
-      }
-      boxed = tryApplyIntrinsic(booleanValueOf, v);
-      if (boxed) {
-        var booleanText = render(boxed.value, depth);
-        var booleanKind = builtinPrototypeKind(
-          v,
-          booleanPrototype,
-          booleanValueOf
-        );
-        if (booleanKind === "builtin") {
-          return "[Boolean: " + booleanText + "]";
+        boxed = tryApplyIntrinsic(stringValueOf, v);
+        if (boxed) {
+          var stringText = render(boxed.value, depth);
+          var stringKind = builtinPrototypeKind(
+            v,
+            stringPrototype,
+            stringValueOf,
+            prototype
+          );
+          if (stringKind === "builtin") return "[String: " + stringText + "]";
+          if (stringKind === "null") {
+            return "[String (null prototype): " + stringText + "]";
+          }
         }
-        if (booleanKind === "null") {
-          return "[Boolean (null prototype): " + booleanText + "]";
+        boxed = tryApplyIntrinsic(booleanValueOf, v);
+        if (boxed) {
+          var booleanText = render(boxed.value, depth);
+          var booleanKind = builtinPrototypeKind(
+            v,
+            booleanPrototype,
+            booleanValueOf,
+            prototype
+          );
+          if (booleanKind === "builtin") {
+            return "[Boolean: " + booleanText + "]";
+          }
+          if (booleanKind === "null") {
+            return "[Boolean (null prototype): " + booleanText + "]";
+          }
         }
-      }
-      boxed = tryApplyIntrinsic(bigintValueOf, v);
-      if (boxed) {
-        var bigintText = render(boxed.value, depth);
-        var bigintKind = builtinPrototypeKind(
-          v,
-          bigintPrototype,
-          bigintValueOf
-        );
-        if (bigintKind === "null") {
-          return "[BigInt (null prototype): " + bigintText + "]";
+        boxed = tryApplyIntrinsic(bigintValueOf, v);
+        if (boxed) {
+          var bigintText = render(boxed.value, depth);
+          var bigintKind = builtinPrototypeKind(
+            v,
+            bigintPrototype,
+            bigintValueOf,
+            prototype
+          );
+          if (bigintKind === "null") {
+            return "[BigInt (null prototype): " + bigintText + "]";
+          }
+          if (bigintKind !== "builtin") boxed = null;
         }
-        if (bigintKind !== "builtin") boxed = null;
-      }
-      if (boxed) {
-        // Unlike the older wrappers above, Node's boxed BigInt/Symbol
-        // rendering intentionally observes a constructor's current
-        // @@hasInstance result. A false or throwing hook selects its generic
-        // object shape, but must not intercept the internal-slot probe.
-        return tryInstanceOf(v, bigintConstructor)
-          ? "[BigInt: " + bigintText + "]"
-          : "Object [BigInt] {}";
-      }
-      boxed = tryApplyIntrinsic(symbolToString, v);
-      if (boxed) {
-        var symbolKind = builtinPrototypeKind(
-          v,
-          symbolPrototype,
-          symbolToString
-        );
-        if (symbolKind === "null") {
-          return "[Symbol (null prototype): " + boxed.value + "]";
+        if (boxed) {
+          // Unlike the older wrappers above, Node's boxed BigInt/Symbol
+          // rendering intentionally observes a constructor's current
+          // @@hasInstance result. A false or throwing hook selects its generic
+          // object shape, but must not intercept the internal-slot probe.
+          return tryInstanceOf(v, bigintConstructor)
+            ? "[BigInt: " + bigintText + "]"
+            : "Object [BigInt] {}";
         }
-        if (symbolKind !== "builtin") boxed = null;
-      }
-      if (boxed) {
-        return tryInstanceOf(v, symbolConstructor)
-          ? "[Symbol: " + boxed.value + "]"
-          : "Object [Symbol] {}";
+        boxed = tryApplyIntrinsic(symbolToString, v);
+        if (boxed) {
+          var symbolKind = builtinPrototypeKind(
+            v,
+            symbolPrototype,
+            symbolToString,
+            prototype
+          );
+          if (symbolKind === "null") {
+            return "[Symbol (null prototype): " + boxed.value + "]";
+          }
+          if (symbolKind !== "builtin") boxed = null;
+        }
+        if (boxed) {
+          return tryInstanceOf(v, symbolConstructor)
+            ? "[Symbol: " + boxed.value + "]"
+            : "Object [Symbol] {}";
+        }
       }
 
       if (depth < 0) return arrayIsArray(v) ? "[Array]" : "[Object]";
 
-      seen.push(v);
+      arrayPush(seen, v);
       var out;
       try {
         if (arrayIsArray(v)) {
@@ -453,7 +508,7 @@
             var k = keys[j];
             var label = isIdentifierKey(k) ? k : quoteString(k);
             var memberDesc = objectGetOwnPropertyDescriptor(v, k);
-            parts.push(label + ": " + renderDescriptor(memberDesc, depth));
+            arrayPush(parts, label + ": " + renderDescriptor(memberDesc, depth));
           }
           var ctorName = constructorName(v);
           out = parts.length
@@ -461,7 +516,7 @@
             : ctorName + "{}";
         }
       } finally {
-        seen.pop();
+        arrayPop(seen);
       }
       return out;
     }
@@ -659,9 +714,11 @@
     var hasOwnToString = hasOwnProperty;
     var hasOwnToPrimitive = hasOwnProperty;
 
-    // Node reads [[ProxyTarget]] here before touching a single property, so a
-    // Proxy's get trap never runs for `%s`. Do the same via the host floor; a
-    // revoked Proxy has no coercion hook at all, so it routes to inspect.
+    // Node reads [[ProxyTarget]] here before touching a single property, so
+    // classification never dispatches a Proxy get trap. Do the same via the
+    // host floor; a revoked Proxy has no coercion hook at all, so it routes to
+    // inspect. (When classification answers "user-defined", `convS` still
+    // coerces the ORIGINAL value, so the trap runs there — on Node too.)
     value = unwrapProxy(value);
     if (value === null) return true;
 
@@ -683,11 +740,13 @@
     // fire the trap here — so a `--node` cross-check difference on a
     // prototype-chain Proxy is expected, not a regression.
     var pointer = value;
+    var hops = MAX_PROTOTYPE_HOPS;
     try {
       do {
         pointer = unwrapProxy(objectGetPrototypeOf(pointer));
       } while (
         pointer !== null &&
+        hops-- > 0 &&
         !hasOwnToString(pointer, "toString") &&
         !hasOwnToPrimitive(pointer, symbolToPrimitive)
       );
@@ -718,7 +777,7 @@
     if (v === null) return "null";
     if (t === "undefined") return "undefined";
     if (t === "boolean") return String(v);
-    if (t === "symbol") return v.toString();
+    if (t === "symbol") return symbolToString(v);
     if (t === "function") return inspect(v, { depth: 0 });
     return hasBuiltInToString(v) ? inspect(v, { depth: 0 }) : String(v);
   }
@@ -753,7 +812,8 @@
       // "Converting circular structure to JSON"; its BigInt/toJSON errors do not
       // mention "circular", so matching the message is safe here (the shim is
       // inert on Node, so this only ever sees jsse's error text).
-      if (e && /circular/i.test(String(e.message))) return "[Circular]";
+      if (e && regexpExec(circularMessagePattern, stringConstructor(e.message)))
+        return "[Circular]";
       throw e;
     }
   }
@@ -765,9 +825,12 @@
       // No format string: inspect every argument, join with a space.
       var pieces = [];
       for (var i = 0; i < args.length; i++) {
-        pieces.push(typeof args[i] === "string" ? args[i] : inspect(args[i]));
+        arrayPush(
+          pieces,
+          typeof args[i] === "string" ? args[i] : inspect(args[i])
+        );
       }
-      return pieces.join(" ");
+      return arrayJoin(pieces, " ");
     }
     // A lone string argument is returned verbatim — Node performs no specifier
     // substitution unless there is at least one argument to format, so e.g.
@@ -781,10 +844,10 @@
     var f = first;
     var n = f.length;
     for (var p = 0; p < n - 1; p++) {
-      if (f.charCodeAt(p) !== 37 /* % */) continue;
-      var next = f.charCodeAt(p + 1);
+      if (stringCharCodeAt(f, p) !== 37 /* % */) continue;
+      var next = stringCharCodeAt(f, p + 1);
       if (next === 37 /* %% */) {
-        out += f.slice(lastPos, p) + "%";
+        out += stringSlice(f, lastPos, p) + "%";
         lastPos = p + 2;
         p++;
         continue;
@@ -804,12 +867,12 @@
         }
       }
       if (repl !== null) {
-        out += f.slice(lastPos, p) + repl;
+        out += stringSlice(f, lastPos, p) + repl;
         lastPos = p + 2;
         p++;
       }
     }
-    out += f.slice(lastPos);
+    out += stringSlice(f, lastPos);
 
     // Trailing arguments beyond the specifiers are appended, space-separated.
     for (; argIndex < args.length; argIndex++) {

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -33,6 +33,9 @@
   var hostExit = typeof __host_exit !== "undefined" ? __host_exit : null;
   var hostProxyTarget =
     typeof __host_proxy_target !== "undefined" ? __host_proxy_target : null;
+  // This metadata escape hatch exists only for the shim. Keep the captured
+  // closure private so bundled library code cannot bypass Proxy handlers.
+  if (hostProxyTarget) delete globalThis.__host_proxy_target;
   var fallbackConsoleLog = console.log;
 
   var NS_PER_SEC = 1000000000;

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -748,12 +748,15 @@
     // as user-defined.
     if (pointer === null) return false;
 
-    var ctor = dataDescriptorValue(
-      objectGetOwnPropertyDescriptor(pointer, "constructor")
-    );
+    // Deliberately an ordinary `.value`/`.name` read, NOT the descriptor
+    // helpers used elsewhere: routing here decides whether `%s` reaches
+    // inspect at all, and tightening it to data-descriptor lookups would
+    // change which values Node-compatibly route there. See the design doc.
+    var descriptor = objectGetOwnPropertyDescriptor(pointer, "constructor");
     return (
-      typeof ctor === "function" &&
-      builtInObjectNames[functionName(ctor)] === true
+      descriptor !== undefined &&
+      typeof descriptor.value === "function" &&
+      builtInObjectNames[descriptor.value.name] === true
     );
   }
 

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -111,11 +111,33 @@
   );
   var errorIsError = errorConstructor.isError;
   var errorPrototype = errorConstructor.prototype;
+  var regexpPrototype = regexpConstructor.prototype;
   var regexpGetSource = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpConstructor.prototype, "source").get
+    objectGetOwnPropertyDescriptor(regexpPrototype, "source").get
   );
-  var regexpToString = functionCall.bind(
-    regexpConstructor.prototype.toString
+  var regexpGetHasIndices = functionCall.bind(
+    objectGetOwnPropertyDescriptor(regexpPrototype, "hasIndices").get
+  );
+  var regexpGetGlobal = functionCall.bind(
+    objectGetOwnPropertyDescriptor(regexpPrototype, "global").get
+  );
+  var regexpGetIgnoreCase = functionCall.bind(
+    objectGetOwnPropertyDescriptor(regexpPrototype, "ignoreCase").get
+  );
+  var regexpGetMultiline = functionCall.bind(
+    objectGetOwnPropertyDescriptor(regexpPrototype, "multiline").get
+  );
+  var regexpGetDotAll = functionCall.bind(
+    objectGetOwnPropertyDescriptor(regexpPrototype, "dotAll").get
+  );
+  var regexpGetUnicode = functionCall.bind(
+    objectGetOwnPropertyDescriptor(regexpPrototype, "unicode").get
+  );
+  var regexpGetUnicodeSets = functionCall.bind(
+    objectGetOwnPropertyDescriptor(regexpPrototype, "unicodeSets").get
+  );
+  var regexpGetSticky = functionCall.bind(
+    objectGetOwnPropertyDescriptor(regexpPrototype, "sticky").get
   );
   var regexpExec = functionCall.bind(regexpConstructor.prototype.exec);
   var identifierKeyPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
@@ -146,6 +168,44 @@
     } catch (e) {
       return false;
     }
+  }
+
+  function formatRegExp(value, source) {
+    var flags = "";
+    if (regexpGetHasIndices(value)) flags += "d";
+    if (regexpGetGlobal(value)) flags += "g";
+    if (regexpGetIgnoreCase(value)) flags += "i";
+    if (regexpGetMultiline(value)) flags += "m";
+    if (regexpGetDotAll(value)) flags += "s";
+    if (regexpGetUnicode(value)) flags += "u";
+    if (regexpGetUnicodeSets(value)) flags += "v";
+    if (regexpGetSticky(value)) flags += "y";
+    return "/" + source + "/" + flags;
+  }
+
+  // Classify a RegExp's presentation from trap-free prototype metadata. A
+  // genuine RegExp can be reparented to an ordinary object while retaining its
+  // internal slot; Node renders that as an ordinary object, not by performing
+  // `source`/`flags` gets through the replacement prototype. A RegExp object in
+  // the chain also recognizes a foreign realm's %RegExp.prototype% without an
+  // `instanceof` or @@hasInstance call.
+  function regexpPrototypeKind(value) {
+    try {
+      var current = unwrapProxy(objectGetPrototypeOf(value));
+      if (current === null) return "null";
+      while (current !== null) {
+        if (
+          current === regexpPrototype ||
+          tryApplyIntrinsic(regexpGetSource, current)
+        ) {
+          return "regexp";
+        }
+        current = unwrapProxy(objectGetPrototypeOf(current));
+      }
+    } catch (e) {
+      // Exotic fallback: keep the value on the ordinary descriptor path.
+    }
+    return "ordinary";
   }
 
   // Walk a Proxy chain down to its non-Proxy target without dispatching to any
@@ -279,12 +339,21 @@
       var boxed;
       // `get RegExp.prototype.source` uniquely does NOT throw for
       // %RegExp.prototype% (it answers "(?:)"), so the slot probe alone would
-      // misreport the prototype itself as a RegExp.
+      // misreport the prototype itself as a RegExp. After detecting a genuine
+      // RegExp, classify its prototype chain before presentation: a reparented
+      // RegExp must not dispatch ordinary `source`/`flags` gets through a user
+      // object. Compose the standard rendering from captured slot getters.
       boxed =
-        v === regexpConstructor.prototype
+        v === regexpPrototype
           ? null
           : tryApplyIntrinsic(regexpGetSource, v);
-      if (boxed) return regexpToString(v);
+      if (boxed) {
+        var regexpKind = regexpPrototypeKind(v);
+        if (regexpKind === "regexp") return formatRegExp(v, boxed.value);
+        if (regexpKind === "null") {
+          return "[RegExp: null prototype] " + formatRegExp(v, boxed.value);
+        }
+      }
       boxed = tryApplyIntrinsic(dateGetTime, v);
       if (boxed) {
         return numberIsNaN(boxed.value) ? "Invalid Date" : dateToISOString(v);

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -120,33 +120,32 @@
   var errorIsError = errorConstructor.isError;
   var errorPrototype = errorConstructor.prototype;
   var regexpPrototype = regexpConstructor.prototype;
-  var regexpGetSource = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "source").get
-  );
-  var regexpGetHasIndices = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "hasIndices").get
-  );
-  var regexpGetGlobal = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "global").get
-  );
-  var regexpGetIgnoreCase = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "ignoreCase").get
-  );
-  var regexpGetMultiline = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "multiline").get
-  );
-  var regexpGetDotAll = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "dotAll").get
-  );
-  var regexpGetUnicode = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "unicode").get
-  );
-  var regexpGetUnicodeSets = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "unicodeSets").get
-  );
-  var regexpGetSticky = functionCall.bind(
-    objectGetOwnPropertyDescriptor(regexpPrototype, "sticky").get
-  );
+
+  // Captured defensively rather than as `descriptor.get`: on a host missing any
+  // one of these accessors that read throws from inside this IIFE, before
+  // `process` and `console` are installed, so a single absent flag would cost
+  // every library test its diagnostic output instead of one rendered letter.
+  function intrinsicGetter(target, key) {
+    var desc = objectGetOwnPropertyDescriptor(target, key);
+    if (!desc || isDataDescriptor(desc)) return null;
+    return typeof desc.get === "function" ? functionCall.bind(desc.get) : null;
+  }
+
+  // Null when the host lacks the accessor: `tryApplyIntrinsic` then rejects the
+  // slot probe and the value falls to the ordinary descriptor path.
+  var regexpGetSource = intrinsicGetter(regexpPrototype, "source");
+
+  // Node's flag order. A getter this host lacks contributes no letter.
+  var REGEXP_FLAGS = [
+    { letter: "d", get: intrinsicGetter(regexpPrototype, "hasIndices") },
+    { letter: "g", get: intrinsicGetter(regexpPrototype, "global") },
+    { letter: "i", get: intrinsicGetter(regexpPrototype, "ignoreCase") },
+    { letter: "m", get: intrinsicGetter(regexpPrototype, "multiline") },
+    { letter: "s", get: intrinsicGetter(regexpPrototype, "dotAll") },
+    { letter: "u", get: intrinsicGetter(regexpPrototype, "unicode") },
+    { letter: "v", get: intrinsicGetter(regexpPrototype, "unicodeSets") },
+    { letter: "y", get: intrinsicGetter(regexpPrototype, "sticky") },
+  ];
   var regexpExec = functionCall.bind(regexpConstructor.prototype.exec);
   var arrayPop = functionCall.bind(arrayConstructor.prototype.pop);
   var stringCharCodeAt = functionCall.bind(
@@ -198,19 +197,20 @@
 
   function formatRegExp(value, source) {
     var flags = "";
-    if (regexpGetHasIndices(value)) flags += "d";
-    if (regexpGetGlobal(value)) flags += "g";
-    if (regexpGetIgnoreCase(value)) flags += "i";
-    if (regexpGetMultiline(value)) flags += "m";
-    if (regexpGetDotAll(value)) flags += "s";
-    if (regexpGetUnicode(value)) flags += "u";
-    if (regexpGetUnicodeSets(value)) flags += "v";
-    if (regexpGetSticky(value)) flags += "y";
+    for (var i = 0; i < REGEXP_FLAGS.length; i++) {
+      var entry = REGEXP_FLAGS[i];
+      if (entry.get && entry.get(value)) flags += entry.letter;
+    }
     return "/" + source + "/" + flags;
   }
 
   // Prototype chains are acyclic in practice, but a Proxy defeats
   // OrdinarySetPrototypeOf's cycle check, so every walk below is bounded.
+  // Exhausting the bound always degrades to the walk's not-found result
+  // ("ordinary" / null / false), never to a verdict read off whichever chain
+  // node the last hop happened to land on. A chain deeper than this therefore
+  // classifies as if it ended there, which diverges from Node; no finite bound
+  // avoids that, and only a pathological chain reaches it.
   var MAX_PROTOTYPE_HOPS = 1000;
 
   // Sentinel for a [[Prototype]] read that threw — an exotic object in the
@@ -590,7 +590,7 @@
       // data properties that are undefined-or-callable. Both may be undefined
       // (`defineProperty(o, k, { get: undefined, set: undefined })`); Node
       // renders that as the absent value, so it must fall through.
-      if (desc && !objectHasOwnProperty(desc, "value")) {
+      if (desc && !isDataDescriptor(desc)) {
         if (desc.get) return desc.set ? "[Getter/Setter]" : "[Getter]";
         if (desc.set) return "[Setter]";
         return render(undefined, depth - 1);
@@ -601,6 +601,10 @@
     // Array length and elements are read from own descriptors on the unwrapped
     // target. A missing descriptor is a hole, never an invitation to read
     // through Array.prototype (which could invoke an inherited getter).
+    // Probing every index is O(length); the O(elements) own-index-key form is
+    // blocked on jsse#516 (Object.getOwnPropertyNames/Reflect.ownKeys omit
+    // index keys assigned after array creation, so every element of a
+    // push-built array would render as a hole).
     function renderArray(v, depth) {
       var length = dataDescriptorValue(
         objectGetOwnPropertyDescriptor(v, "length")
@@ -742,11 +746,14 @@
     var hops = MAX_PROTOTYPE_HOPS;
     try {
       do {
+        // Exhausting the bound means the owner was not found, exactly as
+        // reaching a null [[Prototype]] does; falling out of the loop with a
+        // non-null pointer would instead classify off an arbitrary chain node.
+        if (hops-- <= 0) return false;
         pointer = unwrapProxy(objectGetPrototypeOf(pointer));
         if (pointer === REVOKED_PROXY) return false;
       } while (
         pointer !== null &&
-        hops-- > 0 &&
         !hasOwnToString(pointer, "toString") &&
         !hasOwnToPrimitive(pointer, symbolToPrimitive)
       );

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -201,7 +201,11 @@
 
   function primitiveString(value, fallback) {
     var type = typeof value;
-    if (type === "object" || type === "function" || type === "undefined") {
+    if (
+      (value !== null && type === "object") ||
+      type === "function" ||
+      type === "undefined"
+    ) {
       return fallback;
     }
     return type === "symbol" ? symbolToString(value) : stringConstructor(value);

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -330,13 +330,12 @@
 
     function renderDescriptor(desc, depth) {
       // Not a data descriptor => an accessor one, whose `get`/`set` are own
-      // data properties that are undefined-or-callable.
+      // data properties that are undefined-or-callable. Both may be undefined
+      // (`defineProperty(o, k, { get: undefined, set: undefined })`); Node
+      // renders that as the absent value, so it must fall through.
       if (desc && !isDataDescriptor(desc)) {
-        return desc.get
-          ? desc.set
-            ? "[Getter/Setter]"
-            : "[Getter]"
-          : "[Setter]";
+        if (desc.get) return desc.set ? "[Getter/Setter]" : "[Getter]";
+        if (desc.set) return "[Setter]";
       }
       return render(dataDescriptorValue(desc), depth - 1);
     }

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -92,6 +92,7 @@
   var regexpConstructor = RegExp;
   var stringConstructor = String;
   var symbolConstructor = Symbol;
+  var typeErrorConstructor = TypeError;
   var arrayIndexOf = functionCall.bind(arrayConstructor.prototype.indexOf);
   var arrayIsArray = arrayConstructor.isArray;
   var arrayJoin = functionCall.bind(arrayConstructor.prototype.join);
@@ -215,6 +216,10 @@
   // Sentinel for a [[Prototype]] read that threw — an exotic object in the
   // no-host fallback. Distinct from every value a real chain can hold.
   var UNKNOWN_PROTOTYPE = {};
+  // The host hook reports a revoked Proxy with null, which must stay distinct
+  // from a genuine null [[Prototype]]. The sentinel is private to this closure
+  // and therefore cannot collide with any object in a rendered value's chain.
+  var REVOKED_PROXY = {};
 
   // The unwrapped [[Prototype]] of `v`. Read once per value and threaded into
   // every builtinPrototypeKind() call below, so classifying eight built-in
@@ -240,10 +245,12 @@
   ) {
     var current = startPrototype;
     if (current === UNKNOWN_PROTOTYPE) return "ordinary";
+    if (current === REVOKED_PROXY) return "revoked";
     if (current === null) return "null";
     try {
       var hops = MAX_PROTOTYPE_HOPS;
       while (current !== null && current !== objectPrototype && hops-- > 0) {
+        if (current === REVOKED_PROXY) return "revoked";
         if (
           current === intrinsicPrototype ||
           (prototypeProbe && tryApplyIntrinsic(prototypeProbe, current))
@@ -260,7 +267,7 @@
 
   // Walk a Proxy chain down to its non-Proxy target without dispatching to any
   // handler. Returns the value unchanged when it is not a Proxy (or when the
-  // host floor is absent) and null for a revoked Proxy.
+  // host floor is absent) and REVOKED_PROXY for a revoked Proxy.
   function unwrapProxy(v) {
     if (!hostProxyTarget) return v;
     // Unbounded on purpose, unlike every prototype walk below: a Proxy's
@@ -270,7 +277,7 @@
     while (true) {
       var target = hostProxyTarget(v);
       if (target === undefined) return v;
-      if (target === null) return null;
+      if (target === null) return REVOKED_PROXY;
       v = target;
     }
   }
@@ -294,7 +301,7 @@
       var hops = MAX_PROTOTYPE_HOPS;
       while (current !== null && hops-- > 0) {
         current = unwrapProxy(current);
-        if (current === null) return null;
+        if (current === null || current === REVOKED_PROXY) return null;
         var desc = objectGetOwnPropertyDescriptor(current, key);
         if (desc) return desc;
         current = objectGetPrototypeOf(current);
@@ -371,7 +378,7 @@
         ctor = dataDescriptorValue(own);
       } else {
         var proto = unwrapProxy(objectGetPrototypeOf(v));
-        var pd = proto
+        var pd = proto && proto !== REVOKED_PROXY
           ? objectGetOwnPropertyDescriptor(proto, "constructor")
           : null;
         if (pd) ctor = dataDescriptorValue(pd);
@@ -421,7 +428,7 @@
       // unwrapped recursively; a revoked Proxy is an opaque terminal value.
       if (t === "object" || t === "function") {
         v = unwrapProxy(v);
-        if (v === null) return "<Revoked Proxy>";
+        if (v === REVOKED_PROXY) return "<Revoked Proxy>";
         t = typeof v;
       }
 
@@ -439,6 +446,11 @@
       var prototype = prototypeOf(v);
       if (prototype !== objectPrototype) {
         var errorKind = builtinPrototypeKind(prototype, errorPrototype, null);
+        if (errorKind === "revoked") {
+          throw new typeErrorConstructor(
+            "Cannot perform 'get' on a proxy that has been revoked"
+          );
+        }
         if (errorKind === "builtin") return renderError(v);
         if (errorKind === "null" && errorIsError && errorIsError(v)) {
           return renderNullPrototypeError(v);
@@ -707,7 +719,7 @@
     // inspect. (When classification answers "user-defined", `convS` still
     // coerces the ORIGINAL value, so the trap runs there — on Node too.)
     value = unwrapProxy(value);
-    if (value === null) return true;
+    if (value === REVOKED_PROXY) return true;
 
     if (typeof value.toString !== "function") {
       if (typeof value[symbolToPrimitive] !== "function") return true;
@@ -731,6 +743,7 @@
     try {
       do {
         pointer = unwrapProxy(objectGetPrototypeOf(pointer));
+        if (pointer === REVOKED_PROXY) return false;
       } while (
         pointer !== null &&
         hops-- > 0 &&

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -54,6 +54,10 @@
   // diagnostic print. Split/join on a plain string separator is equivalent and
   // touches no user-replaceable hook.
   function replaceAll(s, needle, replacement) {
+    // The needle is absent from most strings; skip the array allocation then.
+    // `indexOf` with a string argument dispatches no user hook (only
+    // `String.prototype.search` consults %Symbol.search%).
+    if (stringIndexOf(s, needle) === -1) return s;
     return arrayJoin(stringSplit(s, needle), replacement);
   }
 
@@ -160,6 +164,18 @@
     symbolConstructor.prototype.toString
   );
   var stringSplit = functionCall.bind(stringConstructor.prototype.split);
+  var stringIndexOf = functionCall.bind(stringConstructor.prototype.indexOf);
+
+  // The wrapper families whose rendering is uniform: probe the internal slot,
+  // classify the prototype chain, emit "[Label: text]". BigInt and Symbol stay
+  // out on purpose — both gate their builtin rendering on a live @@hasInstance
+  // check, and Symbol's probe already yields a string, so folding them in would
+  // cost more variation flags than the table saves.
+  var BOXED_WRAPPERS = [
+    { label: "Number", probe: numberValueOf, prototype: numberPrototype },
+    { label: "String", probe: stringValueOf, prototype: stringPrototype },
+    { label: "Boolean", probe: booleanValueOf, prototype: booleanPrototype },
+  ];
 
   function tryApplyIntrinsic(intrinsic, value) {
     try {
@@ -218,15 +234,11 @@
   // that built-in family. Slot-bearing prototype objects also recognize the
   // corresponding chain from another realm without invoking @@hasInstance.
   function builtinPrototypeKind(
-    value,
+    startPrototype,
     intrinsicPrototype,
-    prototypeProbe,
-    startPrototype
+    prototypeProbe
   ) {
-    // [[Prototype]] is always an object or null, never undefined, so undefined
-    // unambiguously means "not supplied".
-    var current =
-      startPrototype === undefined ? prototypeOf(value) : startPrototype;
+    var current = startPrototype;
     if (current === UNKNOWN_PROTOTYPE) return "ordinary";
     if (current === null) return "null";
     try {
@@ -251,6 +263,10 @@
   // host floor is absent) and null for a revoked Proxy.
   function unwrapProxy(v) {
     if (!hostProxyTarget) return v;
+    // Unbounded on purpose, unlike every prototype walk below: a Proxy's
+    // [[ProxyTarget]] is fixed at construction and can never be made to point
+    // back at the Proxy, so a target chain is acyclic by construction and
+    // finite in the number of live Proxies.
     while (true) {
       var target = hostProxyTarget(v);
       if (target === undefined) return v;
@@ -301,22 +317,86 @@
     return "<" + count + " empty item" + (count === 1 ? "" : "s") + ">";
   }
 
-  function isLegacyWrapperPrototype(v) {
-    return (
-      v === numberPrototype || v === stringPrototype || v === booleanPrototype
-    );
-  }
-
   function primitiveString(value, fallback) {
     var type = typeof value;
     if (
-      (value !== null && type === "object") ||
-      type === "function" ||
-      type === "undefined"
+      value !== null &&
+      (type === "object" || type === "function" || type === "undefined")
     ) {
       return fallback;
     }
     return type === "symbol" ? symbolToString(value) : stringConstructor(value);
+  }
+
+  function errorField(v, key, fallback) {
+    return primitiveString(
+      dataDescriptorValue(findPropertyDescriptor(v, key)),
+      fallback
+    );
+  }
+
+  function renderError(v) {
+    // Test the raw descriptor value first. Stringifying a falsy primitive
+    // such as 0 or false would otherwise turn it into a truthy string and
+    // suppress the normal `[Error: message]` fallback.
+    var stackValue = dataDescriptorValue(findPropertyDescriptor(v, "stack"));
+    if (stackValue) {
+      var stack = primitiveString(stackValue, "");
+      if (stack) return stack;
+    }
+
+    var name = errorField(v, "name", "Error");
+    var message = errorField(v, "message", "");
+    var text = !name ? message : !message ? name : name + ": " + message;
+    return "[" + text + "]";
+  }
+
+  function renderNullPrototypeError(v) {
+    var name = errorField(v, "name", "Error") || "Error";
+    var message = errorField(v, "message", "");
+    return (
+      "[" + name + ": null prototype]" + (message ? ": " + message : "")
+    );
+  }
+
+  // Derive the "ClassName " prefix without a plain `v.constructor` get, which
+  // would invoke an accessor `constructor` or a Proxy get-trap — Node reads
+  // constructor metadata via the prototype chain, not by calling a getter. Use
+  // data descriptors only, and treat any exotic-trap throw as "no prefix".
+  function constructorName(v) {
+    try {
+      var ctor;
+      var own = objectGetOwnPropertyDescriptor(v, "constructor");
+      if (own) {
+        ctor = dataDescriptorValue(own);
+      } else {
+        var proto = unwrapProxy(objectGetPrototypeOf(v));
+        var pd = proto
+          ? objectGetOwnPropertyDescriptor(proto, "constructor")
+          : null;
+        if (pd) ctor = dataDescriptorValue(pd);
+      }
+      // Node's getConstructorName only accepts a callable `constructor` with
+      // a non-empty name; anything else yields no prefix at all (never a bare
+      // leading space).
+      ctor = unwrapProxy(ctor);
+      if (typeof ctor !== "function") return "";
+      // Node accepts a `constructor` only when the value is an INSTANCE of
+      // it, and a constructor's own `prototype` object never is. Rejecting
+      // that self-reference gives every intrinsic prototype Node's plain
+      // `{}` rendering without enumerating them one by one.
+      if (
+        dataDescriptorValue(
+          objectGetOwnPropertyDescriptor(ctor, "prototype")
+        ) === v
+      ) {
+        return "";
+      }
+      var name = functionName(ctor);
+      return name && name !== "Object" ? name + " " : "";
+    } catch (e) {
+      return "";
+    }
   }
 
   function inspect(value, opts) {
@@ -358,7 +438,7 @@
       // eight chain walks) is pure waste for the commonest object shape.
       var prototype = prototypeOf(v);
       if (prototype !== objectPrototype) {
-        var errorKind = builtinPrototypeKind(v, errorPrototype, null, prototype);
+        var errorKind = builtinPrototypeKind(prototype, errorPrototype, null);
         if (errorKind === "builtin") return renderError(v);
         if (errorKind === "null" && errorIsError && errorIsError(v)) {
           return renderNullPrototypeError(v);
@@ -366,7 +446,10 @@
         var boxed;
         // `get RegExp.prototype.source` uniquely does NOT throw for
         // %RegExp.prototype% (it answers "(?:)"), so the slot probe alone would
-        // misreport the prototype itself as a RegExp. After detecting a genuine
+        // misreport the prototype itself as a RegExp. Only reachable when
+        // library code reparents %RegExp.prototype% — an unreparented one is a
+        // direct child of %Object.prototype% and never enters this block at
+        // all. After detecting a genuine
         // RegExp, classify its prototype chain before presentation: a reparented
         // RegExp must not dispatch ordinary `source`/`flags` gets through a user
         // object. Compose the standard rendering from captured slot getters.
@@ -376,10 +459,9 @@
             : tryApplyIntrinsic(regexpGetSource, v);
         if (boxed) {
           var regexpKind = builtinPrototypeKind(
-            v,
+            prototype,
             regexpPrototype,
-            regexpGetSource,
-            prototype
+            regexpGetSource
           );
           if (regexpKind === "builtin") return formatRegExp(v, boxed.value);
           if (regexpKind === "null") {
@@ -392,100 +474,70 @@
             ? "Invalid Date"
             : dateToISOString(v);
           var dateKind = builtinPrototypeKind(
-            v,
+            prototype,
             datePrototype,
-            dateGetTime,
-            prototype
+            dateGetTime
           );
           if (dateKind === "builtin") return dateText;
           if (dateKind === "null") {
             return "[Date: null prototype] " + dateText;
           }
         }
-        boxed = tryApplyIntrinsic(numberValueOf, v);
-        if (boxed) {
-          var numberText = render(boxed.value, depth);
-          var numberKind = builtinPrototypeKind(
-            v,
-            numberPrototype,
-            numberValueOf,
-            prototype
+        for (var w = 0; w < BOXED_WRAPPERS.length; w++) {
+          var wrapper = BOXED_WRAPPERS[w];
+          boxed = tryApplyIntrinsic(wrapper.probe, v);
+          if (!boxed) continue;
+          var wrapperText = render(boxed.value, depth);
+          var wrapperKind = builtinPrototypeKind(
+            prototype,
+            wrapper.prototype,
+            wrapper.probe
           );
-          if (numberKind === "builtin") return "[Number: " + numberText + "]";
-          if (numberKind === "null") {
-            return "[Number (null prototype): " + numberText + "]";
+          if (wrapperKind === "builtin") {
+            return "[" + wrapper.label + ": " + wrapperText + "]";
           }
-        }
-        boxed = tryApplyIntrinsic(stringValueOf, v);
-        if (boxed) {
-          var stringText = render(boxed.value, depth);
-          var stringKind = builtinPrototypeKind(
-            v,
-            stringPrototype,
-            stringValueOf,
-            prototype
-          );
-          if (stringKind === "builtin") return "[String: " + stringText + "]";
-          if (stringKind === "null") {
-            return "[String (null prototype): " + stringText + "]";
-          }
-        }
-        boxed = tryApplyIntrinsic(booleanValueOf, v);
-        if (boxed) {
-          var booleanText = render(boxed.value, depth);
-          var booleanKind = builtinPrototypeKind(
-            v,
-            booleanPrototype,
-            booleanValueOf,
-            prototype
-          );
-          if (booleanKind === "builtin") {
-            return "[Boolean: " + booleanText + "]";
-          }
-          if (booleanKind === "null") {
-            return "[Boolean (null prototype): " + booleanText + "]";
+          if (wrapperKind === "null") {
+            return (
+              "[" + wrapper.label + " (null prototype): " + wrapperText + "]"
+            );
           }
         }
         boxed = tryApplyIntrinsic(bigintValueOf, v);
         if (boxed) {
           var bigintText = render(boxed.value, depth);
           var bigintKind = builtinPrototypeKind(
-            v,
+            prototype,
             bigintPrototype,
-            bigintValueOf,
-            prototype
+            bigintValueOf
           );
           if (bigintKind === "null") {
             return "[BigInt (null prototype): " + bigintText + "]";
           }
-          if (bigintKind !== "builtin") boxed = null;
-        }
-        if (boxed) {
-          // Unlike the older wrappers above, Node's boxed BigInt/Symbol
-          // rendering intentionally observes a constructor's current
-          // @@hasInstance result. A false or throwing hook selects its generic
-          // object shape, but must not intercept the internal-slot probe.
-          return tryInstanceOf(v, bigintConstructor)
-            ? "[BigInt: " + bigintText + "]"
-            : "Object [BigInt] {}";
+          if (bigintKind === "builtin") {
+            // Unlike the wrappers above, Node's boxed BigInt/Symbol rendering
+            // intentionally observes a constructor's current @@hasInstance
+            // result. A false or throwing hook selects its generic object
+            // shape, but must not intercept the internal-slot probe.
+            return tryInstanceOf(v, bigintConstructor)
+              ? "[BigInt: " + bigintText + "]"
+              : "Object [BigInt] {}";
+          }
         }
         boxed = tryApplyIntrinsic(symbolToString, v);
         if (boxed) {
           var symbolKind = builtinPrototypeKind(
-            v,
+            prototype,
             symbolPrototype,
-            symbolToString,
-            prototype
+            symbolToString
           );
           if (symbolKind === "null") {
             return "[Symbol (null prototype): " + boxed.value + "]";
           }
-          if (symbolKind !== "builtin") boxed = null;
-        }
-        if (boxed) {
-          return tryInstanceOf(v, symbolConstructor)
-            ? "[Symbol: " + boxed.value + "]"
-            : "Object [Symbol] {}";
+          if (symbolKind === "builtin") {
+            return tryInstanceOf(v, symbolConstructor)
+              ? "[Symbol: " + boxed.value + "]"
+              : "Object [Symbol] {}";
+          }
         }
       }
 
@@ -526,11 +578,12 @@
       // data properties that are undefined-or-callable. Both may be undefined
       // (`defineProperty(o, k, { get: undefined, set: undefined })`); Node
       // renders that as the absent value, so it must fall through.
-      if (desc && !isDataDescriptor(desc)) {
+      if (desc && !objectHasOwnProperty(desc, "value")) {
         if (desc.get) return desc.set ? "[Getter/Setter]" : "[Getter]";
         if (desc.set) return "[Setter]";
+        return render(undefined, depth - 1);
       }
-      return render(dataDescriptorValue(desc), depth - 1);
+      return render(desc ? desc.value : undefined, depth - 1);
     }
 
     // Array length and elements are read from own descriptors on the unwrapped
@@ -566,68 +619,6 @@
       return "[ " + arrayJoin(parts, ", ") + " ]";
     }
 
-    function errorField(v, key, fallback) {
-      return primitiveString(
-        dataDescriptorValue(findPropertyDescriptor(v, key)),
-        fallback
-      );
-    }
-
-    function renderError(v) {
-      // Test the raw descriptor value first. Stringifying a falsy primitive
-      // such as 0 or false would otherwise turn it into a truthy string and
-      // suppress the normal `[Error: message]` fallback.
-      var stackValue = dataDescriptorValue(findPropertyDescriptor(v, "stack"));
-      if (stackValue) {
-        var stack = primitiveString(stackValue, "");
-        if (stack) return stack;
-      }
-
-      var name = errorField(v, "name", "Error");
-      var message = errorField(v, "message", "");
-      var text = !name ? message : !message ? name : name + ": " + message;
-      return "[" + text + "]";
-    }
-
-    function renderNullPrototypeError(v) {
-      var name = errorField(v, "name", "Error") || "Error";
-      var message = errorField(v, "message", "");
-      return (
-        "[" + name + ": null prototype]" + (message ? ": " + message : "")
-      );
-    }
-
-    // Derive the "ClassName " prefix without a plain `v.constructor` get, which
-    // would invoke an accessor `constructor` or a Proxy get-trap — Node reads
-    // constructor metadata via the prototype chain, not by calling a getter. Use
-    // data descriptors only, and treat any exotic-trap throw as "no prefix".
-    function constructorName(v) {
-      try {
-        // Match Node's ordinary-object presentation for these intrinsic
-        // prototype singletons instead of emitting `Number {}` and friends.
-        if (isLegacyWrapperPrototype(v)) return "";
-        var ctor;
-        var own = objectGetOwnPropertyDescriptor(v, "constructor");
-        if (own) {
-          ctor = dataDescriptorValue(own);
-        } else {
-          var proto = unwrapProxy(objectGetPrototypeOf(v));
-          var pd = proto
-            ? objectGetOwnPropertyDescriptor(proto, "constructor")
-            : null;
-          if (pd) ctor = dataDescriptorValue(pd);
-        }
-        // Node's getConstructorName only accepts a callable `constructor` with
-        // a non-empty name; anything else yields no prefix at all (never a bare
-        // leading space).
-        ctor = unwrapProxy(ctor);
-        if (typeof ctor !== "function") return "";
-        var name = functionName(ctor);
-        return name && name !== "Object" ? name + " " : "";
-      } catch (e) {
-        return "";
-      }
-    }
 
     return render(value, maxDepth);
   }
@@ -699,10 +690,6 @@
   })();
   var symbolToPrimitive = symbolConstructor.toPrimitive;
 
-  function hasOwnProperty(value, key) {
-    return objectHasOwnProperty(value, key);
-  }
-
   function returnFalse() {
     return false;
   }
@@ -711,8 +698,8 @@
   // prototype method is user-defined even when inherited, while coercion hooks
   // owned by a built-in prototype route through inspect.
   function hasBuiltInToString(value) {
-    var hasOwnToString = hasOwnProperty;
-    var hasOwnToPrimitive = hasOwnProperty;
+    var hasOwnToString = objectHasOwnProperty;
+    var hasOwnToPrimitive = objectHasOwnProperty;
 
     // Node reads [[ProxyTarget]] here before touching a single property, so
     // classification never dispatches a Proxy get trap. Do the same via the
@@ -724,13 +711,13 @@
 
     if (typeof value.toString !== "function") {
       if (typeof value[symbolToPrimitive] !== "function") return true;
-      if (hasOwnProperty(value, symbolToPrimitive)) return false;
+      if (objectHasOwnProperty(value, symbolToPrimitive)) return false;
       hasOwnToString = returnFalse;
-    } else if (hasOwnProperty(value, "toString")) {
+    } else if (objectHasOwnProperty(value, "toString")) {
       return false;
     } else if (typeof value[symbolToPrimitive] !== "function") {
       hasOwnToPrimitive = returnFalse;
-    } else if (hasOwnProperty(value, symbolToPrimitive)) {
+    } else if (objectHasOwnProperty(value, symbolToPrimitive)) {
       return false;
     }
 
@@ -761,11 +748,12 @@
     // as user-defined.
     if (pointer === null) return false;
 
-    var descriptor = objectGetOwnPropertyDescriptor(pointer, "constructor");
+    var ctor = dataDescriptorValue(
+      objectGetOwnPropertyDescriptor(pointer, "constructor")
+    );
     return (
-      descriptor !== undefined &&
-      typeof descriptor.value === "function" &&
-      builtInObjectNames[descriptor.value.name] === true
+      typeof ctor === "function" &&
+      builtInObjectNames[functionName(ctor)] === true
     );
   }
 

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -388,8 +388,14 @@
     }
 
     function renderError(v) {
-      var stack = errorField(v, "stack", "");
-      if (stack) return stack;
+      // Test the raw descriptor value first. Stringifying a falsy primitive
+      // such as 0 or false would otherwise turn it into a truthy string and
+      // suppress the normal `[Error: message]` fallback.
+      var stackValue = dataDescriptorValue(findPropertyDescriptor(v, "stack"));
+      if (stackValue) {
+        var stack = primitiveString(stackValue, "");
+        if (stack) return stack;
+      }
 
       var name = errorField(v, "name", "Error");
       var message = errorField(v, "message", "");

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -63,6 +63,10 @@
 
   function quoteString(s) {
     s = stringConstructor(s);
+    // The overwhelmingly common string needs no escaping at all, and one
+    // scan settles that; the replaceAll chain below scans three times
+    // unconditionally. Non-global pattern, so `lastIndex` is untouched.
+    if (regexpExec(escapableCharPattern, s) === null) return "'" + s + "'";
     return (
       "'" +
       replaceAll(
@@ -153,6 +157,7 @@
   );
   var stringSlice = functionCall.bind(stringConstructor.prototype.slice);
   var identifierKeyPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+  var escapableCharPattern = /[\\'\n]/;
   var circularMessagePattern = /circular/i;
   var numberValueOf = functionCall.bind(numberConstructor.prototype.valueOf);
   var stringValueOf = functionCall.bind(stringConstructor.prototype.valueOf);
@@ -222,9 +227,10 @@
   var REVOKED_PROXY = {};
 
   // The unwrapped [[Prototype]] of `v`. Read once per value and threaded into
-  // every builtinPrototypeKind() call below, so classifying eight built-in
-  // families costs one metadata read rather than eight — and, in the no-host
-  // fallback where `v` may still be a Proxy, one getPrototypeOf trap.
+  // every builtinPrototypeKind() call below plus constructorName(), so
+  // classifying eight built-in families and deriving the class-name prefix
+  // costs one metadata read rather than nine — and, in the no-host fallback
+  // where `v` may still be a Proxy, one getPrototypeOf trap.
   function prototypeOf(v) {
     try {
       return unwrapProxy(objectGetPrototypeOf(v));
@@ -295,6 +301,13 @@
     return isDataDescriptor(desc) ? desc.value : undefined;
   }
 
+  // The canonical safe read of this module: an own property's value, taken
+  // from its data descriptor, so neither an accessor nor a Proxy get trap is
+  // observed. `undefined` when the property is absent or accessor-valued.
+  function ownDataValue(obj, key) {
+    return dataDescriptorValue(objectGetOwnPropertyDescriptor(obj, key));
+  }
+
   function findPropertyDescriptor(v, key) {
     try {
       var current = v;
@@ -316,7 +329,7 @@
   // A function's `name` read from its own data descriptor only, so neither an
   // accessor `name` nor a Proxy get trap is observed. Returns "" when absent.
   function functionName(fn) {
-    var name = dataDescriptorValue(objectGetOwnPropertyDescriptor(fn, "name"));
+    var name = ownDataValue(fn, "name");
     return typeof name === "string" ? name : "";
   }
 
@@ -370,35 +383,33 @@
   // would invoke an accessor `constructor` or a Proxy get-trap — Node reads
   // constructor metadata via the prototype chain, not by calling a getter. Use
   // data descriptors only, and treat any exotic-trap throw as "no prefix".
-  function constructorName(v) {
+  // `prototype` is the caller's already-unwrapped [[Prototype]] of `v`, so no
+  // second metadata read (and, on the no-host fallback, no second
+  // getPrototypeOf trap) is needed here.
+  function constructorName(v, prototype) {
     try {
-      var ctor;
-      var own = objectGetOwnPropertyDescriptor(v, "constructor");
-      if (own) {
-        ctor = dataDescriptorValue(own);
-      } else {
-        var proto = unwrapProxy(objectGetPrototypeOf(v));
-        var pd = proto && proto !== REVOKED_PROXY
-          ? objectGetOwnPropertyDescriptor(proto, "constructor")
-          : null;
-        if (pd) ctor = dataDescriptorValue(pd);
+      // An own `constructor` wins even when it is accessor-valued: the first
+      // descriptor found is the one Node's walk would stop at, and
+      // dataDescriptorValue then declines to call the getter.
+      var desc = objectGetOwnPropertyDescriptor(v, "constructor");
+      if (
+        !desc &&
+        prototype &&
+        prototype !== REVOKED_PROXY &&
+        prototype !== UNKNOWN_PROTOTYPE
+      ) {
+        desc = objectGetOwnPropertyDescriptor(prototype, "constructor");
       }
       // Node's getConstructorName only accepts a callable `constructor` with
       // a non-empty name; anything else yields no prefix at all (never a bare
       // leading space).
-      ctor = unwrapProxy(ctor);
+      var ctor = unwrapProxy(dataDescriptorValue(desc));
       if (typeof ctor !== "function") return "";
       // Node accepts a `constructor` only when the value is an INSTANCE of
       // it, and a constructor's own `prototype` object never is. Rejecting
       // that self-reference gives every intrinsic prototype Node's plain
       // `{}` rendering without enumerating them one by one.
-      if (
-        dataDescriptorValue(
-          objectGetOwnPropertyDescriptor(ctor, "prototype")
-        ) === v
-      ) {
-        return "";
-      }
+      if (ownDataValue(ctor, "prototype") === v) return "";
       var name = functionName(ctor);
       return name && name !== "Object" ? name + " " : "";
     } catch (e) {
@@ -421,16 +432,16 @@
       if (t === "boolean") return stringConstructor(v);
       if (t === "symbol") return symbolToString(v);
 
-      // Node's native inspector can read [[ProxyTarget]] without dispatching
-      // through the handler. The --node host floor exposes that one piece of
-      // metadata so the JS shim can do the same before any instanceof,
-      // reflection, property access, or enumeration. Nested Proxies are
-      // unwrapped recursively; a revoked Proxy is an opaque terminal value.
-      if (t === "object" || t === "function") {
-        v = unwrapProxy(v);
-        if (v === REVOKED_PROXY) return "<Revoked Proxy>";
-        t = typeof v;
-      }
+      // Every primitive `typeof` has returned by now, so `v` is an object or
+      // a function. Node's native inspector can read [[ProxyTarget]] without
+      // dispatching through the handler. The --node host floor exposes that
+      // one piece of metadata so the JS shim can do the same before any
+      // instanceof, reflection, property access, or enumeration. Nested
+      // Proxies are unwrapped recursively; a revoked Proxy is an opaque
+      // terminal value.
+      v = unwrapProxy(v);
+      if (v === REVOKED_PROXY) return "<Revoked Proxy>";
+      t = typeof v;
 
       if (t === "function") {
         var name = functionName(v);
@@ -444,7 +455,17 @@
       // whole built-in classification below (seven throwing slot probes and
       // eight chain walks) is pure waste for the commonest object shape.
       var prototype = prototypeOf(v);
+      // `Array.isArray` reads an internal slot and pierces a Proxy without
+      // dispatching a trap, so this is free of user code. Hoisted above the
+      // classification block, which it prunes, and reused by both call sites
+      // below.
+      var isArr = arrayIsArray(v);
       if (prototype !== objectPrototype) {
+        // This first classification does double duty: "revoked" is a property
+        // of the CHAIN, not of the Error family, and every walk below would
+        // report it too — but only this one throws. It must therefore stay
+        // ahead of them all, and outside the `isArr` guard, so an array whose
+        // chain contains a revoked Proxy still throws.
         var errorKind = builtinPrototypeKind(prototype, errorPrototype, null);
         if (errorKind === "revoked") {
           throw new typeErrorConstructor(
@@ -455,6 +476,17 @@
         if (errorKind === "null" && errorIsError && errorIsError(v)) {
           return renderNullPrototypeError(v);
         }
+      }
+
+      // Internal-slot presentation. An Array exotic object is created by
+      // ArrayCreate, never by OrdinaryCreateFromConstructor, so it cannot
+      // carry [[RegExpMatcher]], [[DateValue]], [[NumberData]],
+      // [[StringData]], [[BooleanData]], [[BigIntData]] or [[SymbolData]].
+      // Every probe below would therefore throw and be caught — six
+      // thrown-and-unwound TypeErrors per array, at every nesting level.
+      // Skipping them for arrays is a zero-divergence prune; the Error
+      // chain walk above is deliberately NOT skipped.
+      if (!isArr && prototype !== objectPrototype) {
         var boxed;
         // `get RegExp.prototype.source` uniquely does NOT throw for
         // %RegExp.prototype% (it answers "(?:)"), so the slot probe alone would
@@ -553,12 +585,12 @@
         }
       }
 
-      if (depth < 0) return arrayIsArray(v) ? "[Array]" : "[Object]";
+      if (depth < 0) return isArr ? "[Array]" : "[Object]";
 
       arrayPush(seen, v);
       var out;
       try {
-        if (arrayIsArray(v)) {
+        if (isArr) {
           out = renderArray(v, depth);
         } else {
           // Own properties are rendered from their descriptors WITHOUT
@@ -574,7 +606,7 @@
             var memberDesc = objectGetOwnPropertyDescriptor(v, k);
             arrayPush(parts, label + ": " + renderDescriptor(memberDesc, depth));
           }
-          var ctorName = constructorName(v);
+          var ctorName = constructorName(v, prototype);
           out = parts.length
             ? ctorName + "{ " + arrayJoin(parts, ", ") + " }"
             : ctorName + "{}";
@@ -593,9 +625,10 @@
       if (desc && !isDataDescriptor(desc)) {
         if (desc.get) return desc.set ? "[Getter/Setter]" : "[Getter]";
         if (desc.set) return "[Setter]";
-        return render(undefined, depth - 1);
+        // Both undefined: fall through to render the absent value, as Node
+        // does.
       }
-      return render(desc ? desc.value : undefined, depth - 1);
+      return render(dataDescriptorValue(desc), depth - 1);
     }
 
     // Array length and elements are read from own descriptors on the unwrapped
@@ -606,9 +639,7 @@
     // index keys assigned after array creation, so every element of a
     // push-built array would render as a hole).
     function renderArray(v, depth) {
-      var length = dataDescriptorValue(
-        objectGetOwnPropertyDescriptor(v, "length")
-      );
+      var length = ownDataValue(v, "length");
       if (typeof length !== "number" || length <= 0) return "[]";
 
       // Collect into a local array and join once. Accumulating with `+=`
@@ -634,7 +665,6 @@
       // element or a hole, and `parts` cannot be empty.
       return "[ " + arrayJoin(parts, ", ") + " ]";
     }
-
 
     return render(value, maxDepth);
   }

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -232,21 +232,26 @@ eq(util.format("%s", /re/g), "/re/g", "%s RegExp uses inspect");
     var original = Object.getOwnPropertyDescriptor(RegExp.prototype, name);
     var sentinel = new Error("patched RegExp " + name);
     var caught;
+    var formatted;
+    var calls = 0;
     try {
       Object.defineProperty(RegExp.prototype, name, {
         configurable: true,
         get: function () {
+          calls++;
           throw sentinel;
         },
       });
       try {
-        util.format("%s", /re/g);
+        formatted = util.format("%s", /re/g);
       } catch (e) {
         caught = e;
       }
       truthy(
-        caught === sentinel,
-        "%s RegExp rethrows patched " + name + " accessor error"
+        hasNodeHost
+          ? caught === undefined && formatted === "/re/g" && calls === 0
+          : caught === sentinel,
+        "%s RegExp handles patched " + name + " accessor"
       );
     } finally {
       Object.defineProperty(RegExp.prototype, name, original);
@@ -255,12 +260,73 @@ eq(util.format("%s", /re/g), "/re/g", "%s RegExp uses inspect");
 
   checkThrowingAccessor("source");
   checkThrowingAccessor("flags");
+  checkThrowingAccessor("global");
 })();
 eq(
   util.format("%s", Object.create(RegExp.prototype)),
   "RegExp {}",
   "%s RegExp prototype spoof falls back to ordinary inspect"
 );
+(function () {
+  var reparented = /x/gi;
+  Object.setPrototypeOf(reparented, {});
+  eq(
+    util.inspect(reparented),
+    "{}",
+    "inspect renders an ordinary-reparented RegExp generically"
+  );
+
+  var nullPrototype = /x/gi;
+  Object.setPrototypeOf(nullPrototype, null);
+  eq(
+    util.inspect(nullPrototype),
+    "[RegExp: null prototype] /x/gi",
+    "inspect renders a null-prototype RegExp from internal slots"
+  );
+
+  var accessorCalls = 0;
+  var accessorPrototype = {};
+  Object.defineProperty(accessorPrototype, "source", {
+    configurable: true,
+    get: function () {
+      accessorCalls++;
+      throw new Error("reparented RegExp source getter called");
+    },
+  });
+  Object.defineProperty(accessorPrototype, "flags", {
+    configurable: true,
+    get: function () {
+      accessorCalls++;
+      throw new Error("reparented RegExp flags getter called");
+    },
+  });
+  var accessorReparented = /x/gi;
+  Object.setPrototypeOf(accessorReparented, accessorPrototype);
+  eq(
+    util.inspect(accessorReparented),
+    "{}",
+    "inspect does not format an ordinary-reparented RegExp through getters"
+  );
+  eq(
+    accessorCalls,
+    0,
+    "inspect invokes no reparented RegExp source or flags getters"
+  );
+
+  var regexpParent = /parent/m;
+  var regexpChild = /child/dgimsuy;
+  Object.setPrototypeOf(regexpChild, regexpParent);
+  eq(
+    util.inspect(regexpChild),
+    "/child/dgimsuy",
+    "inspect recognizes a RegExp-slot prototype without instanceof"
+  );
+  eq(
+    util.inspect(new RegExp("unicode-sets", "v")),
+    "/unicode-sets/v",
+    "inspect composes the unicode-sets RegExp flag from its internal slot"
+  );
+})();
 eq(
   util.format("%s", { toString: null, a: 1 }),
   "{ toString: null, a: 1 }",

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1047,6 +1047,24 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "inspect stringifies a null Error name"
   );
 
+  // Stack truthiness is decided before primitive stringification. Otherwise a
+  // falsy value such as 0 becomes the truthy string "0" and replaces the Error
+  // fallback entirely.
+  var falsyStacks = [0, -0, 0n, false, NaN, null, ""];
+  for (var falsyIndex = 0; falsyIndex < falsyStacks.length; falsyIndex++) {
+    var falsyStackError = new Error("m");
+    Object.defineProperty(falsyStackError, "stack", {
+      configurable: true,
+      value: falsyStacks[falsyIndex],
+      writable: true,
+    });
+    eq(
+      util.inspect(falsyStackError),
+      "[Error: m]",
+      "inspect ignores falsy Error stack " + falsyIndex
+    );
+  }
+
   // A hole has no own descriptor. Inspection must preserve it rather than
   // falling through to an inherited indexed getter.
   var inheritedReads = 0;

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1011,6 +1011,35 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "inspect invokes no Error stack/name/message getters"
   );
 
+  // `null` is safe to stringify despite `typeof null === "object"`. Suppress
+  // Node's native data-valued stack so these fallback renderings agree across
+  // engines and can be byte-compared.
+  var nullMessageError = new Error("m");
+  Object.defineProperty(nullMessageError, "stack", {
+    configurable: true,
+    get: undefined,
+    set: undefined,
+  });
+  nullMessageError.message = null;
+  eq(
+    util.inspect(nullMessageError),
+    "[Error: null]",
+    "inspect stringifies a null Error message"
+  );
+
+  var nullNameError = new Error("m");
+  Object.defineProperty(nullNameError, "stack", {
+    configurable: true,
+    get: undefined,
+    set: undefined,
+  });
+  nullNameError.name = null;
+  eq(
+    util.inspect(nullNameError),
+    "[null: m]",
+    "inspect stringifies a null Error name"
+  );
+
   // A hole has no own descriptor. Inspection must preserve it rather than
   // falling through to an inherited indexed getter.
   var inheritedReads = 0;

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -18,11 +18,13 @@
 var util =
   typeof globalThis.util !== "undefined" ? globalThis.util : require("util");
 
-// True only under jsse `--node`, where the host floor lets the shim read
-// [[ProxyTarget]]. Trap/getter-count assertions apply to that shim alone: on
-// Node the same probes legitimately fire, so they are gated rather than skipped
-// (the "ok N - name" line still prints on both, keeping output byte-identical).
-var hasProxyTargetHost = typeof __host_proxy_target !== "undefined";
+// True only under jsse `--node`. The shim captures the Proxy-target hook and
+// removes its global binding before this bundle code runs, so use another host
+// primitive as the engine marker. Trap/getter-count assertions apply to the
+// shim alone: on Node the same probes may legitimately fire, so they are gated
+// rather than skipped (the "ok N - name" line still prints on both, keeping
+// output byte-identical).
+var hasNodeHost = typeof __host_write !== "undefined";
 
 var testNo = 0;
 
@@ -73,6 +75,11 @@ function capture(fn) {
 }
 
 console.log("# node-shim self-test");
+eq(
+  typeof globalThis.__host_proxy_target,
+  "undefined",
+  "shim hides the Proxy-target host hook"
+);
 
 // ---- util.format: %s ------------------------------------------------------
 eq(util.format("%s", "hi"), "hi", "%s string");
@@ -412,7 +419,7 @@ eq(
       "%s Error ignores throwing stack and patched toString"
     );
     truthy(
-      !hasProxyTargetHost || stackReads === 0,
+      !hasNodeHost || stackReads === 0,
       "%s shim does not read an Error stack getter"
     );
   } finally {
@@ -674,7 +681,7 @@ eq(
     "%s handles a throwing Proxy prototype walk"
   );
   truthy(
-    !hasProxyTargetHost || formatted !== "PROXY STRING",
+    !hasNodeHost || formatted !== "PROXY STRING",
     "%s does not invoke a Proxy get trap"
   );
 })();
@@ -960,7 +967,7 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   var revocable = Proxy.revocable({ a: 1 }, proxyHandler);
   revocable.revoke();
   truthy(
-    !hasProxyTargetHost ||
+    !hasNodeHost ||
       util.inspect(revocable.proxy) === "<Revoked Proxy>",
     "inspect renders a revoked Proxy"
   );
@@ -1000,7 +1007,7 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "inspect handles Error stack/name/message accessors"
   );
   truthy(
-    !hasProxyTargetHost || errorReads === 0,
+    !hasNodeHost || errorReads === 0,
     "inspect invokes no Error stack/name/message getters"
   );
 
@@ -1064,7 +1071,7 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   chained.a = 1;
   eq(util.format("%s", chained), "{ a: 1 }", "%s renders a proxied prototype");
   truthy(
-    !hasProxyTargetHost || protoTraps === 0,
+    !hasNodeHost || protoTraps === 0,
     "%s invokes no prototype-chain Proxy reflection traps"
   );
 

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -626,6 +626,26 @@ eq(
   "Number {}",
   "%s Number prototype spoof falls back to ordinary inspect"
 );
+// The %s classification tail reads `constructor.value.name` as an ORDINARY
+// get, unlike the descriptor-only reads elsewhere in the shim. Tightening it
+// would reroute this value to String(v) and print "[object Object]"; Node
+// invokes the accessor and routes to inspect, so the shim must too.
+(function () {
+  var original = Object.getOwnPropertyDescriptor(Object, "name");
+  Object.defineProperty(Object, "name", {
+    configurable: true,
+    get: function () {
+      return "Object";
+    },
+  });
+  var formatted;
+  try {
+    formatted = util.format("%s", { a: 1 });
+  } finally {
+    Object.defineProperty(Object, "name", original);
+  }
+  eq(formatted, "{ a: 1 }", "%s routes via an accessor constructor name");
+})();
 eq(
   util.format("%s", Object.create(String.prototype)),
   "String {}",

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -18,6 +18,12 @@
 var util =
   typeof globalThis.util !== "undefined" ? globalThis.util : require("util");
 
+// True only under jsse `--node`, where the host floor lets the shim read
+// [[ProxyTarget]]. Trap/getter-count assertions apply to that shim alone: on
+// Node the same probes legitimately fire, so they are gated rather than skipped
+// (the "ok N - name" line still prints on both, keeping output byte-identical).
+var hasProxyTargetHost = typeof __host_proxy_target !== "undefined";
+
 var testNo = 0;
 
 function ok(name) {
@@ -406,7 +412,7 @@ eq(
       "%s Error ignores throwing stack and patched toString"
     );
     truthy(
-      typeof __host_proxy_target === "undefined" || stackReads === 0,
+      !hasProxyTargetHost || stackReads === 0,
       "%s shim does not read an Error stack getter"
     );
   } finally {
@@ -668,7 +674,7 @@ eq(
     "%s handles a throwing Proxy prototype walk"
   );
   truthy(
-    typeof __host_proxy_target === "undefined" || formatted !== "PROXY STRING",
+    !hasProxyTargetHost || formatted !== "PROXY STRING",
     "%s does not invoke a Proxy get trap"
   );
 })();
@@ -954,7 +960,7 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   var revocable = Proxy.revocable({ a: 1 }, proxyHandler);
   revocable.revoke();
   truthy(
-    typeof __host_proxy_target === "undefined" ||
+    !hasProxyTargetHost ||
       util.inspect(revocable.proxy) === "<Revoked Proxy>",
     "inspect renders a revoked Proxy"
   );
@@ -994,7 +1000,7 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "inspect handles Error stack/name/message accessors"
   );
   truthy(
-    typeof __host_proxy_target === "undefined" || errorReads === 0,
+    !hasProxyTargetHost || errorReads === 0,
     "inspect invokes no Error stack/name/message getters"
   );
 
@@ -1018,6 +1024,34 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "inspect preserves sparse-array holes"
   );
   eq(inheritedReads, 0, "inspect does not read inherited array elements");
+
+  // A Proxy in the PROTOTYPE CHAIN, not as the inspected value itself. The
+  // `%s` classification walk used to reflect on each prototype directly, so a
+  // proxied prototype ran getPrototypeOf/getOwnPropertyDescriptor traps during
+  // a diagnostic print. Unwrapping at every hop is a deliberate divergence from
+  // Node (which does fire that trap), hence the host gate.
+  var protoTraps = 0;
+  var chainHandler = {
+    getPrototypeOf: function (t) {
+      protoTraps++;
+      return Object.getPrototypeOf(t);
+    },
+    getOwnPropertyDescriptor: function (t, k) {
+      protoTraps++;
+      return Object.getOwnPropertyDescriptor(t, k);
+    },
+    ownKeys: function (t) {
+      protoTraps++;
+      return Reflect.ownKeys(t);
+    },
+  };
+  var chained = Object.create(new Proxy({}, chainHandler));
+  chained.a = 1;
+  eq(util.format("%s", chained), "{ a: 1 }", "%s renders a proxied prototype");
+  truthy(
+    !hasProxyTargetHost || protoTraps === 0,
+    "%s invokes no prototype-chain Proxy reflection traps"
+  );
 
   // A normal named class still gets its "ClassName " prefix.
   function Widget() {

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -359,6 +359,115 @@ eq(
 (function () {
   var cases = [
     [
+      "Error",
+      function () {
+        return new Error("m");
+      },
+      "{}",
+      "[Error: null prototype]: m",
+    ],
+    [
+      "Date",
+      function () {
+        return new Date(0);
+      },
+      "{}",
+      "[Date: null prototype] 1970-01-01T00:00:00.000Z",
+    ],
+    [
+      "Number",
+      function () {
+        return new Number(3);
+      },
+      "{}",
+      "[Number (null prototype): 3]",
+    ],
+    [
+      "String",
+      function () {
+        return new String("x");
+      },
+      "{ '0': 'x' }",
+      "[String (null prototype): 'x']",
+    ],
+    [
+      "Boolean",
+      function () {
+        return new Boolean(true);
+      },
+      "{}",
+      "[Boolean (null prototype): true]",
+    ],
+    [
+      "BigInt",
+      function () {
+        return Object(3n);
+      },
+      "{}",
+      "[BigInt (null prototype): 3n]",
+    ],
+    [
+      "Symbol",
+      function () {
+        return Object(Symbol("x"));
+      },
+      "{}",
+      "[Symbol (null prototype): Symbol(x)]",
+    ],
+  ];
+
+  for (var i = 0; i < cases.length; i++) {
+    var item = cases[i];
+    var ordinary = item[1]();
+    Object.setPrototypeOf(ordinary, {});
+    eq(
+      util.inspect(ordinary),
+      item[2],
+      "inspect renders an ordinary-reparented " + item[0] + " generically"
+    );
+
+    var nullPrototype = item[1]();
+    Object.setPrototypeOf(nullPrototype, null);
+    var nullOutput = util.inspect(nullPrototype);
+    truthy(
+      item[0] === "Error" && !hasNodeHost
+        ? nullOutput.indexOf("[Error: null prototype]") === 0
+        : nullOutput === item[3],
+      "inspect renders a null-prototype " + item[0] + " explicitly"
+    );
+  }
+
+  var prototypeTrapCalls = 0;
+  var proxyPrototype = new Proxy(
+    {},
+    {
+      getPrototypeOf: function () {
+        prototypeTrapCalls++;
+        throw new Error("reparented wrapper prototype trap called");
+      },
+    }
+  );
+  var proxiedPrototypeNumber = new Number(3);
+  Object.setPrototypeOf(proxiedPrototypeNumber, proxyPrototype);
+  var proxiedPrototypeOutput;
+  var proxiedPrototypeError;
+  try {
+    proxiedPrototypeOutput = util.inspect(proxiedPrototypeNumber);
+  } catch (e) {
+    proxiedPrototypeError = e;
+  }
+  truthy(
+    hasNodeHost
+      ? proxiedPrototypeError === undefined &&
+          proxiedPrototypeOutput === "{}" &&
+          prototypeTrapCalls === 0
+      : proxiedPrototypeError instanceof Error,
+    "inspect classifies a reparented wrapper without prototype traps"
+  );
+})();
+(function () {
+  var cases = [
+    [
       Date,
       function () {
         return new Date(0);

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -657,9 +657,19 @@ eq(
     }
   );
   var formatted = util.format("%s", proxy);
+  // Node reads [[ProxyTarget]] before any property access, so the trap-provided
+  // toString never runs and the target is inspected instead ("Proxy({})" with
+  // Node's marker, "{}" from the shim, which adds no marker). "PROXY STRING" is
+  // the degraded no-host fallback, where a Proxy stays opaque.
   truthy(
-    formatted === "PROXY STRING" || formatted === "Proxy({})",
+    formatted === "PROXY STRING" ||
+      formatted === "Proxy({})" ||
+      formatted === "{}",
     "%s handles a throwing Proxy prototype walk"
+  );
+  truthy(
+    typeof __host_proxy_target === "undefined" || formatted !== "PROXY STRING",
+    "%s does not invoke a Proxy get trap"
   );
 })();
 (function () {
@@ -939,9 +949,15 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   );
   eq(proxyCalls, 0, "inspect invokes no nested Proxy traps");
 
+  // util.inspect output is never byte-compared against Node (see the header),
+  // so the exact revoked-Proxy marker is asserted only for the shim under test.
   var revocable = Proxy.revocable({ a: 1 }, proxyHandler);
   revocable.revoke();
-  eq(util.inspect(revocable.proxy), "<Revoked Proxy>", "inspect renders a revoked Proxy");
+  truthy(
+    typeof __host_proxy_target === "undefined" ||
+      util.inspect(revocable.proxy) === "<Revoked Proxy>",
+    "inspect renders a revoked Proxy"
+  );
   eq(proxyCalls, 0, "inspect invokes no revoked Proxy traps");
 
   // Error metadata must be read from descriptors. Throwing accessors shadow

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1222,18 +1222,13 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
 
   var nestedProxy = new Proxy(objectProxy, proxyHandler);
   // Node 24 unwraps only the outer Proxy here and observes the inner throwing
-  // get trap; Node 26 recursively unwraps both. Exercise the shim invariant on
-  // JSSE and emit the same assertion line on either Node version.
-  if (hasNodeHost) {
-    truthy(
-      util.inspect(nestedProxy).indexOf("a: 1") !== -1,
-      "inspect safely unwraps nested Proxies (jsse only)"
-    );
-  } else {
-    // Name the line for what it is: on Node nothing is asserted here, and a
-    // reader of the output should not be told otherwise.
-    ok("inspect safely unwraps nested Proxies (jsse only)");
-  }
+  // get trap; Node 26 recursively unwraps both. Short-circuit so inspect is
+  // never called on Node, and the same assertion line is emitted there — the
+  // `(jsse only)` label names what the line does and does not assert.
+  truthy(
+    !hasNodeHost || util.inspect(nestedProxy).indexOf("a: 1") !== -1,
+    "inspect safely unwraps nested Proxies (jsse only)"
+  );
   eq(proxyCalls, 0, "inspect invokes no nested Proxy traps");
 
   // util.inspect output is never byte-compared against Node (see the header),

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -320,11 +320,12 @@ eq(
 
   var regexpParent = /parent/m;
   var regexpChild = /child/dgimsuy;
+  Object.setPrototypeOf(regexpParent, {});
   Object.setPrototypeOf(regexpChild, regexpParent);
   eq(
     util.inspect(regexpChild),
-    "/child/dgimsuy",
-    "inspect recognizes a RegExp-slot prototype without instanceof"
+    "{}",
+    "inspect does not treat a same-family RegExp instance as the intrinsic prototype"
   );
   eq(
     util.inspect(new RegExp("unicode-sets", "v")),
@@ -429,6 +430,18 @@ eq(
       util.inspect(ordinary),
       item[2],
       "inspect renders an ordinary-reparented " + item[0] + " generically"
+    );
+
+    var slotBearingParent = item[1]();
+    Object.setPrototypeOf(slotBearingParent, {});
+    var slotBearingChild = item[1]();
+    Object.setPrototypeOf(slotBearingChild, slotBearingParent);
+    eq(
+      util.inspect(slotBearingChild),
+      item[2],
+      "inspect does not treat a same-family " +
+        item[0] +
+        " instance as the intrinsic prototype"
     );
 
     var nullPrototype = item[1]();

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -405,7 +405,10 @@ eq(
       "[Error: throwing stack sentinel]",
       "%s Error ignores throwing stack and patched toString"
     );
-    eq(stackReads, 1, "%s Error reads a stack getter once");
+    truthy(
+      typeof __host_proxy_target === "undefined" || stackReads === 0,
+      "%s shim does not read an Error stack getter"
+    );
   } finally {
     Error.prototype.toString = originalToString;
   }
@@ -888,6 +891,118 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     inspectedProxy === "{ a: 1 }" || inspectedProxy === "Proxy({ a: 1 })",
     "inspect does not trip a Proxy constructor trap"
   );
+
+  // The --node shim can unwrap Proxy targets through host metadata, just as
+  // Node's native inspector does. No handler trap may run, including the array
+  // length get and the reflection traps used by ordinary object rendering.
+  var proxyCalls = 0;
+  var proxyHandler = {
+    get: function () {
+      proxyCalls++;
+      throw new Error("Proxy get trap called");
+    },
+    getPrototypeOf: function () {
+      proxyCalls++;
+      throw new Error("Proxy getPrototypeOf trap called");
+    },
+    ownKeys: function () {
+      proxyCalls++;
+      throw new Error("Proxy ownKeys trap called");
+    },
+    getOwnPropertyDescriptor: function () {
+      proxyCalls++;
+      throw new Error("Proxy getOwnPropertyDescriptor trap called");
+    },
+  };
+  var arrayProxy = new Proxy([1, , 3], proxyHandler);
+  var inspectedArrayProxy = util.inspect(arrayProxy);
+  truthy(
+    inspectedArrayProxy.indexOf("1") !== -1 &&
+      inspectedArrayProxy.indexOf("3") !== -1 &&
+      inspectedArrayProxy.indexOf("empty item") !== -1,
+    "inspect renders an array-target Proxy without traps"
+  );
+  eq(proxyCalls, 0, "inspect invokes no array-target Proxy traps");
+
+  var objectProxy = new Proxy({ a: 1 }, proxyHandler);
+  var inspectedObjectProxy = util.inspect(objectProxy);
+  truthy(
+    inspectedObjectProxy.indexOf("a: 1") !== -1,
+    "inspect renders an object-target Proxy without traps"
+  );
+  eq(proxyCalls, 0, "inspect invokes no object-target Proxy traps");
+
+  var nestedProxy = new Proxy(objectProxy, proxyHandler);
+  truthy(
+    util.inspect(nestedProxy).indexOf("a: 1") !== -1,
+    "inspect safely unwraps nested Proxies"
+  );
+  eq(proxyCalls, 0, "inspect invokes no nested Proxy traps");
+
+  var revocable = Proxy.revocable({ a: 1 }, proxyHandler);
+  revocable.revoke();
+  eq(util.inspect(revocable.proxy), "<Revoked Proxy>", "inspect renders a revoked Proxy");
+  eq(proxyCalls, 0, "inspect invokes no revoked Proxy traps");
+
+  // Error metadata must be read from descriptors. Throwing accessors shadow
+  // inherited defaults but are never called by the JSSE shim. Node's native
+  // output differs across releases, so only the structural string is shared;
+  // the host marker narrows the no-read assertion to the shim under test.
+  var errorReads = 0;
+  var accessorError = new Error("accessor sentinel");
+  Object.defineProperty(accessorError, "stack", {
+    configurable: true,
+    get: function () {
+      errorReads++;
+      throw new Error("stack getter called");
+    },
+  });
+  Object.defineProperty(accessorError, "name", {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      errorReads++;
+      throw new Error("name getter called");
+    },
+  });
+  Object.defineProperty(accessorError, "message", {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      errorReads++;
+      throw new Error("message getter called");
+    },
+  });
+  truthy(
+    typeof util.inspect(accessorError) === "string",
+    "inspect handles Error stack/name/message accessors"
+  );
+  truthy(
+    typeof __host_proxy_target === "undefined" || errorReads === 0,
+    "inspect invokes no Error stack/name/message getters"
+  );
+
+  // A hole has no own descriptor. Inspection must preserve it rather than
+  // falling through to an inherited indexed getter.
+  var inheritedReads = 0;
+  var sparsePrototype = Object.create(Array.prototype);
+  Object.defineProperty(sparsePrototype, "1", {
+    configurable: true,
+    get: function () {
+      inheritedReads++;
+      throw new Error("inherited array getter called");
+    },
+  });
+  var sparse = new Array(3);
+  sparse[2] = 3;
+  Object.setPrototypeOf(sparse, sparsePrototype);
+  eq(
+    util.inspect(sparse),
+    "[ <2 empty items>, 3 ]",
+    "inspect preserves sparse-array holes"
+  );
+  eq(inheritedReads, 0, "inspect does not read inherited array elements");
+
   // A normal named class still gets its "ClassName " prefix.
   function Widget() {
     this.a = 1;

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1025,6 +1025,21 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   );
   eq(inheritedReads, 0, "inspect does not read inherited array elements");
 
+  // An accessor descriptor may carry BOTH `get` and `set` as undefined. Node
+  // renders the absent value rather than a [Getter]/[Setter] marker, so this
+  // agrees across engines and is byte-compared.
+  var bothUndefined = {};
+  Object.defineProperty(bothUndefined, "x", {
+    get: undefined,
+    set: undefined,
+    enumerable: true,
+  });
+  eq(
+    util.inspect(bothUndefined),
+    "{ x: undefined }",
+    "inspect renders an all-undefined accessor as its absent value"
+  );
+
   // A Proxy in the PROTOTYPE CHAIN, not as the inspected value itself. The
   // `%s` classification walk used to reflect on each prototype directly, so a
   // proxied prototype ran getPrototypeOf/getOwnPropertyDescriptor traps during

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -442,6 +442,56 @@ eq(
     );
   }
 
+  var revokedCases = [
+    [
+      "RegExp",
+      function () {
+        return /x/gi;
+      },
+    ],
+  ].concat(cases);
+  var revokedPrototypeTrapCalls = 0;
+  var revokedPrototypeHandler = {
+    get: function () {
+      revokedPrototypeTrapCalls++;
+      throw new Error("revoked prototype get trap called");
+    },
+    getOwnPropertyDescriptor: function () {
+      revokedPrototypeTrapCalls++;
+      throw new Error("revoked prototype descriptor trap called");
+    },
+    getPrototypeOf: function () {
+      revokedPrototypeTrapCalls++;
+      throw new Error("revoked prototype getPrototypeOf trap called");
+    },
+    ownKeys: function () {
+      revokedPrototypeTrapCalls++;
+      throw new Error("revoked prototype ownKeys trap called");
+    },
+  };
+  for (var r = 0; r < revokedCases.length; r++) {
+    var revokedItem = revokedCases[r];
+    var revokedPrototype = Proxy.revocable({}, revokedPrototypeHandler);
+    var revokedValue = revokedItem[1]();
+    Object.setPrototypeOf(revokedValue, revokedPrototype.proxy);
+    revokedPrototype.revoke();
+    var revokedError;
+    try {
+      util.inspect(revokedValue);
+    } catch (e) {
+      revokedError = e;
+    }
+    truthy(
+      revokedError instanceof TypeError,
+      "inspect rejects a revoked-Proxy prototype on " + revokedItem[0]
+    );
+  }
+  eq(
+    revokedPrototypeTrapCalls,
+    0,
+    "inspect invokes no traps on revoked built-in prototypes"
+  );
+
   var prototypeTrapCalls = 0;
   var proxyPrototype = new Proxy(
     {},

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -956,10 +956,17 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   eq(proxyCalls, 0, "inspect invokes no object-target Proxy traps");
 
   var nestedProxy = new Proxy(objectProxy, proxyHandler);
-  truthy(
-    util.inspect(nestedProxy).indexOf("a: 1") !== -1,
-    "inspect safely unwraps nested Proxies"
-  );
+  // Node 24 unwraps only the outer Proxy here and observes the inner throwing
+  // get trap; Node 26 recursively unwraps both. Exercise the shim invariant on
+  // JSSE and emit the same assertion line on either Node version.
+  if (hasNodeHost) {
+    truthy(
+      util.inspect(nestedProxy).indexOf("a: 1") !== -1,
+      "inspect safely unwraps nested Proxies"
+    );
+  } else {
+    ok("inspect safely unwraps nested Proxies");
+  }
   eq(proxyCalls, 0, "inspect invokes no nested Proxy traps");
 
   // util.inspect output is never byte-compared against Node (see the header),

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -6,8 +6,13 @@
 //
 // Deterministic surfaces (util.format specifiers, byte-accurate stdout, the
 // count/group/assert output shapes) are asserted exactly. util.inspect is
-// best-effort (issue #230), so it is only smoke-tested structurally — never
-// byte-compared against Node.
+// best-effort (issue #230), so its assertions are mixed on purpose: the
+// hardening cases assert a MECHANISM (trap/getter counters staying at 0, the
+// descriptor path being taken) and are engine-independent, while the rendering
+// cases assert exact strings and are therefore Node-version-sensitive. Where a
+// rendering is known to differ across Node releases the assertion is gated on
+// `hasNodeHost` and labelled "(jsse only)", so stdout stays byte-identical
+// without claiming Node verified something it never ran.
 //
 // This file is not esbuild-bundled: scripts/run-node-shim-selftest.sh simply
 // concatenates the shim in front of it. On jsse the shim installs globalThis.util;
@@ -1152,10 +1157,12 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   if (hasNodeHost) {
     truthy(
       util.inspect(nestedProxy).indexOf("a: 1") !== -1,
-      "inspect safely unwraps nested Proxies"
+      "inspect safely unwraps nested Proxies (jsse only)"
     );
   } else {
-    ok("inspect safely unwraps nested Proxies");
+    // Name the line for what it is: on Node nothing is asserted here, and a
+    // reader of the output should not be told otherwise.
+    ok("inspect safely unwraps nested Proxies (jsse only)");
   }
   eq(proxyCalls, 0, "inspect invokes no nested Proxy traps");
 
@@ -1211,12 +1218,16 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
   // `null` is safe to stringify despite `typeof null === "object"`. Suppress
   // Node's native data-valued stack so these fallback renderings agree across
   // engines and can be byte-compared.
-  var nullMessageError = new Error("m");
-  Object.defineProperty(nullMessageError, "stack", {
-    configurable: true,
-    get: undefined,
-    set: undefined,
-  });
+  function stripStack(err) {
+    Object.defineProperty(err, "stack", {
+      configurable: true,
+      get: undefined,
+      set: undefined,
+    });
+    return err;
+  }
+
+  var nullMessageError = stripStack(new Error("m"));
   nullMessageError.message = null;
   eq(
     util.inspect(nullMessageError),
@@ -1224,12 +1235,7 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "inspect stringifies a null Error message"
   );
 
-  var nullNameError = new Error("m");
-  Object.defineProperty(nullNameError, "stack", {
-    configurable: true,
-    get: undefined,
-    set: undefined,
-  });
+  var nullNameError = stripStack(new Error("m"));
   nullNameError.name = null;
   eq(
     util.inspect(nullNameError),

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -275,6 +275,21 @@ eq(
   "[Symbol: Symbol(wrapped)]",
   "%s Symbol wrapper"
 );
+eq(
+  util.inspect(Number.prototype),
+  "{}",
+  "inspect renders Number.prototype as an ordinary object"
+);
+eq(
+  util.inspect(String.prototype),
+  "{}",
+  "inspect renders String.prototype as an ordinary object"
+);
+eq(
+  util.inspect(Boolean.prototype),
+  "{}",
+  "inspect renders Boolean.prototype as an ordinary object"
+);
 (function () {
   var cases = [
     [

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -1,12 +1,12 @@
 //! Node host-compat "syscall floor" (issue #229).
 //!
 //! The genuinely-cannot-be-pure-JS primitives — byte I/O, OS entropy, a
-//! monotonic high-resolution clock, and the process-exit path — exposed to the
-//! Node prelude only and gated behind the `--node` CLI flag. When the gate is
-//! off (the default, and always the case under test262) none of these globals
-//! are installed and every host-floor check elsewhere in the interpreter is
-//! inert, so the default global environment is byte-identical to a build
-//! without this feature.
+//! monotonic high-resolution clock, the process-exit path, and trap-free Proxy
+//! metadata — exposed to the Node prelude only and gated behind the `--node`
+//! CLI flag. When the gate is off (the default, and always the case under
+//! test262) none of these globals are installed and every host-floor check
+//! elsewhere in the interpreter is inert, so the default global environment is
+//! byte-identical to a build without this feature.
 //!
 //! The primitives are installed as **non-enumerable** properties named
 //! `__host_*` on the global object. They are internal plumbing: the higher-level
@@ -160,5 +160,39 @@ impl Interpreter {
             },
         ));
         self.install_host_global("__host_random_bytes", random_fn);
+
+        // __host_proxy_target(value) -> target | null | undefined
+        //
+        // Trap-free Proxy metadata for the JS-only util.inspect shim. Ordinary
+        // ECMAScript reflection must dispatch through Proxy handler traps, so
+        // it cannot reproduce Node's internal getProxyDetails-based inspection
+        // without this narrow host seam. Return the target for an active Proxy,
+        // null for a revoked Proxy, and undefined for every non-Proxy value.
+        let proxy_target_fn = self.create_function(JsFunction::native(
+            "__host_proxy_target".to_string(),
+            1,
+            |interp, _this, args| {
+                let Some(obj_id) = args.first().and_then(JsValue::as_object_id) else {
+                    return Completion::Normal(JsValue::UNDEFINED);
+                };
+                let Some(obj) = interp.get_object_cell(obj_id) else {
+                    return Completion::Normal(JsValue::UNDEFINED);
+                };
+                let obj = obj.borrow();
+                let Some(proxy) = obj.proxy() else {
+                    return Completion::Normal(JsValue::UNDEFINED);
+                };
+                if proxy.revoked {
+                    return Completion::Normal(JsValue::NULL);
+                }
+                Completion::Normal(
+                    proxy
+                        .target_id
+                        .map(JsValue::object)
+                        .unwrap_or(JsValue::NULL),
+                )
+            },
+        ));
+        self.install_host_global("__host_proxy_target", proxy_target_fn);
     }
 }

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -175,22 +175,11 @@ impl Interpreter {
                 let Some(obj_id) = args.first().and_then(JsValue::as_object_id) else {
                     return Completion::Normal(JsValue::UNDEFINED);
                 };
-                let Some(obj) = interp.get_object_cell(obj_id) else {
-                    return Completion::Normal(JsValue::UNDEFINED);
-                };
-                let obj = obj.borrow();
-                let Some(proxy) = obj.proxy() else {
-                    return Completion::Normal(JsValue::UNDEFINED);
-                };
-                if proxy.revoked {
-                    return Completion::Normal(JsValue::NULL);
-                }
-                Completion::Normal(
-                    proxy
-                        .target_id
-                        .map(JsValue::object)
-                        .unwrap_or(JsValue::NULL),
-                )
+                Completion::Normal(match interp.get_proxy_info(obj_id) {
+                    None => JsValue::UNDEFINED,
+                    Some((false, Some(target_id), _)) => JsValue::object(target_id),
+                    Some(_) => JsValue::NULL,
+                })
             },
         ));
         self.install_host_global("__host_proxy_target", proxy_target_fn);

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3389,6 +3389,10 @@ mod node_host_tests {
               const d = Object.getOwnPropertyDescriptor(globalThis, name);
               if (!d) throw new Error(name + " missing");
               if (d.enumerable) throw new Error(name + " is enumerable");
+              // node-shim.js deletes __host_proxy_target under "use strict" to
+              // keep the Proxy-metadata seam private; a non-configurable
+              // binding would make that delete throw and kill the prelude.
+              if (!d.configurable) throw new Error(name + " is not configurable");
               if (typeof globalThis[name] !== "function") throw new Error(name + " not a function");
               if (Object.keys(globalThis).includes(name)) throw new Error(name + " shows in keys");
             }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3371,12 +3371,13 @@ mod node_host_tests {
               typeof globalThis.__host_exit,
               typeof __host_hrtime,
               typeof __host_random_bytes,
+              typeof __host_proxy_target,
             ].join(",");
             "#,
         );
         assert_eq!(
             global_string(&interp, "r"),
-            "undefined,undefined,undefined,undefined"
+            "undefined,undefined,undefined,undefined,undefined"
         );
     }
 
@@ -3384,7 +3385,7 @@ mod node_host_tests {
     fn host_globals_are_non_enumerable_functions() {
         assert_node_ok(
             r#"
-            for (const name of ["__host_write","__host_exit","__host_hrtime","__host_random_bytes"]) {
+            for (const name of ["__host_write","__host_exit","__host_hrtime","__host_random_bytes","__host_proxy_target"]) {
               const d = Object.getOwnPropertyDescriptor(globalThis, name);
               if (!d) throw new Error(name + " missing");
               if (d.enumerable) throw new Error(name + " is enumerable");
@@ -3449,6 +3450,35 @@ mod node_host_tests {
             threw = false;
             try { __host_random_bytes(2 ** 31); } catch (e) { threw = e instanceof RangeError; }
             if (!threw) throw new Error("oversize not rejected");
+            "#,
+        );
+    }
+
+    #[test]
+    fn host_proxy_target_bypasses_handler_traps() {
+        assert_node_ok(
+            r#"
+            let calls = 0;
+            const target = { value: 1 };
+            const proxy = new Proxy(target, {
+              get() { calls++; throw new Error("get trap"); },
+              getPrototypeOf() { calls++; throw new Error("getPrototypeOf trap"); },
+              ownKeys() { calls++; throw new Error("ownKeys trap"); },
+              getOwnPropertyDescriptor() {
+                calls++;
+                throw new Error("getOwnPropertyDescriptor trap");
+              },
+            });
+            if (__host_proxy_target(proxy) !== target) throw new Error("wrong target");
+            if (__host_proxy_target(target) !== undefined) throw new Error("ordinary object");
+            if (__host_proxy_target(1) !== undefined) throw new Error("primitive");
+            if (calls !== 0) throw new Error("handler trap invoked");
+
+            const revocable = Proxy.revocable({}, {});
+            revocable.revoke();
+            if (__host_proxy_target(revocable.proxy) !== null) {
+              throw new Error("revoked Proxy marker");
+            }
             "#,
         );
     }


### PR DESCRIPTION
## Summary

- add a `--node`-gated Proxy-target metadata hook so `util.inspect` can unwrap active and nested Proxies without invoking handler traps, then hide the captured hook before library code runs
- render Error metadata, array length/elements, sparse holes, and constructor/function names through safe descriptors without calling getters
- preserve Node-compatible `null` Error metadata and falsy-stack fallbacks without coercing objects or invoking user code
- classify reparented Error, Date, RegExp, and boxed-primitive values through trap-free prototype metadata, using generic or family-specific null-prototype presentation as Node does
- require the captured intrinsic prototype for specialized built-in rendering so arbitrary same-family instances in a prototype chain stay generic
- compose RegExp output from captured source and individual flag slot getters so replacement accessors cannot run
- render intrinsic Number/String/Boolean prototypes as ordinary objects while retaining internal-slot probes for genuine wrappers
- cover throwing Proxy traps, revoked/nested Proxies, Error accessors/metadata, reparented built-ins, hidden host plumbing, wrapper prototypes, same-family prototype instances, and inherited sparse-array accessors in the Node-cross-checked shim self-test

## Validation

- `./scripts/run-node-shim-selftest.sh --no-build` (247 assertions, byte-identical with Node)
- `./scripts/run-shim-fixtures.sh`
- `uv run python scripts/run-custom-tests.py` (12/12)
- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release` (549 passed, 1 ignored; integration and smoke tests passed)
- String split test262: 240/240
- Date/Error/RegExp/Number/String/Boolean/BigInt/Symbol test262: 8,700/8,700
- Proxy test262: 607/607
- Array.isArray test262: 58/58
- full test262: 99,568/99,568, zero regressions

Closes #251
