### PR TITLE
fix(interpreter): bound proxy prototype cycles

### DIFF
--- a/docs/specs/2026-08-25-proxy-cyclic-prototype-chain-design.md
+++ b/docs/specs/2026-08-25-proxy-cyclic-prototype-chain-design.md
@@ -1,0 +1,83 @@
+# Proxy-mediated cyclic prototype-chain recovery
+
+## Goal
+
+Make prototype-chain operations on a cycle routed through a Proxy fail with a
+catchable `RangeError: Maximum call stack size exceeded` instead of exhausting
+the Rust thread stack or looping forever. Preserve the specification-required
+ability to construct such a cycle.
+
+## Specification constraints
+
+`OrdinarySetPrototypeOf` (ECMA-262 §10.1.2.1) deliberately stops its cycle
+check when it reaches an object whose `[[GetPrototypeOf]]` is not the ordinary
+internal method. The accompanying note guarantees acyclicity only for chains
+made entirely of ordinary objects. The test262
+`Object/prototype/__proto__/set-cycle-shadowed.js` test requires a Proxy to
+remain an escape hatch, so rejecting the assignment is not a valid fix.
+
+`OrdinaryGet`, `OrdinarySetWithOwnDescriptor`, and `OrdinaryHasProperty`
+(§§10.1.8–10.1.9) forward to the next object's corresponding internal method
+when an own property is absent. Proxy `[[Get]]`, `[[Set]]`, and
+`[[HasProperty]]` (§10.5) forward to their target when the handler method is
+missing. In combination, those rules can repeatedly enter the same cycle.
+The specification does not prescribe a particular resource limit, but a host
+resource failure must remain catchable; Node reports a stack-exhaustion
+`RangeError` for these operations.
+
+## Approaches considered
+
+1. Reject a prototype assignment when a Proxy target closes the cycle. This
+   contradicts `OrdinarySetPrototypeOf` and the existing test262 requirement.
+2. Track visited object identities and fail on repetition. This detects the
+   small repro immediately, but is observably wrong when a Proxy handler getter
+   mutates the chain before returning `undefined`, or when a `getPrototypeOf`
+   trap returns a repeated object temporarily and later terminates.
+3. Bound Proxy forwarding within each prototype-chain operation. Selected.
+   Ordinary-only chains keep their existing behaviour and depth capacity. A
+   chain can cycle only through a non-ordinary `[[GetPrototypeOf]]`, and every
+   JSSE cycle in scope therefore repeatedly crosses a Proxy forwarding seam.
+   A generous soft bound permits dynamic chains to terminate while preventing
+   native recursion or an unbounded iterative walk.
+
+Rewriting every internal method and consumer as one iterative state machine
+would also avoid native recursion, but it would be a much larger semantic
+change and would still need a resource policy for dynamic Proxy traps.
+
+## Design
+
+Define one interpreter-wide Proxy-chain forwarding limit. The canonical
+`[[Get]]`, `[[Set]]`, and `[[HasProperty]]` entry points start a forwarding
+counter at zero. Their private recursive implementations preserve the counter
+across ordinary prototype edges and increment it only when a Proxy has no
+applicable trap and directly forwards to its target. Crossing the limit creates
+the same `RangeError` and message as the existing call/evaluation stack guards.
+
+Calls into user code retain normal operation boundaries. A getter, setter, or
+Proxy trap that starts a new MOP operation receives a fresh counter; ordinary
+handler lookup also remains independently guarded. This prevents a caught
+inner exhaustion from poisoning later operations and permits handlers to
+mutate a chain before a direct forwarding step continues.
+
+Proxy-aware iterative prototype consumers apply the same policy. Ordinary
+`instanceof` counts Proxy objects encountered while walking
+`[[GetPrototypeOf]]`; Proxy-started `for-in` enumeration does likewise. These
+paths currently loop without growing the Rust stack, so the shared bound turns
+their unrecoverable hang into the same catchable resource error.
+
+Own properties continue to short-circuit before any forwarding. Metadata-only
+helpers that intentionally inspect stored descriptors/prototype slots remain
+unchanged.
+
+## Error handling and verification
+
+The thrown value is a realm-appropriate `RangeError` with message
+`Maximum call stack size exceeded`. Regression coverage constructs the
+spec-permitted `ordinary -> ordinary -> Proxy(target ordinary)` cycle and
+checks missing-property `[[Get]]`, `[[Set]]`, and `[[HasProperty]]`, plus the
+two iterative consumers. It also verifies own properties still short-circuit,
+the error is catchable, and an ordinary operation succeeds after recovery.
+
+Targeted test262 validation covers Object prototype mutation and Proxy get,
+set, has, and prototype traps. The complete custom and test262 suites remain
+the regression gates; the existing pass count is not expected to change.

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -7750,11 +7750,18 @@ impl Interpreter {
         };
         // Step 6: Walk O.[[GetPrototypeOf]]() chain (proxy-aware)
         let mut current_val = obj.clone();
