### PR TITLE
fix(node-shim): cap inspected array entries

### DIFF
--- a/docs/specs/2026-08-25-node-shim-max-array-length-design.md
+++ b/docs/specs/2026-08-25-node-shim-max-array-length-design.md
@@ -1,0 +1,51 @@
+# Bounded Node-Shim Array Inspection
+
+## Context
+
+The library-harness `util.inspect` shim reads an Array's own `length` data
+descriptor, then probes every index with `Object.getOwnPropertyDescriptor`.
+This avoids inherited getters but makes inspection O(`length`): logging
+`new Array(1_000_000)` performs one million index-descriptor reads.
+
+ECMAScript specifies Array `length` and indexed own properties, but not Node's
+host-provided `util.inspect`. Node 26.5.0 defaults `maxArrayLength` to 100. It
+truncates 101 dense elements after 100, but coalesces a sparse hole run into one
+rendered entry and can therefore find distant elements without scanning every
+index. JSSE cannot efficiently reproduce that sparse behavior until issue #516
+fixes own-index enumeration for arrays populated after creation.
+
+## Approaches considered
+
+1. Keep scanning until 100 rendered values or hole runs have been found. This
+   follows Node's sparse presentation more closely, but an all-hole array still
+   scans its complete length and leaves the reported hang intact.
+2. Enumerate own index keys and render at most 100 entries. This is both bounded
+   and closest to Node, but `Object.getOwnPropertyNames` and `Reflect.ownKeys`
+   currently omit indices added by `push`, assignment, or `fill` (issue #516).
+3. Probe only the first 100 indices and represent the remaining indices with a
+   truncation suffix. This is selected because it provides a hard complexity
+   bound with the existing reliable descriptor seam. Dense arrays match Node;
+   sparse arrays may truncate holes or omit distant elements and are explicitly
+   best-effort until issue #516 enables approach 2.
+
+## Design
+
+`renderArray` limits its descriptor loop to `min(length, 100)`. Existing hole
+coalescing and accessor-safe descriptor rendering remain unchanged inside that
+window. If `length` exceeds the window, it appends `... N more item` or
+`... N more items`, where `N` is the number of uninspected indices.
+
+The cap is deliberately fixed rather than exposing the full Node
+`maxArrayLength` option surface: issue #515 asks for the default safety bound,
+and the shim documents `util.inspect` as a best-effort formatter rather than a
+complete Node implementation.
+
+## Validation
+
+The node-shim self-test will assert the exact dense 101-element rendering on
+both engines. A one-million-hole case will assert Node's native coalesced output
+on Node and the shim's bounded prefix-plus-suffix output on JSSE, ensuring the
+performance-triggering shape cannot regress to a full-length scan. This is a
+host-harness change, not ECMAScript behavior, so there is no targeted test262
+area and no test262 pass-count change expected; the normal full-suite gate is
+still run for regressions.

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -39,6 +39,7 @@
   var fallbackConsoleLog = console.log;
 
   var NS_PER_SEC = 1000000000;
+  var MAX_INSPECT_ARRAY_LENGTH = 100;
 
   // ---- util.inspect (best-effort) ------------------------------------------
   //
@@ -615,13 +616,15 @@
     // Array length and elements are read from own descriptors on the unwrapped
     // target. A missing descriptor is a hole, never an invitation to read
     // through Array.prototype (which could invoke an inherited getter).
-    // Probing every index is O(length); the O(elements) own-index-key form is
+    // Keep descriptor probes bounded even for enormous sparse arrays. The
+    // O(elements) own-index-key form needed for Node-exact sparse truncation is
     // blocked on jsse#516 (Object.getOwnPropertyNames/Reflect.ownKeys omit
-    // index keys assigned after array creation, so every element of a
-    // push-built array would render as a hole).
+    // index keys assigned after array creation).
     function renderArray(v, depth) {
       var length = ownDataValue(v, "length");
       if (typeof length !== "number" || length <= 0) return "[]";
+      var renderLength =
+        length < MAX_INSPECT_ARRAY_LENGTH ? length : MAX_INSPECT_ARRAY_LENGTH;
 
       // Collect into a local array and join once. Accumulating with `+=`
       // instead is superlinear here: JsString is a flat buffer with no rope
@@ -629,7 +632,7 @@
       var parts = [];
       var holes = 0;
 
-      for (var i = 0; i < length; i++) {
+      for (var i = 0; i < renderLength; i++) {
         var desc = objectGetOwnPropertyDescriptor(v, i);
         if (!desc) {
           holes++;
@@ -642,8 +645,15 @@
         arrayPush(parts, renderDescriptor(desc, depth));
       }
       if (holes) arrayPush(parts, emptyItems(holes));
-      // `length > 0` guarantees the loop ran, so every index became either an
-      // element or a hole, and `parts` cannot be empty.
+      if (renderLength < length) {
+        var remaining = length - renderLength;
+        arrayPush(
+          parts,
+          "... " + remaining + " more item" + (remaining === 1 ? "" : "s")
+        );
+      }
+      // `length > 0` guarantees either the loop ran or a truncation marker was
+      // added, so `parts` cannot be empty.
       return "[ " + arrayJoin(parts, ", ") + " ]";
     }
 

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1142,6 +1142,24 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     arr.indexOf("1") !== -1 && arr.indexOf("2") !== -1 && arr.indexOf("3") !== -1,
     "inspect renders array elements"
   );
+  var denseOverLimit = [];
+  var denseExpectedParts = [];
+  for (var denseIndex = 0; denseIndex < 101; denseIndex++) {
+    denseOverLimit.push(denseIndex);
+    if (denseIndex < 100) denseExpectedParts.push(String(denseIndex));
+  }
+  eq(
+    util.inspect(denseOverLimit, { breakLength: Infinity, compact: true }),
+    "[ " + denseExpectedParts.join(", ") + ", ... 1 more item ]",
+    "inspect caps dense arrays at 100 entries"
+  );
+  eq(
+    util.inspect(new Array(1000000)),
+    hasNodeHost
+      ? "[ <100 empty items>, ... 999900 more items ]"
+      : "[ <1000000 empty items> ]",
+    "inspect bounds sparse-array descriptor probes"
+  );
   var cyc = {};
   cyc.self = cyc;
   var ci = util.inspect(cyc);


### PR DESCRIPTION
## Summary

- bound `util.inspect` array descriptor probes to the first 100 indices
- append Node-style singular/plural `... N more item(s)` truncation output
- add dense Node-exact and million-hole performance regression coverage
- document the deliberate sparse-output trade-off pending reliable own-index enumeration in #516

## Validation

- `./scripts/run-node-shim-selftest.sh --no-build`
- `./scripts/run-shim-fixtures.sh`
- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py`
- `uv run python scripts/run-test262.py` (99,568/99,568; zero regressions)

Closes #515