### PR TITLE
fix(interpreter): preserve generator for-of lexical bindings

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -8427,7 +8427,7 @@ impl Interpreter {
         let mut pending_loop_control = restored_pending_loop_control;
         let mut saved_finally_exception: Option<JsValue> = restored_saved_finally_exception;
         // Stack tracking active for-of loops for break/continue/return iterator close
-        let mut for_of_stack: Vec<AsyncForOfLoopState> = saved_for_of_stack;
+        let mut for_of_stack: Vec<ForOfLoopState> = saved_for_of_stack;
         // An abrupt completion may need to visit a catch/finally inside an
         // enclosing loop before that loop itself can be closed. Keep that
         // obligation across suspension until the handler completes normally.
@@ -8765,7 +8765,7 @@ impl Interpreter {
             self.in_state_machine = true;
             let exec_env = for_of_stack
                 .last()
-                .map_or(&func_env, AsyncForOfLoopState::effective_env)
+                .map_or(&func_env, ForOfLoopState::effective_env)
                 .clone();
             let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &exec_env);
             self.in_state_machine = saved_in_state_machine;
@@ -9144,7 +9144,7 @@ impl Interpreter {
                     self.gc_root_value(&iterator);
                     self.pending_iter_close.push(iterator.clone());
                     self.env_set(&func_env, iter_var, iterator).ok();
-                    for_of_stack.push(AsyncForOfLoopState {
+                    for_of_stack.push(ForOfLoopState {
                         iter_var: iter_var.clone(),
                         head_state,
                         after_state: forinit_after,
@@ -9172,7 +9172,7 @@ impl Interpreter {
                         Some(pos) => pos,
                         None => {
                             debug_assert!(false, "for-of head without an active loop state");
-                            for_of_stack.push(AsyncForOfLoopState {
+                            for_of_stack.push(ForOfLoopState {
                                 iter_var: iter_var.clone(),
                                 head_state: current_id,
                                 after_state,
@@ -9377,7 +9377,7 @@ impl Interpreter {
 
     fn close_async_for_of_loop(
         &mut self,
-        loop_state: AsyncForOfLoopState,
+        loop_state: ForOfLoopState,
         func_env: &EnvRef,
         completion: Completion,
     ) -> Completion {
@@ -9416,7 +9416,7 @@ impl Interpreter {
     /// iteration disposal.
     fn unwind_async_for_of_loops(
         &mut self,
-        for_of_stack: &mut Vec<AsyncForOfLoopState>,
+        for_of_stack: &mut Vec<ForOfLoopState>,
         from: usize,
         func_env: &EnvRef,
         mut completion: Completion,
@@ -9470,7 +9470,7 @@ impl Interpreter {
         resolve_fn: &JsValue,
         reject_fn: &JsValue,
         await_val: &JsValue,
-        for_of_stack: &[AsyncForOfLoopState],
+        for_of_stack: &[ForOfLoopState],
     ) {
         let promise = self.promise_resolve_value(await_val);
         let promise_id = if let Some(o) = (promise)

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -8448,7 +8448,7 @@ impl Interpreter {
                     // loop remain available for a close failure.
                     try_stack.truncate(loop_state.try_depth);
                     unwind_completion =
-                        self.close_async_for_of_loop(loop_state, &func_env, unwind_completion);
+                        self.close_for_of_loop(loop_state, &func_env, unwind_completion, None);
                     match &unwind_completion {
                         Completion::Exit(code) => {
                             self.scheduler.remove_async_function_state(async_id);
@@ -9387,11 +9387,32 @@ impl Interpreter {
         }
     }
 
-    fn close_async_for_of_loop(
+    /// A transformed generator for-of is represented both by its loop-state
+    /// entry and by the inline-iterator fallback captured at suspension. Once
+    /// the loop-state unwinder closes it, discard the fallback copy so a later
+    /// `return()` does not call the iterator's `return` method twice.
+    fn remove_generator_inline_iterator(&mut self, generator_id: u64, iterator: &JsValue) {
+        let Some(iterator_id) = iterator.as_object_id() else {
+            return;
+        };
+        let remove_entry = self
+            .generator_inline_iters
+            .get_mut(&generator_id)
+            .is_some_and(|iterators| {
+                iterators.retain(|value| value.as_object_id() != Some(iterator_id));
+                iterators.is_empty()
+            });
+        if remove_entry {
+            self.generator_inline_iters.remove(&generator_id);
+        }
+    }
+
+    fn close_for_of_loop(
         &mut self,
         loop_state: ForOfLoopState,
         func_env: &EnvRef,
         completion: Completion,
+        generator_id: Option<u64>,
     ) -> Completion {
         let mut completion = match loop_state.iteration_env {
             Some(env) => self.dispose_resources(&env, completion),
@@ -9404,16 +9425,24 @@ impl Interpreter {
         if matches!(completion, Completion::Exit(_)) {
             if let Some(iterator) = iterator {
                 self.unroot_for_of_iterator(&iterator);
+                if let Some(generator_id) = generator_id {
+                    self.remove_generator_inline_iterator(generator_id, &iterator);
+                }
             }
             return completion;
         }
         if let Some(iterator) = iterator {
             let close_result = self.iterator_close_result(&iterator);
             self.unroot_for_of_iterator(&iterator);
+            if let Some(generator_id) = generator_id {
+                self.remove_generator_inline_iterator(generator_id, &iterator);
+            }
             if let Some(code) = self.pending_exit {
                 return Completion::Exit(code);
             }
-            if !completion.is_abrupt()
+            // IteratorClose preserves an existing throw completion, but a
+            // close failure replaces normal, break, continue, or return.
+            if !matches!(completion, Completion::Throw(_))
                 && let Err(error) = close_result
             {
                 completion = Completion::Throw(error);
@@ -9434,7 +9463,7 @@ impl Interpreter {
         mut completion: Completion,
     ) -> Completion {
         for loop_state in for_of_stack.drain(from..).rev() {
-            completion = self.close_async_for_of_loop(loop_state, func_env, completion);
+            completion = self.close_for_of_loop(loop_state, func_env, completion, None);
             if matches!(completion, Completion::Exit(_)) {
                 break;
             }

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -9091,28 +9091,7 @@ impl Interpreter {
                 } => {
                     // §14.7.5.12 ForIn/OfHeadEvaluation: create TDZ bindings
                     // before evaluating the iterable expression
-                    let iterable_env = if let ForInOfLeft::Variable(decl) = left
-                        && !matches!(decl.kind, VarKind::Var)
-                    {
-                        let head_env = Environment::new(Some(term_env.clone()));
-                        let mut tdz_names = Vec::new();
-                        if let Some(d) = decl.declarations.first() {
-                            d.pattern.bound_names(&mut tdz_names);
-                        }
-                        let binding_kind = match decl.kind {
-                            VarKind::Let => BindingKind::Let,
-                            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => {
-                                BindingKind::Const
-                            }
-                            VarKind::Var => unreachable!(),
-                        };
-                        for name in &tdz_names {
-                            head_env.borrow_mut().declare(name, binding_kind);
-                        }
-                        head_env
-                    } else {
-                        term_env.clone()
-                    };
+                    let iterable_env = Self::for_of_head_tdz_env(left, &term_env);
 
                     let iterable_result = self.eval_expr(iterable, &iterable_env);
 
@@ -9365,6 +9344,29 @@ impl Interpreter {
                 }
             }
         }
+    }
+
+    /// §14.7.5.12 ForIn/OfHeadEvaluation steps 1-2: the lexical head's names
+    /// are in TDZ while the iterable expression is evaluated, in a temporary
+    /// environment that no loop iteration ever uses.
+    fn for_of_head_tdz_env(left: &ForInOfLeft, env: &EnvRef) -> EnvRef {
+        let ForInOfLeft::Variable(decl) = left else {
+            return env.clone();
+        };
+        let binding_kind = match decl.kind {
+            VarKind::Var => return env.clone(),
+            VarKind::Let => BindingKind::Let,
+            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => BindingKind::Const,
+        };
+        let head_env = Environment::new(Some(env.clone()));
+        let mut tdz_names = Vec::new();
+        if let Some(d) = decl.declarations.first() {
+            d.pattern.bound_names(&mut tdz_names);
+        }
+        for name in &tdz_names {
+            head_env.borrow_mut().declare(name, binding_kind);
+        }
+        head_env
     }
 
     fn unroot_async_for_of_iterator(&mut self, iterator: &JsValue) {

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -8652,7 +8652,7 @@ impl Interpreter {
                     let loop_state = for_of_stack.remove(pos);
                     let iterator = func_env.borrow().get(&loop_state.iter_var);
                     if let Some(iterator) = iterator {
-                        self.unroot_async_for_of_iterator(&iterator);
+                        self.unroot_for_of_iterator(&iterator);
                     }
                 }
 
@@ -8763,11 +8763,11 @@ impl Interpreter {
             }
 
             self.in_state_machine = true;
-            let exec_env = for_of_stack
+            let term_env = for_of_stack
                 .last()
                 .map_or(&func_env, ForOfLoopState::effective_env)
                 .clone();
-            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &exec_env);
+            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &term_env);
             self.in_state_machine = saved_in_state_machine;
             // `__host_exit` in the async body (issue #242) propagates out as
             // `Completion::Exit` instead of settling the result promise; the
@@ -8852,7 +8852,6 @@ impl Interpreter {
                 return Completion::Normal(JsValue::UNDEFINED);
             }
 
-            let term_env = exec_env;
             match terminator {
                 StateTerminator::Await {
                     value,
@@ -9263,7 +9262,7 @@ impl Interpreter {
                             .borrow()
                             .get(iter_var)
                             .unwrap_or(JsValue::UNDEFINED);
-                        self.unroot_async_for_of_iterator(&iterator);
+                        self.unroot_for_of_iterator(&iterator);
                         for_of_stack.remove(loop_pos);
                         current_id = after_state;
                     } else {
@@ -9275,7 +9274,7 @@ impl Interpreter {
                                 continue;
                             }
                         };
-                        let needs_iter_env = matches!(left, ForInOfLeft::Variable(decl) if !matches!(decl.kind, VarKind::Var));
+                        let needs_iter_env = Self::for_of_head_lexical(left).is_some();
                         let outer_env = for_of_stack[loop_pos].outer_env.clone();
                         let bind_env = if needs_iter_env {
                             let ie = Environment::new(Some(outer_env));
@@ -9289,11 +9288,9 @@ impl Interpreter {
                                 let is_using =
                                     matches!(decl.kind, VarKind::Using | VarKind::AwaitUsing);
                                 if is_using {
-                                    let hint = if decl.kind == VarKind::AwaitUsing {
-                                        crate::interpreter::types::DisposeHint::Async
-                                    } else {
-                                        crate::interpreter::types::DisposeHint::Sync
-                                    };
+                                    let hint = crate::interpreter::types::DisposeHint::for_var_kind(
+                                        decl.kind,
+                                    );
                                     if let Err(e) =
                                         self.add_disposable_resource(&bind_env, &value, hint)
                                     {
@@ -9346,17 +9343,30 @@ impl Interpreter {
         }
     }
 
+    /// The declaration and `BindingKind` of a lexical for-in/of head, or
+    /// `None` when the head is not lexical (`var`, or an assignment pattern).
+    /// A lexical head is exactly the case that needs a TDZ head environment
+    /// and a fresh per-iteration environment.
+    pub(crate) fn for_of_head_lexical(
+        left: &ForInOfLeft,
+    ) -> Option<(&VariableDeclaration, BindingKind)> {
+        let ForInOfLeft::Variable(decl) = left else {
+            return None;
+        };
+        let kind = match decl.kind {
+            VarKind::Var => return None,
+            VarKind::Let => BindingKind::Let,
+            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => BindingKind::Const,
+        };
+        Some((decl, kind))
+    }
+
     /// §14.7.5.12 ForIn/OfHeadEvaluation steps 1-2: the lexical head's names
     /// are in TDZ while the iterable expression is evaluated, in a temporary
     /// environment that no loop iteration ever uses.
     fn for_of_head_tdz_env(left: &ForInOfLeft, env: &EnvRef) -> EnvRef {
-        let ForInOfLeft::Variable(decl) = left else {
+        let Some((decl, binding_kind)) = Self::for_of_head_lexical(left) else {
             return env.clone();
-        };
-        let binding_kind = match decl.kind {
-            VarKind::Var => return env.clone(),
-            VarKind::Let => BindingKind::Let,
-            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => BindingKind::Const,
         };
         let head_env = Environment::new(Some(env.clone()));
         let mut tdz_names = Vec::new();
@@ -9369,7 +9379,7 @@ impl Interpreter {
         head_env
     }
 
-    fn unroot_async_for_of_iterator(&mut self, iterator: &JsValue) {
+    fn unroot_for_of_iterator(&mut self, iterator: &JsValue) {
         self.gc_unroot_value(iterator);
         if let Some(iterator_id) = iterator.as_object_id() {
             self.pending_iter_close
@@ -9393,13 +9403,13 @@ impl Interpreter {
         let iterator = func_env.borrow().get(&loop_state.iter_var);
         if matches!(completion, Completion::Exit(_)) {
             if let Some(iterator) = iterator {
-                self.unroot_async_for_of_iterator(&iterator);
+                self.unroot_for_of_iterator(&iterator);
             }
             return completion;
         }
         if let Some(iterator) = iterator {
             let close_result = self.iterator_close_result(&iterator);
-            self.unroot_async_for_of_iterator(&iterator);
+            self.unroot_for_of_iterator(&iterator);
             if let Some(code) = self.pending_exit {
                 return Completion::Exit(code);
             }

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -472,7 +472,7 @@ impl Interpreter {
         this: &JsValue,
         sent_value: JsValue,
     ) -> Completion {
-        use crate::interpreter::generator_transform::StateTerminator;
+        use crate::interpreter::generator_transform::{LoopControlTarget, StateTerminator};
 
         let Some(o) = (this)
             .as_object_id()
@@ -841,7 +841,7 @@ impl Interpreter {
                     {
                         pending_return = ret_val_opt.take();
                         let finally_state = current_try_stack[i].finally_state.unwrap();
-                        current_try_stack = current_try_stack[..i].to_vec();
+                        current_try_stack = current_try_stack[..=i].to_vec();
                         current_id = finally_state;
                         break;
                     }
@@ -1288,7 +1288,7 @@ impl Interpreter {
                         {
                             pending_return = ret_val_opt.take();
                             let finally_state = current_try_stack[i].finally_state.unwrap();
-                            current_try_stack = current_try_stack[..i].to_vec();
+                            current_try_stack = current_try_stack[..=i].to_vec();
                             current_id = finally_state;
                             break;
                         }
@@ -1380,31 +1380,72 @@ impl Interpreter {
                     return Completion::Throw(throw_val);
                 }
 
-                StateTerminator::Goto(next_state) => {
-                    if let Err(e) = self.align_generator_for_of_stack(
+                // Async-function transforms are currently the only machines
+                // that emit LoopControl. If a shared transform emits one for a
+                // generator, abrupt loop cleanup is identical to Goto.
+                StateTerminator::Goto(next_state)
+                | StateTerminator::LoopControl(LoopControlTarget {
+                    target_state: next_state,
+                    ..
+                }) => {
+                    if let Err(completion) = self.align_generator_for_of_stack(
                         o.id,
                         &mut for_of_stack,
+                        &mut current_try_stack,
                         &func_env,
                         *next_state,
                     ) {
-                        return Completion::Throw(e);
+                        match completion {
+                            Completion::Throw(error) => {
+                                // The driver marked the generator Executing at
+                                // entry. Restore a resumable snapshot before
+                                // handing the close failure to the ordinary
+                                // throw-resume path, which owns catch/finally
+                                // routing and terminal state transitions.
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state:
+                                                StateMachineExecutionState::SuspendedAtState {
+                                                    state_id: current_id,
+                                                },
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: current_try_stack,
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return self.generator_throw_state_machine(this, error);
+                            }
+                            Completion::Exit(code) => {
+                                self.generator_inline_iters.remove(&o.id);
+                                self.generator_for_of_stacks.remove(&o.id);
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state: StateMachineExecutionState::Completed,
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: vec![],
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return Completion::Exit(code);
+                            }
+                            _ => unreachable!("for-of unwind returned a non-abrupt completion"),
+                        }
                     }
                     current_id = *next_state;
-                }
-
-                // Async-function transforms are the only machines that emit
-                // LoopControl. Preserve ordinary generator behavior if a
-                // shared transform ever produces one here.
-                StateTerminator::LoopControl(target) => {
-                    if let Err(e) = self.align_generator_for_of_stack(
-                        o.id,
-                        &mut for_of_stack,
-                        &func_env,
-                        target.target_state,
-                    ) {
-                        return Completion::Throw(e);
-                    }
-                    current_id = target.target_state;
                 }
 
                 StateTerminator::ConditionalGoto {
@@ -1489,39 +1530,29 @@ impl Interpreter {
                         return Completion::Throw(exc);
                     }
                     if let Some(ret_val) = pending_return.take() {
-                        // Check for more enclosing try-finally blocks
-                        let mut ret_val_opt = Some(ret_val);
-                        for i in (0..current_try_stack.len()).rev() {
-                            if !current_try_stack[i].entered_finally
-                                && current_try_stack[i].finally_state.is_some()
-                            {
-                                pending_return = ret_val_opt.take();
-                                let finally_state = current_try_stack[i].finally_state.unwrap();
-                                current_try_stack = current_try_stack[..i].to_vec();
-                                current_id = finally_state;
-                                break;
-                            }
-                        }
-                        if ret_val_opt.is_none() {
-                            continue;
-                        }
-                        let ret_val = ret_val_opt.unwrap();
-                        // No more finally blocks — complete the generator
+                        // Re-enter the abrupt-return driver after each finally.
+                        // It uses loop `try_depth` boundaries to decide which
+                        // iteration environments close before the next outer
+                        // finally, and which remain until an inner finally has
+                        // finished.
+                        self.sync_generator_for_of_stack(o.id, &for_of_stack);
                         obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                             IteratorState::StateMachineGenerator {
                                 state_machine,
                                 func_env,
                                 is_strict,
-                                execution_state: StateMachineExecutionState::Completed,
+                                execution_state: StateMachineExecutionState::SuspendedAtState {
+                                    state_id: *after_state,
+                                },
                                 _sent_value: JsValue::UNDEFINED,
-                                try_stack: vec![],
+                                try_stack: current_try_stack,
                                 pending_binding: None,
                                 delegated_iterator: None,
                                 pending_exception: None,
                                 pending_return: None,
                             },
                         );
-                        return Completion::Normal(self.create_iter_result_object(ret_val, true));
+                        return self.generator_return_state_machine(this, ret_val);
                     }
                     current_id = *after_state;
                 }
@@ -2116,12 +2147,12 @@ impl Interpreter {
             func_env,
             is_strict,
             execution_state,
-            try_stack,
+            mut try_stack,
             delegated_iterator,
             ..
         }) = state
         {
-            match execution_state {
+            let suspended_state_id = match execution_state {
                 StateMachineExecutionState::Executing => {
                     return Completion::Throw(
                         self.create_type_error("Generator is already running"),
@@ -2147,8 +2178,8 @@ impl Interpreter {
                     );
                     return Completion::Normal(self.create_iter_result_object(value, true));
                 }
-                StateMachineExecutionState::SuspendedAtState { .. } => {}
-            }
+                StateMachineExecutionState::SuspendedAtState { state_id } => state_id,
+            };
 
             if let Some(ref deleg_info) = delegated_iterator {
                 let iterator = deleg_info.iterator.clone();
@@ -2304,19 +2335,95 @@ impl Interpreter {
                 }
             }
 
-            // Walk the try_stack to find a try with a finally block
-            let mut finally_idx = None;
-            for i in (0..try_stack.len()).rev() {
-                if !try_stack[i].entered_finally && try_stack[i].finally_state.is_some() {
-                    finally_idx = Some(i);
-                    break;
+            obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                IteratorState::StateMachineGenerator {
+                    state_machine: state_machine.clone(),
+                    func_env: func_env.clone(),
+                    is_strict,
+                    execution_state: StateMachineExecutionState::Executing,
+                    _sent_value: JsValue::UNDEFINED,
+                    try_stack: try_stack.clone(),
+                    pending_binding: None,
+                    delegated_iterator: None,
+                    pending_exception: None,
+                    pending_return: None,
+                },
+            );
+
+            // A return injected at a suspended yield is the loop body's abrupt
+            // completion. Finalizers lexically inside the loop run before its
+            // iteration environment is disposed; finalizers surrounding the
+            // loop run after disposal and IteratorClose.
+            let finally_idx = (0..try_stack.len())
+                .rev()
+                .find(|&i| !try_stack[i].entered_finally && try_stack[i].finally_state.is_some());
+            let mut for_of_stack = self
+                .generator_for_of_stacks
+                .get(&o.id)
+                .cloned()
+                .unwrap_or_default();
+            let unwind_from = finally_idx.map_or(0, |handler_depth| {
+                for_of_stack
+                    .iter()
+                    .position(|loop_state| loop_state.try_depth > handler_depth)
+                    .unwrap_or(for_of_stack.len())
+            });
+            let return_completion = self.unwind_generator_for_of_loops(
+                o.id,
+                &mut for_of_stack,
+                &mut try_stack,
+                &func_env,
+                unwind_from,
+                Completion::Return(value.clone()),
+            );
+            let return_value = match return_completion {
+                Completion::Return(return_value) => return_value,
+                Completion::Throw(error) => {
+                    obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                        IteratorState::StateMachineGenerator {
+                            state_machine,
+                            func_env,
+                            is_strict,
+                            execution_state: StateMachineExecutionState::SuspendedAtState {
+                                state_id: suspended_state_id,
+                            },
+                            _sent_value: JsValue::UNDEFINED,
+                            try_stack,
+                            pending_binding: None,
+                            delegated_iterator: None,
+                            pending_exception: None,
+                            pending_return: None,
+                        },
+                    );
+                    return self.generator_throw_state_machine(this, error);
                 }
-            }
+                Completion::Exit(code) => {
+                    self.generator_inline_iters.remove(&o.id);
+                    self.generator_for_of_stacks.remove(&o.id);
+                    obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                        IteratorState::StateMachineGenerator {
+                            state_machine,
+                            func_env,
+                            is_strict,
+                            execution_state: StateMachineExecutionState::Completed,
+                            _sent_value: JsValue::UNDEFINED,
+                            try_stack: vec![],
+                            pending_binding: None,
+                            delegated_iterator: None,
+                            pending_exception: None,
+                            pending_return: None,
+                        },
+                    );
+                    return Completion::Exit(code);
+                }
+                _ => value.clone(),
+            };
 
             if let Some(idx) = finally_idx {
                 let finally_state = try_stack[idx].finally_state.unwrap();
-                // Keep try_stack entries below the one we're entering finally for
-                let remaining_stack = try_stack[..idx].to_vec();
+                // Keep the selected entry until TryExit so EnterFinally marks
+                // and pops that context, not the surrounding one.
+                let remaining_stack = try_stack[..=idx].to_vec();
                 obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                     IteratorState::StateMachineGenerator {
                         state_machine,
@@ -2330,7 +2437,7 @@ impl Interpreter {
                         pending_binding: None,
                         delegated_iterator: None,
                         pending_exception: None,
-                        pending_return: Some(value.clone()),
+                        pending_return: Some(return_value.clone()),
                     },
                 );
                 return self.generator_next_state_machine(this, JsValue::UNDEFINED);
@@ -3537,7 +3644,7 @@ impl Interpreter {
         resolve_fn: JsValue,
         reject_fn: JsValue,
     ) -> Completion {
-        use crate::interpreter::generator_transform::StateTerminator;
+        use crate::interpreter::generator_transform::{LoopControlTarget, StateTerminator};
 
         let Some(o) = (this)
             .as_object_id()
@@ -5496,35 +5603,49 @@ impl Interpreter {
                     return Completion::Normal(promise);
                 }
 
-                StateTerminator::Goto(next_state) => {
-                    if let Err(e) = self.align_generator_for_of_stack(
+                // Async-function transforms are currently the only machines
+                // that emit LoopControl. If a shared transform emits one for
+                // an async generator, cleanup is identical to Goto.
+                StateTerminator::Goto(next_state)
+                | StateTerminator::LoopControl(LoopControlTarget {
+                    target_state: next_state,
+                    ..
+                }) => {
+                    if let Err(completion) = self.align_generator_for_of_stack(
                         o.id,
                         &mut for_of_stack,
+                        &mut current_try_stack,
                         &func_env,
                         *next_state,
                     ) {
-                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
-                        self.drain_microtasks();
-                        return Completion::Normal(promise);
+                        self.generator_inline_iters.remove(&o.id);
+                        self.generator_for_of_stacks.remove(&o.id);
+                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                            IteratorState::StateMachineAsyncGenerator {
+                                state_machine,
+                                func_env,
+                                is_strict,
+                                execution_state: StateMachineExecutionState::Completed,
+                                _sent_value: JsValue::UNDEFINED,
+                                try_stack: vec![],
+                                pending_binding: None,
+                                delegated_iterator: None,
+                                pending_exception: None,
+                                pending_return: None,
+                            },
+                        );
+                        return match completion {
+                            Completion::Throw(error) => {
+                                let _ =
+                                    self.call_function(&reject_fn, &JsValue::UNDEFINED, &[error]);
+                                self.drain_microtasks();
+                                Completion::Normal(promise)
+                            }
+                            Completion::Exit(code) => Completion::Exit(code),
+                            _ => unreachable!("for-of unwind returned a non-abrupt completion"),
+                        };
                     }
                     current_id = *next_state;
-                }
-
-                // Async-function transforms are the only machines that emit
-                // LoopControl. Preserve ordinary async-generator behavior if
-                // a shared transform ever produces one here.
-                StateTerminator::LoopControl(target) => {
-                    if let Err(e) = self.align_generator_for_of_stack(
-                        o.id,
-                        &mut for_of_stack,
-                        &func_env,
-                        target.target_state,
-                    ) {
-                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
-                        self.drain_microtasks();
-                        return Completion::Normal(promise);
-                    }
-                    current_id = target.target_state;
                 }
 
                 StateTerminator::ConditionalGoto {
@@ -7172,9 +7293,10 @@ impl Interpreter {
         &mut self,
         generator_id: u64,
         for_of_stack: &mut Vec<ForOfLoopState>,
+        try_stack: &mut Vec<TryContextInfo>,
         func_env: &EnvRef,
         target_state: usize,
-    ) -> Result<(), JsValue> {
+    ) -> Result<(), Completion> {
         // Jumping to a loop's `after_state` leaves that loop, so it closes;
         // jumping to its `head_state` is the next iteration, so it stays.
         let keep_len = if let Some(pos) = for_of_stack
@@ -7191,32 +7313,43 @@ impl Interpreter {
             for_of_stack.len()
         };
 
+        match self.unwind_generator_for_of_loops(
+            generator_id,
+            for_of_stack,
+            try_stack,
+            func_env,
+            keep_len,
+            Completion::Empty,
+        ) {
+            completion @ (Completion::Throw(_) | Completion::Exit(_)) => Err(completion),
+            _ => Ok(()),
+        }
+    }
+
+    /// Close transformed generator for-of loops from the inside out while
+    /// carrying the current completion through per-iteration disposal and
+    /// IteratorClose. Handlers lexically inside a loop have finished before
+    /// that loop closes, so discard them at the loop's recorded boundary.
+    fn unwind_generator_for_of_loops(
+        &mut self,
+        generator_id: u64,
+        for_of_stack: &mut Vec<ForOfLoopState>,
+        try_stack: &mut Vec<TryContextInfo>,
+        func_env: &EnvRef,
+        keep_len: usize,
+        mut completion: Completion,
+    ) -> Completion {
         while for_of_stack.len() > keep_len {
             let loop_state = for_of_stack.pop().expect("loop stack is non-empty");
-            let mut error = None;
-            if let Some(env) = loop_state.iteration_env
-                && let Completion::Throw(e) = self.dispose_resources(&env, Completion::Empty)
-            {
-                error = Some(e);
-            }
-            // The borrow must end before `iterator_close_result` runs the
-            // user's `return` method, which may write bindings in this same
-            // environment.
-            let iterator = func_env.borrow().get(&loop_state.iter_var);
-            if let Some(iterator) = iterator {
-                let close_result = self.iterator_close_result(&iterator);
-                self.unroot_for_of_iterator(&iterator);
-                // A disposer error takes precedence over a close error.
-                error = error.or(close_result.err());
-            }
-            if let Some(e) = error {
-                self.sync_generator_for_of_stack(generator_id, for_of_stack);
-                return Err(e);
+            try_stack.truncate(loop_state.try_depth);
+            completion =
+                self.close_for_of_loop(loop_state, func_env, completion, Some(generator_id));
+            if matches!(completion, Completion::Exit(_)) {
+                break;
             }
         }
-
         self.sync_generator_for_of_stack(generator_id, for_of_stack);
-        Ok(())
+        completion
     }
 
     /// Mirrors the driver's local loop stack into the GC-visible map, so a

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -752,8 +752,7 @@ impl Interpreter {
                 } else {
                     self.generator_inline_iters.insert(o.id, pending);
                 }
-                self.generator_for_of_stacks
-                    .insert(o.id, for_of_stack.clone());
+                self.sync_generator_for_of_stack(o.id, &for_of_stack);
                 obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                     IteratorState::StateMachineGenerator {
                         state_machine: state_machine.clone(),
@@ -1227,8 +1226,7 @@ impl Interpreter {
                     } else {
                         self.generator_inline_iters.insert(o.id, pending);
                     }
-                    self.generator_for_of_stacks
-                        .insert(o.id, for_of_stack.clone());
+                    self.sync_generator_for_of_stack(o.id, &for_of_stack);
                     obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                         IteratorState::StateMachineGenerator {
                             state_machine,
@@ -1624,28 +1622,7 @@ impl Interpreter {
                     // §14.7.5.5: lexical head names are in TDZ while the RHS
                     // is evaluated, but that temporary environment is not the
                     // environment used by any loop iteration.
-                    let iterable_env = if let ForInOfLeft::Variable(decl) = left
-                        && !matches!(decl.kind, VarKind::Var)
-                    {
-                        let head_env = Environment::new(Some(term_env.clone()));
-                        let mut tdz_names = Vec::new();
-                        if let Some(d) = decl.declarations.first() {
-                            d.pattern.bound_names(&mut tdz_names);
-                        }
-                        let binding_kind = match decl.kind {
-                            VarKind::Let => BindingKind::Let,
-                            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => {
-                                BindingKind::Const
-                            }
-                            VarKind::Var => unreachable!(),
-                        };
-                        for name in &tdz_names {
-                            head_env.borrow_mut().declare(name, binding_kind);
-                        }
-                        head_env
-                    } else {
-                        term_env.clone()
-                    };
+                    let iterable_env = Self::for_of_head_tdz_env(left, &term_env);
 
                     let iterable_val = match self.eval_expr(iterable, &iterable_env) {
                         Completion::Normal(v) => v,
@@ -1728,8 +1705,7 @@ impl Interpreter {
                         outer_env: term_env.clone(),
                         iteration_env: None,
                     });
-                    self.generator_for_of_stacks
-                        .insert(o.id, for_of_stack.clone());
+                    self.sync_generator_for_of_stack(o.id, &for_of_stack);
                     current_id = *head_state;
                 }
 
@@ -1760,19 +1736,54 @@ impl Interpreter {
                         }
                     };
 
-                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take()
-                        && let Completion::Throw(e) =
-                            self.dispose_resources(&iteration_env, Completion::Empty)
-                    {
-                        return Completion::Throw(e);
-                    }
-
                     let iterator = func_env
                         .borrow()
                         .bindings
                         .get(iter_var)
                         .map(|b| b.value.clone())
                         .unwrap_or(JsValue::UNDEFINED);
+
+                    // §14.7.5.6 step 7.h: a throwing disposer ends the loop
+                    // with a throw completion, so the iterator still closes
+                    // and the generator's own handlers still see the error.
+                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take()
+                        && let Completion::Throw(e) =
+                            self.dispose_resources(&iteration_env, Completion::Empty)
+                    {
+                        self.iterator_close(&iterator, e.clone());
+                        self.gc_unroot_value(&iterator);
+                        for_of_stack.remove(loop_pos);
+                        self.sync_generator_for_of_stack(o.id, &for_of_stack);
+                        if let Some(try_info) = current_try_stack.pop() {
+                            if let Some(catch_state) = try_info.catch_state {
+                                pending_exception = Some(e);
+                                current_id = catch_state;
+                                continue;
+                            } else if let Some(finally_state) = try_info.finally_state {
+                                // TryExit re-throws whatever `pending_exception`
+                                // still holds once the finally body completes.
+                                pending_exception = Some(e);
+                                current_id = finally_state;
+                                continue;
+                            }
+                        }
+                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                            IteratorState::StateMachineGenerator {
+                                state_machine,
+                                func_env,
+                                is_strict,
+                                execution_state: StateMachineExecutionState::Completed,
+                                _sent_value: JsValue::UNDEFINED,
+                                try_stack: vec![],
+                                pending_binding: None,
+                                delegated_iterator: None,
+                                pending_exception: None,
+                                pending_return: None,
+                            },
+                        );
+                        return Completion::Throw(e);
+                    }
+
                     let step_result = match self.iterator_next(&iterator) {
                         Ok(v) => v,
                         Err(e) => {
@@ -1824,12 +1835,7 @@ impl Interpreter {
                                 });
                             }
                             for_of_stack.remove(loop_pos);
-                            if for_of_stack.is_empty() {
-                                self.generator_for_of_stacks.remove(&o.id);
-                            } else {
-                                self.generator_for_of_stacks
-                                    .insert(o.id, for_of_stack.clone());
-                            }
+                            self.sync_generator_for_of_stack(o.id, &for_of_stack);
                             current_id = *after_state;
                         }
                         Ok(false) => {
@@ -1875,8 +1881,7 @@ impl Interpreter {
                             let bind_env = if needs_iteration_env {
                                 let iteration_env = Environment::new(Some(outer_env));
                                 for_of_stack[loop_pos].iteration_env = Some(iteration_env.clone());
-                                self.generator_for_of_stacks
-                                    .insert(o.id, for_of_stack.clone());
+                                self.sync_generator_for_of_stack(o.id, &for_of_stack);
                                 iteration_env
                             } else {
                                 outer_env
@@ -4679,8 +4684,7 @@ impl Interpreter {
                 } else {
                     self.generator_inline_iters.insert(o.id, pending);
                 }
-                self.generator_for_of_stacks
-                    .insert(o.id, for_of_stack.clone());
+                self.sync_generator_for_of_stack(o.id, &for_of_stack);
                 // Any Completion::Yield from exec_statements is an inline yield:
                 // it came from a loop body or complex control flow that isn't
                 // decomposed by the state machine transformer. Use InlineYield
@@ -5768,28 +5772,7 @@ impl Interpreter {
                     after_state: forinit_after,
                     is_await,
                 } => {
-                    let iterable_env = if let ForInOfLeft::Variable(decl) = left
-                        && !matches!(decl.kind, VarKind::Var)
-                    {
-                        let head_env = Environment::new(Some(term_env.clone()));
-                        let mut tdz_names = Vec::new();
-                        if let Some(d) = decl.declarations.first() {
-                            d.pattern.bound_names(&mut tdz_names);
-                        }
-                        let binding_kind = match decl.kind {
-                            VarKind::Let => BindingKind::Let,
-                            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => {
-                                BindingKind::Const
-                            }
-                            VarKind::Var => unreachable!(),
-                        };
-                        for name in &tdz_names {
-                            head_env.borrow_mut().declare(name, binding_kind);
-                        }
-                        head_env
-                    } else {
-                        term_env.clone()
-                    };
+                    let iterable_env = Self::for_of_head_tdz_env(left, &term_env);
 
                     let iterable_val = match self.eval_expr(iterable, &iterable_env) {
                         Completion::Normal(v) => v,
@@ -5921,8 +5904,7 @@ impl Interpreter {
                         outer_env: term_env.clone(),
                         iteration_env: None,
                     });
-                    self.generator_for_of_stacks
-                        .insert(o.id, for_of_stack.clone());
+                    self.sync_generator_for_of_stack(o.id, &for_of_stack);
                     current_id = *head_state;
                 }
 
@@ -5953,21 +5935,57 @@ impl Interpreter {
                         }
                     };
 
-                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take()
-                        && let Completion::Throw(e) =
-                            self.dispose_resources(&iteration_env, Completion::Empty)
-                    {
-                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
-                        self.drain_microtasks();
-                        return Completion::Normal(promise);
-                    }
-
                     let iterator = func_env
                         .borrow()
                         .bindings
                         .get(iter_var)
                         .map(|b| b.value.clone())
                         .unwrap_or(JsValue::UNDEFINED);
+
+                    // §14.7.5.6 step 7.h: a throwing disposer ends the loop
+                    // with a throw completion, so the iterator still closes
+                    // and the generator's own handlers still see the error.
+                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take()
+                        && let Completion::Throw(e) =
+                            self.dispose_resources(&iteration_env, Completion::Empty)
+                    {
+                        self.iterator_close(&iterator, e.clone());
+                        self.gc_unroot_value(&iterator);
+                        for_of_stack.remove(loop_pos);
+                        self.sync_generator_for_of_stack(o.id, &for_of_stack);
+                        if let Some(try_info) = current_try_stack.pop() {
+                            if let Some(catch_state) = try_info.catch_state {
+                                pending_exception = Some(e);
+                                current_id = catch_state;
+                                continue;
+                            } else if let Some(finally_state) = try_info.finally_state {
+                                // TryExit re-throws whatever `pending_exception`
+                                // still holds once the finally body completes.
+                                pending_exception = Some(e);
+                                current_id = finally_state;
+                                continue;
+                            }
+                        }
+                        self.generator_inline_iters.remove(&o.id);
+                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                            IteratorState::StateMachineAsyncGenerator {
+                                state_machine,
+                                func_env,
+                                is_strict,
+                                execution_state: StateMachineExecutionState::Completed,
+                                _sent_value: JsValue::UNDEFINED,
+                                try_stack: vec![],
+                                pending_binding: None,
+                                delegated_iterator: None,
+                                pending_exception: None,
+                                pending_return: None,
+                            },
+                        );
+                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
+                        self.drain_microtasks();
+                        return Completion::Normal(promise);
+                    }
+
                     let step_result = match self.iterator_next(&iterator) {
                         Ok(v) => v,
                         Err(e) => {
@@ -6068,12 +6086,7 @@ impl Interpreter {
                                 });
                             }
                             for_of_stack.remove(loop_pos);
-                            if for_of_stack.is_empty() {
-                                self.generator_for_of_stacks.remove(&o.id);
-                            } else {
-                                self.generator_for_of_stacks
-                                    .insert(o.id, for_of_stack.clone());
-                            }
+                            self.sync_generator_for_of_stack(o.id, &for_of_stack);
                             current_id = *after_state;
                         }
                         Ok(false) => {
@@ -6123,8 +6136,7 @@ impl Interpreter {
                             let bind_env = if needs_iteration_env {
                                 let iteration_env = Environment::new(Some(outer_env));
                                 for_of_stack[loop_pos].iteration_env = Some(iteration_env.clone());
-                                self.generator_for_of_stacks
-                                    .insert(o.id, for_of_stack.clone());
+                                self.sync_generator_for_of_stack(o.id, &for_of_stack);
                                 iteration_env
                             } else {
                                 outer_env
@@ -7197,28 +7209,45 @@ impl Interpreter {
 
         while for_of_stack.len() > keep_len {
             let loop_state = for_of_stack.pop().expect("loop stack is non-empty");
-            if let Some(iteration_env) = loop_state.iteration_env
-                && let Completion::Throw(e) =
-                    self.dispose_resources(&iteration_env, Completion::Empty)
-            {
-                return Err(e);
-            }
-            if let Some(iterator) = func_env.borrow().get(&loop_state.iter_var) {
-                self.iterator_close_result(&iterator)?;
-                self.gc_unroot_value(&iterator);
-                if let Some(iterator_id) = iterator.as_object_id() {
-                    self.pending_iter_close
-                        .retain(|value| value.as_object_id() != Some(iterator_id));
+            let mut error = match loop_state.iteration_env {
+                Some(env) => match self.dispose_resources(&env, Completion::Empty) {
+                    Completion::Throw(e) => Some(e),
+                    _ => None,
+                },
+                None => None,
+            };
+            // The borrow must end before `iterator_close_result` runs the
+            // user's `return` method, which may write bindings in this same
+            // environment.
+            let iterator = func_env.borrow().get(&loop_state.iter_var);
+            if let Some(iterator) = iterator {
+                let close_result = self.iterator_close_result(&iterator);
+                self.unroot_async_for_of_iterator(&iterator);
+                if error.is_none()
+                    && let Err(e) = close_result
+                {
+                    error = Some(e);
                 }
+            }
+            if let Some(e) = error {
+                self.sync_generator_for_of_stack(generator_id, for_of_stack);
+                return Err(e);
             }
         }
 
+        self.sync_generator_for_of_stack(generator_id, for_of_stack);
+        Ok(())
+    }
+
+    /// Mirrors the driver's local loop stack into the GC-visible map, so a
+    /// collection triggered by user code sees exactly the environments the
+    /// driver still holds.
+    fn sync_generator_for_of_stack(&mut self, generator_id: u64, for_of_stack: &[ForOfLoopState]) {
         if for_of_stack.is_empty() {
             self.generator_for_of_stacks.remove(&generator_id);
         } else {
             self.generator_for_of_stacks
-                .insert(generator_id, for_of_stack.clone());
+                .insert(generator_id, for_of_stack.to_vec());
         }
-        Ok(())
     }
 }

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -726,11 +726,11 @@ impl Interpreter {
             }
 
             self.in_state_machine = true;
-            let exec_env = for_of_stack
+            let term_env = for_of_stack
                 .last()
                 .map_or(&func_env, ForOfLoopState::effective_env)
                 .clone();
-            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &exec_env);
+            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &term_env);
             self.in_state_machine = saved_in_state_machine;
             while let Completion::TailCall { func, this, args } = stmt_result {
                 stmt_result = self.call_function(&func, &this, &args);
@@ -892,7 +892,6 @@ impl Interpreter {
                 return Completion::Normal(self.create_iter_result_object(ret_val, true));
             }
 
-            let term_env = exec_env;
             match &terminator {
                 StateTerminator::Yield {
                     value,
@@ -1872,11 +1871,7 @@ impl Interpreter {
                                     return Completion::Throw(e);
                                 }
                             };
-                            let needs_iteration_env = matches!(
-                                left,
-                                ForInOfLeft::Variable(decl)
-                                    if !matches!(decl.kind, VarKind::Var)
-                            );
+                            let needs_iteration_env = Self::for_of_head_lexical(left).is_some();
                             let outer_env = for_of_stack[loop_pos].outer_env.clone();
                             let bind_env = if needs_iteration_env {
                                 let iteration_env = Environment::new(Some(outer_env));
@@ -1897,11 +1892,7 @@ impl Interpreter {
                                         }
                                     };
                                     if matches!(decl.kind, VarKind::Using | VarKind::AwaitUsing) {
-                                        let hint = if decl.kind == VarKind::AwaitUsing {
-                                            DisposeHint::Async
-                                        } else {
-                                            DisposeHint::Sync
-                                        };
+                                        let hint = DisposeHint::for_var_kind(decl.kind);
                                         if let Err(e) =
                                             self.add_disposable_resource(&bind_env, &val, hint)
                                         {
@@ -4504,11 +4495,11 @@ impl Interpreter {
             }
 
             self.in_state_machine = true;
-            let exec_env = for_of_stack
+            let term_env = for_of_stack
                 .last()
                 .map_or(&func_env, ForOfLoopState::effective_env)
                 .clone();
-            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &exec_env);
+            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &term_env);
             self.in_state_machine = saved_in_state_machine;
             while let Completion::TailCall { func, this, args } = stmt_result {
                 stmt_result = self.call_function(&func, &this, &args);
@@ -4722,7 +4713,6 @@ impl Interpreter {
                 return Completion::Normal(promise);
             }
 
-            let term_env = exec_env;
             match &terminator {
                 StateTerminator::Yield {
                     value,
@@ -6127,11 +6117,7 @@ impl Interpreter {
                                     return Completion::Normal(promise);
                                 }
                             };
-                            let needs_iteration_env = matches!(
-                                left,
-                                ForInOfLeft::Variable(decl)
-                                    if !matches!(decl.kind, VarKind::Var)
-                            );
+                            let needs_iteration_env = Self::for_of_head_lexical(left).is_some();
                             let outer_env = for_of_stack[loop_pos].outer_env.clone();
                             let bind_env = if needs_iteration_env {
                                 let iteration_env = Environment::new(Some(outer_env));
@@ -6152,11 +6138,7 @@ impl Interpreter {
                                         }
                                     };
                                     if matches!(decl.kind, VarKind::Using | VarKind::AwaitUsing) {
-                                        let hint = if decl.kind == VarKind::AwaitUsing {
-                                            DisposeHint::Async
-                                        } else {
-                                            DisposeHint::Sync
-                                        };
+                                        let hint = DisposeHint::for_var_kind(decl.kind);
                                         if let Err(e) =
                                             self.add_disposable_resource(&bind_env, &val, hint)
                                         {
@@ -7193,6 +7175,8 @@ impl Interpreter {
         func_env: &EnvRef,
         target_state: usize,
     ) -> Result<(), JsValue> {
+        // Jumping to a loop's `after_state` leaves that loop, so it closes;
+        // jumping to its `head_state` is the next iteration, so it stays.
         let keep_len = if let Some(pos) = for_of_stack
             .iter()
             .rposition(|loop_state| loop_state.after_state == target_state)
@@ -7209,25 +7193,21 @@ impl Interpreter {
 
         while for_of_stack.len() > keep_len {
             let loop_state = for_of_stack.pop().expect("loop stack is non-empty");
-            let mut error = match loop_state.iteration_env {
-                Some(env) => match self.dispose_resources(&env, Completion::Empty) {
-                    Completion::Throw(e) => Some(e),
-                    _ => None,
-                },
-                None => None,
-            };
+            let mut error = None;
+            if let Some(env) = loop_state.iteration_env
+                && let Completion::Throw(e) = self.dispose_resources(&env, Completion::Empty)
+            {
+                error = Some(e);
+            }
             // The borrow must end before `iterator_close_result` runs the
             // user's `return` method, which may write bindings in this same
             // environment.
             let iterator = func_env.borrow().get(&loop_state.iter_var);
             if let Some(iterator) = iterator {
                 let close_result = self.iterator_close_result(&iterator);
-                self.unroot_async_for_of_iterator(&iterator);
-                if error.is_none()
-                    && let Err(e) = close_result
-                {
-                    error = Some(e);
-                }
+                self.unroot_for_of_iterator(&iterator);
+                // A disposer error takes precedence over a close error.
+                error = error.or(close_result.err());
             }
             if let Some(e) = error {
                 self.sync_generator_for_of_stack(generator_id, for_of_stack);
@@ -7244,10 +7224,18 @@ impl Interpreter {
     /// driver still holds.
     fn sync_generator_for_of_stack(&mut self, generator_id: u64, for_of_stack: &[ForOfLoopState]) {
         if for_of_stack.is_empty() {
-            self.generator_for_of_stacks.remove(&generator_id);
+            // Generators with no for-of hit this on every state transition;
+            // skip hashing the id when the table holds nothing to remove.
+            if !self.generator_for_of_stacks.is_empty() {
+                self.generator_for_of_stacks.remove(&generator_id);
+            }
         } else {
-            self.generator_for_of_stacks
-                .insert(generator_id, for_of_stack.to_vec());
+            let slot = self
+                .generator_for_of_stacks
+                .entry(generator_id)
+                .or_default();
+            slot.clear();
+            slot.extend_from_slice(for_of_stack);
         }
     }
 }

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -709,6 +709,43 @@ impl Interpreter {
             .cloned()
             .unwrap_or_default();
 
+        macro_rules! route_exception {
+            ($error:expr) => {{
+                match self.route_generator_exception(
+                    o.id,
+                    &mut for_of_stack,
+                    &mut current_try_stack,
+                    &func_env,
+                    &mut pending_exception,
+                    &mut current_id,
+                    $error,
+                ) {
+                    Completion::Empty => continue,
+                    Completion::Throw(error) => error,
+                    Completion::Exit(code) => {
+                        self.generator_inline_iters.remove(&o.id);
+                        self.generator_for_of_stacks.remove(&o.id);
+                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                            IteratorState::StateMachineGenerator {
+                                state_machine,
+                                func_env,
+                                is_strict,
+                                execution_state: StateMachineExecutionState::Completed,
+                                _sent_value: JsValue::UNDEFINED,
+                                try_stack: vec![],
+                                pending_binding: None,
+                                delegated_iterator: None,
+                                pending_exception: None,
+                                pending_return: None,
+                            },
+                        );
+                        return Completion::Exit(code);
+                    }
+                    _ => unreachable!("routing a throw returned a non-abrupt completion"),
+                }
+            }};
+        }
+
         loop {
             let terminator = state_machine.states[current_id].terminator.clone();
 
@@ -803,16 +840,7 @@ impl Interpreter {
                 // Route genuine throws through the generator body's
                 // catch/finally states (a `Completion::Exit` was handled
                 // above and never reaches here).
-                if let Some(try_info) = current_try_stack.pop() {
-                    if let Some(catch_state) = try_info.catch_state {
-                        pending_exception = Some(e);
-                        current_id = catch_state;
-                        continue;
-                    } else if let Some(finally_state) = try_info.finally_state {
-                        current_id = finally_state;
-                        continue;
-                    }
-                }
+                let e = route_exception!(e);
                 // §27.5.3.3: DisposeResources when generator throws
                 let disp = self.dispose_resources(&func_env, Completion::Throw(e));
                 obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
@@ -872,16 +900,7 @@ impl Interpreter {
                                 // catch/finally handling (a `Completion::Exit`
                                 // takes the `other` arm below and never reaches
                                 // here — issue #242).
-                                if let Some(try_info) = current_try_stack.pop() {
-                                    if let Some(catch_state) = try_info.catch_state {
-                                        pending_exception = Some(e);
-                                        current_id = catch_state;
-                                        continue;
-                                    } else if let Some(finally_state) = try_info.finally_state {
-                                        current_id = finally_state;
-                                        continue;
-                                    }
-                                }
+                                let e = route_exception!(e);
                                 obj_rc.borrow_mut().kind =
                                     crate::interpreter::types::ObjectKind::Iterator(
                                         IteratorState::StateMachineGenerator {
@@ -1278,13 +1297,9 @@ impl Interpreter {
                         }
                     };
 
-                    if let Some(try_info) = current_try_stack.pop()
-                        && let Some(catch_state) = try_info.catch_state
-                    {
-                        current_id = catch_state;
-                        continue;
-                    }
+                    let throw_val = route_exception!(throw_val);
 
+                    let disp = self.dispose_resources(&func_env, Completion::Throw(throw_val));
                     obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                         IteratorState::StateMachineGenerator {
                             state_machine,
@@ -1300,7 +1315,7 @@ impl Interpreter {
                         },
                     );
                     self.generator_inline_iters.remove(&o.id);
-                    return Completion::Throw(throw_val);
+                    return disp;
                 }
 
                 // Async-function transforms are currently the only machines
@@ -1425,17 +1440,7 @@ impl Interpreter {
                     current_try_stack.pop();
                     if let Some(exc) = pending_exception.take() {
                         // Re-throw pending exception after finally completes
-                        if let Some(try_info) = current_try_stack.pop() {
-                            if let Some(catch_state) = try_info.catch_state {
-                                pending_exception = Some(exc);
-                                current_id = catch_state;
-                                continue;
-                            } else if let Some(finally_state) = try_info.finally_state {
-                                pending_exception = Some(exc);
-                                current_id = finally_state;
-                                continue;
-                            }
-                        }
+                        let exc = route_exception!(exc);
                         obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                             IteratorState::StateMachineGenerator {
                                 state_machine,
@@ -1581,16 +1586,7 @@ impl Interpreter {
                     let iterable_val = match self.eval_expr(iterable, &iterable_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
-                            if let Some(try_info) = current_try_stack.pop() {
-                                if let Some(catch_state) = try_info.catch_state {
-                                    pending_exception = Some(e);
-                                    current_id = catch_state;
-                                    continue;
-                                } else if let Some(finally_state) = try_info.finally_state {
-                                    current_id = finally_state;
-                                    continue;
-                                }
-                            }
+                            let e = route_exception!(e);
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
                                     IteratorState::StateMachineGenerator {
@@ -1613,16 +1609,7 @@ impl Interpreter {
                     let iterator = match self.get_iterator(&iterable_val) {
                         Ok(iter) => iter,
                         Err(e) => {
-                            if let Some(try_info) = current_try_stack.pop() {
-                                if let Some(catch_state) = try_info.catch_state {
-                                    pending_exception = Some(e);
-                                    current_id = catch_state;
-                                    continue;
-                                } else if let Some(finally_state) = try_info.finally_state {
-                                    current_id = finally_state;
-                                    continue;
-                                }
-                            }
+                            let e = route_exception!(e);
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
                                     IteratorState::StateMachineGenerator {
@@ -1710,19 +1697,7 @@ impl Interpreter {
                         self.gc_unroot_value(&iterator);
                         for_of_stack.remove(loop_pos);
                         self.sync_generator_for_of_stack(o.id, &for_of_stack);
-                        if let Some(try_info) = current_try_stack.pop() {
-                            if let Some(catch_state) = try_info.catch_state {
-                                pending_exception = Some(e);
-                                current_id = catch_state;
-                                continue;
-                            } else if let Some(finally_state) = try_info.finally_state {
-                                // TryExit re-throws whatever `pending_exception`
-                                // still holds once the finally body completes.
-                                pending_exception = Some(e);
-                                current_id = finally_state;
-                                continue;
-                            }
-                        }
+                        let e = route_exception!(e);
                         obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                             IteratorState::StateMachineGenerator {
                                 state_machine,
@@ -1749,14 +1724,7 @@ impl Interpreter {
                                 loop_pos,
                                 &iterator,
                             );
-                            if Self::enter_generator_exception_handler(
-                                &mut current_try_stack,
-                                &mut pending_exception,
-                                &mut current_id,
-                                e.clone(),
-                            ) {
-                                continue;
-                            }
+                            let e = route_exception!(e);
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
                                     IteratorState::StateMachineGenerator {
@@ -1807,14 +1775,7 @@ impl Interpreter {
                                         loop_pos,
                                         &iterator,
                                     );
-                                    if Self::enter_generator_exception_handler(
-                                        &mut current_try_stack,
-                                        &mut pending_exception,
-                                        &mut current_id,
-                                        e.clone(),
-                                    ) {
-                                        continue;
-                                    }
+                                    let e = route_exception!(e);
                                     obj_rc.borrow_mut().kind =
                                         crate::interpreter::types::ObjectKind::Iterator(
                                             IteratorState::StateMachineGenerator {
@@ -1866,14 +1827,7 @@ impl Interpreter {
                                                 loop_pos,
                                                 &iterator,
                                             );
-                                            if Self::enter_generator_exception_handler(
-                                                &mut current_try_stack,
-                                                &mut pending_exception,
-                                                &mut current_id,
-                                                e.clone(),
-                                            ) {
-                                                continue;
-                                            }
+                                            let e = route_exception!(e);
                                             obj_rc.borrow_mut().kind =
                                                 crate::interpreter::types::ObjectKind::Iterator(
                                                     IteratorState::StateMachineGenerator {
@@ -1904,14 +1858,7 @@ impl Interpreter {
                                             loop_pos,
                                             &iterator,
                                         );
-                                        if Self::enter_generator_exception_handler(
-                                            &mut current_try_stack,
-                                            &mut pending_exception,
-                                            &mut current_id,
-                                            e.clone(),
-                                        ) {
-                                            continue;
-                                        }
+                                        let e = route_exception!(e);
                                         obj_rc.borrow_mut().kind =
                                             crate::interpreter::types::ObjectKind::Iterator(
                                                 IteratorState::StateMachineGenerator {
@@ -1942,14 +1889,7 @@ impl Interpreter {
                                                 loop_pos,
                                                 &iterator,
                                             );
-                                            if Self::enter_generator_exception_handler(
-                                                &mut current_try_stack,
-                                                &mut pending_exception,
-                                                &mut current_id,
-                                                e.clone(),
-                                            ) {
-                                                continue;
-                                            }
+                                            let e = route_exception!(e);
                                             obj_rc.borrow_mut().kind =
                                                 crate::interpreter::types::ObjectKind::Iterator(
                                                     IteratorState::StateMachineGenerator {
@@ -2005,14 +1945,7 @@ impl Interpreter {
                                 loop_pos,
                                 &iterator,
                             );
-                            if Self::enter_generator_exception_handler(
-                                &mut current_try_stack,
-                                &mut pending_exception,
-                                &mut current_id,
-                                e.clone(),
-                            ) {
-                                continue;
-                            }
+                            let e = route_exception!(e);
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
                                     IteratorState::StateMachineGenerator {
@@ -2460,13 +2393,13 @@ impl Interpreter {
             func_env,
             is_strict,
             execution_state,
-            try_stack,
+            mut try_stack,
             delegated_iterator,
             pending_return: stored_pending_return,
             ..
         }) = state
         {
-            match execution_state {
+            let suspended_state_id = match execution_state {
                 StateMachineExecutionState::Executing => {
                     return Completion::Throw(
                         self.create_type_error("Generator is already running"),
@@ -2490,8 +2423,8 @@ impl Interpreter {
                     );
                     return Completion::Throw(exception);
                 }
-                StateMachineExecutionState::SuspendedAtState { .. } => {}
-            }
+                StateMachineExecutionState::SuspendedAtState { state_id } => state_id,
+            };
 
             if let Some(ref deleg_info) = delegated_iterator {
                 let iterator = deleg_info.iterator.clone();
@@ -2684,68 +2617,81 @@ impl Interpreter {
                 }
             }
 
-            // Walk try_stack from innermost to outermost to find a handler
-            for i in (0..try_stack.len()).rev() {
-                let try_info = &try_stack[i];
-                if !try_info.entered_catch
-                    && !try_info.entered_finally
-                    && let Some(catch_state) = try_info.catch_state
-                {
+            let mut for_of_stack = self
+                .generator_for_of_stacks
+                .get(&o.id)
+                .cloned()
+                .unwrap_or_default();
+            let mut pending_exception = None;
+            let mut handler_state = suspended_state_id;
+            match self.route_generator_exception(
+                o.id,
+                &mut for_of_stack,
+                &mut try_stack,
+                &func_env,
+                &mut pending_exception,
+                &mut handler_state,
+                exception,
+            ) {
+                Completion::Empty => {
                     obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                         IteratorState::StateMachineGenerator {
                             state_machine,
                             func_env,
                             is_strict,
                             execution_state: StateMachineExecutionState::SuspendedAtState {
-                                state_id: catch_state,
+                                state_id: handler_state,
                             },
                             _sent_value: JsValue::UNDEFINED,
-                            try_stack: try_stack[..i].to_vec(),
+                            try_stack,
                             pending_binding: None,
                             delegated_iterator: None,
-                            pending_exception: Some(exception.clone()),
+                            pending_exception,
                             pending_return: stored_pending_return,
                         },
                     );
                     return self.generator_next_state_machine(this, JsValue::UNDEFINED);
                 }
-                if !try_info.entered_finally
-                    && let Some(finally_state) = try_info.finally_state
-                {
+                Completion::Throw(error) => {
+                    self.generator_inline_iters.remove(&o.id);
+                    self.generator_for_of_stacks.remove(&o.id);
                     obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                         IteratorState::StateMachineGenerator {
                             state_machine,
                             func_env,
                             is_strict,
-                            execution_state: StateMachineExecutionState::SuspendedAtState {
-                                state_id: finally_state,
-                            },
+                            execution_state: StateMachineExecutionState::Completed,
                             _sent_value: JsValue::UNDEFINED,
-                            try_stack: try_stack[..i].to_vec(),
+                            try_stack: vec![],
                             pending_binding: None,
                             delegated_iterator: None,
-                            pending_exception: Some(exception.clone()),
-                            pending_return: stored_pending_return,
+                            pending_exception: None,
+                            pending_return: None,
                         },
                     );
-                    return self.generator_next_state_machine(this, JsValue::UNDEFINED);
+                    return Completion::Throw(error);
                 }
+                Completion::Exit(code) => {
+                    self.generator_inline_iters.remove(&o.id);
+                    self.generator_for_of_stacks.remove(&o.id);
+                    obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                        IteratorState::StateMachineGenerator {
+                            state_machine,
+                            func_env,
+                            is_strict,
+                            execution_state: StateMachineExecutionState::Completed,
+                            _sent_value: JsValue::UNDEFINED,
+                            try_stack: vec![],
+                            pending_binding: None,
+                            delegated_iterator: None,
+                            pending_exception: None,
+                            pending_return: None,
+                        },
+                    );
+                    return Completion::Exit(code);
+                }
+                _ => unreachable!("routing a throw returned a non-abrupt completion"),
             }
-
-            obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
-                IteratorState::StateMachineGenerator {
-                    state_machine,
-                    func_env,
-                    is_strict,
-                    execution_state: StateMachineExecutionState::Completed,
-                    _sent_value: JsValue::UNDEFINED,
-                    try_stack: vec![],
-                    pending_binding: None,
-                    delegated_iterator: None,
-                    pending_exception: None,
-                    pending_return: None,
-                },
-            );
         }
         Completion::Throw(exception)
     }
@@ -4427,32 +4373,49 @@ impl Interpreter {
             .get(&o.id)
             .cloned()
             .unwrap_or_default();
+
+        macro_rules! route_exception {
+            ($error:expr) => {{
+                match self.route_generator_exception(
+                    o.id,
+                    &mut for_of_stack,
+                    &mut current_try_stack,
+                    &func_env,
+                    &mut pending_exception,
+                    &mut current_id,
+                    $error,
+                ) {
+                    Completion::Empty => continue,
+                    Completion::Throw(error) => error,
+                    Completion::Exit(code) => {
+                        self.generator_inline_iters.remove(&o.id);
+                        self.generator_for_of_stacks.remove(&o.id);
+                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                            IteratorState::StateMachineAsyncGenerator {
+                                state_machine,
+                                func_env,
+                                is_strict,
+                                execution_state: StateMachineExecutionState::Completed,
+                                _sent_value: JsValue::UNDEFINED,
+                                try_stack: vec![],
+                                pending_binding: None,
+                                delegated_iterator: None,
+                                pending_exception: None,
+                                pending_return: None,
+                            },
+                        );
+                        return Completion::Exit(code);
+                    }
+                    _ => unreachable!("routing a throw returned a non-abrupt completion"),
+                }
+            }};
+        }
         loop {
             if check_abrupt_on_resume {
                 check_abrupt_on_resume = false;
                 // Check pending_exception before executing state (handles .throw() with no try/catch)
                 if let Some(exc) = pending_exception.take() {
-                    let mut handled = false;
-                    for i in (0..current_try_stack.len()).rev() {
-                        if !current_try_stack[i].entered_catch
-                            && !current_try_stack[i].entered_finally
-                        {
-                            if let Some(catch_state) = current_try_stack[i].catch_state {
-                                pending_exception = Some(exc.clone());
-                                current_id = catch_state;
-                                handled = true;
-                                break;
-                            } else if let Some(finally_state) = current_try_stack[i].finally_state {
-                                pending_exception = Some(exc.clone());
-                                current_id = finally_state;
-                                handled = true;
-                                break;
-                            }
-                        }
-                    }
-                    if handled {
-                        continue;
-                    }
+                    let exc = route_exception!(exc);
                     let disp = self.dispose_resources(&func_env, Completion::Throw(exc));
                     let exc = match disp {
                         Completion::Throw(e) => e,
@@ -4657,16 +4620,7 @@ impl Interpreter {
                 // Route genuine throws through the async generator body's
                 // catch/finally states (a `Completion::Exit` was handled above
                 // and never reaches here).
-                if let Some(try_info) = current_try_stack.pop() {
-                    if let Some(catch_state) = try_info.catch_state {
-                        pending_exception = Some(e);
-                        current_id = catch_state;
-                        continue;
-                    } else if let Some(finally_state) = try_info.finally_state {
-                        current_id = finally_state;
-                        continue;
-                    }
-                }
+                let e = route_exception!(e);
                 // §27.6.3.3: DisposeResources when async generator throws
                 let disp = self.dispose_resources(&func_env, Completion::Throw(e));
                 let e = match disp {
@@ -4800,16 +4754,7 @@ impl Interpreter {
                                 // catch/finally handling (a `Completion::Exit`
                                 // takes the `other` arm below and never reaches
                                 // here — issue #242).
-                                if let Some(try_info) = current_try_stack.pop() {
-                                    if let Some(catch_state) = try_info.catch_state {
-                                        pending_exception = Some(e);
-                                        current_id = catch_state;
-                                        continue;
-                                    } else if let Some(finally_state) = try_info.finally_state {
-                                        current_id = finally_state;
-                                        continue;
-                                    }
-                                }
+                                let e = route_exception!(e);
                                 self.generator_inline_iters.remove(&o.id);
                                 obj_rc.borrow_mut().kind =
                                     crate::interpreter::types::ObjectKind::Iterator(
@@ -5709,14 +5654,14 @@ impl Interpreter {
                         }
                     };
 
-                    if let Some(try_info) = current_try_stack.pop()
-                        && let Some(catch_state) = try_info.catch_state
-                    {
-                        pending_exception = Some(throw_val);
-                        current_id = catch_state;
-                        continue;
-                    }
+                    let throw_val = route_exception!(throw_val);
 
+                    let disp = self.dispose_resources(&func_env, Completion::Throw(throw_val));
+                    let throw_val = match disp {
+                        Completion::Throw(error) => error,
+                        Completion::Exit(code) => return Completion::Exit(code),
+                        _ => unreachable!("disposing a throw must stay abrupt"),
+                    };
                     self.generator_inline_iters.remove(&o.id);
                     obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                         IteratorState::StateMachineAsyncGenerator {
@@ -5844,17 +5789,7 @@ impl Interpreter {
                     current_try_stack.pop();
                     if let Some(exc) = pending_exception.take() {
                         // Re-throw pending exception after finally completes
-                        if let Some(try_info) = current_try_stack.pop() {
-                            if let Some(catch_state) = try_info.catch_state {
-                                pending_exception = Some(exc);
-                                current_id = catch_state;
-                                continue;
-                            } else if let Some(finally_state) = try_info.finally_state {
-                                pending_exception = Some(exc);
-                                current_id = finally_state;
-                                continue;
-                            }
-                        }
+                        let exc = route_exception!(exc);
                         self.generator_inline_iters.remove(&o.id);
                         obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                             IteratorState::StateMachineAsyncGenerator {
@@ -5999,16 +5934,7 @@ impl Interpreter {
                     let iterable_val = match self.eval_expr(iterable, &iterable_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
-                            if let Some(try_info) = current_try_stack.pop() {
-                                if let Some(catch_state) = try_info.catch_state {
-                                    pending_exception = Some(e);
-                                    current_id = catch_state;
-                                    continue;
-                                } else if let Some(finally_state) = try_info.finally_state {
-                                    current_id = finally_state;
-                                    continue;
-                                }
-                            }
+                            let e = route_exception!(e);
                             self.generator_inline_iters.remove(&o.id);
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
@@ -6041,16 +5967,7 @@ impl Interpreter {
                         match self.get_async_iterator(&iterable_val) {
                             Ok(iter) => iter,
                             Err(e) => {
-                                if let Some(try_info) = current_try_stack.pop() {
-                                    if let Some(catch_state) = try_info.catch_state {
-                                        pending_exception = Some(e);
-                                        current_id = catch_state;
-                                        continue;
-                                    } else if let Some(finally_state) = try_info.finally_state {
-                                        current_id = finally_state;
-                                        continue;
-                                    }
-                                }
+                                let e = route_exception!(e);
                                 self.generator_inline_iters.remove(&o.id);
                                 obj_rc.borrow_mut().kind =
                                     crate::interpreter::types::ObjectKind::Iterator(
@@ -6076,16 +5993,7 @@ impl Interpreter {
                         match self.get_iterator(&iterable_val) {
                             Ok(iter) => iter,
                             Err(e) => {
-                                if let Some(try_info) = current_try_stack.pop() {
-                                    if let Some(catch_state) = try_info.catch_state {
-                                        pending_exception = Some(e);
-                                        current_id = catch_state;
-                                        continue;
-                                    } else if let Some(finally_state) = try_info.finally_state {
-                                        current_id = finally_state;
-                                        continue;
-                                    }
-                                }
+                                let e = route_exception!(e);
                                 self.generator_inline_iters.remove(&o.id);
                                 obj_rc.borrow_mut().kind =
                                     crate::interpreter::types::ObjectKind::Iterator(
@@ -6177,19 +6085,7 @@ impl Interpreter {
                         self.gc_unroot_value(&iterator);
                         for_of_stack.remove(loop_pos);
                         self.sync_generator_for_of_stack(o.id, &for_of_stack);
-                        if let Some(try_info) = current_try_stack.pop() {
-                            if let Some(catch_state) = try_info.catch_state {
-                                pending_exception = Some(e);
-                                current_id = catch_state;
-                                continue;
-                            } else if let Some(finally_state) = try_info.finally_state {
-                                // TryExit re-throws whatever `pending_exception`
-                                // still holds once the finally body completes.
-                                pending_exception = Some(e);
-                                current_id = finally_state;
-                                continue;
-                            }
-                        }
+                        let e = route_exception!(e);
                         self.generator_inline_iters.remove(&o.id);
                         obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                             IteratorState::StateMachineAsyncGenerator {
@@ -6219,14 +6115,7 @@ impl Interpreter {
                                 loop_pos,
                                 &iterator,
                             );
-                            if Self::enter_generator_exception_handler(
-                                &mut current_try_stack,
-                                &mut pending_exception,
-                                &mut current_id,
-                                e.clone(),
-                            ) {
-                                continue;
-                            }
+                            let e = route_exception!(e);
                             self.generator_inline_iters.remove(&o.id);
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
@@ -6258,14 +6147,7 @@ impl Interpreter {
                                     loop_pos,
                                     &iterator,
                                 );
-                                if Self::enter_generator_exception_handler(
-                                    &mut current_try_stack,
-                                    &mut pending_exception,
-                                    &mut current_id,
-                                    e.clone(),
-                                ) {
-                                    continue;
-                                }
+                                let e = route_exception!(e);
                                 self.generator_inline_iters.remove(&o.id);
                                 obj_rc.borrow_mut().kind =
                                     crate::interpreter::types::ObjectKind::Iterator(
@@ -6329,14 +6211,7 @@ impl Interpreter {
                                         loop_pos,
                                         &iterator,
                                     );
-                                    if Self::enter_generator_exception_handler(
-                                        &mut current_try_stack,
-                                        &mut pending_exception,
-                                        &mut current_id,
-                                        e.clone(),
-                                    ) {
-                                        continue;
-                                    }
+                                    let e = route_exception!(e);
                                     self.generator_inline_iters.remove(&o.id);
                                     obj_rc.borrow_mut().kind =
                                         crate::interpreter::types::ObjectKind::Iterator(
@@ -6392,14 +6267,7 @@ impl Interpreter {
                                                 loop_pos,
                                                 &iterator,
                                             );
-                                            if Self::enter_generator_exception_handler(
-                                                &mut current_try_stack,
-                                                &mut pending_exception,
-                                                &mut current_id,
-                                                e.clone(),
-                                            ) {
-                                                continue;
-                                            }
+                                            let e = route_exception!(e);
                                             self.generator_inline_iters.remove(&o.id);
                                             obj_rc.borrow_mut().kind =
                                                 crate::interpreter::types::ObjectKind::Iterator(
@@ -6437,14 +6305,7 @@ impl Interpreter {
                                             loop_pos,
                                             &iterator,
                                         );
-                                        if Self::enter_generator_exception_handler(
-                                            &mut current_try_stack,
-                                            &mut pending_exception,
-                                            &mut current_id,
-                                            e.clone(),
-                                        ) {
-                                            continue;
-                                        }
+                                        let e = route_exception!(e);
                                         self.generator_inline_iters.remove(&o.id);
                                         obj_rc.borrow_mut().kind =
                                             crate::interpreter::types::ObjectKind::Iterator(
@@ -6482,14 +6343,7 @@ impl Interpreter {
                                                 loop_pos,
                                                 &iterator,
                                             );
-                                            if Self::enter_generator_exception_handler(
-                                                &mut current_try_stack,
-                                                &mut pending_exception,
-                                                &mut current_id,
-                                                e.clone(),
-                                            ) {
-                                                continue;
-                                            }
+                                            let e = route_exception!(e);
                                             self.generator_inline_iters.remove(&o.id);
                                             obj_rc.borrow_mut().kind =
                                                 crate::interpreter::types::ObjectKind::Iterator(
@@ -6549,14 +6403,7 @@ impl Interpreter {
                                 loop_pos,
                                 &iterator,
                             );
-                            if Self::enter_generator_exception_handler(
-                                &mut current_try_stack,
-                                &mut pending_exception,
-                                &mut current_id,
-                                e.clone(),
-                            ) {
-                                continue;
-                            }
+                            let e = route_exception!(e);
                             self.generator_inline_iters.remove(&o.id);
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
@@ -7499,25 +7346,69 @@ impl Interpreter {
         self.sync_generator_for_of_stack(generator_id, for_of_stack);
     }
 
-    fn enter_generator_exception_handler(
+    /// Route a generator throw to the nearest active handler, first unwinding
+    /// every transformed for-of loop crossed on the way there. A handler
+    /// lexically inside a loop retains that loop; a handler outside it sees
+    /// the restored outer environment after IteratorClose.
+    fn route_generator_exception(
+        &mut self,
+        generator_id: u64,
+        for_of_stack: &mut Vec<ForOfLoopState>,
         try_stack: &mut Vec<TryContextInfo>,
+        func_env: &EnvRef,
         pending_exception: &mut Option<JsValue>,
         current_id: &mut usize,
         error: JsValue,
-    ) -> bool {
-        if let Some(try_info) = try_stack.pop() {
-            if let Some(catch_state) = try_info.catch_state {
-                *pending_exception = Some(error);
-                *current_id = catch_state;
-                return true;
+    ) -> Completion {
+        let handler = (0..try_stack.len()).rev().find_map(|depth| {
+            let try_info = &try_stack[depth];
+            if !try_info.entered_catch
+                && !try_info.entered_finally
+                && let Some(catch_state) = try_info.catch_state
+            {
+                return Some((depth, catch_state, true, try_info.finally_state.is_some()));
             }
-            if let Some(finally_state) = try_info.finally_state {
-                *pending_exception = Some(error);
-                *current_id = finally_state;
-                return true;
+            if !try_info.entered_finally
+                && let Some(finally_state) = try_info.finally_state
+            {
+                return Some((depth, finally_state, false, true));
             }
+            None
+        });
+
+        let keep_len = handler.map_or(0, |(handler_depth, _, _, _)| {
+            for_of_stack
+                .iter()
+                .position(|loop_state| loop_state.try_depth > handler_depth)
+                .unwrap_or(for_of_stack.len())
+        });
+        let completion = self.unwind_generator_for_of_loops(
+            generator_id,
+            for_of_stack,
+            try_stack,
+            func_env,
+            keep_len,
+            Completion::Throw(error),
+        );
+        let error = match completion {
+            Completion::Throw(error) => error,
+            Completion::Exit(code) => return Completion::Exit(code),
+            _ => unreachable!("unwinding a throw must preserve abrupt completion"),
+        };
+
+        if let Some((depth, handler_state, is_catch, has_finally)) = handler {
+            let retained_depth = if is_catch && !has_finally {
+                depth
+            } else {
+                depth + 1
+            };
+            try_stack.truncate(retained_depth);
+            *pending_exception = Some(error);
+            *current_id = handler_state;
+            Completion::Empty
+        } else {
+            Completion::Throw(error)
         }
-        false
     }
 
     /// Close transformed generator for-of loops from the inside out while

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -1686,33 +1686,62 @@ impl Interpreter {
                         .map(|b| b.value.clone())
                         .unwrap_or(JsValue::UNDEFINED);
 
-                    // §14.7.5.6 step 7.h: a throwing disposer ends the loop
-                    // with a throw completion, so the iterator still closes
-                    // and the generator's own handlers still see the error.
-                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take()
-                        && let Completion::Throw(e) =
-                            self.dispose_resources(&iteration_env, Completion::Empty)
-                    {
-                        self.iterator_close(&iterator, e.clone());
-                        self.gc_unroot_value(&iterator);
-                        for_of_stack.remove(loop_pos);
-                        self.sync_generator_for_of_stack(o.id, &for_of_stack);
-                        let e = route_exception!(e);
-                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
-                            IteratorState::StateMachineGenerator {
-                                state_machine,
-                                func_env,
-                                is_strict,
-                                execution_state: StateMachineExecutionState::Completed,
-                                _sent_value: JsValue::UNDEFINED,
-                                try_stack: vec![],
-                                pending_binding: None,
-                                delegated_iterator: None,
-                                pending_exception: None,
-                                pending_return: None,
-                            },
-                        );
-                        return Completion::Throw(e);
+                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take() {
+                        match self.dispose_resources(&iteration_env, Completion::Empty) {
+                            // §14.7.5.6 step 7.h: a throwing disposer ends the
+                            // loop with a throw completion, so the iterator
+                            // still closes and the generator's handlers see it.
+                            Completion::Throw(e) => {
+                                self.iterator_close(&iterator, e.clone());
+                                self.gc_unroot_value(&iterator);
+                                for_of_stack.remove(loop_pos);
+                                self.sync_generator_for_of_stack(o.id, &for_of_stack);
+                                let e = route_exception!(e);
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state: StateMachineExecutionState::Completed,
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: vec![],
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return Completion::Throw(e);
+                            }
+                            // `__host_exit` is terminal and uncatchable. Drop
+                            // all saved loop state without invoking any further
+                            // disposer or iterator `return()` user code.
+                            Completion::Exit(code) => {
+                                self.discard_generator_for_of_loops_on_exit(
+                                    o.id,
+                                    &mut for_of_stack,
+                                    &func_env,
+                                );
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state: StateMachineExecutionState::Completed,
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: vec![],
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return Completion::Exit(code);
+                            }
+                            _ => {}
+                        }
                     }
 
                     let step_result = match self.iterator_next(&iterator) {
@@ -2769,6 +2798,9 @@ impl Interpreter {
         if !is_executing && queue_len == 1 {
             let this_clone = this.clone();
             self.async_gen_process_queue(&this_clone);
+            if let Some(code) = self.pending_exit {
+                return Completion::Exit(code);
+            }
         }
 
         Completion::Normal(promise)
@@ -2818,6 +2850,15 @@ impl Interpreter {
                     request.reject_fn.clone(),
                 ),
         };
+
+        // The queue driver has no Completion return channel of its own. Latch
+        // a terminal host exit here so the current JS call/microtask stops and
+        // the outer event-loop boundary can propagate the exit. The request
+        // promise deliberately remains unsettled.
+        if let Completion::Exit(code) = result {
+            self.pending_exit = Some(code);
+            return;
+        }
 
         // If the yield suspended asynchronously (pending promise), don't pop — the
         // fulfill/reject handler will pop and schedule the next request
@@ -6074,36 +6115,65 @@ impl Interpreter {
                         .map(|b| b.value.clone())
                         .unwrap_or(JsValue::UNDEFINED);
 
-                    // §14.7.5.6 step 7.h: a throwing disposer ends the loop
-                    // with a throw completion, so the iterator still closes
-                    // and the generator's own handlers still see the error.
-                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take()
-                        && let Completion::Throw(e) =
-                            self.dispose_resources(&iteration_env, Completion::Empty)
-                    {
-                        self.iterator_close(&iterator, e.clone());
-                        self.gc_unroot_value(&iterator);
-                        for_of_stack.remove(loop_pos);
-                        self.sync_generator_for_of_stack(o.id, &for_of_stack);
-                        let e = route_exception!(e);
-                        self.generator_inline_iters.remove(&o.id);
-                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
-                            IteratorState::StateMachineAsyncGenerator {
-                                state_machine,
-                                func_env,
-                                is_strict,
-                                execution_state: StateMachineExecutionState::Completed,
-                                _sent_value: JsValue::UNDEFINED,
-                                try_stack: vec![],
-                                pending_binding: None,
-                                delegated_iterator: None,
-                                pending_exception: None,
-                                pending_return: None,
-                            },
-                        );
-                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
-                        self.drain_microtasks();
-                        return Completion::Normal(promise);
+                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take() {
+                        match self.dispose_resources(&iteration_env, Completion::Empty) {
+                            // §14.7.5.6 step 7.h: a throwing disposer ends the
+                            // loop with a throw completion, so the iterator
+                            // still closes and the generator's handlers see it.
+                            Completion::Throw(e) => {
+                                self.iterator_close(&iterator, e.clone());
+                                self.gc_unroot_value(&iterator);
+                                for_of_stack.remove(loop_pos);
+                                self.sync_generator_for_of_stack(o.id, &for_of_stack);
+                                let e = route_exception!(e);
+                                self.generator_inline_iters.remove(&o.id);
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineAsyncGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state: StateMachineExecutionState::Completed,
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: vec![],
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
+                                self.drain_microtasks();
+                                return Completion::Normal(promise);
+                            }
+                            // Leave the result promise unsettled: a terminal
+                            // host exit propagates through the queue boundary,
+                            // never through normal promise settlement.
+                            Completion::Exit(code) => {
+                                self.discard_generator_for_of_loops_on_exit(
+                                    o.id,
+                                    &mut for_of_stack,
+                                    &func_env,
+                                );
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineAsyncGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state: StateMachineExecutionState::Completed,
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: vec![],
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return Completion::Exit(code);
+                            }
+                            _ => {}
+                        }
                     }
 
                     let step_result = match self.iterator_next(&iterator) {
@@ -7343,6 +7413,25 @@ impl Interpreter {
         for_of_stack.remove(loop_pos);
         self.unroot_for_of_iterator(iterator);
         self.remove_generator_inline_iterator(generator_id, iterator);
+        self.sync_generator_for_of_stack(generator_id, for_of_stack);
+    }
+
+    /// Release the internal representation of every active generator for-of
+    /// loop after a terminal host exit. This is bookkeeping only: `Exit` must
+    /// not invoke another disposer or iterator `return()` callback.
+    fn discard_generator_for_of_loops_on_exit(
+        &mut self,
+        generator_id: u64,
+        for_of_stack: &mut Vec<ForOfLoopState>,
+        func_env: &EnvRef,
+    ) {
+        for loop_state in for_of_stack.drain(..).rev() {
+            let iterator = func_env.borrow().get(&loop_state.iter_var);
+            if let Some(iterator) = iterator {
+                self.unroot_for_of_iterator(&iterator);
+            }
+        }
+        self.generator_inline_iters.remove(&generator_id);
         self.sync_generator_for_of_stack(generator_id, for_of_stack);
     }
 

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -1820,16 +1820,19 @@ impl Interpreter {
                     let step_result = match self.iterator_next(&iterator) {
                         Ok(v) => v,
                         Err(e) => {
-                            self.gc_unroot_value(&iterator);
-                            if let Some(try_info) = current_try_stack.pop() {
-                                if let Some(catch_state) = try_info.catch_state {
-                                    pending_exception = Some(e);
-                                    current_id = catch_state;
-                                    continue;
-                                } else if let Some(finally_state) = try_info.finally_state {
-                                    current_id = finally_state;
-                                    continue;
-                                }
+                            self.discard_failed_generator_for_of_loop(
+                                o.id,
+                                &mut for_of_stack,
+                                loop_pos,
+                                &iterator,
+                            );
+                            if Self::enter_generator_exception_handler(
+                                &mut current_try_stack,
+                                &mut pending_exception,
+                                &mut current_id,
+                                e.clone(),
+                            ) {
+                                continue;
                             }
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
@@ -1875,16 +1878,19 @@ impl Interpreter {
                             let val = match self.iterator_value(&step_result) {
                                 Ok(v) => v,
                                 Err(e) => {
-                                    self.gc_unroot_value(&iterator);
-                                    if let Some(try_info) = current_try_stack.pop() {
-                                        if let Some(catch_state) = try_info.catch_state {
-                                            pending_exception = Some(e);
-                                            current_id = catch_state;
-                                            continue;
-                                        } else if let Some(finally_state) = try_info.finally_state {
-                                            current_id = finally_state;
-                                            continue;
-                                        }
+                                    self.discard_failed_generator_for_of_loop(
+                                        o.id,
+                                        &mut for_of_stack,
+                                        loop_pos,
+                                        &iterator,
+                                    );
+                                    if Self::enter_generator_exception_handler(
+                                        &mut current_try_stack,
+                                        &mut pending_exception,
+                                        &mut current_id,
+                                        e.clone(),
+                                    ) {
+                                        continue;
                                     }
                                     obj_rc.borrow_mut().kind =
                                         crate::interpreter::types::ObjectKind::Iterator(
@@ -1931,7 +1937,36 @@ impl Interpreter {
                                             self.add_disposable_resource(&bind_env, &val, hint)
                                         {
                                             self.iterator_close(&iterator, e.clone());
-                                            self.gc_unroot_value(&iterator);
+                                            self.discard_failed_generator_for_of_loop(
+                                                o.id,
+                                                &mut for_of_stack,
+                                                loop_pos,
+                                                &iterator,
+                                            );
+                                            if Self::enter_generator_exception_handler(
+                                                &mut current_try_stack,
+                                                &mut pending_exception,
+                                                &mut current_id,
+                                                e.clone(),
+                                            ) {
+                                                continue;
+                                            }
+                                            obj_rc.borrow_mut().kind =
+                                                crate::interpreter::types::ObjectKind::Iterator(
+                                                    IteratorState::StateMachineGenerator {
+                                                        state_machine,
+                                                        func_env,
+                                                        is_strict,
+                                                        execution_state:
+                                                            StateMachineExecutionState::Completed,
+                                                        _sent_value: JsValue::UNDEFINED,
+                                                        try_stack: vec![],
+                                                        pending_binding: None,
+                                                        delegated_iterator: None,
+                                                        pending_exception: None,
+                                                        pending_return: None,
+                                                    },
+                                                );
                                             return Completion::Throw(e);
                                         }
                                     }
@@ -1940,18 +1975,19 @@ impl Interpreter {
                                             self.bind_pattern(&d.pattern, val, kind, &bind_env)
                                     {
                                         self.iterator_close(&iterator, e.clone());
-                                        self.gc_unroot_value(&iterator);
-                                        if let Some(try_info) = current_try_stack.pop() {
-                                            if let Some(catch_state) = try_info.catch_state {
-                                                pending_exception = Some(e);
-                                                current_id = catch_state;
-                                                continue;
-                                            } else if let Some(finally_state) =
-                                                try_info.finally_state
-                                            {
-                                                current_id = finally_state;
-                                                continue;
-                                            }
+                                        self.discard_failed_generator_for_of_loop(
+                                            o.id,
+                                            &mut for_of_stack,
+                                            loop_pos,
+                                            &iterator,
+                                        );
+                                        if Self::enter_generator_exception_handler(
+                                            &mut current_try_stack,
+                                            &mut pending_exception,
+                                            &mut current_id,
+                                            e.clone(),
+                                        ) {
+                                            continue;
                                         }
                                         obj_rc.borrow_mut().kind =
                                             crate::interpreter::types::ObjectKind::Iterator(
@@ -1977,18 +2013,19 @@ impl Interpreter {
                                         Completion::Normal(_) | Completion::Empty => {}
                                         Completion::Throw(e) => {
                                             self.iterator_close(&iterator, e.clone());
-                                            self.gc_unroot_value(&iterator);
-                                            if let Some(try_info) = current_try_stack.pop() {
-                                                if let Some(catch_state) = try_info.catch_state {
-                                                    pending_exception = Some(e);
-                                                    current_id = catch_state;
-                                                    continue;
-                                                } else if let Some(finally_state) =
-                                                    try_info.finally_state
-                                                {
-                                                    current_id = finally_state;
-                                                    continue;
-                                                }
+                                            self.discard_failed_generator_for_of_loop(
+                                                o.id,
+                                                &mut for_of_stack,
+                                                loop_pos,
+                                                &iterator,
+                                            );
+                                            if Self::enter_generator_exception_handler(
+                                                &mut current_try_stack,
+                                                &mut pending_exception,
+                                                &mut current_id,
+                                                e.clone(),
+                                            ) {
+                                                continue;
                                             }
                                             obj_rc.borrow_mut().kind =
                                                 crate::interpreter::types::ObjectKind::Iterator(
@@ -2039,16 +2076,19 @@ impl Interpreter {
                             current_id = *body_state;
                         }
                         Err(e) => {
-                            self.gc_unroot_value(&iterator);
-                            if let Some(try_info) = current_try_stack.pop() {
-                                if let Some(catch_state) = try_info.catch_state {
-                                    pending_exception = Some(e);
-                                    current_id = catch_state;
-                                    continue;
-                                } else if let Some(finally_state) = try_info.finally_state {
-                                    current_id = finally_state;
-                                    continue;
-                                }
+                            self.discard_failed_generator_for_of_loop(
+                                o.id,
+                                &mut for_of_stack,
+                                loop_pos,
+                                &iterator,
+                            );
+                            if Self::enter_generator_exception_handler(
+                                &mut current_try_stack,
+                                &mut pending_exception,
+                                &mut current_id,
+                                e.clone(),
+                            ) {
+                                continue;
                             }
                             obj_rc.borrow_mut().kind =
                                 crate::interpreter::types::ObjectKind::Iterator(
@@ -6106,16 +6146,19 @@ impl Interpreter {
                     let step_result = match self.iterator_next(&iterator) {
                         Ok(v) => v,
                         Err(e) => {
-                            self.gc_unroot_value(&iterator);
-                            if let Some(try_info) = current_try_stack.pop() {
-                                if let Some(catch_state) = try_info.catch_state {
-                                    pending_exception = Some(e);
-                                    current_id = catch_state;
-                                    continue;
-                                } else if let Some(finally_state) = try_info.finally_state {
-                                    current_id = finally_state;
-                                    continue;
-                                }
+                            self.discard_failed_generator_for_of_loop(
+                                o.id,
+                                &mut for_of_stack,
+                                loop_pos,
+                                &iterator,
+                            );
+                            if Self::enter_generator_exception_handler(
+                                &mut current_try_stack,
+                                &mut pending_exception,
+                                &mut current_id,
+                                e.clone(),
+                            ) {
+                                continue;
                             }
                             self.generator_inline_iters.remove(&o.id);
                             obj_rc.borrow_mut().kind =
@@ -6142,16 +6185,19 @@ impl Interpreter {
                         match self.await_value(&step_result) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
-                                self.gc_unroot_value(&iterator);
-                                if let Some(try_info) = current_try_stack.pop() {
-                                    if let Some(catch_state) = try_info.catch_state {
-                                        pending_exception = Some(e);
-                                        current_id = catch_state;
-                                        continue;
-                                    } else if let Some(finally_state) = try_info.finally_state {
-                                        current_id = finally_state;
-                                        continue;
-                                    }
+                                self.discard_failed_generator_for_of_loop(
+                                    o.id,
+                                    &mut for_of_stack,
+                                    loop_pos,
+                                    &iterator,
+                                );
+                                if Self::enter_generator_exception_handler(
+                                    &mut current_try_stack,
+                                    &mut pending_exception,
+                                    &mut current_id,
+                                    e.clone(),
+                                ) {
+                                    continue;
                                 }
                                 self.generator_inline_iters.remove(&o.id);
                                 obj_rc.borrow_mut().kind =
@@ -6210,16 +6256,19 @@ impl Interpreter {
                             let val = match self.iterator_value(&step_result) {
                                 Ok(v) => v,
                                 Err(e) => {
-                                    self.gc_unroot_value(&iterator);
-                                    if let Some(try_info) = current_try_stack.pop() {
-                                        if let Some(catch_state) = try_info.catch_state {
-                                            pending_exception = Some(e);
-                                            current_id = catch_state;
-                                            continue;
-                                        } else if let Some(finally_state) = try_info.finally_state {
-                                            current_id = finally_state;
-                                            continue;
-                                        }
+                                    self.discard_failed_generator_for_of_loop(
+                                        o.id,
+                                        &mut for_of_stack,
+                                        loop_pos,
+                                        &iterator,
+                                    );
+                                    if Self::enter_generator_exception_handler(
+                                        &mut current_try_stack,
+                                        &mut pending_exception,
+                                        &mut current_id,
+                                        e.clone(),
+                                    ) {
+                                        continue;
                                     }
                                     self.generator_inline_iters.remove(&o.id);
                                     obj_rc.borrow_mut().kind =
@@ -6270,7 +6319,37 @@ impl Interpreter {
                                             self.add_disposable_resource(&bind_env, &val, hint)
                                         {
                                             self.iterator_close(&iterator, e.clone());
-                                            self.gc_unroot_value(&iterator);
+                                            self.discard_failed_generator_for_of_loop(
+                                                o.id,
+                                                &mut for_of_stack,
+                                                loop_pos,
+                                                &iterator,
+                                            );
+                                            if Self::enter_generator_exception_handler(
+                                                &mut current_try_stack,
+                                                &mut pending_exception,
+                                                &mut current_id,
+                                                e.clone(),
+                                            ) {
+                                                continue;
+                                            }
+                                            self.generator_inline_iters.remove(&o.id);
+                                            obj_rc.borrow_mut().kind =
+                                                crate::interpreter::types::ObjectKind::Iterator(
+                                                    IteratorState::StateMachineAsyncGenerator {
+                                                        state_machine,
+                                                        func_env,
+                                                        is_strict,
+                                                        execution_state:
+                                                            StateMachineExecutionState::Completed,
+                                                        _sent_value: JsValue::UNDEFINED,
+                                                        try_stack: vec![],
+                                                        pending_binding: None,
+                                                        delegated_iterator: None,
+                                                        pending_exception: None,
+                                                        pending_return: None,
+                                                    },
+                                                );
                                             let _ = self.call_function(
                                                 &reject_fn,
                                                 &JsValue::UNDEFINED,
@@ -6285,18 +6364,19 @@ impl Interpreter {
                                             self.bind_pattern(&d.pattern, val, kind, &bind_env)
                                     {
                                         self.iterator_close(&iterator, e.clone());
-                                        self.gc_unroot_value(&iterator);
-                                        if let Some(try_info) = current_try_stack.pop() {
-                                            if let Some(catch_state) = try_info.catch_state {
-                                                pending_exception = Some(e);
-                                                current_id = catch_state;
-                                                continue;
-                                            } else if let Some(finally_state) =
-                                                try_info.finally_state
-                                            {
-                                                current_id = finally_state;
-                                                continue;
-                                            }
+                                        self.discard_failed_generator_for_of_loop(
+                                            o.id,
+                                            &mut for_of_stack,
+                                            loop_pos,
+                                            &iterator,
+                                        );
+                                        if Self::enter_generator_exception_handler(
+                                            &mut current_try_stack,
+                                            &mut pending_exception,
+                                            &mut current_id,
+                                            e.clone(),
+                                        ) {
+                                            continue;
                                         }
                                         self.generator_inline_iters.remove(&o.id);
                                         obj_rc.borrow_mut().kind =
@@ -6329,18 +6409,19 @@ impl Interpreter {
                                         Completion::Normal(_) | Completion::Empty => {}
                                         Completion::Throw(e) => {
                                             self.iterator_close(&iterator, e.clone());
-                                            self.gc_unroot_value(&iterator);
-                                            if let Some(try_info) = current_try_stack.pop() {
-                                                if let Some(catch_state) = try_info.catch_state {
-                                                    pending_exception = Some(e);
-                                                    current_id = catch_state;
-                                                    continue;
-                                                } else if let Some(finally_state) =
-                                                    try_info.finally_state
-                                                {
-                                                    current_id = finally_state;
-                                                    continue;
-                                                }
+                                            self.discard_failed_generator_for_of_loop(
+                                                o.id,
+                                                &mut for_of_stack,
+                                                loop_pos,
+                                                &iterator,
+                                            );
+                                            if Self::enter_generator_exception_handler(
+                                                &mut current_try_stack,
+                                                &mut pending_exception,
+                                                &mut current_id,
+                                                e.clone(),
+                                            ) {
+                                                continue;
                                             }
                                             self.generator_inline_iters.remove(&o.id);
                                             obj_rc.borrow_mut().kind =
@@ -6395,16 +6476,19 @@ impl Interpreter {
                             current_id = *body_state;
                         }
                         Err(e) => {
-                            self.gc_unroot_value(&iterator);
-                            if let Some(try_info) = current_try_stack.pop() {
-                                if let Some(catch_state) = try_info.catch_state {
-                                    pending_exception = Some(e);
-                                    current_id = catch_state;
-                                    continue;
-                                } else if let Some(finally_state) = try_info.finally_state {
-                                    current_id = finally_state;
-                                    continue;
-                                }
+                            self.discard_failed_generator_for_of_loop(
+                                o.id,
+                                &mut for_of_stack,
+                                loop_pos,
+                                &iterator,
+                            );
+                            if Self::enter_generator_exception_handler(
+                                &mut current_try_stack,
+                                &mut pending_exception,
+                                &mut current_id,
+                                e.clone(),
+                            ) {
+                                continue;
                             }
                             self.generator_inline_iters.remove(&o.id);
                             obj_rc.borrow_mut().kind =
@@ -7330,6 +7414,43 @@ impl Interpreter {
             completion @ (Completion::Throw(_) | Completion::Exit(_)) => Err(completion),
             _ => Ok(()),
         }
+    }
+
+    /// Remove both saved representations of a failed loop after its caller
+    /// has applied the required close behavior. Iterator protocol failures
+    /// call this directly; binding failures call IteratorClose first.
+    fn discard_failed_generator_for_of_loop(
+        &mut self,
+        generator_id: u64,
+        for_of_stack: &mut Vec<ForOfLoopState>,
+        loop_pos: usize,
+        iterator: &JsValue,
+    ) {
+        for_of_stack.remove(loop_pos);
+        self.unroot_for_of_iterator(iterator);
+        self.remove_generator_inline_iterator(generator_id, iterator);
+        self.sync_generator_for_of_stack(generator_id, for_of_stack);
+    }
+
+    fn enter_generator_exception_handler(
+        try_stack: &mut Vec<TryContextInfo>,
+        pending_exception: &mut Option<JsValue>,
+        current_id: &mut usize,
+        error: JsValue,
+    ) -> bool {
+        if let Some(try_info) = try_stack.pop() {
+            if let Some(catch_state) = try_info.catch_state {
+                *pending_exception = Some(error);
+                *current_id = catch_state;
+                return true;
+            }
+            if let Some(finally_state) = try_info.finally_state {
+                *pending_exception = Some(error);
+                *current_id = finally_state;
+                return true;
+            }
+        }
+        false
     }
 
     /// Close transformed generator for-of loops from the inside out while

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -703,6 +703,11 @@ impl Interpreter {
         let mut inline_yield_target: Option<usize> = initial_inline_yield_target;
         let mut inline_yield_sent: Option<JsValue> = initial_inline_yield_sent;
         let mut inline_yield_prev_sent: Option<Vec<JsValue>> = initial_inline_yield_prev_sent;
+        let mut for_of_stack = self
+            .generator_for_of_stacks
+            .get(&o.id)
+            .cloned()
+            .unwrap_or_default();
 
         loop {
             let terminator = state_machine.states[current_id].terminator.clone();
@@ -721,7 +726,11 @@ impl Interpreter {
             }
 
             self.in_state_machine = true;
-            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &func_env);
+            let exec_env = for_of_stack
+                .last()
+                .map_or(&func_env, ForOfLoopState::effective_env)
+                .clone();
+            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &exec_env);
             self.in_state_machine = saved_in_state_machine;
             while let Completion::TailCall { func, this, args } = stmt_result {
                 stmt_result = self.call_function(&func, &this, &args);
@@ -743,6 +752,8 @@ impl Interpreter {
                 } else {
                     self.generator_inline_iters.insert(o.id, pending);
                 }
+                self.generator_for_of_stacks
+                    .insert(o.id, for_of_stack.clone());
                 obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                     IteratorState::StateMachineGenerator {
                         state_machine: state_machine.clone(),
@@ -882,6 +893,7 @@ impl Interpreter {
                 return Completion::Normal(self.create_iter_result_object(ret_val, true));
             }
 
+            let term_env = exec_env;
             match &terminator {
                 StateTerminator::Yield {
                     value,
@@ -890,7 +902,7 @@ impl Interpreter {
                     sent_value_binding,
                 } => {
                     let yield_val = if let Some(expr) = value {
-                        let mut _result = self.eval_expr(expr, &func_env);
+                        let mut _result = self.eval_expr(expr, &term_env);
                         while let Completion::TailCall { func, this, args } = _result {
                             _result = self.call_function(&func, &this, &args);
                         }
@@ -1161,14 +1173,14 @@ impl Interpreter {
                             if let Some(binding) = sent_value_binding {
                                 match &binding.kind {
                                     SentValueBindingKind::Variable(name) => {
-                                        self.env_set(&func_env, name, value.clone()).ok();
+                                        self.env_set(&term_env, name, value.clone()).ok();
                                     }
                                     SentValueBindingKind::Pattern(pattern) => {
                                         let _ = self.bind_pattern(
                                             pattern,
                                             value.clone(),
                                             BindingKind::Var,
-                                            &func_env,
+                                            &term_env,
                                         );
                                     }
                                     SentValueBindingKind::Discard
@@ -1215,6 +1227,8 @@ impl Interpreter {
                     } else {
                         self.generator_inline_iters.insert(o.id, pending);
                     }
+                    self.generator_for_of_stacks
+                        .insert(o.id, for_of_stack.clone());
                     obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                         IteratorState::StateMachineGenerator {
                             state_machine,
@@ -1236,7 +1250,7 @@ impl Interpreter {
 
                 StateTerminator::Return(expr) => {
                     let ret_val = if let Some(e) = expr {
-                        let mut result = self.eval_expr(e, &func_env);
+                        let mut result = self.eval_expr(e, &term_env);
                         while let Completion::TailCall { func, this, args } = result {
                             result = self.call_function(&func, &this, &args);
                         }
@@ -1333,7 +1347,7 @@ impl Interpreter {
 
                 StateTerminator::Throw(expr) => {
                     let throw_val = {
-                        let mut result = self.eval_expr(expr, &func_env);
+                        let mut result = self.eval_expr(expr, &term_env);
                         while let Completion::TailCall { func, this, args } = result {
                             result = self.call_function(&func, &this, &args);
                         }
@@ -1370,6 +1384,14 @@ impl Interpreter {
                 }
 
                 StateTerminator::Goto(next_state) => {
+                    if let Err(e) = self.align_generator_for_of_stack(
+                        o.id,
+                        &mut for_of_stack,
+                        &func_env,
+                        *next_state,
+                    ) {
+                        return Completion::Throw(e);
+                    }
                     current_id = *next_state;
                 }
 
@@ -1377,6 +1399,14 @@ impl Interpreter {
                 // LoopControl. Preserve ordinary generator behavior if a
                 // shared transform ever produces one here.
                 StateTerminator::LoopControl(target) => {
+                    if let Err(e) = self.align_generator_for_of_stack(
+                        o.id,
+                        &mut for_of_stack,
+                        &func_env,
+                        target.target_state,
+                    ) {
+                        return Completion::Throw(e);
+                    }
                     current_id = target.target_state;
                 }
 
@@ -1385,7 +1415,7 @@ impl Interpreter {
                     true_state,
                     false_state,
                 } => {
-                    let cond_val = match self.eval_expr(condition, &func_env) {
+                    let cond_val = match self.eval_expr(condition, &term_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
                             obj_rc.borrow_mut().kind =
@@ -1506,7 +1536,7 @@ impl Interpreter {
                     let exception_val = pending_exception.take().unwrap_or(JsValue::UNDEFINED);
                     if let Some(pattern) = param {
                         let _ =
-                            self.bind_pattern(pattern, exception_val, BindingKind::Let, &func_env);
+                            self.bind_pattern(pattern, exception_val, BindingKind::Let, &term_env);
                     }
                     current_id = *body_state;
                 }
@@ -1524,7 +1554,7 @@ impl Interpreter {
                     default_state,
                     after_state,
                 } => {
-                    let disc_val = match self.eval_expr(discriminant, &func_env) {
+                    let disc_val = match self.eval_expr(discriminant, &term_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
                             obj_rc.borrow_mut().kind =
@@ -1549,7 +1579,7 @@ impl Interpreter {
 
                     let mut matched = false;
                     for case in cases {
-                        let case_val = match self.eval_expr(&case.test, &func_env) {
+                        let case_val = match self.eval_expr(&case.test, &term_env) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
                                 obj_rc.borrow_mut().kind =
@@ -1586,12 +1616,38 @@ impl Interpreter {
                     iterable,
                     iter_var,
                     next_var: _,
-                    left: _,
+                    left,
                     head_state,
-                    after_state: _,
+                    after_state: forinit_after,
                     is_await: _,
                 } => {
-                    let iterable_val = match self.eval_expr(iterable, &func_env) {
+                    // §14.7.5.5: lexical head names are in TDZ while the RHS
+                    // is evaluated, but that temporary environment is not the
+                    // environment used by any loop iteration.
+                    let iterable_env = if let ForInOfLeft::Variable(decl) = left
+                        && !matches!(decl.kind, VarKind::Var)
+                    {
+                        let head_env = Environment::new(Some(term_env.clone()));
+                        let mut tdz_names = Vec::new();
+                        if let Some(d) = decl.declarations.first() {
+                            d.pattern.bound_names(&mut tdz_names);
+                        }
+                        let binding_kind = match decl.kind {
+                            VarKind::Let => BindingKind::Let,
+                            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => {
+                                BindingKind::Const
+                            }
+                            VarKind::Var => unreachable!(),
+                        };
+                        for name in &tdz_names {
+                            head_env.borrow_mut().declare(name, binding_kind);
+                        }
+                        head_env
+                    } else {
+                        term_env.clone()
+                    };
+
+                    let iterable_val = match self.eval_expr(iterable, &iterable_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
                             if let Some(try_info) = current_try_stack.pop() {
@@ -1664,6 +1720,16 @@ impl Interpreter {
                             deletable: false,
                         },
                     );
+                    for_of_stack.push(ForOfLoopState {
+                        iter_var: iter_var.clone(),
+                        head_state: *head_state,
+                        after_state: *forinit_after,
+                        try_depth: current_try_stack.len(),
+                        outer_env: term_env.clone(),
+                        iteration_env: None,
+                    });
+                    self.generator_for_of_stacks
+                        .insert(o.id, for_of_stack.clone());
                     current_id = *head_state;
                 }
 
@@ -1675,6 +1741,32 @@ impl Interpreter {
                     after_state,
                     is_await: _,
                 } => {
+                    let loop_pos = match for_of_stack
+                        .iter()
+                        .rposition(|loop_state| loop_state.iter_var == *iter_var)
+                    {
+                        Some(pos) => pos,
+                        None => {
+                            debug_assert!(false, "for-of head without an active loop state");
+                            for_of_stack.push(ForOfLoopState {
+                                iter_var: iter_var.clone(),
+                                head_state: current_id,
+                                after_state: *after_state,
+                                try_depth: current_try_stack.len(),
+                                outer_env: term_env.clone(),
+                                iteration_env: None,
+                            });
+                            for_of_stack.len() - 1
+                        }
+                    };
+
+                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take()
+                        && let Completion::Throw(e) =
+                            self.dispose_resources(&iteration_env, Completion::Empty)
+                    {
+                        return Completion::Throw(e);
+                    }
+
                     let iterator = func_env
                         .borrow()
                         .bindings
@@ -1731,6 +1823,13 @@ impl Interpreter {
                                     }
                                 });
                             }
+                            for_of_stack.remove(loop_pos);
+                            if for_of_stack.is_empty() {
+                                self.generator_for_of_stacks.remove(&o.id);
+                            } else {
+                                self.generator_for_of_stacks
+                                    .insert(o.id, for_of_stack.clone());
+                            }
                             current_id = *after_state;
                         }
                         Ok(false) => {
@@ -1767,6 +1866,22 @@ impl Interpreter {
                                     return Completion::Throw(e);
                                 }
                             };
+                            let needs_iteration_env = matches!(
+                                left,
+                                ForInOfLeft::Variable(decl)
+                                    if !matches!(decl.kind, VarKind::Var)
+                            );
+                            let outer_env = for_of_stack[loop_pos].outer_env.clone();
+                            let bind_env = if needs_iteration_env {
+                                let iteration_env = Environment::new(Some(outer_env));
+                                for_of_stack[loop_pos].iteration_env = Some(iteration_env.clone());
+                                self.generator_for_of_stacks
+                                    .insert(o.id, for_of_stack.clone());
+                                iteration_env
+                            } else {
+                                outer_env
+                            };
+
                             match left {
                                 ForInOfLeft::Variable(decl) => {
                                     let kind = match decl.kind {
@@ -1776,9 +1891,23 @@ impl Interpreter {
                                             crate::interpreter::types::BindingKind::Const
                                         }
                                     };
+                                    if matches!(decl.kind, VarKind::Using | VarKind::AwaitUsing) {
+                                        let hint = if decl.kind == VarKind::AwaitUsing {
+                                            DisposeHint::Async
+                                        } else {
+                                            DisposeHint::Sync
+                                        };
+                                        if let Err(e) =
+                                            self.add_disposable_resource(&bind_env, &val, hint)
+                                        {
+                                            self.iterator_close(&iterator, e.clone());
+                                            self.gc_unroot_value(&iterator);
+                                            return Completion::Throw(e);
+                                        }
+                                    }
                                     if let Some(d) = decl.declarations.first()
                                         && let Err(e) =
-                                            self.bind_pattern(&d.pattern, val, kind, &func_env)
+                                            self.bind_pattern(&d.pattern, val, kind, &bind_env)
                                     {
                                         self.iterator_close(&iterator, e.clone());
                                         self.gc_unroot_value(&iterator);
@@ -1814,7 +1943,7 @@ impl Interpreter {
                                     }
                                 }
                                 ForInOfLeft::Pattern(pat) => {
-                                    match self.assign_to_for_pattern(pat, val, &func_env) {
+                                    match self.assign_to_for_pattern(pat, val, &term_env) {
                                         Completion::Normal(_) | Completion::Empty => {}
                                         Completion::Throw(e) => {
                                             self.iterator_close(&iterator, e.clone());
@@ -4224,6 +4353,11 @@ impl Interpreter {
         let mut inline_yield_sent: Option<JsValue> = initial_inline_yield_sent;
         let mut inline_yield_prev_sent: Option<Vec<JsValue>> = initial_inline_yield_prev_sent;
         let mut check_abrupt_on_resume = check_abrupt_on_resume;
+        let mut for_of_stack = self
+            .generator_for_of_stacks
+            .get(&o.id)
+            .cloned()
+            .unwrap_or_default();
         loop {
             if check_abrupt_on_resume {
                 check_abrupt_on_resume = false;
@@ -4365,7 +4499,11 @@ impl Interpreter {
             }
 
             self.in_state_machine = true;
-            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &func_env);
+            let exec_env = for_of_stack
+                .last()
+                .map_or(&func_env, ForOfLoopState::effective_env)
+                .clone();
+            let mut stmt_result = self.exec_body(&state_machine.states[current_id].body, &exec_env);
             self.in_state_machine = saved_in_state_machine;
             while let Completion::TailCall { func, this, args } = stmt_result {
                 stmt_result = self.call_function(&func, &this, &args);
@@ -4541,6 +4679,8 @@ impl Interpreter {
                 } else {
                     self.generator_inline_iters.insert(o.id, pending);
                 }
+                self.generator_for_of_stacks
+                    .insert(o.id, for_of_stack.clone());
                 // Any Completion::Yield from exec_statements is an inline yield:
                 // it came from a loop body or complex control flow that isn't
                 // decomposed by the state machine transformer. Use InlineYield
@@ -4578,6 +4718,7 @@ impl Interpreter {
                 return Completion::Normal(promise);
             }
 
+            let term_env = exec_env;
             match &terminator {
                 StateTerminator::Yield {
                     value,
@@ -4586,7 +4727,7 @@ impl Interpreter {
                     sent_value_binding,
                 } => {
                     let yield_val = if let Some(expr) = value {
-                        match self.eval_expr(expr, &func_env) {
+                        match self.eval_expr(expr, &term_env) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
                                 // Route genuine throws through the try-stack for
@@ -5109,7 +5250,7 @@ impl Interpreter {
                 StateTerminator::Return(expr) => {
                     if let Some(e) = expr {
                         // return expr; — §13.10.1 step 3: Await(exprValue)
-                        let mut result = self.eval_expr(e, &func_env);
+                        let mut result = self.eval_expr(e, &term_env);
                         while let Completion::TailCall { func, this, args } = result {
                             result = self.call_function(&func, &this, &args);
                         }
@@ -5317,7 +5458,7 @@ impl Interpreter {
 
                 StateTerminator::Throw(expr) => {
                     let throw_val = {
-                        let mut result = self.eval_expr(expr, &func_env);
+                        let mut result = self.eval_expr(expr, &term_env);
                         while let Completion::TailCall { func, this, args } = result {
                             result = self.call_function(&func, &this, &args);
                         }
@@ -5362,6 +5503,16 @@ impl Interpreter {
                 }
 
                 StateTerminator::Goto(next_state) => {
+                    if let Err(e) = self.align_generator_for_of_stack(
+                        o.id,
+                        &mut for_of_stack,
+                        &func_env,
+                        *next_state,
+                    ) {
+                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
+                        self.drain_microtasks();
+                        return Completion::Normal(promise);
+                    }
                     current_id = *next_state;
                 }
 
@@ -5369,6 +5520,16 @@ impl Interpreter {
                 // LoopControl. Preserve ordinary async-generator behavior if
                 // a shared transform ever produces one here.
                 StateTerminator::LoopControl(target) => {
+                    if let Err(e) = self.align_generator_for_of_stack(
+                        o.id,
+                        &mut for_of_stack,
+                        &func_env,
+                        target.target_state,
+                    ) {
+                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
+                        self.drain_microtasks();
+                        return Completion::Normal(promise);
+                    }
                     current_id = target.target_state;
                 }
 
@@ -5377,7 +5538,7 @@ impl Interpreter {
                     true_state,
                     false_state,
                 } => {
-                    let cond_val = match self.eval_expr(condition, &func_env) {
+                    let cond_val = match self.eval_expr(condition, &term_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
                             self.generator_inline_iters.remove(&o.id);
@@ -5504,7 +5665,7 @@ impl Interpreter {
                     let exception_val = pending_exception.take().unwrap_or(JsValue::UNDEFINED);
                     if let Some(pattern) = param {
                         let _ =
-                            self.bind_pattern(pattern, exception_val, BindingKind::Let, &func_env);
+                            self.bind_pattern(pattern, exception_val, BindingKind::Let, &term_env);
                     }
                     current_id = *body_state;
                 }
@@ -5522,7 +5683,7 @@ impl Interpreter {
                     default_state,
                     after_state,
                 } => {
-                    let disc_val = match self.eval_expr(discriminant, &func_env) {
+                    let disc_val = match self.eval_expr(discriminant, &term_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
                             self.generator_inline_iters.remove(&o.id);
@@ -5556,7 +5717,7 @@ impl Interpreter {
 
                     let mut matched = false;
                     for case in cases {
-                        let case_val = match self.eval_expr(&case.test, &func_env) {
+                        let case_val = match self.eval_expr(&case.test, &term_env) {
                             Completion::Normal(v) => v,
                             Completion::Throw(e) => {
                                 self.generator_inline_iters.remove(&o.id);
@@ -5602,12 +5763,35 @@ impl Interpreter {
                     iterable,
                     iter_var,
                     next_var: _,
-                    left: _,
+                    left,
                     head_state,
-                    after_state: _,
+                    after_state: forinit_after,
                     is_await,
                 } => {
-                    let iterable_val = match self.eval_expr(iterable, &func_env) {
+                    let iterable_env = if let ForInOfLeft::Variable(decl) = left
+                        && !matches!(decl.kind, VarKind::Var)
+                    {
+                        let head_env = Environment::new(Some(term_env.clone()));
+                        let mut tdz_names = Vec::new();
+                        if let Some(d) = decl.declarations.first() {
+                            d.pattern.bound_names(&mut tdz_names);
+                        }
+                        let binding_kind = match decl.kind {
+                            VarKind::Let => BindingKind::Let,
+                            VarKind::Const | VarKind::Using | VarKind::AwaitUsing => {
+                                BindingKind::Const
+                            }
+                            VarKind::Var => unreachable!(),
+                        };
+                        for name in &tdz_names {
+                            head_env.borrow_mut().declare(name, binding_kind);
+                        }
+                        head_env
+                    } else {
+                        term_env.clone()
+                    };
+
+                    let iterable_val = match self.eval_expr(iterable, &iterable_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
                             if let Some(try_info) = current_try_stack.pop() {
@@ -5729,6 +5913,16 @@ impl Interpreter {
                             deletable: false,
                         },
                     );
+                    for_of_stack.push(ForOfLoopState {
+                        iter_var: iter_var.clone(),
+                        head_state: *head_state,
+                        after_state: *forinit_after,
+                        try_depth: current_try_stack.len(),
+                        outer_env: term_env.clone(),
+                        iteration_env: None,
+                    });
+                    self.generator_for_of_stacks
+                        .insert(o.id, for_of_stack.clone());
                     current_id = *head_state;
                 }
 
@@ -5740,6 +5934,34 @@ impl Interpreter {
                     after_state,
                     is_await,
                 } => {
+                    let loop_pos = match for_of_stack
+                        .iter()
+                        .rposition(|loop_state| loop_state.iter_var == *iter_var)
+                    {
+                        Some(pos) => pos,
+                        None => {
+                            debug_assert!(false, "for-of head without an active loop state");
+                            for_of_stack.push(ForOfLoopState {
+                                iter_var: iter_var.clone(),
+                                head_state: current_id,
+                                after_state: *after_state,
+                                try_depth: current_try_stack.len(),
+                                outer_env: term_env.clone(),
+                                iteration_env: None,
+                            });
+                            for_of_stack.len() - 1
+                        }
+                    };
+
+                    if let Some(iteration_env) = for_of_stack[loop_pos].iteration_env.take()
+                        && let Completion::Throw(e) =
+                            self.dispose_resources(&iteration_env, Completion::Empty)
+                    {
+                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
+                        self.drain_microtasks();
+                        return Completion::Normal(promise);
+                    }
+
                     let iterator = func_env
                         .borrow()
                         .bindings
@@ -5845,6 +6067,13 @@ impl Interpreter {
                                     }
                                 });
                             }
+                            for_of_stack.remove(loop_pos);
+                            if for_of_stack.is_empty() {
+                                self.generator_for_of_stacks.remove(&o.id);
+                            } else {
+                                self.generator_for_of_stacks
+                                    .insert(o.id, for_of_stack.clone());
+                            }
                             current_id = *after_state;
                         }
                         Ok(false) => {
@@ -5885,6 +6114,22 @@ impl Interpreter {
                                     return Completion::Normal(promise);
                                 }
                             };
+                            let needs_iteration_env = matches!(
+                                left,
+                                ForInOfLeft::Variable(decl)
+                                    if !matches!(decl.kind, VarKind::Var)
+                            );
+                            let outer_env = for_of_stack[loop_pos].outer_env.clone();
+                            let bind_env = if needs_iteration_env {
+                                let iteration_env = Environment::new(Some(outer_env));
+                                for_of_stack[loop_pos].iteration_env = Some(iteration_env.clone());
+                                self.generator_for_of_stacks
+                                    .insert(o.id, for_of_stack.clone());
+                                iteration_env
+                            } else {
+                                outer_env
+                            };
+
                             match left {
                                 ForInOfLeft::Variable(decl) => {
                                     let kind = match decl.kind {
@@ -5894,9 +6139,29 @@ impl Interpreter {
                                             crate::interpreter::types::BindingKind::Const
                                         }
                                     };
+                                    if matches!(decl.kind, VarKind::Using | VarKind::AwaitUsing) {
+                                        let hint = if decl.kind == VarKind::AwaitUsing {
+                                            DisposeHint::Async
+                                        } else {
+                                            DisposeHint::Sync
+                                        };
+                                        if let Err(e) =
+                                            self.add_disposable_resource(&bind_env, &val, hint)
+                                        {
+                                            self.iterator_close(&iterator, e.clone());
+                                            self.gc_unroot_value(&iterator);
+                                            let _ = self.call_function(
+                                                &reject_fn,
+                                                &JsValue::UNDEFINED,
+                                                &[e],
+                                            );
+                                            self.drain_microtasks();
+                                            return Completion::Normal(promise);
+                                        }
+                                    }
                                     if let Some(d) = decl.declarations.first()
                                         && let Err(e) =
-                                            self.bind_pattern(&d.pattern, val, kind, &func_env)
+                                            self.bind_pattern(&d.pattern, val, kind, &bind_env)
                                     {
                                         self.iterator_close(&iterator, e.clone());
                                         self.gc_unroot_value(&iterator);
@@ -5939,7 +6204,7 @@ impl Interpreter {
                                     }
                                 }
                                 ForInOfLeft::Pattern(pat) => {
-                                    match self.assign_to_for_pattern(pat, val, &func_env) {
+                                    match self.assign_to_for_pattern(pat, val, &term_env) {
                                         Completion::Normal(_) | Completion::Empty => {}
                                         Completion::Throw(e) => {
                                             self.iterator_close(&iterator, e.clone());
@@ -6091,7 +6356,7 @@ impl Interpreter {
                     resume_state,
                     sent_value_binding,
                 } => {
-                    let await_val = match self.eval_expr(value, &func_env) {
+                    let await_val = match self.eval_expr(value, &term_env) {
                         Completion::Normal(v) => v,
                         Completion::Throw(e) => {
                             pending_exception = Some(e);
@@ -6907,5 +7172,53 @@ impl Interpreter {
         let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[exception]);
         self.drain_microtasks();
         Completion::Normal(promise)
+    }
+
+    fn align_generator_for_of_stack(
+        &mut self,
+        generator_id: u64,
+        for_of_stack: &mut Vec<ForOfLoopState>,
+        func_env: &EnvRef,
+        target_state: usize,
+    ) -> Result<(), JsValue> {
+        let keep_len = if let Some(pos) = for_of_stack
+            .iter()
+            .rposition(|loop_state| loop_state.after_state == target_state)
+        {
+            pos
+        } else if let Some(pos) = for_of_stack
+            .iter()
+            .rposition(|loop_state| loop_state.head_state == target_state)
+        {
+            pos + 1
+        } else {
+            for_of_stack.len()
+        };
+
+        while for_of_stack.len() > keep_len {
+            let loop_state = for_of_stack.pop().expect("loop stack is non-empty");
+            if let Some(iteration_env) = loop_state.iteration_env
+                && let Completion::Throw(e) =
+                    self.dispose_resources(&iteration_env, Completion::Empty)
+            {
+                return Err(e);
+            }
+            if let Some(iterator) = func_env.borrow().get(&loop_state.iter_var) {
+                self.iterator_close_result(&iterator)?;
+                self.gc_unroot_value(&iterator);
+                if let Some(iterator_id) = iterator.as_object_id() {
+                    self.pending_iter_close
+                        .retain(|value| value.as_object_id() != Some(iterator_id));
+                }
+            }
+        }
+
+        if for_of_stack.is_empty() {
+            self.generator_for_of_stacks.remove(&generator_id);
+        } else {
+            self.generator_for_of_stacks
+                .insert(generator_id, for_of_stack.clone());
+        }
+        Ok(())
     }
 }

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -833,63 +833,24 @@ impl Interpreter {
                 return disp;
             }
             if let Completion::Return(v) = stmt_result {
-                // Check try_stack for enclosing finally blocks before completing
-                let mut ret_val_opt = Some(v);
-                for i in (0..current_try_stack.len()).rev() {
-                    if !current_try_stack[i].entered_finally
-                        && current_try_stack[i].finally_state.is_some()
-                    {
-                        pending_return = ret_val_opt.take();
-                        let finally_state = current_try_stack[i].finally_state.unwrap();
-                        current_try_stack = current_try_stack[..=i].to_vec();
-                        current_id = finally_state;
-                        break;
-                    }
-                }
-                if ret_val_opt.is_none() {
-                    continue;
-                }
-                let v = ret_val_opt.unwrap();
-                // §27.5.3.3: DisposeResources when generator returns
-                let disp = self.dispose_resources(&func_env, Completion::Return(v));
-                let ret_val = match disp {
-                    Completion::Return(v) => v,
-                    Completion::Throw(e) => {
-                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
-                            IteratorState::StateMachineGenerator {
-                                state_machine,
-                                func_env,
-                                is_strict,
-                                execution_state: StateMachineExecutionState::Completed,
-                                _sent_value: JsValue::UNDEFINED,
-                                try_stack: vec![],
-                                pending_binding: None,
-                                delegated_iterator: None,
-                                pending_exception: None,
-                                pending_return: None,
-                            },
-                        );
-                        self.generator_inline_iters.remove(&o.id);
-                        return Completion::Throw(e);
-                    }
-                    _ => JsValue::UNDEFINED,
-                };
+                self.sync_generator_for_of_stack(o.id, &for_of_stack);
                 obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                     IteratorState::StateMachineGenerator {
                         state_machine,
                         func_env,
                         is_strict,
-                        execution_state: StateMachineExecutionState::Completed,
+                        execution_state: StateMachineExecutionState::SuspendedAtState {
+                            state_id: current_id,
+                        },
                         _sent_value: JsValue::UNDEFINED,
-                        try_stack: vec![],
+                        try_stack: current_try_stack,
                         pending_binding: None,
                         delegated_iterator: None,
-                        pending_exception: None,
-                        pending_return: None,
+                        pending_exception: pending_exception.take(),
+                        pending_return: pending_return.take(),
                     },
                 );
-                self.generator_inline_iters.remove(&o.id);
-                return Completion::Normal(self.create_iter_result_object(ret_val, true));
+                return self.generator_return_state_machine(this, v);
             }
 
             match &terminator {
@@ -1280,66 +1241,28 @@ impl Interpreter {
                         JsValue::UNDEFINED
                     };
 
-                    // Check try_stack for enclosing finally blocks before completing
-                    let mut ret_val_opt = Some(ret_val);
-                    for i in (0..current_try_stack.len()).rev() {
-                        if !current_try_stack[i].entered_finally
-                            && current_try_stack[i].finally_state.is_some()
-                        {
-                            pending_return = ret_val_opt.take();
-                            let finally_state = current_try_stack[i].finally_state.unwrap();
-                            current_try_stack = current_try_stack[..=i].to_vec();
-                            current_id = finally_state;
-                            break;
-                        }
-                    }
-                    if ret_val_opt.is_none() {
-                        continue;
-                    }
-                    let ret_val = ret_val_opt.unwrap();
-
-                    // §27.5.3.3: DisposeResources when generator completes via return
-                    let disp = self.dispose_resources(&func_env, Completion::Return(ret_val));
-                    let ret_val = match disp {
-                        Completion::Return(v) => v,
-                        Completion::Throw(e) => {
-                            obj_rc.borrow_mut().kind =
-                                crate::interpreter::types::ObjectKind::Iterator(
-                                    IteratorState::StateMachineGenerator {
-                                        state_machine,
-                                        func_env,
-                                        is_strict,
-                                        execution_state: StateMachineExecutionState::Completed,
-                                        _sent_value: JsValue::UNDEFINED,
-                                        try_stack: vec![],
-                                        pending_binding: None,
-                                        delegated_iterator: None,
-                                        pending_exception: None,
-                                        pending_return: None,
-                                    },
-                                );
-                            self.generator_inline_iters.remove(&o.id);
-                            return Completion::Throw(e);
-                        }
-                        _ => JsValue::UNDEFINED,
-                    };
-
+                    // A source-level return is the same abrupt completion as
+                    // one injected through Generator.prototype.return. Reuse
+                    // that path so inner finalizers, per-iteration disposal,
+                    // IteratorClose, and outer finalizers keep their ordering.
+                    self.sync_generator_for_of_stack(o.id, &for_of_stack);
                     obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                         IteratorState::StateMachineGenerator {
                             state_machine,
                             func_env,
                             is_strict,
-                            execution_state: StateMachineExecutionState::Completed,
+                            execution_state: StateMachineExecutionState::SuspendedAtState {
+                                state_id: current_id,
+                            },
                             _sent_value: JsValue::UNDEFINED,
-                            try_stack: vec![],
+                            try_stack: current_try_stack,
                             pending_binding: None,
                             delegated_iterator: None,
-                            pending_exception: None,
-                            pending_return: None,
+                            pending_exception: pending_exception.take(),
+                            pending_return: pending_return.take(),
                         },
                     );
-                    self.generator_inline_iters.remove(&o.id);
-                    return Completion::Normal(self.create_iter_result_object(ret_val, true));
+                    return self.generator_return_state_machine(this, ret_val);
                 }
 
                 StateTerminator::Throw(expr) => {
@@ -4556,76 +4479,124 @@ impl Interpreter {
                 }
                 // Check pending_return before executing state (handles .return() with no try/catch)
                 if let Some(ret_val) = pending_return.take() {
-                    if current_try_stack.is_empty() {
-                        if let Some(iters) = self.generator_inline_iters.remove(&o.id) {
-                            for iter in iters {
-                                if let Err(e) = self.iterator_close_result(&iter) {
-                                    self.generator_inline_iters.remove(&o.id);
-                                    obj_rc.borrow_mut().kind =
-                                        crate::interpreter::types::ObjectKind::Iterator(
-                                            IteratorState::StateMachineAsyncGenerator {
-                                                state_machine,
-                                                func_env,
-                                                is_strict,
-                                                execution_state:
-                                                    StateMachineExecutionState::Completed,
-                                                _sent_value: JsValue::UNDEFINED,
-                                                try_stack: vec![],
-                                                pending_binding: None,
-                                                delegated_iterator: None,
-                                                pending_exception: None,
-                                                pending_return: None,
-                                            },
-                                        );
-                                    let _ =
-                                        self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
-                                    self.drain_microtasks();
-                                    return Completion::Normal(promise);
-                                }
-                            }
-                        }
-                        self.generator_inline_iters.remove(&o.id);
-                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
-                            IteratorState::StateMachineAsyncGenerator {
-                                state_machine,
-                                func_env,
-                                is_strict,
-                                execution_state: StateMachineExecutionState::Completed,
-                                _sent_value: JsValue::UNDEFINED,
-                                try_stack: vec![],
-                                pending_binding: None,
-                                delegated_iterator: None,
-                                pending_exception: None,
-                                pending_return: None,
-                            },
-                        );
-                        let promise_id = if let Some(po) = (promise)
-                            .as_object_id()
-                            .map(|id| crate::types::JsObject { id })
-                        {
-                            po.id
-                        } else {
-                            0
-                        };
-                        return self.async_generator_await_return(ret_val, promise_id);
-                    }
-                    // Has try/finally — route to finally handler
-                    let mut return_handled = false;
-                    for i in (0..current_try_stack.len()).rev() {
-                        if !current_try_stack[i].entered_finally
-                            && let Some(finally_state) = current_try_stack[i].finally_state
-                        {
-                            pending_return = Some(ret_val.clone());
-                            current_id = finally_state;
-                            return_handled = true;
-                            break;
-                        }
-                    }
-                    if return_handled {
+                    // A yield can suspend while evaluating a destructuring
+                    // pattern. Those expression-level iterators are inside
+                    // every lexical finally and for-of loop, so close them
+                    // before unwinding either. A close failure replaces the
+                    // injected return and must enter the generator's handlers.
+                    let active_for_of_iterator_ids: Vec<u64> = for_of_stack
+                        .iter()
+                        .filter_map(|loop_state| {
+                            func_env
+                                .borrow()
+                                .get(&loop_state.iter_var)
+                                .and_then(|iterator| iterator.as_object_id())
+                        })
+                        .collect();
+                    let inline_close_error = self
+                        .generator_inline_iters
+                        .remove(&o.id)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|iterator| {
+                            iterator.as_object_id().is_none_or(|iterator_id| {
+                                !active_for_of_iterator_ids.contains(&iterator_id)
+                            })
+                        })
+                        .find_map(|iterator| self.iterator_close_result(&iterator).err());
+                    if let Some(error) = inline_close_error {
+                        pending_exception = Some(error);
+                        check_abrupt_on_resume = true;
                         continue;
                     }
-                    // No finally — just propagate
-                    pending_return = Some(ret_val);
+
+                    let finally_idx = (0..current_try_stack.len()).rev().find(|&i| {
+                        !current_try_stack[i].entered_finally
+                            && current_try_stack[i].finally_state.is_some()
+                    });
+                    let unwind_from = finally_idx.map_or(0, |handler_depth| {
+                        for_of_stack
+                            .iter()
+                            .position(|loop_state| loop_state.try_depth > handler_depth)
+                            .unwrap_or(for_of_stack.len())
+                    });
+                    let return_completion = self.unwind_generator_for_of_loops(
+                        o.id,
+                        &mut for_of_stack,
+                        &mut current_try_stack,
+                        &func_env,
+                        unwind_from,
+                        Completion::Return(ret_val),
+                    );
+                    let return_value = match return_completion {
+                        Completion::Return(value) => value,
+                        Completion::Throw(error) => {
+                            pending_exception = Some(error);
+                            check_abrupt_on_resume = true;
+                            continue;
+                        }
+                        Completion::Exit(code) => {
+                            self.generator_inline_iters.remove(&o.id);
+                            self.generator_for_of_stacks.remove(&o.id);
+                            obj_rc.borrow_mut().kind =
+                                crate::interpreter::types::ObjectKind::Iterator(
+                                    IteratorState::StateMachineAsyncGenerator {
+                                        state_machine,
+                                        func_env,
+                                        is_strict,
+                                        execution_state: StateMachineExecutionState::Completed,
+                                        _sent_value: JsValue::UNDEFINED,
+                                        try_stack: vec![],
+                                        pending_binding: None,
+                                        delegated_iterator: None,
+                                        pending_exception: None,
+                                        pending_return: None,
+                                    },
+                                );
+                            return Completion::Exit(code);
+                        }
+                        _ => JsValue::UNDEFINED,
+                    };
+
+                    if let Some(idx) = finally_idx {
+                        let finally_state = current_try_stack[idx].finally_state.unwrap();
+                        current_try_stack = current_try_stack[..=idx].to_vec();
+                        pending_return = Some(return_value);
+                        current_id = finally_state;
+                        continue;
+                    }
+
+                    let completion =
+                        self.dispose_resources(&func_env, Completion::Return(return_value));
+                    self.generator_inline_iters.remove(&o.id);
+                    self.generator_for_of_stacks.remove(&o.id);
+                    obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
+                        IteratorState::StateMachineAsyncGenerator {
+                            state_machine,
+                            func_env,
+                            is_strict,
+                            execution_state: StateMachineExecutionState::Completed,
+                            _sent_value: JsValue::UNDEFINED,
+                            try_stack: vec![],
+                            pending_binding: None,
+                            delegated_iterator: None,
+                            pending_exception: None,
+                            pending_return: None,
+                        },
+                    );
+                    return match completion {
+                        Completion::Return(value) => {
+                            let promise_id = promise.as_object_id().unwrap_or(0);
+                            self.async_generator_await_return(value, promise_id)
+                        }
+                        Completion::Throw(error) => {
+                            let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[error]);
+                            self.drain_microtasks();
+                            Completion::Normal(promise)
+                        }
+                        Completion::Exit(code) => Completion::Exit(code),
+                        _ => unreachable!("disposing an async return changed its completion kind"),
+                    };
                 }
             } // end if check_abrupt_on_resume
 
@@ -4722,75 +4693,26 @@ impl Interpreter {
                 return Completion::Normal(promise);
             }
             if let Completion::Return(v) = stmt_result {
-                // §27.6.3.3: DisposeResources when async generator returns
-                let disp = self.dispose_resources(&func_env, Completion::Return(v));
-                let v = match disp {
-                    Completion::Return(v) => v,
-                    Completion::Throw(e) => {
-                        self.generator_inline_iters.remove(&o.id);
-                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
-                            IteratorState::StateMachineAsyncGenerator {
-                                state_machine,
-                                func_env,
-                                is_strict,
-                                execution_state: StateMachineExecutionState::Completed,
-                                _sent_value: JsValue::UNDEFINED,
-                                try_stack: vec![],
-                                pending_binding: None,
-                                delegated_iterator: None,
-                                pending_exception: None,
-                                pending_return: None,
-                            },
-                        );
-                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
-                        self.drain_microtasks();
-                        return Completion::Normal(promise);
-                    }
-                    _ => JsValue::UNDEFINED,
-                };
-                let awaited = match self.await_value(&v) {
-                    Completion::Normal(av) => av,
-                    Completion::Throw(e) => {
-                        self.generator_inline_iters.remove(&o.id);
-                        obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
-                            IteratorState::StateMachineAsyncGenerator {
-                                state_machine,
-                                func_env,
-                                is_strict,
-                                execution_state: StateMachineExecutionState::Completed,
-                                _sent_value: JsValue::UNDEFINED,
-                                try_stack: vec![],
-                                pending_binding: None,
-                                delegated_iterator: None,
-                                pending_exception: None,
-                                pending_return: None,
-                            },
-                        );
-                        let _ = self.call_function(&reject_fn, &JsValue::UNDEFINED, &[e]);
-                        self.drain_microtasks();
-                        return Completion::Normal(promise);
-                    }
-                    _ => JsValue::UNDEFINED,
-                };
-                self.generator_inline_iters.remove(&o.id);
+                self.sync_generator_for_of_stack(o.id, &for_of_stack);
                 obj_rc.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(
                     IteratorState::StateMachineAsyncGenerator {
                         state_machine,
                         func_env,
                         is_strict,
-                        execution_state: StateMachineExecutionState::Completed,
+                        execution_state: StateMachineExecutionState::SuspendedAtState {
+                            state_id: current_id,
+                        },
                         _sent_value: JsValue::UNDEFINED,
-                        try_stack: vec![],
+                        try_stack: current_try_stack,
                         pending_binding: None,
                         delegated_iterator: None,
-                        pending_exception: None,
-                        pending_return: None,
+                        pending_exception: pending_exception.take(),
+                        pending_return: pending_return.take(),
                     },
                 );
-                let iter_result = self.create_iter_result_object(awaited, true);
-                let _ = self.call_function(&resolve_fn, &JsValue::UNDEFINED, &[iter_result]);
-                self.drain_microtasks();
-                return Completion::Normal(promise);
+                return self.async_generator_return_state_machine_with_promise(
+                    this, v, promise, resolve_fn, reject_fn,
+                );
             }
             if let Completion::Yield(yield_val) = stmt_result {
                 let _is_destructuring = self.destructuring_yield;
@@ -5435,6 +5357,89 @@ impl Interpreter {
                             }
                         };
 
+                        if current_try_stack.iter().any(|try_info| {
+                            !try_info.entered_finally && try_info.finally_state.is_some()
+                        }) {
+                            self.sync_generator_for_of_stack(o.id, &for_of_stack);
+                            obj_rc.borrow_mut().kind =
+                                crate::interpreter::types::ObjectKind::Iterator(
+                                    IteratorState::StateMachineAsyncGenerator {
+                                        state_machine,
+                                        func_env,
+                                        is_strict,
+                                        execution_state:
+                                            StateMachineExecutionState::SuspendedAtState {
+                                                state_id: current_id,
+                                            },
+                                        _sent_value: JsValue::UNDEFINED,
+                                        try_stack: current_try_stack,
+                                        pending_binding: None,
+                                        delegated_iterator: None,
+                                        pending_exception: pending_exception.take(),
+                                        pending_return: pending_return.take(),
+                                    },
+                                );
+                            return self.async_generator_return_state_machine_with_promise(
+                                this, ret_val, promise, resolve_fn, reject_fn,
+                            );
+                        }
+
+                        let return_completion = self.unwind_generator_for_of_loops(
+                            o.id,
+                            &mut for_of_stack,
+                            &mut current_try_stack,
+                            &func_env,
+                            0,
+                            Completion::Return(ret_val),
+                        );
+                        let ret_val = match return_completion {
+                            Completion::Return(value) => value,
+                            Completion::Throw(error) => {
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineAsyncGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state:
+                                                StateMachineExecutionState::SuspendedAtState {
+                                                    state_id: current_id,
+                                                },
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: current_try_stack,
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return self.async_generator_throw_state_machine_with_promise(
+                                    this, error, promise, resolve_fn, reject_fn,
+                                );
+                            }
+                            Completion::Exit(code) => {
+                                self.generator_inline_iters.remove(&o.id);
+                                self.generator_for_of_stacks.remove(&o.id);
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineAsyncGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state: StateMachineExecutionState::Completed,
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: vec![],
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return Completion::Exit(code);
+                            }
+                            _ => JsValue::UNDEFINED,
+                        };
+
                         // §27.6.3.3: DisposeResources
                         let disp =
                             self.dispose_resources(&func_env, Completion::Return(ret_val.clone()));
@@ -5551,8 +5556,93 @@ impl Interpreter {
                         return Completion::Normal(promise);
                     } else {
                         // return; — no expression, no Await per §13.10.1
+                        if current_try_stack.iter().any(|try_info| {
+                            !try_info.entered_finally && try_info.finally_state.is_some()
+                        }) {
+                            self.sync_generator_for_of_stack(o.id, &for_of_stack);
+                            obj_rc.borrow_mut().kind =
+                                crate::interpreter::types::ObjectKind::Iterator(
+                                    IteratorState::StateMachineAsyncGenerator {
+                                        state_machine,
+                                        func_env,
+                                        is_strict,
+                                        execution_state:
+                                            StateMachineExecutionState::SuspendedAtState {
+                                                state_id: current_id,
+                                            },
+                                        _sent_value: JsValue::UNDEFINED,
+                                        try_stack: current_try_stack,
+                                        pending_binding: None,
+                                        delegated_iterator: None,
+                                        pending_exception: pending_exception.take(),
+                                        pending_return: pending_return.take(),
+                                    },
+                                );
+                            return self.async_generator_return_state_machine_with_promise(
+                                this,
+                                JsValue::UNDEFINED,
+                                promise,
+                                resolve_fn,
+                                reject_fn,
+                            );
+                        }
+                        let return_completion = self.unwind_generator_for_of_loops(
+                            o.id,
+                            &mut for_of_stack,
+                            &mut current_try_stack,
+                            &func_env,
+                            0,
+                            Completion::Return(JsValue::UNDEFINED),
+                        );
+                        let return_value = match return_completion {
+                            Completion::Return(value) => value,
+                            Completion::Throw(error) => {
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineAsyncGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state:
+                                                StateMachineExecutionState::SuspendedAtState {
+                                                    state_id: current_id,
+                                                },
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: current_try_stack,
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return self.async_generator_throw_state_machine_with_promise(
+                                    this, error, promise, resolve_fn, reject_fn,
+                                );
+                            }
+                            Completion::Exit(code) => {
+                                self.generator_inline_iters.remove(&o.id);
+                                self.generator_for_of_stacks.remove(&o.id);
+                                obj_rc.borrow_mut().kind =
+                                    crate::interpreter::types::ObjectKind::Iterator(
+                                        IteratorState::StateMachineAsyncGenerator {
+                                            state_machine,
+                                            func_env,
+                                            is_strict,
+                                            execution_state: StateMachineExecutionState::Completed,
+                                            _sent_value: JsValue::UNDEFINED,
+                                            try_stack: vec![],
+                                            pending_binding: None,
+                                            delegated_iterator: None,
+                                            pending_exception: None,
+                                            pending_return: None,
+                                        },
+                                    );
+                                return Completion::Exit(code);
+                            }
+                            _ => JsValue::UNDEFINED,
+                        };
                         let disp = self
-                            .dispose_resources(&func_env, Completion::Return(JsValue::UNDEFINED));
+                            .dispose_resources(&func_env, Completion::Return(return_value.clone()));
                         match disp {
                             Completion::Return(_) => {}
                             Completion::Throw(e) => {
@@ -5593,7 +5683,7 @@ impl Interpreter {
                                 pending_return: None,
                             },
                         );
-                        let iter_result = self.create_iter_result_object(JsValue::UNDEFINED, true);
+                        let iter_result = self.create_iter_result_object(return_value, true);
                         let _ =
                             self.call_function(&resolve_fn, &JsValue::UNDEFINED, &[iter_result]);
                         return Completion::Normal(promise);
@@ -5785,33 +5875,10 @@ impl Interpreter {
                         return Completion::Normal(promise);
                     }
                     if let Some(ret_val) = pending_return.take() {
-                        if current_try_stack.is_empty() {
-                            self.generator_inline_iters.remove(&o.id);
-                            obj_rc.borrow_mut().kind =
-                                crate::interpreter::types::ObjectKind::Iterator(
-                                    IteratorState::StateMachineAsyncGenerator {
-                                        state_machine,
-                                        func_env,
-                                        is_strict,
-                                        execution_state: StateMachineExecutionState::Completed,
-                                        _sent_value: JsValue::UNDEFINED,
-                                        try_stack: vec![],
-                                        pending_binding: None,
-                                        delegated_iterator: None,
-                                        pending_exception: None,
-                                        pending_return: None,
-                                    },
-                                );
-                            let iter_result = self.create_iter_result_object(ret_val, true);
-                            let _ = self.call_function(
-                                &resolve_fn,
-                                &JsValue::UNDEFINED,
-                                &[iter_result],
-                            );
-                            self.drain_microtasks();
-                            return Completion::Normal(promise);
-                        }
                         pending_return = Some(ret_val);
+                        check_abrupt_on_resume = true;
+                        current_id = *after_state;
+                        continue;
                     }
                     current_id = *after_state;
                 }

--- a/src/interpreter/exec.rs
+++ b/src/interpreter/exec.rs
@@ -1170,11 +1170,7 @@ impl Interpreter {
                 }
             }
             if is_using {
-                let hint = if decl.kind == VarKind::AwaitUsing {
-                    DisposeHint::Async
-                } else {
-                    DisposeHint::Sync
-                };
+                let hint = DisposeHint::for_var_kind(decl.kind);
                 if let Err(e) = self.add_disposable_resource(env, &val, hint) {
                     return Completion::Throw(e);
                 }
@@ -2104,11 +2100,7 @@ impl Interpreter {
                         &for_env
                     };
                     if is_using {
-                        let hint = if decl.kind == VarKind::AwaitUsing {
-                            DisposeHint::Async
-                        } else {
-                            DisposeHint::Sync
-                        };
+                        let hint = DisposeHint::for_var_kind(decl.kind);
                         if let Err(e) = self.add_disposable_resource(bind_env, &val, hint) {
                             self.iterator_close(iterator, e.clone());
                             return Completion::Throw(e);

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -352,6 +352,14 @@ impl Interpreter {
                 Self::collect_value_roots(val, &mut roots);
             }
         }
+        for for_of_stack in self.generator_for_of_stacks.values() {
+            for loop_state in for_of_stack {
+                Self::collect_env_roots(&loop_state.outer_env, &mut roots, &mut seen_envs);
+                if let Some(ref env) = loop_state.iteration_env {
+                    Self::collect_env_roots(env, &mut roots, &mut seen_envs);
+                }
+            }
+        }
         for val in self.iterator_next_cache.values() {
             Self::collect_value_roots(val, &mut roots);
         }
@@ -632,6 +640,7 @@ impl Interpreter {
         self.function_realm_map.remove(&id);
         self.iterator_next_cache.remove(&id);
         self.generator_inline_iters.remove(&id);
+        self.generator_for_of_stacks.remove(&id);
     }
 
     fn gc_collect_major(&mut self) {

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -353,12 +353,7 @@ impl Interpreter {
             }
         }
         for for_of_stack in self.generator_for_of_stacks.values() {
-            for loop_state in for_of_stack {
-                Self::collect_env_roots(&loop_state.outer_env, &mut roots, &mut seen_envs);
-                if let Some(ref env) = loop_state.iteration_env {
-                    Self::collect_env_roots(env, &mut roots, &mut seen_envs);
-                }
-            }
+            Self::collect_for_of_stack_roots(for_of_stack, &mut roots, &mut seen_envs);
         }
         for val in self.iterator_next_cache.values() {
             Self::collect_value_roots(val, &mut roots);
@@ -373,12 +368,7 @@ impl Interpreter {
             if let Some(ref v) = afs.saved_finally_exception {
                 Self::collect_value_roots(v, &mut roots);
             }
-            for loop_state in &afs.for_of_stack {
-                Self::collect_env_roots(&loop_state.outer_env, &mut roots, &mut seen_envs);
-                if let Some(ref env) = loop_state.iteration_env {
-                    Self::collect_env_roots(env, &mut roots, &mut seen_envs);
-                }
-            }
+            Self::collect_for_of_stack_roots(&afs.for_of_stack, &mut roots, &mut seen_envs);
         }
 
         (roots, seen_envs)
@@ -1023,6 +1013,23 @@ impl Interpreter {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Roots the environments a suspended driver's for-of stack still holds.
+    /// Shared by the async-function states and the generator side table so a
+    /// new field on `ForOfLoopState` cannot be traced in one and missed in the
+    /// other.
+    fn collect_for_of_stack_roots(
+        for_of_stack: &[ForOfLoopState],
+        worklist: &mut Vec<u64>,
+        seen_envs: &mut HashSet<usize>,
+    ) {
+        for loop_state in for_of_stack {
+            Self::collect_env_roots(&loop_state.outer_env, worklist, seen_envs);
+            if let Some(ref env) = loop_state.iteration_env {
+                Self::collect_env_roots(env, worklist, seen_envs);
+            }
         }
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -250,6 +250,7 @@ pub(crate) struct Interpreter {
     /// the native-stack guard fires.
     pub(crate) active_array_joins: Vec<u64>,
     pub(crate) generator_inline_iters: FxHashMap<u64, Vec<JsValue>>,
+    pub(crate) generator_for_of_stacks: FxHashMap<u64, Vec<ForOfLoopState>>,
     pub(crate) scheduler: scheduler::JobScheduler,
     cached_has_instance_key: Option<JsPropertyKey>,
     module_registry: HashMap<(usize, ModuleKey), Rc<RefCell<LoadedModule>>>,
@@ -560,6 +561,7 @@ impl Interpreter {
             pending_iter_close: Vec::new(),
             active_array_joins: Vec::new(),
             generator_inline_iters: FxHashMap::default(),
+            generator_for_of_stacks: FxHashMap::default(),
             scheduler: scheduler::JobScheduler::default(),
             cached_has_instance_key: None,
             module_registry: HashMap::new(),

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3594,6 +3594,119 @@ mod node_host_tests {
     }
 
     #[test]
+    fn host_exit_from_generator_loop_disposer_stops_iteration() {
+        // A resumed generator disposes the previous `for (using ...)`
+        // iteration before requesting the next value. An exit from that
+        // disposer must complete the generator without calling next() or
+        // IteratorClose afterward.
+        let (interp, c) = run_node_script(
+            r#"
+            globalThis.nextCalls = 0;
+            globalThis.cleanup = "no";
+            globalThis.after = "no";
+            globalThis.iter = {
+              done: false,
+              [Symbol.iterator]() { return this; },
+              next() {
+                globalThis.nextCalls++;
+                if (this.done) return { done: true };
+                this.done = true;
+                return {
+                  value: { [Symbol.dispose]() { __host_exit(3); } },
+                  done: false,
+                };
+              },
+              return() { globalThis.cleanup = "ran"; return { done: true }; },
+            };
+            function* g() {
+              for (using resource of iter) {
+                yield resource;
+              }
+            }
+            globalThis.gen = g();
+            gen.next();
+            gen.next();
+            globalThis.after = "yes";
+            "#,
+        );
+        assert!(matches!(c, Completion::Exit(3)));
+        assert_eq!(interp.pending_exit, Some(3));
+        assert_eq!(global_number(&interp, "nextCalls"), 1.0);
+        assert_eq!(global_string(&interp, "cleanup"), "no");
+        assert_eq!(global_string(&interp, "after"), "no");
+
+        let generator_id = global_object_id(&interp, "gen");
+        let iterator_id = global_object_id(&interp, "iter");
+        let generator = interp.get_object(generator_id).unwrap();
+        assert!(matches!(
+            generator.borrow().iterator_state(),
+            Some(IteratorState::StateMachineGenerator {
+                execution_state: StateMachineExecutionState::Completed,
+                ..
+            })
+        ));
+        assert!(!interp.generator_for_of_stacks.contains_key(&generator_id));
+        assert!(!interp.generator_inline_iters.contains_key(&generator_id));
+        assert!(!interp.gc_temp_roots.contains(&iterator_id));
+    }
+
+    #[test]
+    fn host_exit_from_async_generator_loop_disposer_stops_iteration() {
+        // The async-generator queue is a completion-less boundary. It must
+        // latch an Exit returned by the resumed state machine, leave the
+        // request promise unsettled, and stop the current reaction immediately.
+        let (interp, _c) = run_node_script(
+            r#"
+            globalThis.nextCalls = 0;
+            globalThis.cleanup = "no";
+            globalThis.after = "no";
+            globalThis.iter = {
+              done: false,
+              [Symbol.iterator]() { return this; },
+              next() {
+                globalThis.nextCalls++;
+                if (this.done) return { done: true };
+                this.done = true;
+                return {
+                  value: { [Symbol.dispose]() { __host_exit(4); } },
+                  done: false,
+                };
+              },
+              return() { globalThis.cleanup = "ran"; return { done: true }; },
+            };
+            async function* g() {
+              for (using resource of iter) {
+                yield resource;
+              }
+            }
+            globalThis.gen = g();
+            gen.next().then(function () {
+              gen.next();
+              globalThis.after = "yes";
+            });
+            "#,
+        );
+        assert_eq!(interp.pending_exit, Some(4));
+        assert_eq!(global_number(&interp, "nextCalls"), 1.0);
+        assert_eq!(global_string(&interp, "cleanup"), "no");
+        assert_eq!(global_string(&interp, "after"), "no");
+
+        let generator_id = global_object_id(&interp, "gen");
+        let iterator_id = global_object_id(&interp, "iter");
+        let generator = interp.get_object(generator_id).unwrap();
+        assert!(matches!(
+            generator.borrow().iterator_state(),
+            Some(IteratorState::StateMachineAsyncGenerator {
+                execution_state: StateMachineExecutionState::Completed,
+                ..
+            })
+        ));
+        assert!(!interp.generator_for_of_stacks.contains_key(&generator_id));
+        assert!(!interp.generator_inline_iters.contains_key(&generator_id));
+        assert!(!interp.gc_temp_roots.contains(&iterator_id));
+    }
+
+    #[test]
     fn host_exit_from_inner_async_iterator_close_skips_outer_cleanup() {
         // An exit requested by an inner iterator's return() must stop the
         // transformed unwind before it invokes an outer iterator's return().

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -341,6 +341,8 @@ pub(crate) struct ForOfLoopState {
     /// Depth of the driver's try stack when the loop began, so an abrupt
     /// completion can tell a `finally` lexically inside the loop (which runs
     /// before IteratorClose) from one outside it (which runs after).
+    /// Only the async-function driver's unwinder reads this; the generator
+    /// drivers record it but do not yet consult it.
     pub(crate) try_depth: usize,
     /// The LexicalEnvironment active when ForIn/OfBodyEvaluation began.
     pub(crate) outer_env: EnvRef,
@@ -741,6 +743,18 @@ pub(crate) struct Environment {
 pub(crate) enum DisposeHint {
     Sync,
     Async,
+}
+
+impl DisposeHint {
+    /// The hint a `using` / `await using` declaration disposes its resources
+    /// with. Non-`using` kinds never reach this.
+    pub(crate) fn for_var_kind(kind: VarKind) -> Self {
+        if kind == VarKind::AwaitUsing {
+            Self::Async
+        } else {
+            Self::Sync
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -329,12 +329,12 @@ pub(crate) struct AsyncFunctionState {
     pub pending_for_of_unwind: Option<PendingForOfUnwind>,
     pub resolve_fn: JsValue,
     pub reject_fn: JsValue,
-    pub for_of_stack: Vec<AsyncForOfLoopState>,
+    pub for_of_stack: Vec<ForOfLoopState>,
     pub module_path: Option<super::ModuleKey>,
 }
 
 #[derive(Clone)]
-pub(crate) struct AsyncForOfLoopState {
+pub(crate) struct ForOfLoopState {
     pub(crate) iter_var: String,
     pub(crate) head_state: usize,
     pub(crate) after_state: usize,
@@ -348,7 +348,7 @@ pub(crate) struct AsyncForOfLoopState {
     pub(crate) iteration_env: Option<EnvRef>,
 }
 
-impl AsyncForOfLoopState {
+impl ForOfLoopState {
     pub(crate) fn effective_env(&self) -> &EnvRef {
         self.iteration_env.as_ref().unwrap_or(&self.outer_env)
     }

--- a/test262-extra/generator-for-of-abrupt-exit-closes-iterators.js
+++ b/test262-extra/generator-for-of-abrupt-exit-closes-iterators.js
@@ -116,3 +116,156 @@ assert.compareArray(
   ['iteration', 'finally'],
   'the finally block runs before the disposer error escapes'
 );
+
+// IteratorClose failures are abrupt completions of the loop and therefore
+// remain inside the generator's own control flow.
+function throwingCloseIterable() {
+  return {
+    [Symbol.iterator]: function () {
+      return {
+        next: function () {
+          return { value: 1, done: false };
+        },
+        return: function () {
+          throw new Test262Error('close');
+        },
+      };
+    },
+  };
+}
+
+function* catchesCloseError() {
+  try {
+    for (const value of throwingCloseIterable()) {
+      yield value;
+      break;
+    }
+  } catch (error) {
+    yield error.message;
+  }
+  yield 'resumed';
+}
+
+assert.compareArray(
+  [...catchesCloseError()],
+  [1, 'close', 'resumed'],
+  'the generator catches an IteratorClose failure and remains resumable'
+);
+
+function* doesNotCatchCloseError() {
+  for (const value of throwingCloseIterable()) {
+    yield value;
+    break;
+  }
+}
+
+var uncaughtClose = doesNotCatchCloseError();
+assert.sameValue(uncaughtClose.next().value, 1);
+assert.throws(
+  Test262Error,
+  function () {
+    uncaughtClose.next();
+  },
+  'an uncaught IteratorClose failure escapes'
+);
+assert.sameValue(
+  uncaughtClose.next().done,
+  true,
+  'an uncaught IteratorClose failure completes rather than wedges the generator'
+);
+
+// A return injected at a suspended yield first completes the loop body. An
+// inner finally therefore runs before per-iteration disposal and IteratorClose,
+// while a finally surrounding the loop runs afterwards.
+var returnEvents = [];
+var returnResource = {
+  [Symbol.dispose]: function () {
+    returnEvents.push('dispose');
+  },
+};
+var returnIterable = {
+  [Symbol.iterator]: function () {
+    return {
+      next: function () {
+        return { value: returnResource, done: false };
+      },
+      return: function () {
+        returnEvents.push('close');
+        return { done: true };
+      },
+    };
+  },
+};
+
+function* closesUsingIterationOnReturn() {
+  try {
+    for (using resource of returnIterable) {
+      try {
+        yield 'body';
+      } finally {
+        returnEvents.push('inner finally');
+      }
+    }
+  } finally {
+    returnEvents.push('outer finally');
+  }
+}
+
+var returned = closesUsingIterationOnReturn();
+assert.sameValue(returned.next().value, 'body');
+var returnResult = returned.return('return value');
+assert.sameValue(returnResult.value, 'return value');
+assert.sameValue(returnResult.done, true);
+assert.compareArray(
+  returnEvents,
+  ['inner finally', 'dispose', 'close', 'outer finally'],
+  'return disposes the active iteration and closes its iterator in spec order'
+);
+assert.sameValue(returned.next().done, true);
+
+// If abrupt return cleanup throws, that throw replaces the return completion
+// and can be handled by a catch surrounding the loop.
+var throwingReturnEvents = [];
+var throwingReturnResource = {
+  [Symbol.dispose]: function () {
+    throwingReturnEvents.push('dispose');
+    throw new Test262Error('return disposer');
+  },
+};
+var throwingReturnIterable = {
+  [Symbol.iterator]: function () {
+    return {
+      next: function () {
+        return { value: throwingReturnResource, done: false };
+      },
+      return: function () {
+        throwingReturnEvents.push('close');
+        return { done: true };
+      },
+    };
+  },
+};
+
+function* catchesReturnDisposerError() {
+  try {
+    for (using resource of throwingReturnIterable) {
+      yield 'body';
+    }
+  } catch (error) {
+    yield error.message;
+  }
+  yield 'resumed';
+}
+
+var throwingReturn = catchesReturnDisposerError();
+assert.sameValue(throwingReturn.next().value, 'body');
+var caughtReturnDisposer = throwingReturn.return('ignored return value');
+assert.sameValue(caughtReturnDisposer.value, 'return disposer');
+assert.sameValue(caughtReturnDisposer.done, false);
+assert.sameValue(throwingReturn.next().value, 'resumed');
+assert.sameValue(throwingReturn.next().done, true);
+assert.compareArray(
+  throwingReturnEvents,
+  ['dispose', 'close'],
+  'a disposer throw still closes the iterator before entering catch'
+);

--- a/test262-extra/generator-for-of-abrupt-exit-closes-iterators.js
+++ b/test262-extra/generator-for-of-abrupt-exit-closes-iterators.js
@@ -1,0 +1,118 @@
+/*---
+description: >
+  A break or a throwing disposer that leaves a generator for-of closes the
+  iterator, disposes the iteration environment, and leaves the generator
+  resumable through its own handlers.
+esid: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+info: |
+  ForIn/OfBodyEvaluation step 7.m: if the loop body produces an abrupt
+  completion, return ? IteratorClose(iteratorRecord, status). The iterator's
+  `return` method runs as ordinary user code, so it may read and write the
+  generator's own bindings while the loop is being closed.
+
+  Step 7.h wraps each iteration in DisposeResources(iterationEnv, result). A
+  disposer that throws turns the iteration into a throw completion, which the
+  generator's own try statements observe before it escapes to the caller.
+includes: [compareArray.js]
+features: [generators, explicit-resource-management]
+---*/
+
+// The iterator's `return` method writes a binding of the generator that is
+// closing it.
+function* breaksOutOfLoop() {
+  var closed = 'not closed';
+  var iterable = {
+    [Symbol.iterator]: function () {
+      return {
+        next: function () {
+          return { value: 1, done: false };
+        },
+        return: function () {
+          closed = 'closed';
+          return { done: true };
+        },
+      };
+    },
+  };
+
+  for (const value of iterable) {
+    yield value;
+    break;
+  }
+
+  yield closed;
+  yield typeof value;
+}
+
+assert.compareArray(
+  [...breaksOutOfLoop()],
+  [1, 'closed', 'undefined'],
+  'break closes the iterator and discards the iteration binding'
+);
+
+// A throwing disposer is a throw completion of the loop, not of the caller.
+function* disposerThrows() {
+  const resources = [
+    {
+      [Symbol.dispose]: function () {
+        throw new Test262Error('disposer');
+      },
+    },
+    { [Symbol.dispose]: function () {} },
+  ];
+
+  try {
+    for (using resource of resources) {
+      yield 'iteration';
+    }
+  } catch (error) {
+    yield error instanceof Test262Error ? 'caught' : 'wrong error';
+  }
+
+  yield 'resumed';
+}
+
+assert.compareArray(
+  [...disposerThrows()],
+  ['iteration', 'caught', 'resumed'],
+  'a throwing disposer is caught by the generator and the generator resumes'
+);
+
+// With no catch, the disposer's error still runs the generator's `finally`
+// and then escapes to the caller.
+function* disposerThrowsPastFinally() {
+  const resources = [
+    {
+      [Symbol.dispose]: function () {
+        throw new Test262Error('disposer');
+      },
+    },
+    { [Symbol.dispose]: function () {} },
+  ];
+
+  try {
+    for (using resource of resources) {
+      yield 'iteration';
+    }
+  } finally {
+    yield 'finally';
+  }
+
+  yield 'unreachable';
+}
+
+var seen = [];
+assert.throws(
+  Test262Error,
+  function () {
+    for (const value of disposerThrowsPastFinally()) {
+      seen.push(value);
+    }
+  },
+  'the disposer error escapes once the generator finally block completes'
+);
+assert.compareArray(
+  seen,
+  ['iteration', 'finally'],
+  'the finally block runs before the disposer error escapes'
+);

--- a/test262-extra/generator-for-of-explicit-return-cleanup.js
+++ b/test262-extra/generator-for-of-explicit-return-cleanup.js
@@ -1,0 +1,174 @@
+/*---
+description: >
+  Source-level returns from transformed generators dispose active for-using
+  bindings and close every exited for-of iterator in spec order.
+esid: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+flags: [async]
+includes: [compareArray.js]
+features: [generators, async-iteration, explicit-resource-management]
+---*/
+
+function trackedSingleValue(value, events) {
+  var done = false;
+  return {
+    [Symbol.iterator]: function () {
+      return {
+        next: function () {
+          if (done) {
+            return { value: undefined, done: true };
+          }
+          done = true;
+          return { value: value, done: false };
+        },
+        return: function () {
+          events.push('close');
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+var syncEvents = [];
+var syncResource = {
+  [Symbol.dispose]: function () {
+    syncEvents.push('dispose');
+  },
+};
+
+function* syncExplicitReturn() {
+  try {
+    for (using resource of trackedSingleValue(syncResource, syncEvents)) {
+      try {
+        yield 'body';
+        return 42;
+      } finally {
+        syncEvents.push('inner finally');
+      }
+    }
+  } finally {
+    syncEvents.push('outer finally');
+  }
+}
+
+var syncReturn = syncExplicitReturn();
+assert.sameValue(syncReturn.next().value, 'body');
+var syncResult = syncReturn.next();
+assert.sameValue(syncResult.value, 42);
+assert.sameValue(syncResult.done, true);
+assert.compareArray(
+  syncEvents,
+  ['inner finally', 'dispose', 'close', 'outer finally'],
+  'sync source return observes finally/dispose/close order'
+);
+
+var plainEvents = [];
+function* plainExplicitReturn() {
+  for (const value of trackedSingleValue(1, plainEvents)) {
+    yield value;
+    return 7;
+  }
+}
+
+var plainReturn = plainExplicitReturn();
+assert.sameValue(plainReturn.next().value, 1);
+assert.sameValue(plainReturn.next().value, 7);
+assert.compareArray(plainEvents, ['close'], 'plain sync for-of closes on source return');
+
+var throwingEvents = [];
+var throwingResource = {
+  [Symbol.dispose]: function () {
+    throwingEvents.push('dispose');
+    throw new Test262Error('dispose');
+  },
+};
+
+function* catchesExplicitReturnCleanupError() {
+  try {
+    for (using resource of trackedSingleValue(throwingResource, throwingEvents)) {
+      yield 'body';
+      return 9;
+    }
+  } catch (error) {
+    yield error.message;
+  }
+  yield 'resumed';
+}
+
+assert.compareArray(
+  [...catchesExplicitReturnCleanupError()],
+  ['body', 'dispose', 'resumed'],
+  'a source-return cleanup error enters the sync generator catch'
+);
+assert.compareArray(throwingEvents, ['dispose', 'close']);
+
+async function* asyncExplicitReturn(events, resource) {
+  try {
+    for (using current of trackedSingleValue(resource, events)) {
+      try {
+        yield 'body';
+        return 42;
+      } finally {
+        events.push('inner finally');
+      }
+    }
+  } finally {
+    events.push('outer finally');
+  }
+}
+
+async function* asyncPlainExplicitReturn(events) {
+  for (const value of trackedSingleValue(1, events)) {
+    yield value;
+    return 7;
+  }
+}
+
+async function* catchesAsyncExplicitReturnCleanupError(events, resource) {
+  try {
+    for (using current of trackedSingleValue(resource, events)) {
+      yield 'body';
+      return 9;
+    }
+  } catch (error) {
+    yield error.message;
+  }
+  yield 'resumed';
+}
+
+async function runAsyncChecks() {
+  var events = [];
+  var resource = {
+    [Symbol.dispose]: function () {
+      events.push('dispose');
+    },
+  };
+  var generator = asyncExplicitReturn(events, resource);
+  assert.sameValue((await generator.next()).value, 'body');
+  var result = await generator.next();
+  assert.sameValue(result.value, 42);
+  assert.sameValue(result.done, true);
+  assert.compareArray(events, ['inner finally', 'dispose', 'close', 'outer finally']);
+
+  var plainEvents = [];
+  var plain = asyncPlainExplicitReturn(plainEvents);
+  assert.sameValue((await plain.next()).value, 1);
+  assert.sameValue((await plain.next()).value, 7);
+  assert.compareArray(plainEvents, ['close']);
+
+  var throwingEvents = [];
+  var throwing = {
+    [Symbol.dispose]: function () {
+      throwingEvents.push('dispose');
+      throw new Test262Error('dispose');
+    },
+  };
+  var caught = catchesAsyncExplicitReturnCleanupError(throwingEvents, throwing);
+  assert.sameValue((await caught.next()).value, 'body');
+  assert.sameValue((await caught.next()).value, 'dispose');
+  assert.sameValue((await caught.next()).value, 'resumed');
+  assert.sameValue((await caught.next()).done, true);
+  assert.compareArray(throwingEvents, ['dispose', 'close']);
+}
+
+runAsyncChecks().then($DONE, $DONE);

--- a/test262-extra/generator-for-of-head-abrupt-completions.js
+++ b/test262-extra/generator-for-of-head-abrupt-completions.js
@@ -1,0 +1,273 @@
+/*---
+description: >
+  Generator for-of head failures discard or close their saved loop state as
+  required and remain resumable through enclosing catch and finally clauses.
+esid: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+info: |
+  ForIn/OfBodyEvaluation propagates failures from IteratorStep and
+  IteratorValue without performing IteratorClose. A failure while initializing
+  the loop binding instead performs IteratorClose before propagating the
+  resulting throw completion through the generator body.
+flags: [async]
+includes: [compareArray.js]
+features: [generators, async-iteration, explicit-resource-management]
+---*/
+
+function protocolFailureIterable(kind, events) {
+  return {
+    [Symbol.iterator]: function () {
+      return {
+        next: function () {
+          if (kind === 'next') {
+            throw new Test262Error('next');
+          }
+          var result = {};
+          Object.defineProperty(result, 'done', {
+            get: function () {
+              if (kind === 'done') {
+                throw new Test262Error('done');
+              }
+              return false;
+            },
+          });
+          Object.defineProperty(result, 'value', {
+            get: function () {
+              throw new Test262Error('value');
+            },
+          });
+          return result;
+        },
+        return: function () {
+          events.push('return');
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+function singleValueIterable(value, events) {
+  var done = false;
+  return {
+    [Symbol.iterator]: function () {
+      return {
+        next: function () {
+          if (done) {
+            return { value: undefined, done: true };
+          }
+          done = true;
+          return { value: value, done: false };
+        },
+        return: function () {
+          events.push('return');
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+function* catchesProtocolFailure(kind, events) {
+  try {
+    for (const value of protocolFailureIterable(kind, events)) {
+      yield 'unreachable ' + value;
+    }
+  } catch (error) {
+    yield error.message;
+  }
+  yield 'resumed';
+}
+
+for (const kind of ['next', 'done', 'value']) {
+  var protocolEvents = [];
+  assert.compareArray(
+    [...catchesProtocolFailure(kind, protocolEvents)],
+    [kind, 'resumed'],
+    kind + ' failure is caught and the sync generator resumes'
+  );
+  assert.compareArray(
+    protocolEvents,
+    [],
+    kind + ' failure does not perform IteratorClose'
+  );
+}
+
+function* catchesRegistrationFailure(iterable) {
+  try {
+    for (using resource of iterable) {
+      yield 'unreachable ' + resource;
+    }
+  } catch (error) {
+    yield error instanceof TypeError ? 'caught TypeError' : error.message;
+  }
+  yield 'resumed';
+}
+
+var nonDisposableEvents = [];
+assert.compareArray(
+  [...catchesRegistrationFailure(singleValueIterable({}, nonDisposableEvents))],
+  ['caught TypeError', 'resumed'],
+  'a non-disposable resource is caught by the sync generator'
+);
+assert.compareArray(
+  nonDisposableEvents,
+  ['return'],
+  'resource-registration failure closes its iterator exactly once'
+);
+
+var disposeGetterError = new Test262Error('dispose getter');
+var throwingDisposeGetter = {};
+Object.defineProperty(throwingDisposeGetter, Symbol.dispose, {
+  get: function () {
+    throw disposeGetterError;
+  },
+});
+var getterEvents = [];
+var getterFailure = catchesRegistrationFailure(
+  singleValueIterable(throwingDisposeGetter, getterEvents)
+);
+assert.sameValue(getterFailure.next().value, 'dispose getter');
+assert.sameValue(getterFailure.next().value, 'resumed');
+assert.sameValue(getterFailure.next().done, true);
+assert.compareArray(getterEvents, ['return']);
+
+var finallyEvents = [];
+function* registrationFailureThroughFinally() {
+  try {
+    for (using resource of singleValueIterable({}, finallyEvents)) {
+      yield 'unreachable ' + resource;
+    }
+  } finally {
+    yield 'finally';
+  }
+}
+
+var throughFinally = registrationFailureThroughFinally();
+assert.sameValue(throughFinally.next().value, 'finally');
+assert.throws(TypeError, function () {
+  throughFinally.next();
+});
+assert.sameValue(throughFinally.next().done, true);
+assert.compareArray(finallyEvents, ['return']);
+
+var bindingEvents = [];
+function* catchesBindingFailure() {
+  try {
+    for (const [value] of singleValueIterable(null, bindingEvents)) {
+      yield 'unreachable ' + value;
+    }
+  } catch (error) {
+    yield error instanceof TypeError ? 'caught TypeError' : error.message;
+  }
+  yield 'resumed';
+}
+
+assert.compareArray(
+  [...catchesBindingFailure()],
+  ['caught TypeError', 'resumed'],
+  'a binding failure is caught by the sync generator'
+);
+assert.compareArray(bindingEvents, ['return'], 'binding failure closes exactly once');
+
+async function* catchesAsyncProtocolFailure(kind, events) {
+  try {
+    for (const value of protocolFailureIterable(kind, events)) {
+      yield 'unreachable ' + value;
+    }
+  } catch (error) {
+    yield error.message;
+  }
+  yield 'resumed';
+}
+
+async function* catchesAsyncRegistrationFailure(iterable) {
+  try {
+    for (using resource of iterable) {
+      yield 'unreachable ' + resource;
+    }
+  } catch (error) {
+    yield error instanceof TypeError ? 'caught TypeError' : error.message;
+  }
+  yield 'resumed';
+}
+
+async function* asyncRegistrationFailureThroughFinally(events) {
+  try {
+    for (using resource of singleValueIterable({}, events)) {
+      yield 'unreachable ' + resource;
+    }
+  } finally {
+    yield 'finally';
+  }
+}
+
+async function* catchesAsyncBindingFailure(events) {
+  try {
+    for (const [value] of singleValueIterable(null, events)) {
+      yield 'unreachable ' + value;
+    }
+  } catch (error) {
+    yield error instanceof TypeError ? 'caught TypeError' : error.message;
+  }
+  yield 'resumed';
+}
+
+async function collectAsync(generator) {
+  var values = [];
+  for (;;) {
+    var result = await generator.next();
+    if (result.done) {
+      return values;
+    }
+    values.push(result.value);
+  }
+}
+
+async function runAsyncChecks() {
+  for (const kind of ['next', 'done', 'value']) {
+    var protocolEvents = [];
+    assert.compareArray(
+      await collectAsync(catchesAsyncProtocolFailure(kind, protocolEvents)),
+      [kind, 'resumed'],
+      kind + ' failure is caught and the async generator resumes'
+    );
+    assert.compareArray(
+      protocolEvents,
+      [],
+      kind + ' failure does not perform IteratorClose in an async generator'
+    );
+  }
+
+  var registrationEvents = [];
+  assert.compareArray(
+    await collectAsync(
+      catchesAsyncRegistrationFailure(singleValueIterable({}, registrationEvents))
+    ),
+    ['caught TypeError', 'resumed'],
+    'a non-disposable resource is caught by the async generator'
+  );
+  assert.compareArray(registrationEvents, ['return']);
+
+  var finallyEvents = [];
+  var throughFinally = asyncRegistrationFailureThroughFinally(finallyEvents);
+  assert.sameValue((await throughFinally.next()).value, 'finally');
+  var finallyError;
+  try {
+    await throughFinally.next();
+  } catch (error) {
+    finallyError = error;
+  }
+  assert.sameValue(finallyError instanceof TypeError, true);
+  assert.sameValue((await throughFinally.next()).done, true);
+  assert.compareArray(finallyEvents, ['return']);
+
+  var bindingEvents = [];
+  assert.compareArray(
+    await collectAsync(catchesAsyncBindingFailure(bindingEvents)),
+    ['caught TypeError', 'resumed'],
+    'a binding failure is caught by the async generator'
+  );
+  assert.compareArray(bindingEvents, ['return']);
+}
+
+runAsyncChecks().then($DONE, $DONE);

--- a/test262-extra/generator-for-of-per-iteration-environments.js
+++ b/test262-extra/generator-for-of-per-iteration-environments.js
@@ -1,0 +1,51 @@
+/*---
+description: >
+  Generator for-of loops preserve fresh lexical bindings across suspension.
+esid: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+info: |
+  ForIn/OfBodyEvaluation creates a new declarative environment for every
+  lexical iteration, evaluates the loop body in that environment, and restores
+  the environment that was active before the loop afterwards.
+
+  Suspending a generator must retain the active iteration environment so that
+  closures created by different iterations capture different bindings.
+flags: [async]
+includes: [compareArray.js]
+features: [generators, async-iteration, destructuring-binding]
+---*/
+
+function* syncGenerator() {
+  for (const value of [1, 2]) {
+    yield function () { return value; };
+  }
+
+  for (let [value] of [[3], [4]]) {
+    yield function () { return value; };
+  }
+}
+
+var syncClosures = [...syncGenerator()];
+assert.compareArray(
+  syncClosures.map(function (closure) { return closure(); }),
+  [1, 2, 3, 4],
+  'sync generator iterations have distinct lexical bindings'
+);
+
+async function* asyncGenerator() {
+  for (const value of [5, 6]) {
+    yield function () { return value; };
+  }
+}
+
+(async function () {
+  var asyncClosures = [];
+  for await (const closure of asyncGenerator()) {
+    asyncClosures.push(closure);
+  }
+
+  assert.compareArray(
+    asyncClosures.map(function (closure) { return closure(); }),
+    [5, 6],
+    'async generator iterations have distinct lexical bindings'
+  );
+})().then($DONE, $DONE);

--- a/test262-extra/generator-for-of-per-iteration-environments.js
+++ b/test262-extra/generator-for-of-per-iteration-environments.js
@@ -31,9 +31,180 @@ assert.compareArray(
   'sync generator iterations have distinct lexical bindings'
 );
 
+function trackedIterable(value, events) {
+  var done = false;
+  return {
+    [Symbol.iterator]: function () {
+      return {
+        next: function () {
+          if (done) {
+            return { value: undefined, done: true };
+          }
+          done = true;
+          return { value: value, done: false };
+        },
+        return: function () {
+          events.push('return');
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+function* syncThrowToOuterCatch(events) {
+  try {
+    for (const value of trackedIterable(1, events)) {
+      yield 'body';
+      throw new Test262Error('body');
+    }
+  } catch (error) {
+    events.push('catch');
+    yield typeof value;
+  }
+}
+
+var syncThrowEvents = [];
+assert.compareArray(
+  [...syncThrowToOuterCatch(syncThrowEvents)],
+  ['body', 'undefined'],
+  'an outer catch runs outside the exited sync iteration environment'
+);
+assert.compareArray(
+  syncThrowEvents,
+  ['return', 'catch'],
+  'IteratorClose precedes the outer sync catch'
+);
+
+function* syncInjectedThrowToOuterCatch(events) {
+  try {
+    for (const value of trackedIterable(1, events)) {
+      yield 'body';
+    }
+  } catch (error) {
+    events.push('catch');
+    yield typeof value;
+  }
+}
+
+var syncInjectedEvents = [];
+var syncInjected = syncInjectedThrowToOuterCatch(syncInjectedEvents);
+assert.sameValue(syncInjected.next().value, 'body');
+assert.sameValue(syncInjected.throw(new Test262Error('injected')).value, 'undefined');
+assert.compareArray(syncInjectedEvents, ['return', 'catch']);
+
+function* syncInnerCatchKeepsIteration(events) {
+  for (const value of trackedIterable(1, events)) {
+    try {
+      yield 'body';
+      throw new Test262Error('body');
+    } catch (error) {
+      events.push('catch');
+      yield typeof value;
+    }
+    break;
+  }
+}
+
+var syncInnerEvents = [];
+assert.compareArray(
+  [...syncInnerCatchKeepsIteration(syncInnerEvents)],
+  ['body', 'number'],
+  'a catch inside the loop retains the active iteration environment'
+);
+assert.compareArray(syncInnerEvents, ['catch', 'return']);
+
+function* syncHeadFailureToOuterCatch(events) {
+  try {
+    for (const outer of trackedIterable(1, events)) {
+      for (const [inner] of [null]) {
+        yield inner;
+      }
+    }
+  } catch (error) {
+    events.push('catch');
+    yield typeof outer;
+  }
+}
+
+var syncHeadEvents = [];
+assert.compareArray(
+  [...syncHeadFailureToOuterCatch(syncHeadEvents)],
+  ['undefined'],
+  'a nested head failure exits the surrounding loop before its outer catch'
+);
+assert.compareArray(syncHeadEvents, ['return', 'catch']);
+
 async function* asyncGenerator() {
   for (const value of [5, 6]) {
     yield function () { return value; };
+  }
+}
+
+async function* asyncThrowToOuterCatch(events) {
+  try {
+    for (const value of trackedIterable(1, events)) {
+      yield 'body';
+      throw new Test262Error('body');
+    }
+  } catch (error) {
+    events.push('catch');
+    yield typeof value;
+  }
+}
+
+async function* asyncInjectedThrowToOuterCatch(events) {
+  try {
+    for (const value of trackedIterable(1, events)) {
+      yield 'body';
+    }
+  } catch (error) {
+    events.push('catch');
+    yield typeof value;
+  }
+}
+
+function trackedAsyncIterable(value, events) {
+  var done = false;
+  return {
+    [Symbol.asyncIterator]: function () {
+      return {
+        next: function () {
+          if (done) {
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          done = true;
+          return Promise.resolve({ value: value, done: false });
+        },
+        return: function () {
+          events.push('return');
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+async function* asyncAwaitThrowToOuterCatch(events) {
+  try {
+    for await (const value of trackedAsyncIterable(1, events)) {
+      yield 'body';
+      throw new Test262Error('body');
+    }
+  } catch (error) {
+    events.push('catch');
+    yield typeof value;
+  }
+}
+
+async function collectAsync(generator) {
+  var values = [];
+  for (;;) {
+    var result = await generator.next();
+    if (result.done) {
+      return values;
+    }
+    values.push(result.value);
   }
 }
 
@@ -48,4 +219,29 @@ async function* asyncGenerator() {
     [5, 6],
     'async generator iterations have distinct lexical bindings'
   );
+
+  var asyncThrowEvents = [];
+  assert.compareArray(
+    await collectAsync(asyncThrowToOuterCatch(asyncThrowEvents)),
+    ['body', 'undefined'],
+    'an outer catch runs outside the exited async-generator iteration environment'
+  );
+  assert.compareArray(asyncThrowEvents, ['return', 'catch']);
+
+  var asyncInjectedEvents = [];
+  var asyncInjected = asyncInjectedThrowToOuterCatch(asyncInjectedEvents);
+  assert.sameValue((await asyncInjected.next()).value, 'body');
+  assert.sameValue(
+    (await asyncInjected.throw(new Test262Error('injected'))).value,
+    'undefined'
+  );
+  assert.compareArray(asyncInjectedEvents, ['return', 'catch']);
+
+  var asyncAwaitEvents = [];
+  assert.compareArray(
+    await collectAsync(asyncAwaitThrowToOuterCatch(asyncAwaitEvents)),
+    ['body', 'undefined'],
+    'for-await-of exits its iteration environment before an outer catch'
+  );
+  assert.compareArray(asyncAwaitEvents, ['return', 'catch']);
 })().then($DONE, $DONE);


### PR DESCRIPTION
## Summary

- retain a fresh lexical environment for each transformed generator for-of iteration
- share loop-state tracking across async functions, sync generators, and async generators
- align nested loop environments across transformed break/continue jumps and trace suspended environments through GC
- add regression coverage for const, destructured let, sync generators, and async generators

## Validation

- cargo fmt --check
- cargo clippy
- cargo build --release
- cargo test --release
- ./scripts/lint.sh
- uv run python scripts/run-custom-tests.py
- uv run python scripts/run-test262.py test262-extra/ --fail-on-failures
- targeted generator and for-of test262 runs (4,302 scenarios)
- full test262: 99,568 / 99,568 (100.00%), zero regressions

Closes #494