### PR TITLE
fix(interpreter): root destructuring targets, keys, and rest values

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An agent-coded JS engine in Rust. I didn't touch a single line of code here. Not
 
 Read more: [jsse - a JavaScript engine built by an agent](https://p.ocmatos.com/blog/jsse-a-javascript-engine-built-by-an-agent.html).
 
-Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **99,620 / 99,620 (100.00%)**.
+Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **99,568 / 99,568 (100.00%)**.
 
 *ES Modules now supported with dynamic `import()` and `import.meta`. Async tests run with Promise/async-await support.*
 

--- a/docs/specs/2026-08-24-private-destructuring-gc-rooting-design.md
+++ b/docs/specs/2026-08-24-private-destructuring-gc-rooting-design.md
@@ -1,0 +1,67 @@
+# Private destructuring receiver GC rooting
+
+## Problem
+
+Destructuring assignment evaluates a non-pattern target before it steps an
+iterator, reads a source property, or evaluates an initializer. The resulting
+Reference Record must remain valid until `PutValue` runs. For a private target
+such as `(new C()).#x`, JSSE currently represents that reference as a
+`DestructLRef::Private` containing only the receiver's arena ID.
+
+The iterator, source getter, or initializer can run arbitrary user code and
+force a collection. Because Rust locals are not traced, the temporary receiver
+can be swept and its arena ID reused before `set_private_field` implements
+`PrivateSet`. The write then either disappears or targets an unrelated slot and
+throws a spurious `TypeError`.
+
+## Considered approaches
+
+1. Root each pre-evaluated private receiver for the remainder of the enclosing
+   destructuring evaluation. This directly preserves the spec Reference Record
+   and uses JSSE's established temporary-root API. This is the selected
+   approach.
+2. Validate the receiver in `set_private_field`. This cannot distinguish the
+   original receiver from a different live object that reused the same arena
+   ID, so no callee-side check can make the stale ID sound.
+3. Change arena IDs to generation-stamped handles or stop reusing them. Either
+   would be a broad representation change unrelated to destructuring semantics.
+4. Root every ordinary and private member target. That may be useful in a
+   separate audit, but expands beyond the three private-target failures tracked
+   by issue #464.
+
+## Design
+
+Each of the three target-to-write sequences saves a `gc_root_frame()` and
+performs its remaining work inside a closure. Immediately after
+`eval_member_lhs_ref` produces a `DestructLRef::Private`, the evaluator calls
+`gc_root_value` on its receiver. The root therefore spans every intervening
+iterator step, iterator value read, source property access, initializer
+evaluation, rest collection, and final `set_private_field` call.
+
+After each closure returns, `gc_unroot_frame()` releases its receiver root.
+Centralized cleanup covers normal completion, throws, and yields without
+duplicating unroot calls. The enclosing array destructuring evaluator retains
+its existing, separately scoped iterator root and iterator-close handling.
+
+## Specification basis
+
+ECMAScript's `IteratorDestructuringAssignmentEvaluation` for both
+`AssignmentElement` and `AssignmentRestElement`, and
+`KeyedDestructuringAssignmentEvaluation` for object properties, evaluate the
+destructuring target into `_lRef_` before operations that can run user code and
+later pass the same `_lRef_` to `PutValue`. `PutValue` dispatches a private
+reference to `PrivateSet`. The implementation must therefore keep the private
+receiver represented by `_lRef_` alive across that entire interval.
+
+## Validation
+
+Add `test262-extra` coverage for:
+
+- an array element private target while `next()` forces collection;
+- an array rest private target while repeated `next()` calls force collection;
+- an object property private target while its source getter forces collection;
+- observable private setters, including an abrupt setter completion, so a
+  silently skipped write cannot satisfy the tests.
+
+Run the custom suite, assignment-destructuring and private-class targeted
+test262 areas, then the repository's full quality gate and full test262 suite.

--- a/docs/specs/2026-08-24-private-destructuring-gc-rooting-design.md
+++ b/docs/specs/2026-08-24-private-destructuring-gc-rooting-design.md
@@ -25,20 +25,27 @@ throws a spurious `TypeError`.
    ID, so no callee-side check can make the stale ID sound.
 3. Change arena IDs to generation-stamped handles or stop reusing them. Either
    would be a broad representation change unrelated to destructuring semantics.
-4. Root every ordinary and private member target. That may be useful in a
-   separate audit, but expands beyond the three private-target failures tracked
-   by issue #464.
+4. Root only the private receiver and defer ordinary member targets to a later
+   audit. Rejected: an ordinary member target's base, its un-coerced key, and
+   each value awaiting `PutValue` are held by the same untraced Rust locals and
+   fail observably today (a lost setter call, a key that coerces to
+   `[object Object]`, or a spurious `TypeError`), so the same frame roots all of
+   them.
 
 ## Design
 
 Each of the three target-to-write sequences saves a `gc_root_frame()` and
 performs its remaining work inside a closure. Immediately after
-`eval_member_lhs_ref` produces a `DestructLRef::Private`, the evaluator calls
-`gc_root_value` on its receiver. The root therefore spans every intervening
-iterator step, iterator value read, source property access, initializer
-evaluation, rest collection, and final `set_private_field` call.
+`eval_member_lhs_ref` produces a reference, `gc_root_destruct_lref` roots
+everything that reference holds: a private or ordinary base, an ordinary
+reference's un-coerced key, and a super reference's receiver. Inside the
+closure, each value collected by a rest element and each value about to be
+written are rooted as well, because `ToPropertyKey` and the write itself run
+user code. The roots therefore span every intervening iterator step, iterator
+value read, source property access, initializer evaluation, rest collection,
+and final write.
 
-After each closure returns, `gc_unroot_frame()` releases its receiver root.
+After each closure returns, `gc_unroot_frame()` releases that frame's roots.
 Centralized cleanup covers normal completion, throws, and yields without
 duplicating unroot calls. The enclosing array destructuring evaluator retains
 its existing, separately scoped iterator root and iterator-close handling.
@@ -61,7 +68,15 @@ Add `test262-extra` coverage for:
 - an array rest private target while repeated `next()` calls force collection;
 - an object property private target while its source getter forces collection;
 - observable private setters, including an abrupt setter completion, so a
-  silently skipped write cannot satisfy the tests.
+  silently skipped write cannot satisfy the tests;
+- a rest element whose iterator mints a fresh object per `next()`, an ordinary
+  member target reachable only through the reference, and a member key object
+  whose `toString` collects, so that ordinary references are covered too.
+
+Known gap: `destructure_object_assignment` still holds the source object
+returned by `ToObject` in an untraced local, so
+`({ x: a, [f()]: b } = { x: 1, y: 2 })` loses `b` when `f` collects. Fixing it
+requires a single-exit restructure of that function and is tracked as #502.
 
 Run the custom suite, assignment-destructuring and private-class targeted
 test262 areas, then the repository's full quality gate and full test262 suite.

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -4344,32 +4344,38 @@ impl Interpreter {
                         }
                     };
 
