### PR TITLE
fix(interpreter): resolve inline labelled continue targets

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -8824,7 +8824,9 @@ impl Interpreter {
                     // An inline statement can surface continue directly rather
                     // than through a LoopControl terminator. Route it through
                     // intervening finalizers before returning to the loop head.
-                    if let Some(pos) = for_of_stack.iter().rposition(|_| label.is_none()) {
+                    if let Some(pos) = for_of_stack.iter().rposition(|loop_state| {
+                        loop_state.matches_continue_target(label.as_deref())
+                    }) {
                         let loop_state = &for_of_stack[pos];
                         let target = LoopControlTarget {
                             target_state: loop_state.head_state,
@@ -9093,6 +9095,7 @@ impl Interpreter {
                 StateTerminator::ForOfInit {
                     ref iterable,
                     ref iter_var,
+                    ref label_set,
                     ref left,
                     head_state,
                     after_state: forinit_after,
@@ -9156,6 +9159,7 @@ impl Interpreter {
                     self.env_set(&func_env, iter_var, iterator).ok();
                     for_of_stack.push(AsyncForOfLoopState {
                         iter_var: iter_var.clone(),
+                        label_set: label_set.clone(),
                         head_state,
                         after_state: forinit_after,
                         try_depth: try_stack.len(),
@@ -9184,6 +9188,7 @@ impl Interpreter {
                             debug_assert!(false, "for-of head without an active loop state");
                             for_of_stack.push(AsyncForOfLoopState {
                                 iter_var: iter_var.clone(),
+                                label_set: vec![],
                                 head_state: current_id,
                                 after_state,
                                 try_depth: try_stack.len(),

--- a/src/interpreter/eval/generator_runtime.rs
+++ b/src/interpreter/eval/generator_runtime.rs
@@ -1585,6 +1585,7 @@ impl Interpreter {
                 StateTerminator::ForOfInit {
                     iterable,
                     iter_var,
+                    label_set: _,
                     next_var: _,
                     left: _,
                     head_state,
@@ -5601,6 +5602,7 @@ impl Interpreter {
                 StateTerminator::ForOfInit {
                     iterable,
                     iter_var,
+                    label_set: _,
                     next_var: _,
                     left: _,
                     head_state,

--- a/src/interpreter/generator_transform.rs
+++ b/src/interpreter/generator_transform.rs
@@ -63,6 +63,7 @@ pub(crate) enum StateTerminator {
     ForOfInit {
         iterable: Expression,
         iter_var: String,
+        label_set: Vec<String>,
         #[allow(dead_code)]
         next_var: String,
         #[allow(dead_code)]
@@ -1963,6 +1964,7 @@ fn transform_for_of_statement(
     ctx.finalize_current_state(StateTerminator::ForOfInit {
         iterable: iterable_expr,
         iter_var: iter_var.clone(),
+        label_set: iteration_labels.clone(),
         next_var: next_var.clone(),
         left: for_of_stmt.left.clone(),
         head_state,

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -336,6 +336,9 @@ pub(crate) struct AsyncFunctionState {
 #[derive(Clone)]
 pub(crate) struct AsyncForOfLoopState {
     pub(crate) iter_var: String,
+    /// The labels attached to this iteration statement. `LoopContinues` uses
+    /// this set to decide whether a labelled continue begins its next iteration.
+    pub(crate) label_set: Vec<String>,
     pub(crate) head_state: usize,
     pub(crate) after_state: usize,
     /// Depth of the driver's try stack when the loop began, so an abrupt
@@ -351,6 +354,10 @@ pub(crate) struct AsyncForOfLoopState {
 impl AsyncForOfLoopState {
     pub(crate) fn effective_env(&self) -> &EnvRef {
         self.iteration_env.as_ref().unwrap_or(&self.outer_env)
+    }
+
+    pub(crate) fn matches_continue_target(&self, target: Option<&str>) -> bool {
+        target.is_none_or(|target| self.label_set.iter().any(|label| label == target))
     }
 }
 

--- a/test262-extra/async-function-loop-control-through-finally.js
+++ b/test262-extra/async-function-loop-control-through-finally.js
@@ -139,6 +139,24 @@ async function continueFromNestedTryRunsFinally() {
   return log;
 }
 
+async function labeledContinueFromNestedInlineTry() {
+  var log = [];
+  outer: for (const outerValue of [1, 2]) {
+    for (const innerValue of trackedIterable(log, 'inline ' + outerValue, [3])) {
+      await null;
+      // This non-suspending try executes inline, so its labelled completion is
+      // resolved by the async driver rather than a LoopControl terminator.
+      try {
+        continue outer;
+      } finally {
+      }
+    }
+    log.push('unreachable');
+  }
+  log.push('after inline labeled continue');
+  return log;
+}
+
 breakThroughAwaitedFinally()
   .then(function (log) {
     assert.compareArray(
@@ -191,6 +209,14 @@ breakThroughAwaitedFinally()
       log,
       ['finally 1', 'finally 2', 'after continue'],
       'an inline continue completion runs the enclosing finally before reaching the loop head'
+    );
+    return labeledContinueFromNestedInlineTry();
+  })
+  .then(function (log) {
+    assert.compareArray(
+      log,
+      ['close inline 1', 'close inline 2', 'after inline labeled continue'],
+      'an inline labelled continue targets its outer loop and closes only the inner iterator'
     );
   })
   .then($DONE, $DONE);


### PR DESCRIPTION
## Summary

- carry transformed for-of label sets into active async loop state
- resolve inline labelled continue completions against the correct outer loop
- cover iterator unwinding when a non-suspending try surfaces continue after await

## Validation

- cargo fmt --check
- cargo clippy
- ./scripts/lint.sh
- cargo build --release
- cargo test --release
- uv run python scripts/run-custom-tests.py
- focused test262-extra regression: 2/2
- test262 for-of: 1,442/1,442
- full default test262: 99,568/99,568 (100.00%)

Closes #496