### PR TITLE
fix(interpreter): discard exited async for-of bindings

### DIFF
--- a/docs/specs/2026-08-24-async-for-of-throw-scope-unwind-design.md
+++ b/docs/specs/2026-08-24-async-for-of-throw-scope-unwind-design.md
@@ -1,0 +1,55 @@
+# Async `for-of` throw scope unwind
+
+## Problem
+
+The async-function state-machine driver now closes every `for-of` iterator
+crossed by a throw before entering its handler. However, async-function setup
+also predeclares every local found by generator analysis as a function-scoped
+`var`. That includes lexical bindings nested in a `for-of` head.
+
+After the exception router removes the exited loop's iteration environment,
+the catch therefore resolves the dead loop name against a synthetic function
+binding and reads `undefined`. ECMA-262 `ForIn/OfBodyEvaluation` restores the
+old lexical environment before returning the throw completion, so the loop
+binding must instead be unresolvable in a catch outside the loop.
+
+## Design
+
+Apply the nested-local part of the declaration rule already used by generator
+and async-generator state machines when initializing an async function:
+
+- existing function-level storage for `var` and top-level lexical locals is
+  unchanged; and
+- lexical locals with nonzero analysis scope depth are not predeclared in the
+  function environment because their transformed runtime scope owns them.
+
+Preserving top-level storage is intentional. Async-function state bodies rely
+on its initialized slots across suspension today; changing those slots to
+lexical bindings is a separate state-machine concern and regresses deferred
+module-import evaluation.
+
+The existing async `for-of` head continues to create and initialize a fresh
+iteration environment. The existing exception router continues to dispose and
+remove that environment before selecting an outside catch or finally. With no
+synthetic fallback binding, identifier resolution in the handler reaches the
+actual outer environment and produces `ReferenceError` when appropriate.
+
+## Alternatives considered
+
+1. Delete or poison bindings while disposing an iteration environment. This
+   would mutate an environment that closures may still retain and would not
+   remove the synthetic function binding.
+2. Special-case identifier resolution while a catch state executes. This
+   would make lexical scope depend on control-flow state and could hide genuine
+   outer bindings.
+3. Add another loop-unwind call at handler entry. The current exception router
+   already drains the exited loop and closes its iterator before the catch, so
+   a second unwind cannot remove the function-level placeholder.
+
+## Validation
+
+Extend the existing async abrupt-completion regression to assert both required
+observables in one scenario: the iterator `return` method runs before the catch
+body, and the loop's per-iteration `const` binding is unresolvable there. Run
+the focused regression, async-function and `for-of` test262 areas, the custom
+suite, and the repository quality gate, followed by the full test262 suite.

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -8210,6 +8210,15 @@ impl Interpreter {
             func_env.borrow_mut().declare(tv, BindingKind::Var);
         }
         for lv in &sm.local_vars {
+            if matches!(
+                lv.kind,
+                VarKind::Let | VarKind::Const | VarKind::Using | VarKind::AwaitUsing
+            ) && lv.scope_depth > 0
+            {
+                // Nested lexical bindings are created by their transformed
+                // runtime scopes and must not leak into the function scope.
+                continue;
+            }
             if !func_env.borrow().bindings.contains_key(&lv.name) {
                 func_env.borrow_mut().declare(&lv.name, BindingKind::Var);
             }

--- a/test262-extra/async-function-for-of-abrupt-completion-unwind.js
+++ b/test262-extra/async-function-for-of-abrupt-completion-unwind.js
@@ -368,6 +368,16 @@ async function bodyThrowClosesBeforeCatchOutsideLoops() {
     }
   } catch (error) {
     bodyThrowOrder.push('catch ' + error);
+    try {
+      bodyThrowOrder.push('outer binding ' + outerValue);
+    } catch (scopeError) {
+      bodyThrowOrder.push('outer binding ' + scopeError.constructor.name);
+    }
+    try {
+      bodyThrowOrder.push('inner binding ' + innerValue);
+    } catch (scopeError) {
+      bodyThrowOrder.push('inner binding ' + scopeError.constructor.name);
+    }
     return 'caught';
   }
 }
@@ -611,8 +621,8 @@ nestedDisposalErrors()
     assert.sameValue(value, 'caught', 'the catch outside both loops handles the body throw');
     assert.sameValue(
       bodyThrowOrder.join(','),
-      'close inner,close outer,catch body throw',
-      'both loops close before a catch outside them runs'
+      'close inner,close outer,catch body throw,outer binding ReferenceError,inner binding ReferenceError',
+      'both loops close and discard their iteration bindings before an outside catch runs'
     );
   })
   .then(function () {


### PR DESCRIPTION
## Summary

- stop synthetic function-scope predeclarations for nested lexical locals in async state machines
- preserve iterator-close ordering while making exited for-of bindings unresolvable in outer catches
- extend the abrupt-completion regression and document the state-machine scope decision

## Validation

- cargo fmt --check
- cargo clippy
- ./scripts/lint.sh
- cargo build --release
- cargo test --release
- uv run python scripts/run-custom-tests.py
- targeted async-function, async-arrow, for-of, and for-await-of test262: 4,277/4,277
- full test262: 99,568/99,568, zero regressions

Closes #488