+        let mut proxy_depth = 0;
         while let Some(current_obj) = current_val
             .as_object_id()
             .map(|id| crate::types::JsObject { id })
         {
             let current_id = current_obj.id;
+            if self.get_proxy_info(current_id).is_some() {
+                proxy_depth = match self.advance_proxy_chain_depth(proxy_depth) {
+                    Ok(depth) => depth,
+                    Err(e) => return Completion::Throw(e),
+                };
+            }
             let next = match self.proxy_get_prototype_of(current_id) {
                 Ok(v) => v,
                 Err(e) => return Completion::Throw(e),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -406,6 +406,16 @@ pub(crate) const CALL_DEPTH_REARM_LIMIT: usize = 3_000;
 /// leaving ample headroom for the error object's own construction.
 pub(crate) const EVAL_DEPTH_LIMIT: usize = 50_000;
 
+/// Maximum number of Proxy forwarding seams one prototype-chain operation may
+/// cross before reporting stack exhaustion. Ordinary-only chains are not
+/// counted: `OrdinarySetPrototypeOf` prevents them from cycling, and their hot
+/// iterative/tail-recursive paths already handle very deep acyclic chains.
+///
+/// A Proxy can legally hide a cycle from `OrdinarySetPrototypeOf`. Keeping this
+/// below the JS call-depth ceiling leaves enough native stack to construct and
+/// throw a catchable `RangeError` instead of reaching SIGABRT first.
+pub(crate) const PROXY_CHAIN_DEPTH_LIMIT: usize = 4_000;
+
 const MAX_POOLED_FUNCTION_ENVIRONMENTS: usize = 256;
 const MAX_POOLED_FUNCTION_BINDING_CAPACITY: usize = 256;
 

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -36,6 +36,16 @@ impl SetOutcome {
 }
 
 impl Interpreter {
+    /// Advance the resource counter shared by Proxy-mediated prototype-chain
+    /// walks. The counter is local to one internal-method operation, so user
+    /// code that starts a nested operation gets an independent budget.
+    pub(crate) fn advance_proxy_chain_depth(&mut self, depth: usize) -> Result<usize, JsValue> {
+        if depth >= PROXY_CHAIN_DEPTH_LIMIT {
+            return Err(self.create_error("RangeError", "Maximum call stack size exceeded"));
+        }
+        Ok(depth + 1)
+    }
+
     /// Canonical [[Set]] entry point (§10.1.9 OrdinarySet + exotic dispatch).
     /// Handles proxy `set` trap, TypedArray integer-index element set,
     /// accessor setter invocation, prototype-chain walk, and receiver logic.
@@ -110,6 +120,16 @@ impl Interpreter {
         key: &K,
         this_val: &JsValue,
     ) -> Completion {
+        self.get_object_property_with_proxy_depth(obj_id, key, this_val, 0)
+    }
+
+    fn get_object_property_with_proxy_depth<K: PropertyKeyLike + ?Sized>(
+        &mut self,
+        obj_id: u64,
+        key: &K,
+        this_val: &JsValue,
+        proxy_depth: usize,
+    ) -> Completion {
         // Single-borrow fast path: classify object and check own property in one borrow
         if let Some(obj) = self.get_object_cell(obj_id) {
             let b = obj.borrow();
@@ -157,7 +177,12 @@ impl Interpreter {
                 drop(b);
                 if let Some(proto_rc) = proto {
                     let proto_id = proto_rc;
-                    return self.get_object_property(proto_id, key, this_val);
+                    return self.get_object_property_with_proxy_depth(
+                        proto_id,
+                        key,
+                        this_val,
+                        proxy_depth,
+                    );
                 }
                 return Completion::Normal(JsValue::UNDEFINED);
             }
@@ -165,7 +190,7 @@ impl Interpreter {
         }
 
         // Slow path: proxy or module namespace objects
-        self.get_object_property_slow(obj_id, key, this_val)
+        self.get_object_property_slow(obj_id, key, this_val, proxy_depth)
     }
 
     fn get_object_property_slow<K: PropertyKeyLike + ?Sized>(
@@ -173,6 +198,7 @@ impl Interpreter {
         obj_id: u64,
         key: &K,
         this_val: &JsValue,
+        proxy_depth: usize,
     ) -> Completion {
         // Check if object is a proxy
         if self.get_proxy_info(obj_id).is_some() {
@@ -216,7 +242,13 @@ impl Interpreter {
                 Ok(None) => {
                     // No trap, fall through to target
                     if let Some(target_id) = target_val.as_object_id() {
-                        return self.get_object_property(target_id, key, this_val);
+                        let next_depth = match self.advance_proxy_chain_depth(proxy_depth) {
+                            Ok(depth) => depth,
+                            Err(e) => return Completion::Throw(e),
+                        };
+                        return self.get_object_property_with_proxy_depth(
+                            target_id, key, this_val, next_depth,
+                        );
                     }
                     return Completion::Normal(JsValue::UNDEFINED);
                 }
@@ -283,7 +315,7 @@ impl Interpreter {
                 };
                 if let Some(proto_rc) = proto {
                     let proto_id = proto_rc;
-                    self.get_object_property(proto_id, key, this_val)
+                    self.get_object_property_with_proxy_depth(proto_id, key, this_val, proxy_depth)
                 } else {
                     Completion::Normal(JsValue::UNDEFINED)
                 }
@@ -296,6 +328,15 @@ impl Interpreter {
         &mut self,
         obj_id: u64,
         key: &K,
+    ) -> Result<bool, JsValue> {
+        self.proxy_has_property_with_proxy_depth(obj_id, key, 0)
+    }
+
+    fn proxy_has_property_with_proxy_depth<K: PropertyKeyLike + ?Sized>(
+        &mut self,
+        obj_id: u64,
+        key: &K,
+        proxy_depth: usize,
     ) -> Result<bool, JsValue> {
         if self.get_proxy_info(obj_id).is_some() {
             let target_val = self.get_proxy_target_val(obj_id);
@@ -325,7 +366,9 @@ impl Interpreter {
                 }
                 Ok(None) => {
                     if let Some(target_id) = target_val.as_object_id() {
-                        return self.proxy_has_property(target_id, key);
+                        let next_depth = self.advance_proxy_chain_depth(proxy_depth)?;
+                        return self
+                            .proxy_has_property_with_proxy_depth(target_id, key, next_depth);
                     }
                     Ok(false)
                 }
@@ -360,7 +403,7 @@ impl Interpreter {
             let proto = obj.borrow().prototype_id;
             if let Some(proto_rc) = proto {
                 let proto_id = proto_rc;
-                return self.proxy_has_property(proto_id, key);
+                return self.proxy_has_property_with_proxy_depth(proto_id, key, proxy_depth);
             }
             Ok(false)
         } else {
@@ -760,6 +803,17 @@ impl Interpreter {
         value: JsValue,
         receiver: &JsValue,
     ) -> Result<SetOutcome, JsValue> {
+        self.proxy_set_with_outcome_and_proxy_depth(obj_id, key, value, receiver, 0)
+    }
+
+    fn proxy_set_with_outcome_and_proxy_depth<K: PropertyKeyLike + ?Sized>(
+        &mut self,
+        obj_id: u64,
+        key: &K,
+        value: JsValue,
+        receiver: &JsValue,
+        proxy_depth: usize,
+    ) -> Result<SetOutcome, JsValue> {
         if self.get_proxy_info(obj_id).is_some() {
             let target_val = self.get_proxy_target_val(obj_id);
             let key_val = self.symbol_key_to_jsvalue(key);
@@ -804,7 +858,10 @@ impl Interpreter {
                 }
                 Ok(None) => {
                     if let Some(target_id) = target_val.as_object_id() {
-                        return self.proxy_set_with_outcome(target_id, key, value, receiver);
+                        let next_depth = self.advance_proxy_chain_depth(proxy_depth)?;
+                        return self.proxy_set_with_outcome_and_proxy_depth(
+                            target_id, key, value, receiver, next_depth,
+                        );
                     }
                     Ok(SetOutcome::Rejected)
                 }
@@ -983,7 +1040,13 @@ impl Interpreter {
             let proto = obj.borrow().prototype_id;
             if let Some(proto_rc) = proto {
                 let proto_id = proto_rc;
-                return self.proxy_set_with_outcome(proto_id, key, value, receiver);
+                return self.proxy_set_with_outcome_and_proxy_depth(
+                    proto_id,
+                    key,
+                    value,
+                    receiver,
+                    proxy_depth,
+                );
             }
             // No prototype: OrdinarySetWithOwnDescriptor with synthetic {writable:true,...} ownDesc.
             // Per spec step 1.c.i + 2.c: call Receiver.[[GetOwnProperty]](P) then act on result.
@@ -1728,6 +1791,7 @@ impl Interpreter {
         let mut seen = HashSet::new();
         let mut keys = Vec::new();
         let mut current_id = Some(obj_id);
+        let mut proxy_depth = 0;
 
         while let Some(cid) = current_id {
             // Get own keys for current object (proxy-aware)
@@ -1751,6 +1815,9 @@ impl Interpreter {
             }
 
             // Walk prototype chain (proxy-aware)
+            if self.get_proxy_info(cid).is_some() {
+                proxy_depth = self.advance_proxy_chain_depth(proxy_depth)?;
+            }
             current_id = self.proxy_get_prototype_of(cid)?.as_object_id();
         }
         Ok(keys)

--- a/tests/proxy-cyclic-prototype-chain-rangeerror.js
+++ b/tests/proxy-cyclic-prototype-chain-rangeerror.js
@@ -1,0 +1,102 @@
+// ECMA-262 §§10.1.2.1, 10.1.7-10.1.9, and 10.5 permit an ordinary
+// prototype cycle routed through a Proxy. Chain-walking internal methods must
+// turn resource exhaustion into a catchable RangeError instead of overflowing
+// the native Rust stack or looping forever (jsse#512).
+
+function makeCycle() {
+  var target = { present: 1 };
+  var middle = {};
+  var proxy = new Proxy(target, {});
+  Object.setPrototypeOf(target, middle);
+  Object.setPrototypeOf(middle, proxy);
+  return { target: target, proxy: proxy };
+}
+
+function assertStackRangeError(label, operation) {
+  var error;
+  try {
+    operation();
+  } catch (caught) {
+    error = caught;
+  }
+
+  if (!(error instanceof RangeError)) {
+    throw new Error(label + " should throw a RangeError");
+  }
+  if (!/stack/i.test(String(error.message))) {
+    throw new Error(label + " should report stack exhaustion: " + error.message);
+  }
+}
+
+var cycle = makeCycle();
+
+// Own descriptors short-circuit before the cycle is traversed.
+if (cycle.target.present !== 1 || !("present" in cycle.target)) {
+  throw new Error("own get/has should not traverse the prototype cycle");
+}
+cycle.target.present = 2;
+if (cycle.target.present !== 2) {
+  throw new Error("own set should not traverse the prototype cycle");
+}
+
+assertStackRangeError("[[Get]]", function () {
+  return cycle.target.missing;
+});
+
+assertStackRangeError("[[Set]]", function () {
+  cycle.target.missing = 1;
+});
+if (Object.prototype.hasOwnProperty.call(cycle.target, "missing")) {
+  throw new Error("failed cyclic [[Set]] should not create a property");
+}
+
+assertStackRangeError("[[HasProperty]]", function () {
+  return "missing" in cycle.target;
+});
+
+function Unrelated() {}
+assertStackRangeError("OrdinaryHasInstance", function () {
+  return cycle.target instanceof Unrelated;
+});
+
+assertStackRangeError("Proxy-started for-in", function () {
+  for (var key in cycle.proxy) {
+    // Enumeration must finish its prototype walk before the body can run.
+  }
+});
+
+// Repeated identity is not itself an error: Proxy hooks may mutate a dynamic
+// chain before an otherwise missing trap forwards to the target.
+var dynamicTarget = {};
+var handlerReads = 0;
+var dynamicHandler = {};
+Object.defineProperty(dynamicHandler, "get", {
+  configurable: true,
+  get: function () {
+    handlerReads++;
+    Object.setPrototypeOf(dynamicTarget, null);
+    return undefined;
+  },
+});
+var dynamicProxy = new Proxy(dynamicTarget, dynamicHandler);
+Object.setPrototypeOf(dynamicTarget, dynamicProxy);
+if (dynamicProxy.missing !== undefined || handlerReads !== 1) {
+  throw new Error("a handler getter should be able to terminate the chain");
+}
+
+var prototypeTrapCalls = 0;
+var dynamicPrototypeProxy;
+dynamicPrototypeProxy = new Proxy({}, {
+  getPrototypeOf: function () {
+    return prototypeTrapCalls++ === 0 ? dynamicPrototypeProxy : null;
+  },
+});
+if (dynamicPrototypeProxy instanceof Unrelated || prototypeTrapCalls !== 2) {
+  throw new Error("a temporarily repeated dynamic prototype should terminate");
+}
+
+// A caught resource error must not poison later property operations.
+var recovered = { value: 42 };
+if (recovered.value !== 42 || !("value" in recovered)) {
+  throw new Error("property operations did not recover after cyclic traversal");
+}


### PR DESCRIPTION
## Summary

- bound repeated Proxy forwarding in chain-walking `[[Get]]`, `[[Set]]`, and `[[HasProperty]]` operations before native stack exhaustion
- apply the same catchable `RangeError` resource policy to Proxy-aware `instanceof` and Proxy-started `for-in` walks
- preserve spec-required Proxy-mediated cycle construction, own-property short-circuiting, deep ordinary chains, and dynamic trap mutation
- add an end-to-end regression test and design rationale

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py` (13/13)
- targeted Object/Proxy test262 (261/261)
- full test262 (99,568/99,568; zero regressions)

Closes #512