### PR TITLE
fix(interpreter): preserve try clause continuation states

### DIFF
--- a/docs/specs/2026-08-24-try-clause-continuation-state-design.md
+++ b/docs/specs/2026-08-24-try-clause-continuation-state-design.md
@@ -1,0 +1,59 @@
+# Try clause continuation states
+
+## Problem
+
+The async-function transformer lets a final statement reuse the continuation
+state supplied by its enclosing construct. This is intentional for transformed
+loops: a `for-of` used as the last statement in a block sets the transform's
+current state to its own `after_state`.
+
+`transform_try_statement` currently finalizes the current state
+unconditionally after transforming a try block or catch body. When the last
+statement is a transformed `for-of`, the current state is already the caller's
+continuation. Finalizing it replaces the continuation's existing terminator.
+For a try nested directly in an outer loop body, this replaces the outer
+`ForOfHead` with a self-directed `Goto`, so execution never enters the loop.
+
+The same alias is possible at catch and finally clause boundaries. A finalizer
+also needs a `TryExit` terminator, so merely skipping its finalization would
+bypass completion restoration.
+
+## Design
+
+Give each try clause an explicit normal-completion target:
+
+- A try block or catch body with a finalizer targets the finalizer entry state.
+- A try block or catch body without a finalizer targets the caller's existing
+  continuation state.
+- Clause finalization emits a `Goto` only when transformation did not already
+  land on that target. This preserves a reused continuation's terminator.
+- A finalizer targets a new private exit state. That exit state owns the
+  `TryExit` terminator that restores a pending completion or continues to the
+  caller's state.
+
+This is a transformer-only change. Runtime loop, iterator, and handler stacks
+retain their existing behavior.
+
+## Alternatives considered
+
+1. Allocate bridge states around every try and catch clause. This prevents
+   aliasing but adds states even when the existing continuation is safe, and it
+   changes more generated control flow than the defect requires.
+2. Make `finalize_current_state` reject every attempt to replace a terminator.
+   This would enforce a broad invariant at one seam, but the transformer also
+   creates placeholder states that are intentionally finalized later, such as
+   finalizer entry and function completion states.
+3. Guard only the exact catch-free reproduction. This is the smallest diff,
+   but leaves the identical alias at catch and finally boundaries.
+
+## Validation
+
+Add a `test262-extra` async regression whose try block ends in a transformed
+`for-of`, matching issue #492. Include catch-final and finally-final variants
+to cover the shared clause-boundary invariant. Each promise must resolve to the
+expected value; before the fix the generated outer loop head is overwritten
+and the test times out.
+
+Run that regression with a short timeout, then the upstream async-function,
+`for-of`, and `try` directories, the custom suite, the Rust quality gate, and
+the full test262 suite.

--- a/src/interpreter/generator_transform.rs
+++ b/src/interpreter/generator_transform.rs
@@ -2035,6 +2035,7 @@ fn transform_try_statement(
     } else {
         None
     };
