### PR TITLE
refactor(interpreter): narrow member LHS suspension channel

### DIFF
--- a/docs/specs/2026-08-24-member-lhs-reference-suspension-channel-design.md
+++ b/docs/specs/2026-08-24-member-lhs-reference-suspension-channel-design.md
@@ -1,0 +1,107 @@
+# Member LHS reference suspension channel
+
+## Goal
+
+Remove the mutable resume-value out-parameter from
+`eval_member_lhs_ref` without changing assignment or destructuring behavior.
+The helper's interface must make a suspended member-reference evaluation
+impossible for any caller to overlook while remaining narrower than the
+interpreter's general `Completion` type.
+
+## Specification constraints
+
+ECMA-262 member-expression evaluation first evaluates the base and then, for a
+computed member, evaluates the key. Either evaluation can suspend at a
+`YieldExpression`. `EvaluatePropertyAccessWithExpressionKey` deliberately
+retains the raw key value: `ToPropertyKey` for `a[b] = c` is deferred until
+after the right-hand side has been evaluated.
+
+Destructuring assignment adds an ordering constraint. Iterator
+`AssignmentElement` and `AssignmentRestElement` evaluation computes a
+non-pattern target reference before stepping or draining the iterator.
+`KeyedDestructuringAssignmentEvaluation` likewise computes the target
+reference before reading the source property. A suspension at that point must
+therefore leave later iterator/property access and write-back unperformed.
+
+## Existing seam
+
+`eval_member_lhs_ref` pre-evaluates member, private, and `super` references for
+the assignment/destructuring module. It currently returns
+`Result<Option<DestructLRef>, JsValue>` while separately writing a yielded
+value through `&mut Option<JsValue>`. `Ok(None)` means the target is not a
+member and remains on the caller's lazy `put_value_to_target` path; `Err`
+contains a thrown JavaScript value.
+
+The three callers are two array-destructuring paths and one
+object-destructuring path. Array destructuring already has a local
+`yield_val` because defaults and lazy target write-back can also suspend, and
+because all such suspensions must pass through shared iterator-close/replay
+bookkeeping. That local state is not part of the helper's interface and
+remains useful.
+
+## Approaches considered
+
+1. **Return a private two-variant evaluation result.** Selected. Add
+   `MemberLhsRef::Ref(Option<DestructLRef>)` and
+   `MemberLhsRef::Suspended(JsValue)`, retaining `Result::Err(JsValue)` for
+   throws. Every caller must exhaustively handle suspension while the existing
+   optional-reference fallback stays intact.
+2. **Return `Result<Option<DestructLRef>, Completion>`.** Rejected. It would
+   remove the out-parameter, but `Completion` admits break, continue, return,
+   await, and other states this helper cannot legitimately produce. That
+   broadens the interface and obscures the useful distinction between a throw
+   and a resumable suspension.
+3. **Add separate `NotMember`, `Ref`, and `Suspended` variants.** Rejected.
+   This makes the same states exhaustive, but expands the new interface only
+   to replace an `Option` that every caller already consumes during its
+   write-back dispatch. Nesting that existing optional result in `Ref` keeps
+   the suspension channel to the two states that matter at this seam.
+
+Storing suspension on `Interpreter` was also excluded because it would turn a
+visible return obligation into hidden mutable state and make locality worse.
+
+## Design
+
+Define the private `MemberLhsRef` enum beside `DestructLRef`. Change
+`eval_member_lhs_ref` to accept only the target and environment and to return
+`Result<MemberLhsRef, JsValue>`. Normal member and non-member outcomes become
+`Ref(Some(...))` and `Ref(None)` respectively. Each of the helper's three
+`Completion::Yield` branches returns `Suspended` directly. Throw branches and
+the timing of `ToPropertyKey` remain unchanged.
+
+At both array-destructuring callers, exhaustively match the helper result.
+`Ref` continues through the existing iterator and write-back algorithm;
+`Suspended` stores the value in the function-local `yield_val` and breaks to
+the shared suspension/iterator bookkeeping; `Err` stays on the shared throw
+path. At the object-destructuring caller, `Suspended` returns
+`Completion::Yield` immediately because that path has no open iterator to
+close or remember.
+
+No generated `yield_val` temporary names or ordinary
+`Completion::Yield(yield_val)` bindings are in scope. No new adapter or public
+seam is introduced.
+
+## Error handling and observable order
+
+Thrown base/key evaluation and `ToPropertyKey` errors remain in the existing
+`Result::Err` channel. A yielded value is moved into `Suspended` without
+cloning. All later observable work remains after the exhaustive match, so a
+suspension still prevents iterator stepping, source property reads,
+initializer evaluation, and target writes.
+
+The refactor does not change GC rooting. Array destructuring keeps the
+iterator rooted until its existing shared exit path, and the pre-evaluated
+reference continues to own its base and raw key across later user code.
+
+## Verification
+
+Use the existing test262 assignment-destructuring coverage for computed-key
+suspension in array elements, array rest targets, object properties, and
+iterator closing. Add a focused `test262-extra` characterization for
+suspension while evaluating a target's base and a `super` computed key if the
+pinned test262 revision does not cover those helper branches.
+
+Run `cargo fmt --check`, `cargo clippy`, `cargo build --release`,
+`cargo test --release`, the focused `test262-extra` characterization, the full
+`test262/test/language/expressions/assignment/dstr/` directory, and the full
+test262 suite. The refactor must not change the baseline pass count.

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -50,6 +50,14 @@ enum DestructLRef {
     Super(u64, JsPropertyKey, JsValue, bool),
 }
 
