### PR TITLE
fix(interpreter): route async continue through finally

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -8330,7 +8330,9 @@ impl Interpreter {
         sent_value: JsValue,
         is_error: bool,
     ) -> Completion {
-        use crate::interpreter::generator_transform::{SentValueBindingKind, StateTerminator};
+        use crate::interpreter::generator_transform::{
+            LoopControlTarget, SentValueBindingKind, StateTerminator,
+        };
 
         let Some(state) = self.scheduler.remove_async_function_state(async_id) else {
             return Completion::Normal(JsValue::UNDEFINED);
@@ -8819,9 +8821,17 @@ impl Interpreter {
                     }
                 }
                 Completion::Continue(label, _) => {
-                    // Jump to head_state for the innermost matching for-of loop
+                    // An inline statement can surface continue directly rather
+                    // than through a LoopControl terminator. Route it through
+                    // intervening finalizers before returning to the loop head.
                     if let Some(pos) = for_of_stack.iter().rposition(|_| label.is_none()) {
-                        current_id = for_of_stack[pos].head_state;
+                        let loop_state = &for_of_stack[pos];
+                        let target = LoopControlTarget {
+                            target_state: loop_state.head_state,
+                            try_depth: loop_state.try_depth,
+                            for_of_depth: pos + 1,
+                        };
+                        route_loop_control!(target);
                         continue;
                     }
                 }

--- a/test262-extra/async-function-loop-control-through-finally.js
+++ b/test262-extra/async-function-loop-control-through-finally.js
@@ -120,6 +120,25 @@ async function labeledContinueThroughFinally() {
   return log;
 }
 
+async function continueFromNestedTryRunsFinally() {
+  var log = [];
+  for (const value of [1, 2]) {
+    try {
+      await null;
+      // This nested non-suspending statement executes inline and surfaces its
+      // continue completion to the async state-machine driver.
+      try {
+        continue;
+      } finally {
+      }
+    } finally {
+      log.push('finally ' + value);
+    }
+  }
+  log.push('after continue');
+  return log;
+}
+
 breakThroughAwaitedFinally()
   .then(function (log) {
     assert.compareArray(
@@ -164,6 +183,14 @@ breakThroughAwaitedFinally()
         'after labeled continue'
       ],
       'labeled continue runs finally and closes nested iterators while retaining its target loop'
+    );
+    return continueFromNestedTryRunsFinally();
+  })
+  .then(function (log) {
+    assert.compareArray(
+      log,
+      ['finally 1', 'finally 2', 'after continue'],
+      'an inline continue completion runs the enclosing finally before reaching the loop head'
     );
   })
   .then($DONE, $DONE);


### PR DESCRIPTION
## Summary

- route inline async `continue` completions through the existing depth-aware loop-control finalizer path
- preserve the active for-of target while allowing `TryExit` to retire intervening try frames
- add a regression covering a nested inline try after `await` across multiple loop iterations

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py`
- targeted TryStatement/for-of test262: 1,832/1,832
- full default test262: 99,568/99,568, 0 regressions

Closes #495