### PR TITLE
fix(interpreter): root computed member target base

### DIFF
--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -4293,7 +4293,16 @@ impl Interpreter {
                 JsValue::string(JsString::from_str(name)),
             )))),
             MemberProperty::Computed(key_expr) => {
-                let raw_key = match self.eval_expr(key_expr, env) {
+                // The base becomes the Reference Record's [[Base]], so it must
+                // survive arbitrary user code while the computed key is
+                // evaluated. Callers cannot root it until this function has
+                // finished constructing the reference.
+                let gc_frame = self.gc_root_frame();
+                self.gc_root_value(&base);
+                let key_result = self.eval_expr(key_expr, env);
+                self.gc_unroot_frame(gc_frame);
+
+                let raw_key = match key_result {
                     Completion::Normal(v) => v,
                     Completion::Throw(e) => return Err(e),
                     Completion::Yield(v) => return Ok(MemberLhsRef::Suspended(v)),

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -1518,6 +1518,24 @@ fn private_destructuring_releases_temp_roots_after_abrupt_completion() {
 }
 
 #[test]
+fn computed_member_destructuring_releases_temp_roots_after_abrupt_key_evaluation() {
+    // The member base is rooted while its computed key is evaluated. An abrupt
+    // key completion must release that scoped root before propagating the throw.
+    let interp = run_script(
+        r#"
+        function fail() { throw new Error("computed key"); }
+        try { [Object.create({})[fail()]] = [1]; } catch (e) {}
+        try { ({ item: Object.create({})[fail()] } = { item: 1 }); } catch (e) {}
+        "#,
+    );
+
+    assert!(
+        interp.gc_temp_roots.is_empty(),
+        "computed member target roots must be released after key evaluation throws"
+    );
+}
+
+#[test]
 fn private_method_call_with_non_iterable_spread_throws() {
     // A spread argument that is not iterable must throw a TypeError, even when the
     // callee is a private method reached through `this.#m(...)`. The private-call

--- a/test262-extra/destructuring-target-value-gc-rooting.js
+++ b/test262-extra/destructuring-target-value-gc-rooting.js
@@ -6,6 +6,11 @@ description: >
 esid: sec-runtime-semantics-destructuringassignmentevaluation
 features: [Symbol.iterator]
 info: |
+  13.3.3.2 EvaluatePropertyAccessWithExpressionKey
+
+  The computed Expression is evaluated after baseValue is obtained, and the
+  resulting Reference Record retains baseValue in its [[Base]] field.
+
   13.15.5.5 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
 
   AssignmentElement : DestructuringAssignmentTarget Initializer?
@@ -95,6 +100,47 @@ var propertyProto = {
 ({ p: Object.create(propertyProto).y } = { get p() { $262.gc(); return "property"; } });
 assert.sameValue(propertyWrites.length, 1, "the object property base setter runs");
 assert.sameValue(propertyWrites[0], "property", "the object property setter receives the value");
+
+// EvaluatePropertyAccessWithExpressionKey retains the base value while the
+// computed key expression runs user code and constructs the Reference Record.
+var computedElementWrites = [];
+var computedElementProto = {
+  set x(value) {
+    computedElementWrites.push(value);
+  },
+};
+
+[Object.create(computedElementProto)[gcThenValue("x")()]] = ["computed element"];
+assert.sameValue(
+  computedElementWrites.length,
+  1,
+  "the computed array element base survives key evaluation"
+);
+assert.sameValue(
+  computedElementWrites[0],
+  "computed element",
+  "the computed array element setter receives the value"
+);
+
+var computedPropertyWrites = [];
+var computedPropertyProto = {
+  set y(value) {
+    computedPropertyWrites.push(value);
+  },
+};
+var computedPropertySource = { p: "computed property" };
+
+({ p: Object.create(computedPropertyProto)[gcThenValue("y")()] } = computedPropertySource);
+assert.sameValue(
+  computedPropertyWrites.length,
+  1,
+  "the computed object property base survives key evaluation"
+);
+assert.sameValue(
+  computedPropertyWrites[0],
+  "computed property",
+  "the computed object property setter receives the value"
+);
 
 // The un-coerced key and the assigned value both outlive the user code that
 // runs before and during ToPropertyKey.


### PR DESCRIPTION
## Summary

- keep a computed member target's evaluated base GC-rooted while its key expression runs user code
- balance the local root frame before propagating normal, throw, or suspension results
- cover array/object destructuring under forced GC and verify abrupt key evaluation does not leak roots

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py`
- targeted test262: 17/17
- full test262: 99,568/99,568 (100.00%, zero regressions)

Closes #505