+/// Result of pre-evaluating a possible member target for destructuring.
+/// Suspension is distinct from the optional-reference channel so callers
+/// cannot mistake a yielded evaluation for a non-member target.
+enum MemberLhsRef {
+    Ref(Option<DestructLRef>),
+    Suspended(JsValue),
+}
+
 impl Interpreter {
     /// §2.1.1.1 EvaluateImportCall: evaluate an import call's options expression
     /// without inspecting the resulting value. The raw value must survive the
@@ -4223,21 +4231,16 @@ impl Interpreter {
         result
     }
 
-    /// Evaluate a member expression as an LHS reference (base object + key string).
-    /// Returns Ok(Some((base, key))) for member expressions,
-    /// Ok(None) for non-member expressions (handled lazily),
-    /// Err(e) if evaluation throws.
-    /// Sets *yield_val if a yield is encountered.
     /// Evaluate a member expression as an lref (Reference) for destructuring.
-    /// Returns base + key info — ToPropertyKey is deferred to PutValue time per spec.
+    /// Returns base + key info or suspension explicitly; ToPropertyKey is
+    /// deferred to PutValue time per spec.
     fn eval_member_lhs_ref(
         &mut self,
         target: &Expression,
         env: &EnvRef,
-        yield_val: &mut Option<JsValue>,
-    ) -> Result<Option<DestructLRef>, JsValue> {
+    ) -> Result<MemberLhsRef, JsValue> {
         let Expression::Member(obj_expr, prop, _) = target else {
-            return Ok(None);
+            return Ok(MemberLhsRef::Ref(None));
         };
 
         // Handle super.prop / super[expr]
@@ -4248,11 +4251,8 @@ impl Interpreter {
                     let raw_key = match self.eval_expr(key_expr, env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => return Err(e),
-                        Completion::Yield(v) => {
-                            *yield_val = Some(v);
-                            return Ok(None);
-                        }
-                        _ => return Ok(None),
+                        Completion::Yield(v) => return Ok(MemberLhsRef::Suspended(v)),
+                        _ => return Ok(MemberLhsRef::Ref(None)),
                     };
                     self.to_property_key(&raw_key)?
                 }
@@ -4265,42 +4265,39 @@ impl Interpreter {
                 .ok_or_else(|| self.create_type_error("No super class"))?;
             let this_val = env.borrow().get("this").unwrap_or(JsValue::UNDEFINED);
             let strict = env.borrow().strict;
-            return Ok(Some(DestructLRef::Super(
+            return Ok(MemberLhsRef::Ref(Some(DestructLRef::Super(
                 super_base_id,
                 key,
                 this_val,
                 strict,
-            )));
+            ))));
         }
 
         let base = match self.eval_expr(obj_expr, env) {
             Completion::Normal(v) => v,
             Completion::Throw(e) => return Err(e),
-            Completion::Yield(v) => {
-                *yield_val = Some(v);
-                return Ok(None);
-            }
-            _ => return Ok(None),
+            Completion::Yield(v) => return Ok(MemberLhsRef::Suspended(v)),
+            _ => return Ok(MemberLhsRef::Ref(None)),
         };
 
         match prop {
-            MemberProperty::Dot(name) => Ok(Some(DestructLRef::Member(
+            MemberProperty::Dot(name) => Ok(MemberLhsRef::Ref(Some(DestructLRef::Member(
                 base,
                 JsValue::string(JsString::from_str(name)),
-            ))),
+            )))),
             MemberProperty::Computed(key_expr) => {
                 let raw_key = match self.eval_expr(key_expr, env) {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
-                    Completion::Yield(v) => {
-                        *yield_val = Some(v);
-                        return Ok(None);
-                    }
-                    _ => return Ok(None),
+                    Completion::Yield(v) => return Ok(MemberLhsRef::Suspended(v)),
+                    _ => return Ok(MemberLhsRef::Ref(None)),
                 };
-                Ok(Some(DestructLRef::Member(base, raw_key)))
+                Ok(MemberLhsRef::Ref(Some(DestructLRef::Member(base, raw_key))))
             }
-            MemberProperty::Private(name) => Ok(Some(DestructLRef::Private(base, name.clone()))),
+            MemberProperty::Private(name) => Ok(MemberLhsRef::Ref(Some(DestructLRef::Private(
+                base,
+                name.clone(),
+            )))),
         }
     }
 
@@ -4342,16 +4339,17 @@ impl Interpreter {
                 }
                 Some(Expression::Spread(inner)) => {
                     // §13.15.5.4 AssignmentRestElement: evaluate LHS ref BEFORE collecting
-                    let precomp = match self.eval_member_lhs_ref(inner, env, &mut yield_val) {
-                        Ok(r) => r,
+                    let precomp = match self.eval_member_lhs_ref(inner, env) {
+                        Ok(MemberLhsRef::Ref(r)) => r,
+                        Ok(MemberLhsRef::Suspended(v)) => {
+                            yield_val = Some(v);
+                            break;
+                        }
                         Err(e) => {
                             error = Some(e);
                             break;
                         }
                     };
-                    if yield_val.is_some() {
-                        break;
-                    }
 
                     // Collect remaining iterator values into rest array
                     let mut rest = Vec::new();
@@ -4432,16 +4430,17 @@ impl Interpreter {
                         };
 
                     // §13.15.5.4: evaluate LHS reference BEFORE stepping the iterator
-                    let precomp = match self.eval_member_lhs_ref(target, env, &mut yield_val) {
-                        Ok(r) => r,
+                    let precomp = match self.eval_member_lhs_ref(target, env) {
+                        Ok(MemberLhsRef::Ref(r)) => r,
+                        Ok(MemberLhsRef::Suspended(v)) => {
+                            yield_val = Some(v);
+                            break;
+                        }
                         Err(e) => {
                             error = Some(e);
                             break;
                         }
                     };
-                    if yield_val.is_some() {
-                        break;
-                    }
 
                     let item = if done {
                         JsValue::UNDEFINED
@@ -4673,14 +4672,11 @@ impl Interpreter {
 
                     // §13.15.5.6 step 1: evaluate lref (base + key expression)
                     // before GetV. ToPropertyKey is deferred to PutValue time.
-                    let mut yield_val: Option<JsValue> = None;
-                    let pre_ref = match self.eval_member_lhs_ref(target, env, &mut yield_val) {
-                        Ok(r) => r,
+                    let pre_ref = match self.eval_member_lhs_ref(target, env) {
+                        Ok(MemberLhsRef::Ref(r)) => r,
+                        Ok(MemberLhsRef::Suspended(v)) => return Completion::Yield(v),
                         Err(e) => return Completion::Throw(e),
                     };
-                    if let Some(yv) = yield_val {
-                        return Completion::Yield(yv);
-                    }
 
                     // Get property via get_object_property (invokes getters/Proxy)
                     let val = if let Some(o) = obj_val

--- a/test262-extra/destructuring-assignment-member-target-suspension.js
+++ b/test262-extra/destructuring-assignment-member-target-suspension.js
@@ -1,0 +1,84 @@
+/*---
+description: Member targets preserve generator suspension during destructuring assignment
+esid: sec-runtime-semantics-destructuringassignmentevaluation
+features: [generators, destructuring-binding]
+info: |
+  MemberExpression : MemberExpression [ Expression ]
+    1. Let baseReference be ? Evaluation of MemberExpression.
+    2. Let baseValue be ? GetValue(baseReference).
+    3. Return ? EvaluatePropertyAccessWithExpressionKey(baseValue, Expression, strict).
+
+  AssignmentElement : DestructuringAssignmentTarget Initializer?
+    1. If DestructuringAssignmentTarget is not a pattern, let lRef be
+       ? Evaluation of DestructuringAssignmentTarget.
+
+  AssignmentRestElement : ... DestructuringAssignmentTarget
+    1. If DestructuringAssignmentTarget is not a pattern, let lRef be
+       ? Evaluation of DestructuringAssignmentTarget.
+
+  KeyedDestructuringAssignmentEvaluation evaluates its non-pattern target
+  reference before reading the source property.
+---*/
+
+var arrayElementSource = [41];
+var arrayElementTarget = {};
+function* assignArrayElementBase() {
+  return [(yield "array element base").slot] = arrayElementSource;
+}
+
+var iter = assignArrayElementBase();
+var step = iter.next();
+assert.sameValue(step.value, "array element base");
+assert.sameValue(step.done, false);
+step = iter.next(arrayElementTarget);
+assert.sameValue(step.value, arrayElementSource);
+assert.sameValue(step.done, true);
+assert.sameValue(arrayElementTarget.slot, 41);
+
+var arrayRestSource = [42, 43];
+var arrayRestTarget = {};
+function* assignArrayRestBase() {
+  return [...(yield "array rest base").slot] = arrayRestSource;
+}
+
+iter = assignArrayRestBase();
+step = iter.next();
+assert.sameValue(step.value, "array rest base");
+assert.sameValue(step.done, false);
+step = iter.next(arrayRestTarget);
+assert.sameValue(step.value, arrayRestSource);
+assert.sameValue(step.done, true);
+assert.compareArray(arrayRestTarget.slot, [42, 43]);
+
+var objectSource = { value: 44 };
+var objectTarget = {};
+function* assignObjectPropertyBase() {
+  return { value: (yield "object property base").slot } = objectSource;
+}
+
+iter = assignObjectPropertyBase();
+step = iter.next();
+assert.sameValue(step.value, "object property base");
+assert.sameValue(step.done, false);
+step = iter.next(objectTarget);
+assert.sameValue(step.value, objectSource);
+assert.sameValue(step.done, true);
+assert.sameValue(objectTarget.slot, 44);
+
+class Parent {}
+class Child extends Parent {
+  *assign(source) {
+    return [super[yield "super key"]] = source;
+  }
+}
+
+var child = new Child();
+var superSource = [45];
+iter = child.assign(superSource);
+step = iter.next();
+assert.sameValue(step.value, "super key");
+assert.sameValue(step.done, false);
+step = iter.next("slot");
+assert.sameValue(step.value, superSource);
+assert.sameValue(step.done, true);
+assert.sameValue(child.slot, 45);


### PR DESCRIPTION
Summary:
- replace eval_member_lhs_ref's mutable yield out-parameter with an exhaustive Ref/Suspended return channel
- keep array iterator suspension bookkeeping local while making every helper caller handle suspension
- add focused coverage for base-expression and super computed-key suspension
- document the interface design and rejected broader channels

Validation:
- cargo fmt --check
- cargo clippy
- cargo build --release
- cargo test --release
- ./scripts/lint.sh
- uv run python scripts/run-custom-tests.py
- uv run python scripts/run-test262.py test262-extra/destructuring-assignment-member-target-suspension.js
- uv run python scripts/run-test262.py test262/test/language/expressions/assignment/dstr/ (640/640)
- uv run python scripts/run-test262.py (99,568/99,568; zero regressions)

Closes #466