### PR TITLE
perf(string): slice substring directly in UTF-16

### DIFF
--- a/docs/specs/2026-08-24-string-substring-utf16-slicing-design.md
+++ b/docs/specs/2026-08-24-string-substring-utf16-slicing-design.md
@@ -1,0 +1,54 @@
+# Direct UTF-16 String Substring Slicing
+
+## Context
+
+`JsString` stores ECMAScript strings as `Arc<Vec<u16>>`, but
+`String.prototype.substring` currently converts its complete receiver to a Rust
+UTF-8 `String`, encodes that value back to UTF-16, slices the requested range,
+decodes the range to UTF-8, and finally encodes the result as a `JsString`.
+Token-sized calls on a large receiver therefore do work proportional to the
+receiver length and also replace any sliced lone surrogate with U+FFFD.
+
+`String.prototype.substr` has the same receiver round trip. The adjacent
+`String.prototype.slice` implementation demonstrates the intended local seam:
+obtain a `JsString`, calculate UTF-16 code-unit indices, and copy only the result
+range into `JsString::from_vec`.
+
+## Design
+
+Both `substring` and Annex B `substr` will obtain the receiver through
+`this_js_string`, preserving `RequireObjectCoercible`/`ToString` behavior while
+retaining the raw code units for primitive strings and String wrappers. Each
+method will continue coercing its arguments in specification order with
+`ToIntegerOrInfinity`:
+
+- `substring` coerces `start`, then `end` when supplied; clamps both indices to
+  `[0, len]`; swaps them when necessary; and copies `units[from..to]`.
+- `substr` coerces `start`, adjusts negative and infinite starts as specified,
+  then coerces `length` when supplied; clamps the length; and copies
+  `units[start..end]`.
+
+The result remains an independently allocated `JsString`. Shared substring
+views or a rope representation are deliberately excluded because they would
+change the engine-wide string representation and could retain large source
+strings for tiny token results.
+
+## Audit Scope
+
+The remaining `this_string_value` users fall into search/comparison,
+case/normalization/locale, trimming/formatting, repetition/padding/concatenation,
+and Annex B HTML operations. Several could later benefit from broader raw
+UTF-16 work, but only `substr` is the same index-only extraction pattern. This
+change leaves the other methods untouched to keep the performance fix narrow.
+
+## Validation
+
+- Add a `test262-extra` regression that slices both halves of a surrogate pair
+  with `substring`, checks swapped indices, and checks String-wrapper receivers.
+- Run the existing test262 `substring` directory and Annex B `substr` directory;
+  the latter already verifies surrogate-pair code-unit slicing.
+- Use a release-mode microbenchmark that repeatedly takes token-sized
+  substrings from a large receiver. Compare identical workloads before and
+  after the change.
+- Run the repository formatting, lint, release build/test, custom-test, and full
+  test262 gates required by the project instructions.

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -448,28 +448,22 @@ impl Interpreter {
                 "substring",
                 2,
                 Rc::new(|interp, this_val, args| {
-                    let s = match this_string_value(interp, this_val) {
+                    let js_str = match this_js_string(interp, this_val) {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let units = utf16_units(&s);
+                    let units = &js_str.code_units;
                     let len = units.len() as f64;
                     let int_start = match args.first() {
-                        Some(v) => match to_num(interp, v) {
-                            Ok(n) => {
-                                let i = to_integer_or_infinity(n);
-                                if n.is_nan() { 0.0 } else { i }
-                            }
+                        Some(v) => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
                     };
                     let int_end = match args.get(1) {
-                        Some(v) if !(v).is_undefined() => match to_num(interp, v) {
-                            Ok(n) => {
-                                let i = to_integer_or_infinity(n);
-                                if n.is_nan() { 0.0 } else { i }
-                            }
+                        Some(v) if !(v).is_undefined() => match to_int_or_inf(interp, v) {
+                            Ok(n) => n,
                             Err(c) => return c,
                         },
                         _ => len,
@@ -481,8 +475,9 @@ impl Interpreter {
                     } else {
                         (final_end, final_start)
                     };
-                    let result = utf16_substring(&units, from, to);
-                    Completion::Normal(JsValue::string(JsString::from_str(&result)))
+                    Completion::Normal(JsValue::string(JsString::from_vec(
+                        units[from..to].to_vec(),
+                    )))
                 }),
             ),
             (
@@ -1570,37 +1565,37 @@ impl Interpreter {
                 "substr".to_string(),
                 2,
                 Rc::new(|interp, this, args| {
-                    let s = match this_string_value(interp, this) {
+                    let js_str = match this_js_string(interp, this) {
                         Ok(s) => s,
                         Err(c) => return c,
                     };
-                    let units = utf16_units(&s);
+                    let units = &js_str.code_units;
                     let len = units.len() as f64;
                     let int_start = match args.first() {
-                        Some(v) => match to_num(interp, v) {
+                        Some(v) => match to_int_or_inf(interp, v) {
                             Ok(n) => n,
                             Err(c) => return c,
                         },
                         None => 0.0,
                     };
-                    let int_start = int_start as i64;
-                    let start = if int_start < 0 {
-                        (len as i64 + int_start).max(0) as usize
+                    let start = if int_start == f64::NEG_INFINITY {
+                        0
+                    } else if int_start < 0.0 {
+                        (len + int_start).max(0.0) as usize
                     } else {
-                        (int_start as usize).min(units.len())
+                        int_start.min(len) as usize
                     };
                     let result_len = match args.get(1) {
                         Some(v) if !(v).is_undefined() => {
-                            let l = match to_num(interp, v) {
+                            let int_length = match to_int_or_inf(interp, v) {
                                 Ok(n) => n,
                                 Err(c) => return c,
                             };
-                            let l = l as i64;
-                            l.max(0) as usize
+                            int_length.max(0.0).min(len) as usize
                         }
                         _ => units.len(),
                     };
-                    let end = (start + result_len).min(units.len());
+                    let end = start.saturating_add(result_len).min(units.len());
                     Completion::Normal(JsValue::string(JsString::from_vec(
                         units[start..end].to_vec(),
                     )))

--- a/test262-extra/String-substring-utf16-code-units.js
+++ b/test262-extra/String-substring-utf16-code-units.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 the JSSE project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.substring
+description: >
+  String.prototype.substring extracts UTF-16 code units without replacing a
+  lone surrogate produced by slicing a surrogate pair.
+info: |
+  String.prototype.substring ( start, end )
+    4. Let len be the length of S.
+    ...
+    9. Let from be min(finalStart, finalEnd).
+    10. Let to be max(finalStart, finalEnd).
+    11. Return the substring of S from from to to.
+
+  ECMAScript String values are sequences of 16-bit unsigned integer values, so
+  the returned substring can contain an unpaired surrogate code unit.
+---*/
+
+var pair = "\ud834\udf06";
+
+var lead = pair.substring(0, 1);
+assert.sameValue(lead.length, 1, "lead surrogate result length");
+assert.sameValue(lead.charCodeAt(0), 0xd834, "lead surrogate code unit");
+
+var trail = pair.substring(1, 2);
+assert.sameValue(trail.length, 1, "trail surrogate result length");
+assert.sameValue(trail.charCodeAt(0), 0xdf06, "trail surrogate code unit");
+
+var swapped = pair.substring(2, 1);
+assert.sameValue(swapped.length, 1, "swapped indices result length");
+assert.sameValue(swapped.charCodeAt(0), 0xdf06, "swapped indices code unit");
+
+var wrapped = new String(pair).substring(0, 1);
+assert.sameValue(wrapped.length, 1, "String wrapper result length");
+assert.sameValue(wrapped.charCodeAt(0), 0xd834, "String wrapper code unit");


### PR DESCRIPTION
## Summary

- keep `String.prototype.substring` and Annex B `substr` in the engine UTF-16 representation
- preserve receiver and argument coercion order while copying only the selected code-unit range
- add coverage proving `substring` preserves lone surrogate code units for primitive and wrapped strings

## Performance

The confirmed cause was full-receiver UTF-16 to UTF-8 to UTF-16 conversion on every call. For 500 four-code-unit substrings from a 1.2M-code-unit receiver:

- before: 1.46-2.67s
- after: 0.01s

The issue #56 `typescript-octane` reproduction now completes one iteration in 30.475s, versus the reported 136-141s baseline, and no longer hits the 120s timeout.

## Validation

- `cargo fmt --check`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release` (554 passed, 1 ignored; integration and smoke tests passed)
- `uv run python scripts/run-custom-tests.py` (12/12)
- targeted `substring` and `substr` test262 (122/122)
- new `test262-extra` regression (2/2)
- full test262 (99,568/99,568, 100.00%, zero regressions)
- `uv run python scripts/run-jetstream.py --test typescript-octane --iterations 1 --timeout 180`

Closes #500