+    let clause_completion_state = finally_entry_state.unwrap_or(after_try);
 
     ctx.finalize_current_state(StateTerminator::TryEnter {
         try_state: try_body_state,
@@ -2050,11 +2051,9 @@ fn transform_try_statement(
     });
 
     ctx.current_state_id = try_body_state;
-    transform_statements(&try_stmt.block, ctx, after_try);
-    if let Some(fin_state) = finally_entry_state {
-        ctx.finalize_current_state(StateTerminator::Goto(fin_state));
-    } else {
-        ctx.finalize_current_state(StateTerminator::Goto(after_try));
+    transform_statements(&try_stmt.block, ctx, clause_completion_state);
+    if ctx.current_state_id != clause_completion_state {
+        ctx.finalize_current_state(StateTerminator::Goto(clause_completion_state));
     }
 
     if let Some(ref info) = catch_info {
@@ -2067,17 +2066,16 @@ fn transform_try_statement(
 
         ctx.current_state_id = catch_body_state;
         if let Some(handler) = &try_stmt.handler {
-            transform_statements(&handler.body, ctx, after_try);
+            transform_statements(&handler.body, ctx, clause_completion_state);
         }
-        if let Some(fin_state) = finally_entry_state {
-            ctx.finalize_current_state(StateTerminator::Goto(fin_state));
-        } else {
-            ctx.finalize_current_state(StateTerminator::Goto(after_try));
+        if ctx.current_state_id != clause_completion_state {
+            ctx.finalize_current_state(StateTerminator::Goto(clause_completion_state));
         }
     }
 
     if let Some(fin_entry_state) = finally_entry_state {
         let finally_body_state = ctx.new_state();
+        let finally_exit_state = ctx.new_state();
         ctx.current_state_id = fin_entry_state;
         ctx.finalize_current_state(StateTerminator::EnterFinally {
             body_state: finally_body_state,
@@ -2085,8 +2083,12 @@ fn transform_try_statement(
 
         ctx.current_state_id = finally_body_state;
         if let Some(finalizer) = &try_stmt.finalizer {
-            transform_statements(finalizer, ctx, after_try);
+            transform_statements(finalizer, ctx, finally_exit_state);
         }
+        if ctx.current_state_id != finally_exit_state {
+            ctx.finalize_current_state(StateTerminator::Goto(finally_exit_state));
+        }
+        ctx.current_state_id = finally_exit_state;
         ctx.finalize_current_state(StateTerminator::TryExit {
             after_state: after_try,
         });

--- a/test262-extra/async-function-final-for-of-in-try-clause.js
+++ b/test262-extra/async-function-final-for-of-in-try-clause.js
@@ -1,0 +1,69 @@
+/*---
+description: >
+  A transformed for-of at the end of a try clause preserves the enclosing
+  loop's continuation state.
+esid: sec-try-statement-runtime-semantics-evaluation
+info: |
+  Evaluation of a try statement preserves the completion of its selected
+  block or catch clause unless a finally clause replaces it. A for-of body
+  evaluates its statement before continuing the enclosing iteration.
+
+  An implementation that lowers await to a state machine must not let a
+  clause's final transformed for-of replace the state supplied by an enclosing
+  loop.
+flags: [async]
+features: [async-functions]
+---*/
+
+async function forOfAtEndOfTry() {
+  for (const outer of [1]) {
+    try {
+      for (const inner of [2]) {
+        await null;
+        return outer + inner;
+      }
+    } catch (error) {
+      return 'caught ' + error;
+    }
+  }
+}
+
+async function forOfAtEndOfCatch() {
+  for (const outer of [1]) {
+    try {
+      await Promise.reject('enter catch');
+    } catch (error) {
+      for (const inner of [2]) {
+        await null;
+        return outer + inner;
+      }
+    }
+  }
+}
+
+async function forOfAtEndOfFinally() {
+  for (const outer of [1]) {
+    try {
+      await null;
+    } finally {
+      for (const inner of [2]) {
+        await null;
+        return outer + inner;
+      }
+    }
+  }
+}
+
+forOfAtEndOfTry()
+  .then(function (value) {
+    assert.sameValue(value, 3, 'the try-final for-of preserves the outer head');
+    return forOfAtEndOfCatch();
+  })
+  .then(function (value) {
+    assert.sameValue(value, 3, 'the catch-final for-of preserves the outer head');
+    return forOfAtEndOfFinally();
+  })
+  .then(function (value) {
+    assert.sameValue(value, 3, 'the finally-final for-of preserves the outer head');
+  })
+  .then($DONE, $DONE);


### PR DESCRIPTION
## Summary

- preserve an enclosing continuation when a transformed `for-of` is the last statement in a try or catch clause
- route finalizers through a private `TryExit` state so they cannot overwrite their caller continuation
- add strict and non-strict async regressions for try-, catch-, and finally-final `for-of` clauses

## Testing

- `cargo fmt --check`
- `cargo clippy`
- `cargo build --release`
- `cargo test --release`
- `./scripts/lint.sh`
- `uv run python scripts/run-custom-tests.py`
- targeted test262: 1,971/1,971
- full test262: 99,568/99,568 (100.00%)

Closes #492