### PR TITLE
fix(interpreter): root object destructuring sources

### DIFF
--- a/docs/specs/2026-08-24-object-destructuring-source-gc-rooting-design.md
+++ b/docs/specs/2026-08-24-object-destructuring-source-gc-rooting-design.md
@@ -1,0 +1,52 @@
+# Object destructuring source GC rooting
+
+## Problem
+
+Object assignment destructuring converts its source with `ToObject`, then
+retains only the resulting arena ID in a Rust local. Computed property names,
+source getters, initializers, nested patterns, rest copying, and target writes
+can all run JavaScript before the pattern finishes. A collection during any of
+that code can sweep the source and reuse its slot, so later property reads no
+longer observe the original value. Primitive sources have the same hazard
+because `ToObject` creates an otherwise unreachable wrapper.
+
+ECMAScript's `DestructuringAssignmentEvaluation` passes the same source value
+through the complete `PropertyDestructuringAssignmentEvaluation`, including
+each property-name evaluation and `GetV`. The implementation must keep JSSE's
+object representation of that value alive for the same interval.
+
+## Considered approaches
+
+1. Save one temporary-root frame after `ToObject`, root the source, evaluate
+   the remainder of the pattern in a closure, and unroot once after the closure
+   returns. This is selected because it directly represents the specification
+   lifetime and centralizes cleanup for every completion kind.
+2. Root the source separately for each property. This would repeat work and
+   add cleanup seams around computed names and rest properties without changing
+   the required lifetime.
+3. Root once and manually unroot before every existing early return. This
+   would be easy to make incomplete as the evaluator changes, leaking roots on
+   an overlooked abrupt or suspended completion.
+
+## Design
+
+`destructure_object_assignment` will continue to reject nullish sources and
+perform `ToObject` before creating the root frame. Immediately after successful
+conversion, it saves a frame and roots `obj_val`. The existing property loop
+runs inside a closure and returns its `Completion` through that single exit.
+After the closure completes, the evaluator truncates the temporary-root stack
+to the saved frame and returns the captured completion.
+
+The target-side frames inside individual properties remain unchanged. They
+have a narrower purpose: preserving a pre-evaluated Reference and pending value
+until `PutValue`. The new enclosing frame preserves only the source for the
+whole pattern.
+
+## Validation
+
+Add `test262-extra` coverage that forces collection from a computed key's
+`toString` and from a source getter. Exercise both ordinary object sources and
+primitive string sources so newly allocated `ToObject` wrappers are covered.
+Run the custom suite, the assignment-destructuring test262 directory, all Rust
+quality gates, and the full test262 suite without updating the feature-branch
+baseline.

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -4639,178 +4639,187 @@ impl Interpreter {
             _ => unreachable!(),
         };
 
-        let mut excluded_keys: Vec<JsPropertyKey> = Vec::new();
+        // Computed keys, getters, initializers, rest copying, and target writes
+        // can all run user code while the ToObject result lives only here.
+        let gc_frame = self.gc_root_frame();
+        self.gc_root_value(&obj_val);
 