-                    // Collect remaining iterator values into rest array
-                    let mut rest = Vec::new();
-                    if !done {
-                        loop {
-                            match self.iterator_step(&iterator) {
-                                Ok(Some(result)) => match self.iterator_value(&result) {
-                                    Ok(v) => rest.push(v),
-                                    Err(e) => {
+                    // Keep a private lRef's receiver alive through iterator
+                    // collection and the eventual PutValue.
+                    let gc_frame = self.gc_root_frame();
+                    if let Some(DestructLRef::Private(base, _)) = &precomp {
+                        self.gc_root_value(base);
+                    }
+
+                    let result = (|| {
+                        // Collect remaining iterator values into rest array
+                        let mut rest = Vec::new();
+                        if !done {
+                            loop {
+                                match self.iterator_step(&iterator) {
+                                    Ok(Some(result)) => match self.iterator_value(&result) {
+                                        Ok(v) => rest.push(v),
+                                        Err(e) => {
+                                            done = true;
+                                            return Completion::Throw(e);
+                                        }
+                                    },
+                                    Ok(None) => {
                                         done = true;
-                                        error = Some(e);
                                         break;
                                     }
-                                },
-                                Ok(None) => {
-                                    done = true;
-                                    break;
-                                }
-                                Err(e) => {
-                                    done = true;
-                                    error = Some(e);
-                                    break;
+                                    Err(e) => {
+                                        done = true;
+                                        return Completion::Throw(e);
+                                    }
                                 }
                             }
                         }
-                    }
-                    if error.is_none() {
+
                         let arr = self.create_array(rest);
                         match precomp {
                             Some(DestructLRef::Member(base, raw_key)) => {
@@ -4379,37 +4385,46 @@ impl Interpreter {
                                         if let Err(e) =
                                             self.set_object_with_key(base, &key, arr, strict)
                                         {
-                                            error = Some(e);
+                                            return Completion::Throw(e);
                                         }
                                     }
                                     Err(e) => {
-                                        error = Some(e);
+                                        return Completion::Throw(e);
                                     }
                                 }
                             }
                             Some(DestructLRef::Private(base, ref name)) => {
                                 if let Err(e) = self.set_private_field(&base, name, arr, env) {
-                                    error = Some(e);
+                                    return Completion::Throw(e);
                                 }
                             }
                             Some(DestructLRef::Super(base_id, ref key, ref this_val, strict)) => {
                                 if let Completion::Throw(e) =
                                     self.super_set_property(base_id, key, arr, this_val, strict)
                                 {
-                                    error = Some(e)
+                                    return Completion::Throw(e);
                                 }
                             }
                             None => match self.put_value_to_target(inner, arr, env) {
                                 Completion::Normal(_) | Completion::Empty => {}
                                 Completion::Throw(e) => {
-                                    error = Some(e);
+                                    return Completion::Throw(e);
                                 }
                                 Completion::Yield(v) => {
-                                    yield_val = Some(v);
+                                    return Completion::Yield(v);
                                 }
                                 _ => {}
                             },
                         }
+                        Completion::Empty
+                    })();
+                    self.gc_unroot_frame(gc_frame);
+
+                    match result {
+                        Completion::Normal(_) | Completion::Empty => {}
+                        Completion::Throw(e) => error = Some(e),
+                        Completion::Yield(v) => yield_val = Some(v),
+                        other => return other,
                     }
                     break;
                 }
@@ -4435,102 +4450,108 @@ impl Interpreter {
                         }
                     };
 
-                    let item = if done {
-                        JsValue::UNDEFINED
-                    } else {
-                        match self.iterator_step(&iterator) {
-                            Ok(Some(result)) => match self.iterator_value(&result) {
-                                Ok(v) => v,
+                    // The target was evaluated before iterator/default user
+                    // code; its private receiver must survive until PutValue.
+                    let gc_frame = self.gc_root_frame();
+                    if let Some(DestructLRef::Private(base, _)) = &precomp {
+                        self.gc_root_value(base);
+                    }
+
+                    let result = (|| {
+                        let item = if done {
+                            JsValue::UNDEFINED
+                        } else {
+                            match self.iterator_step(&iterator) {
+                                Ok(Some(result)) => match self.iterator_value(&result) {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        done = true;
+                                        return Completion::Throw(e);
+                                    }
+                                },
+                                Ok(None) => {
+                                    done = true;
+                                    JsValue::UNDEFINED
+                                }
                                 Err(e) => {
                                     done = true;
-                                    error = Some(e);
-                                    break;
+                                    return Completion::Throw(e);
                                 }
-                            },
-                            Ok(None) => {
-                                done = true;
-                                JsValue::UNDEFINED
                             }
-                            Err(e) => {
-                                done = true;
-                                error = Some(e);
-                                break;
-                            }
-                        }
-                    };
+                        };
 
-                    let val = if item.is_undefined() {
-                        if let Some(default) = default_expr {
-                            match self.eval_expr(default, env) {
-                                Completion::Normal(v) => {
-                                    if let Expression::Identifier(name) = target
-                                        && default.is_anonymous_function_definition()
-                                    {
-                                        self.set_function_name(&v, name);
+                        let val = if item.is_undefined() {
+                            if let Some(default) = default_expr {
+                                match self.eval_expr(default, env) {
+                                    Completion::Normal(v) => {
+                                        if let Expression::Identifier(name) = target
+                                            && default.is_anonymous_function_definition()
+                                        {
+                                            self.set_function_name(&v, name);
+                                        }
+                                        v
                                     }
-                                    v
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    Completion::Yield(v) => return Completion::Yield(v),
+                                    other => return other,
                                 }
-                                Completion::Throw(e) => {
-                                    error = Some(e);
-                                    break;
-                                }
-                                Completion::Yield(v) => {
-                                    yield_val = Some(v);
-                                    break;
-                                }
-                                other => return other,
+                            } else {
+                                item
                             }
                         } else {
                             item
-                        }
-                    } else {
-                        item
-                    };
+                        };
 
-                    match precomp {
-                        Some(DestructLRef::Member(base, raw_key)) => {
-                            match self.to_property_key(&raw_key) {
-                                Ok(key) => {
-                                    let strict = env.borrow().strict;
-                                    if let Err(e) =
-                                        self.set_object_with_key(base, &key, val, strict)
-                                    {
-                                        error = Some(e);
-                                        break;
+                        match precomp {
+                            Some(DestructLRef::Member(base, raw_key)) => {
+                                match self.to_property_key(&raw_key) {
+                                    Ok(key) => {
+                                        let strict = env.borrow().strict;
+                                        if let Err(e) =
+                                            self.set_object_with_key(base, &key, val, strict)
+                                        {
+                                            return Completion::Throw(e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        return Completion::Throw(e);
                                     }
                                 }
-                                Err(e) => {
-                                    error = Some(e);
-                                    break;
+                            }
+                            Some(DestructLRef::Private(base, ref name)) => {
+                                if let Err(e) = self.set_private_field(&base, name, val, env) {
+                                    return Completion::Throw(e);
                                 }
                             }
+                            Some(DestructLRef::Super(base_id, ref key, ref this_val, strict)) => {
+                                if let Completion::Throw(e) =
+                                    self.super_set_property(base_id, key, val, this_val, strict)
+                                {
+                                    return Completion::Throw(e);
+                                }
+                            }
+                            None => match self.put_value_to_target(target, val, env) {
+                                Completion::Normal(_) | Completion::Empty => {}
+                                Completion::Throw(e) => return Completion::Throw(e),
+                                Completion::Yield(v) => return Completion::Yield(v),
+                                _ => {}
+                            },
                         }
-                        Some(DestructLRef::Private(base, ref name)) => {
-                            if let Err(e) = self.set_private_field(&base, name, val, env) {
-                                error = Some(e);
-                                break;
-                            }
+                        Completion::Empty
+                    })();
+                    self.gc_unroot_frame(gc_frame);
+
+                    match result {
+                        Completion::Normal(_) | Completion::Empty => {}
+                        Completion::Throw(e) => {
+                            error = Some(e);
+                            break;
                         }
-                        Some(DestructLRef::Super(base_id, ref key, ref this_val, strict)) => {
-                            if let Completion::Throw(e) =
-                                self.super_set_property(base_id, key, val, this_val, strict)
-                            {
-                                error = Some(e);
-                                break;
-                            }
+                        Completion::Yield(v) => {
+                            yield_val = Some(v);
+                            break;
                         }
-                        None => match self.put_value_to_target(target, val, env) {
-                            Completion::Normal(_) | Completion::Empty => {}
-                            Completion::Throw(e) => {
-                                error = Some(e);
-                                break;
-                            }
-                            Completion::Yield(v) => {
-                                yield_val = Some(v);
-                                break;
-                            }
-                            _ => {}
-                        },
+                        other => return other,
                     }
                 }
             }
@@ -4671,76 +4692,94 @@ impl Interpreter {
                         Err(e) => return Completion::Throw(e),
                     };
 
-                    // Get property via get_object_property (invokes getters/Proxy)
-                    let val = if let Some(o) = obj_val
-                        .as_object_id()
-                        .map(|id| crate::types::JsObject { id })
-                    {
-                        match self.get_object_property(o.id, &key, &obj_val) {
-                            Completion::Normal(v) => v,
-                            Completion::Throw(e) => return Completion::Throw(e),
-                            Completion::Yield(v) => return Completion::Yield(v),
-                            _ => JsValue::UNDEFINED,
-                        }
-                    } else {
-                        JsValue::UNDEFINED
-                    };
+                    // GetV and an initializer can run user code after the
+                    // target is evaluated, so retain a private receiver.
+                    let gc_frame = self.gc_root_frame();
+                    if let Some(DestructLRef::Private(base, _)) = &pre_ref {
+                        self.gc_root_value(base);
+                    }
 
-                    let val = if val.is_undefined() {
-                        if let Some(default) = default_expr {
-                            match self.eval_expr(default, env) {
-                                Completion::Normal(v) => {
-                                    if let Expression::Identifier(name) = target
-                                        && default.is_anonymous_function_definition()
-                                    {
-                                        self.set_function_name(&v, name);
-                                    }
-                                    v
-                                }
+                    let result = (|| {
+                        // Get property via get_object_property (invokes getters/Proxy)
+                        let val = if let Some(o) = obj_val
+                            .as_object_id()
+                            .map(|id| crate::types::JsObject { id })
+                        {
+                            match self.get_object_property(o.id, &key, &obj_val) {
+                                Completion::Normal(v) => v,
                                 Completion::Throw(e) => return Completion::Throw(e),
                                 Completion::Yield(v) => return Completion::Yield(v),
-                                other => return other,
+                                _ => JsValue::UNDEFINED,
+                            }
+                        } else {
+                            JsValue::UNDEFINED
+                        };
+
+                        let val = if val.is_undefined() {
+                            if let Some(default) = default_expr {
+                                match self.eval_expr(default, env) {
+                                    Completion::Normal(v) => {
+                                        if let Expression::Identifier(name) = target
+                                            && default.is_anonymous_function_definition()
+                                        {
+                                            self.set_function_name(&v, name);
+                                        }
+                                        v
+                                    }
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    Completion::Yield(v) => return Completion::Yield(v),
+                                    other => return other,
+                                }
+                            } else {
+                                val
                             }
                         } else {
                             val
-                        }
-                    } else {
-                        val
-                    };
+                        };
 
-                    if let Some(lref) = pre_ref {
-                        match lref {
-                            DestructLRef::Member(base_val, raw_key) => {
-                                match self.to_property_key(&raw_key) {
-                                    Ok(key) => {
-                                        let strict = env.borrow().strict;
-                                        if let Err(e) =
-                                            self.set_object_with_key(base_val, &key, val, strict)
-                                        {
-                                            return Completion::Throw(e);
+                        if let Some(lref) = pre_ref {
+                            match lref {
+                                DestructLRef::Member(base_val, raw_key) => {
+                                    match self.to_property_key(&raw_key) {
+                                        Ok(key) => {
+                                            let strict = env.borrow().strict;
+                                            if let Err(e) = self
+                                                .set_object_with_key(base_val, &key, val, strict)
+                                            {
+                                                return Completion::Throw(e);
+                                            }
                                         }
+                                        Err(e) => return Completion::Throw(e),
                                     }
-                                    Err(e) => return Completion::Throw(e),
+                                }
+                                DestructLRef::Private(base_val, ref name) => {
+                                    if let Err(e) =
+                                        self.set_private_field(&base_val, name, val, env)
+                                    {
+                                        return Completion::Throw(e);
+                                    }
+                                }
+                                DestructLRef::Super(base_id, ref key, ref this_val, strict) => {
+                                    if let Completion::Throw(e) =
+                                        self.super_set_property(base_id, key, val, this_val, strict)
+                                    {
+                                        return Completion::Throw(e);
+                                    }
                                 }
                             }
-                            DestructLRef::Private(base_val, ref name) => {
-                                if let Err(e) = self.set_private_field(&base_val, name, val, env) {
-                                    return Completion::Throw(e);
-                                }
-                            }
-                            DestructLRef::Super(base_id, ref key, ref this_val, strict) => {
-                                if let Completion::Throw(e) =
-                                    self.super_set_property(base_id, key, val, this_val, strict)
-                                {
-                                    return Completion::Throw(e);
-                                }
+                        } else {
+                            match self.put_value_to_target(target, val, env) {
+                                Completion::Normal(_) | Completion::Empty => {}
+                                other => return other,
                             }
                         }
-                    } else {
-                        match self.put_value_to_target(target, val, env) {
-                            Completion::Normal(_) | Completion::Empty => {}
-                            other => return other,
-                        }
+                        Completion::Empty
+                    })();
+                    self.gc_unroot_frame(gc_frame);
+
+                    match result {
+                        Completion::Normal(_) | Completion::Empty => {}
+                        other => return other,
                     }
                 }
                 _ => continue,

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -4224,6 +4224,20 @@ impl Interpreter {
         result
     }
 
+    /// Root every object a destructuring lRef depends on until PutValue.
+    /// The base, the raw key awaiting ToPropertyKey, and a super reference's
+    /// receiver are all held only by Rust locals across arbitrary user code.
+    fn gc_root_destruct_lref(&mut self, lref: &DestructLRef) {
+        match lref {
+            DestructLRef::Member(base, raw_key) => {
+                self.gc_root_value(base);
+                self.gc_root_value(raw_key);
+            }
+            DestructLRef::Private(base, _) => self.gc_root_value(base),
+            DestructLRef::Super(_, _, this_val, _) => self.gc_root_value(this_val),
+        }
+    }
+
     /// Evaluate a member expression as an lref (Reference) for destructuring.
     /// Returns base + key info or suspension explicitly; ToPropertyKey is
     /// deferred to PutValue time per spec.
@@ -4344,11 +4358,11 @@ impl Interpreter {
                         }
                     };
 
-                    // Keep a private lRef's receiver alive through iterator
-                    // collection and the eventual PutValue.
+                    // Keep the lRef's base, pending key, and receiver alive
+                    // through iterator collection and the eventual PutValue.
                     let gc_frame = self.gc_root_frame();
-                    if let Some(DestructLRef::Private(base, _)) = &precomp {
-                        self.gc_root_value(base);
+                    if let Some(lref) = &precomp {
+                        self.gc_root_destruct_lref(lref);
                     }
 
                     let result = (|| {
@@ -4358,7 +4372,12 @@ impl Interpreter {
                             loop {
                                 match self.iterator_step(&iterator) {
                                     Ok(Some(result)) => match self.iterator_value(&result) {
-                                        Ok(v) => rest.push(v),
+                                        Ok(v) => {
+                                            // Later steps run user code; the
+                                            // Vec is invisible to the GC.
+                                            self.gc_root_value(&v);
+                                            rest.push(v);
+                                        }
                                         Err(e) => {
                                             done = true;
                                             return Completion::Throw(e);
@@ -4377,6 +4396,8 @@ impl Interpreter {
                         }
 
                         let arr = self.create_array(rest);
+                        // ToPropertyKey and the write itself can run user code.
+                        self.gc_root_value(&arr);
                         match precomp {
                             Some(DestructLRef::Member(base, raw_key)) => {
                                 match self.to_property_key(&raw_key) {
@@ -4451,10 +4472,10 @@ impl Interpreter {
                     };
 
                     // The target was evaluated before iterator/default user
-                    // code; its private receiver must survive until PutValue.
+                    // code; its lRef must survive until PutValue.
                     let gc_frame = self.gc_root_frame();
-                    if let Some(DestructLRef::Private(base, _)) = &precomp {
-                        self.gc_root_value(base);
+                    if let Some(lref) = &precomp {
+                        self.gc_root_destruct_lref(lref);
                     }
 
                     let result = (|| {
@@ -4502,6 +4523,8 @@ impl Interpreter {
                             item
                         };
 
+                        // ToPropertyKey and the write itself can run user code.
+                        self.gc_root_value(&val);
                         match precomp {
                             Some(DestructLRef::Member(base, raw_key)) => {
                                 match self.to_property_key(&raw_key) {
@@ -4693,10 +4716,10 @@ impl Interpreter {
                     };
 
                     // GetV and an initializer can run user code after the
-                    // target is evaluated, so retain a private receiver.
+                    // target is evaluated, so retain the whole lRef.
                     let gc_frame = self.gc_root_frame();
-                    if let Some(DestructLRef::Private(base, _)) = &pre_ref {
-                        self.gc_root_value(base);
+                    if let Some(lref) = &pre_ref {
+                        self.gc_root_destruct_lref(lref);
                     }
 
                     let result = (|| {
@@ -4737,6 +4760,8 @@ impl Interpreter {
                             val
                         };
 
+                        // ToPropertyKey and the write itself can run user code.
+                        self.gc_root_value(&val);
                         if let Some(lref) = pre_ref {
                             match lref {
                                 DestructLRef::Member(base_val, raw_key) => {

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1483,6 +1483,41 @@ fn private_logical_assign_releases_temp_roots_after_abrupt_completion() {
 }
 
 #[test]
+fn private_destructuring_releases_temp_roots_after_abrupt_completion() {
+    // Destructuring evaluates each private target before iterator/property
+    // access. Throws from those intervening operations must release both the
+    // private receiver's scoped root and the array iterator's existing root.
+    let interp = run_script(
+        r#"
+        var throwingIterable = {
+            [Symbol.iterator]: function () {
+                return {
+                    next: function () { throw new Error("iterator step"); }
+                };
+            }
+        };
+        var throwingSource = {
+            get item() { throw new Error("source getter"); }
+        };
+        class C {
+            set #x(v) {}
+            static element() { [(new C()).#x] = throwingIterable; }
+            static rest() { [...(new C()).#x] = throwingIterable; }
+            static property() { ({ item: (new C()).#x } = throwingSource); }
+        }
+        try { C.element(); } catch (e) {}
+        try { C.rest(); } catch (e) {}
+        try { C.property(); } catch (e) {}
+        "#,
+    );
+
+    assert!(
+        interp.gc_temp_roots.is_empty(),
+        "private destructuring temporary roots must be released after a throw"
+    );
+}
+
+#[test]
 fn private_method_call_with_non_iterable_spread_throws() {
     // A spread argument that is not iterable must throw a TypeError, even when the
     // callee is a private method reached through `this.#m(...)`. The private-call

--- a/test262-extra/destructuring-target-value-gc-rooting.js
+++ b/test262-extra/destructuring-target-value-gc-rooting.js
@@ -1,0 +1,134 @@
+/*---
+description: >
+  A destructuring assignment's member target, its pending property key, and the
+  values it assigns stay reachable across the iterator, getter, and
+  ToPropertyKey user code that runs between target evaluation and PutValue.
+esid: sec-runtime-semantics-destructuringassignmentevaluation
+features: [Symbol.iterator]
+info: |
+  13.15.5.5 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+  AssignmentElement : DestructuringAssignmentTarget Initializer?
+    1. If DestructuringAssignmentTarget is not a pattern, let lRef be
+       ? Evaluation of DestructuringAssignmentTarget.
+    2. Step the iterator and obtain the assigned value.
+    8. Return ? PutValue(lRef, v).
+
+  AssignmentRestElement : ... DestructuringAssignmentTarget
+    2. Repeat, collecting each remaining iterator value into A.
+    5. Return ? PutValue(lRef, A).
+
+  13.15.5.6 Runtime Semantics: KeyedDestructuringAssignmentEvaluation
+
+  PutValue on a property Reference performs ToPropertyKey on the held key and
+  then invokes the receiver's [[Set]]. Every value that participates -- the
+  base, the un-coerced key, each already collected rest value, and the value
+  being written -- must therefore survive the intervening user code.
+---*/
+
+function gcThenValue(value) {
+  return function () {
+    $262.gc();
+    return value;
+  };
+}
+
+// Rest collection must retain the values already taken from the iterator while
+// later next() calls run user code.
+var restSource = {
+  [Symbol.iterator]: function () {
+    var index = 0;
+    return {
+      next: function () {
+        $262.gc();
+        if (index === 3) {
+          return { done: true };
+        }
+        return { value: { marker: { deep: index++ } }, done: false };
+      },
+    };
+  },
+};
+
+var rest;
+[...rest] = restSource;
+assert.sameValue(rest.length, 3, "every iterator value is collected");
+assert.sameValue(rest[0].marker.deep, 0, "the first collected value survives");
+assert.sameValue(rest[1].marker.deep, 1, "the second collected value survives");
+assert.sameValue(rest[2].marker.deep, 2, "the third collected value survives");
+
+// A member target's base is reachable only through the Reference Record.
+var elementWrites = [];
+var elementProto = {
+  set x(value) {
+    elementWrites.push(value);
+  },
+};
+
+var singleStep = {
+  [Symbol.iterator]: function () {
+    var taken = false;
+    return {
+      next: function () {
+        $262.gc();
+        if (taken) {
+          return { done: true };
+        }
+        taken = true;
+        return { value: "element", done: false };
+      },
+    };
+  },
+};
+
+[Object.create(elementProto).x] = singleStep;
+assert.sameValue(elementWrites.length, 1, "the array element base setter runs");
+assert.sameValue(elementWrites[0], "element", "the array element setter receives the value");
+
+var propertyWrites = [];
+var propertyProto = {
+  set y(value) {
+    propertyWrites.push(value);
+  },
+};
+
+({ p: Object.create(propertyProto).y } = { get p() { $262.gc(); return "property"; } });
+assert.sameValue(propertyWrites.length, 1, "the object property base setter runs");
+assert.sameValue(propertyWrites[0], "property", "the object property setter receives the value");
+
+// The un-coerced key and the assigned value both outlive the user code that
+// runs before and during ToPropertyKey.
+var elementTarget = {};
+[elementTarget[{ toString: gcThenValue("elementKey") }]] = {
+  [Symbol.iterator]: function () {
+    var taken = false;
+    return {
+      next: function () {
+        $262.gc();
+        if (taken) {
+          return { done: true };
+        }
+        taken = true;
+        return { value: { marker: 42 }, done: false };
+      },
+    };
+  },
+};
+assert.sameValue(
+  elementTarget.elementKey.marker,
+  42,
+  "the array element key and value survive ToPropertyKey"
+);
+
+var propertyTarget = {};
+({ p: propertyTarget[{ toString: gcThenValue("propertyKey") }] } = {
+  get p() {
+    $262.gc();
+    return { marker: 7 };
+  },
+});
+assert.sameValue(
+  propertyTarget.propertyKey.marker,
+  7,
+  "the object property key and value survive ToPropertyKey"
+);

--- a/test262-extra/private-destructuring-gc-rooting.js
+++ b/test262-extra/private-destructuring-gc-rooting.js
@@ -1,0 +1,138 @@
+/*---
+description: >
+  A private reference's receiver stays reachable from target evaluation through
+  iterator or property access and the eventual destructuring-assignment write.
+esid: sec-runtime-semantics-destructuringassignmentevaluation
+features: [class, class-methods-private, Symbol.iterator]
+info: |
+  13.15.5.5 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+  AssignmentElement : DestructuringAssignmentTarget Initializer?
+    1. If DestructuringAssignmentTarget is not a pattern, let lRef be
+       ? Evaluation of DestructuringAssignmentTarget.
+    2. Step the iterator and obtain the assigned value.
+    ...
+    8. Return ? PutValue(lRef, v).
+
+  AssignmentRestElement : ... DestructuringAssignmentTarget
+    1. If DestructuringAssignmentTarget is not a pattern, let lRef be
+       ? Evaluation of DestructuringAssignmentTarget.
+    2. Collect the remaining iterator values into an Array.
+    ...
+    5. Return ? PutValue(lRef, A).
+
+  13.15.5.6 Runtime Semantics: KeyedDestructuringAssignmentEvaluation
+
+  AssignmentElement : DestructuringAssignmentTarget Initializer?
+    1. If DestructuringAssignmentTarget is not a pattern, let lRef be
+       ? Evaluation of DestructuringAssignmentTarget.
+    2. Let v be ? GetV(value, propertyName).
+    ...
+    7. Return ? PutValue(lRef, rhsValue).
+
+  In every form, the Reference produced before arbitrary user code must retain
+  its temporary private receiver until PutValue dispatches to PrivateSet.
+---*/
+
+function collectingIterable(values) {
+  return {
+    [Symbol.iterator]: function () {
+      var index = 0;
+      return {
+        next: function () {
+          $262.gc();
+          if (index === values.length) {
+            return { done: true };
+          }
+          return { value: values[index++], done: false };
+        },
+      };
+    },
+  };
+}
+
+// AssignmentElement evaluates the private target before iterator.next().
+var elementWrites = [];
+var elementError;
+
+class ArrayElementTarget {
+  set #x(value) {
+    elementWrites.push(value);
+  }
+
+  static assign() {
+    [(new ArrayElementTarget()).#x] = collectingIterable([42]);
+  }
+}
+
+try {
+  ArrayElementTarget.assign();
+} catch (error) {
+  elementError = error;
+}
+
+// AssignmentRestElement retains the target while every remaining value is
+// collected. A distinct setter throw proves PrivateSet was actually reached.
+class SetterThrew extends Error {}
+
+var restWrite;
+var restError;
+
+class ArrayRestTarget {
+  set #x(value) {
+    restWrite = value;
+    throw new SetterThrew("array rest setter ran");
+  }
+
+  static assign() {
+    [...(new ArrayRestTarget()).#x] = collectingIterable([1, 2]);
+  }
+}
+
+try {
+  ArrayRestTarget.assign();
+} catch (error) {
+  restError = error;
+}
+
+// KeyedDestructuringAssignmentEvaluation evaluates the private target before
+// GetV invokes the source getter. Its returned object also forces arena reuse
+// if collection swept the target receiver.
+var propertyWrites = [];
+var propertyError;
+
+class ObjectPropertyTarget {
+  set #x(value) {
+    propertyWrites.push(value.marker);
+  }
+
+  static assign(source) {
+    ({ item: (new ObjectPropertyTarget()).#x } = source);
+  }
+}
+
+var source = {
+  get item() {
+    $262.gc();
+    return { marker: 7 };
+  },
+};
+
+try {
+  ObjectPropertyTarget.assign(source);
+} catch (error) {
+  propertyError = error;
+}
+
+assert.sameValue(elementError, undefined, "array element assignment completes normally");
+assert.sameValue(elementWrites.length, 1, "array element setter runs once");
+assert.sameValue(elementWrites[0], 42, "array element setter receives the iterator value");
+
+assert.sameValue(restError instanceof SetterThrew, true, "array rest setter throw propagates");
+assert.sameValue(restWrite.length, 2, "array rest setter receives the collected array");
+assert.sameValue(restWrite[0], 1, "array rest preserves the first iterator value");
+assert.sameValue(restWrite[1], 2, "array rest preserves the second iterator value");
+
+assert.sameValue(propertyError, undefined, "object property assignment completes normally");
+assert.sameValue(propertyWrites.length, 1, "object property setter runs once");
+assert.sameValue(propertyWrites[0], 7, "object property setter receives the getter value");


### PR DESCRIPTION
## Summary

Root everything a destructuring assignment's target side depends on, from
target evaluation through the iterator, getter, initializer, and
`ToPropertyKey` user code that runs before `PutValue`.

- root the whole reference via a new `gc_root_destruct_lref` helper: a private
  or ordinary member base, an ordinary reference's un-coerced key, and a super
  reference's receiver
- root each rest value as it is taken from the iterator, and the value (or rest
  array) about to be written
- release each temporary-root frame on normal, throw, and yield completions
- cover array element, array rest, and object property targets plus abrupt root
  cleanup
- document the spec lifetime and rejected arena/callee alternatives

## Observable failures fixed

Beyond the private-receiver `TypeError` from #464, a collection during that
user code produced three more wrong results, each confirmed against Node:

- `[Object.create(proto).x] = it` — a member base reachable only through the
  reference dies, so `PutValue` silently skips the inherited setter
- `[t[{toString(){ return "kk" }}]] = it` — the un-coerced key dies and coerces
  to `"[object Object]"`
- a GC-forcing key `toString` — the pending value dies and `undefined` is
  stored instead of the iterated value
- `[...rest] = it` where `next()` collects — already-collected rest values die
  in the untraced `Vec`, giving `undefined` fields and reused arena slots

## Known gap

`destructure_object_assignment` holds the *source* `ToObject` result in an
untraced local, so `({ x: a, [f()]: b } = { x: 1, y: 2 })` loses `b` when `f`
collects. The repair needs a single-exit restructure of that function, which is
outside this issue's scope — tracked as #502.

## Validation

- `cargo fmt --check`
- `./scripts/lint.sh` (rustfmt + clippy)
- `cargo build --release`
- `cargo test --release` (549 + 3 + 2 + 1 passed, 0 failed)
- `uv run python scripts/run-custom-tests.py` (12/12)
- targeted assignment/private test262 (661/661)
- `uv run python scripts/run-test262.py test262-extra/` (201/201), and the
  same suite under `--bytecode` (201/201)
- new regression verified to **fail on the pre-fix build and pass after**, in
  both the default and `--bytecode` VMs (2/2 scenarios each — sloppy + strict),
  with a byte-exact `eval.rs` restore confirmed by `diff` between the builds
- full `uv run python scripts/run-test262.py` (99,568/99,568; zero regressions)

The full run reported 323 pre-existing new passes relative to the stale
`origin/main:test262-pass.txt` baseline. This fix does not move an official
test262 scenario. `README.md` now records the measured 99,568/99,568 result;
the feature-branch baseline remains unchanged.

Closes #464