-        for prop in props {
-            // Handle rest: {...rest} = obj
-            if let Expression::Spread(inner) = &prop.value {
-                let rest_obj_id = self.create_object_id();
-                if let Some(o) = obj_val
-                    .as_object_id()
-                    .map(|id| crate::types::JsObject { id })
-                {
-                    let pairs = match self.copy_data_properties(o.id, &obj_val, &excluded_keys) {
-                        Ok(p) => p,
-                        Err(e) => return Completion::Throw(e),
-                    };
-                    for (k, v) in pairs {
-                        self.get_object_cell_expect(rest_obj_id)
-                            .borrow_mut()
-                            .insert_value(k, v);
-                    }
-                }
-                let rest_id = rest_obj_id;
-                let rest_val = JsValue::object(rest_id);
-                match self.put_value_to_target(inner, rest_val, env) {
-                    Completion::Normal(_) | Completion::Empty => {}
-                    other => return other,
-                }
-                continue;
-            }
+        let result = (|| {
+            let mut excluded_keys: Vec<JsPropertyKey> = Vec::new();
 
-            match &prop.kind {
-                PropertyKind::Init => {
-                    let key = match &prop.key {
-                        PropertyKey::Identifier(s) => JsPropertyKey::from(s.clone()),
-                        PropertyKey::String(s) => {
-                            JsPropertyKey::from_js_string(&JsString::from_vec(s.clone()))
-                        }
-                        PropertyKey::Number(n) => {
-                            JsPropertyKey::from(to_js_string(&JsValue::number(*n)))
-                        }
-                        PropertyKey::Computed(expr) => match self.eval_expr(expr, env) {
-                            Completion::Normal(v) => match self.to_property_key(&v) {
-                                Ok(k) => k,
-                                Err(e) => return Completion::Throw(e),
-                            },
-                            Completion::Throw(e) => return Completion::Throw(e),
-                            Completion::Yield(v) => return Completion::Yield(v),
-                            other => return other,
-                        },
-                        PropertyKey::Private(_) => {
-                            return Completion::Throw(self.create_type_error(
-                                "Private names are not valid in object patterns",
-                            ));
-                        }
-                    };
-                    excluded_keys.push(key.clone());
-
-                    // Per spec §13.15.5.6: extract target BEFORE GetV and evaluate lref first.
-                    let (target, default_expr) = if let Expression::Assign(
-                        AssignOp::Assign,
-                        target,
-                        default,
-                    ) = &prop.value
+            for prop in props {
+                // Handle rest: {...rest} = obj
+                if let Expression::Spread(inner) = &prop.value {
+                    let rest_obj_id = self.create_object_id();
+                    if let Some(o) = obj_val
+                        .as_object_id()
+                        .map(|id| crate::types::JsObject { id })
                     {
-                        (target.as_ref(), Some(default.as_ref()))
-                    } else {
-                        (&prop.value, None)
-                    };
-
-                    // §13.15.5.6 step 1: evaluate lref (base + key expression)
-                    // before GetV. ToPropertyKey is deferred to PutValue time.
-                    let pre_ref = match self.eval_member_lhs_ref(target, env) {
-                        Ok(MemberLhsRef::Ref(r)) => r,
-                        Ok(MemberLhsRef::Suspended(v)) => return Completion::Yield(v),
-                        Err(e) => return Completion::Throw(e),
-                    };
-
-                    // GetV and an initializer can run user code after the
-                    // target is evaluated, so retain the whole lRef.
-                    let gc_frame = self.gc_root_frame();
-                    if let Some(lref) = &pre_ref {
-                        self.gc_root_destruct_lref(lref);
-                    }
-
-                    let result = (|| {
-                        // Get property via get_object_property (invokes getters/Proxy)
-                        let val = if let Some(o) = obj_val
-                            .as_object_id()
-                            .map(|id| crate::types::JsObject { id })
+                        let pairs = match self.copy_data_properties(o.id, &obj_val, &excluded_keys)
                         {
-                            match self.get_object_property(o.id, &key, &obj_val) {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => return Completion::Throw(e),
-                                Completion::Yield(v) => return Completion::Yield(v),
-                                _ => JsValue::UNDEFINED,
-                            }
-                        } else {
-                            JsValue::UNDEFINED
+                            Ok(p) => p,
+                            Err(e) => return Completion::Throw(e),
                         };
-
-                        let val = if val.is_undefined() {
-                            if let Some(default) = default_expr {
-                                match self.eval_expr(default, env) {
-                                    Completion::Normal(v) => {
-                                        if let Expression::Identifier(name) = target
-                                            && default.is_anonymous_function_definition()
-                                        {
-                                            self.set_function_name(&v, name);
-                                        }
-                                        v
-                                    }
-                                    Completion::Throw(e) => return Completion::Throw(e),
-                                    Completion::Yield(v) => return Completion::Yield(v),
-                                    other => return other,
-                                }
-                            } else {
-                                val
-                            }
-                        } else {
-                            val
-                        };
-
-                        // ToPropertyKey and the write itself can run user code.
-                        self.gc_root_value(&val);
-                        if let Some(lref) = pre_ref {
-                            match lref {
-                                DestructLRef::Member(base_val, raw_key) => {
-                                    match self.to_property_key(&raw_key) {
-                                        Ok(key) => {
-                                            let strict = env.borrow().strict;
-                                            if let Err(e) = self
-                                                .set_object_with_key(base_val, &key, val, strict)
-                                            {
-                                                return Completion::Throw(e);
-                                            }
-                                        }
-                                        Err(e) => return Completion::Throw(e),
-                                    }
-                                }
-                                DestructLRef::Private(base_val, ref name) => {
-                                    if let Err(e) =
-                                        self.set_private_field(&base_val, name, val, env)
-                                    {
-                                        return Completion::Throw(e);
-                                    }
-                                }
-                                DestructLRef::Super(base_id, ref key, ref this_val, strict) => {
-                                    if let Completion::Throw(e) =
-                                        self.super_set_property(base_id, key, val, this_val, strict)
-                                    {
-                                        return Completion::Throw(e);
-                                    }
-                                }
-                            }
-                        } else {
-                            match self.put_value_to_target(target, val, env) {
-                                Completion::Normal(_) | Completion::Empty => {}
-                                other => return other,
-                            }
+                        for (k, v) in pairs {
+                            self.get_object_cell_expect(rest_obj_id)
+                                .borrow_mut()
+                                .insert_value(k, v);
                         }
-                        Completion::Empty
-                    })();
-                    self.gc_unroot_frame(gc_frame);
-
-                    match result {
+                    }
+                    let rest_id = rest_obj_id;
+                    let rest_val = JsValue::object(rest_id);
+                    match self.put_value_to_target(inner, rest_val, env) {
                         Completion::Normal(_) | Completion::Empty => {}
                         other => return other,
                     }
+                    continue;
                 }
-                _ => continue,
+
+                match &prop.kind {
+                    PropertyKind::Init => {
+                        let key = match &prop.key {
+                            PropertyKey::Identifier(s) => JsPropertyKey::from(s.clone()),
+                            PropertyKey::String(s) => {
+                                JsPropertyKey::from_js_string(&JsString::from_vec(s.clone()))
+                            }
+                            PropertyKey::Number(n) => {
+                                JsPropertyKey::from(to_js_string(&JsValue::number(*n)))
+                            }
+                            PropertyKey::Computed(expr) => match self.eval_expr(expr, env) {
+                                Completion::Normal(v) => match self.to_property_key(&v) {
+                                    Ok(k) => k,
+                                    Err(e) => return Completion::Throw(e),
+                                },
+                                Completion::Throw(e) => return Completion::Throw(e),
+                                Completion::Yield(v) => return Completion::Yield(v),
+                                other => return other,
+                            },
+                            PropertyKey::Private(_) => {
+                                return Completion::Throw(self.create_type_error(
+                                    "Private names are not valid in object patterns",
+                                ));
+                            }
+                        };
+                        excluded_keys.push(key.clone());
+
+                        // Per spec §13.15.5.6: extract target BEFORE GetV and evaluate lref first.
+                        let (target, default_expr) =
+                            if let Expression::Assign(AssignOp::Assign, target, default) =
+                                &prop.value
+                            {
+                                (target.as_ref(), Some(default.as_ref()))
+                            } else {
+                                (&prop.value, None)
+                            };
+
+                        // §13.15.5.6 step 1: evaluate lref (base + key expression)
+                        // before GetV. ToPropertyKey is deferred to PutValue time.
+                        let pre_ref = match self.eval_member_lhs_ref(target, env) {
+                            Ok(MemberLhsRef::Ref(r)) => r,
+                            Ok(MemberLhsRef::Suspended(v)) => return Completion::Yield(v),
+                            Err(e) => return Completion::Throw(e),
+                        };
+
+                        // GetV and an initializer can run user code after the
+                        // target is evaluated, so retain the whole lRef.
+                        let gc_frame = self.gc_root_frame();
+                        if let Some(lref) = &pre_ref {
+                            self.gc_root_destruct_lref(lref);
+                        }
+
+                        let result = (|| {
+                            // Get property via get_object_property (invokes getters/Proxy)
+                            let val = if let Some(o) = obj_val
+                                .as_object_id()
+                                .map(|id| crate::types::JsObject { id })
+                            {
+                                match self.get_object_property(o.id, &key, &obj_val) {
+                                    Completion::Normal(v) => v,
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    Completion::Yield(v) => return Completion::Yield(v),
+                                    _ => JsValue::UNDEFINED,
+                                }
+                            } else {
+                                JsValue::UNDEFINED
+                            };
+
+                            let val = if val.is_undefined() {
+                                if let Some(default) = default_expr {
+                                    match self.eval_expr(default, env) {
+                                        Completion::Normal(v) => {
+                                            if let Expression::Identifier(name) = target
+                                                && default.is_anonymous_function_definition()
+                                            {
+                                                self.set_function_name(&v, name);
+                                            }
+                                            v
+                                        }
+                                        Completion::Throw(e) => return Completion::Throw(e),
+                                        Completion::Yield(v) => return Completion::Yield(v),
+                                        other => return other,
+                                    }
+                                } else {
+                                    val
+                                }
+                            } else {
+                                val
+                            };
+
+                            // ToPropertyKey and the write itself can run user code.
+                            self.gc_root_value(&val);
+                            if let Some(lref) = pre_ref {
+                                match lref {
+                                    DestructLRef::Member(base_val, raw_key) => {
+                                        match self.to_property_key(&raw_key) {
+                                            Ok(key) => {
+                                                let strict = env.borrow().strict;
+                                                if let Err(e) = self.set_object_with_key(
+                                                    base_val, &key, val, strict,
+                                                ) {
+                                                    return Completion::Throw(e);
+                                                }
+                                            }
+                                            Err(e) => return Completion::Throw(e),
+                                        }
+                                    }
+                                    DestructLRef::Private(base_val, ref name) => {
+                                        if let Err(e) =
+                                            self.set_private_field(&base_val, name, val, env)
+                                        {
+                                            return Completion::Throw(e);
+                                        }
+                                    }
+                                    DestructLRef::Super(base_id, ref key, ref this_val, strict) => {
+                                        if let Completion::Throw(e) = self
+                                            .super_set_property(base_id, key, val, this_val, strict)
+                                        {
+                                            return Completion::Throw(e);
+                                        }
+                                    }
+                                }
+                            } else {
+                                match self.put_value_to_target(target, val, env) {
+                                    Completion::Normal(_) | Completion::Empty => {}
+                                    other => return other,
+                                }
+                            }
+                            Completion::Empty
+                        })();
+                        self.gc_unroot_frame(gc_frame);
+
+                        match result {
+                            Completion::Normal(_) | Completion::Empty => {}
+                            other => return other,
+                        }
+                    }
+                    _ => continue,
+                }
             }
-        }
-        Completion::Normal(JsValue::UNDEFINED)
+            Completion::Normal(JsValue::UNDEFINED)
+        })();
+
+        self.gc_unroot_frame(gc_frame);
+        result
     }
 
     fn eval_call(

--- a/test262-extra/destructuring-source-value-gc-rooting.js
+++ b/test262-extra/destructuring-source-value-gc-rooting.js
@@ -1,0 +1,101 @@
+/*---
+description: >
+  Object assignment destructuring keeps its source object reachable while
+  computed property names and source getters run user code.
+esid: sec-runtime-semantics-destructuringassignmentevaluation
+info: |
+  Runtime Semantics: DestructuringAssignmentEvaluation
+
+  ObjectAssignmentPattern : { AssignmentPropertyList }
+    1. Perform ? RequireObjectCoercible(value).
+    2. Perform ? PropertyDestructuringAssignmentEvaluation of
+       AssignmentPropertyList with argument value.
+
+  Runtime Semantics: PropertyDestructuringAssignmentEvaluation
+
+  AssignmentProperty : PropertyName : AssignmentElement
+    1. Let name be ? Evaluation of PropertyName.
+    2. Perform ? KeyedDestructuringAssignmentEvaluation of AssignmentElement
+       with arguments value and name.
+
+  The same value participates in every property-name evaluation and GetV for
+  the complete pattern. JSSE's ToObject representation of that value must
+  therefore survive user code for both object and primitive sources.
+---*/
+
+var objectComputed;
+({
+  [{
+    toString: function () {
+      $262.gc();
+      return "value";
+    },
+  }]: objectComputed,
+} = { value: 1 });
+assert.sameValue(
+  objectComputed,
+  1,
+  "an object source survives computed property-key coercion"
+);
+
+var primitiveComputed;
+({
+  [{
+    toString: function () {
+      $262.gc();
+      return "1";
+    },
+  }]: primitiveComputed,
+} = "ab");
+assert.sameValue(
+  primitiveComputed,
+  "b",
+  "a primitive source wrapper survives computed property-key coercion"
+);
+
+var objectGetterValue;
+var objectAfterGetter;
+({
+  gc: objectGetterValue,
+  after: objectAfterGetter,
+} = {
+  get gc() {
+    $262.gc();
+    return 2;
+  },
+  after: 3,
+});
+assert.sameValue(objectGetterValue, 2, "an object source getter returns its value");
+assert.sameValue(
+  objectAfterGetter,
+  3,
+  "an object source survives collection in an earlier getter"
+);
+
+Object.defineProperty(String.prototype, "destructuringGc", {
+  configurable: true,
+  get: function () {
+    $262.gc();
+    return "getter";
+  },
+});
+
+var primitiveGetterValue;
+var primitiveAfterGetter;
+({
+  destructuringGc: primitiveGetterValue,
+  1: primitiveAfterGetter,
+} = "ab");
+
+delete String.prototype.destructuringGc;
+
+assert.sameValue(
+  primitiveGetterValue,
+  "getter",
+  "a getter receives the primitive source wrapper"
+);
+assert.sameValue(
+  primitiveAfterGetter,
+  "b",
+  "a primitive source wrapper survives collection in an earlier getter"
+);


### PR DESCRIPTION
## Summary

- root the `ToObject` result for the full object assignment-destructuring evaluation
- centralize temporary-root cleanup across normal, abrupt, and suspended completions
- cover forced GC from computed-key coercion and source getters for object and primitive sources

## Validation

- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py`
- targeted assignment-destructuring test262: 15/15
- targeted GC regression tests: 6/6
- full test262: 99,568/99,568, zero regressions

Closes #502