### PR TITLE
fix(array): enumerate dynamically added elements

### DIFF
--- a/src/interpreter/builtins/mod.rs
+++ b/src/interpreter/builtins/mod.rs
@@ -5239,38 +5239,97 @@ impl Interpreter {
                                     }
                                 }
                             }
-                            let keys_and_descs: Vec<(JsPropertyKey, PropertyDescriptor)> = {
-                                let b = obj.borrow();
-                                b.properties
-                                    .iter()
-                                    .map(|(k, d)| (k.clone(), d.clone()))
-                                    .collect()
-                            };
-                            for (key, desc) in keys_and_descs {
-                                let new_desc = if desc.is_accessor_descriptor() {
-                                    PropertyDescriptor {
-                                        configurable: Some(false),
-                                        value: None,
-                                        writable: None,
-                                        get: None,
-                                        set: None,
-                                        enumerable: None,
-                                    }
-                                } else {
-                                    PropertyDescriptor {
-                                        configurable: Some(false),
-                                        writable: Some(false),
-                                        value: None,
-                                        get: None,
-                                        set: None,
-                                        enumerable: None,
-                                    }
+                            let is_array = obj.borrow().array_elements().is_some();
+                            if is_array {
+                                let keys = match interp.proxy_own_keys(obj_id) {
+                                    Ok(keys) => keys,
+                                    Err(e) => return Completion::Throw(e),
                                 };
-                                // §7.3.8 DefinePropertyOrThrow: throw if [[DefineOwnProperty]] returns false
-                                if !obj.borrow_mut().define_own_property(key.clone(), new_desc) {
-                                    return Completion::Throw(interp.create_type_error(&format!(
-                                        "Cannot freeze property '{key}'"
-                                    )));
+                                for key_val in keys {
+                                    let key = to_property_key_string(&key_val);
+                                    let desc_val = match interp
+                                        .proxy_get_own_property_descriptor(obj_id, &key)
+                                    {
+                                        Ok(v) => v,
+                                        Err(e) => return Completion::Throw(e),
+                                    };
+                                    if desc_val.is_undefined() {
+                                        continue;
+                                    }
+                                    let desc = match interp.to_property_descriptor(&desc_val) {
+                                        Ok(desc) => desc,
+                                        Err(Some(e)) => return Completion::Throw(e),
+                                        Err(None) => continue,
+                                    };
+                                    let new_desc = if desc.is_accessor_descriptor() {
+                                        PropertyDescriptor {
+                                            configurable: Some(false),
+                                            value: None,
+                                            writable: None,
+                                            get: None,
+                                            set: None,
+                                            enumerable: None,
+                                        }
+                                    } else {
+                                        PropertyDescriptor {
+                                            configurable: Some(false),
+                                            writable: Some(false),
+                                            value: None,
+                                            get: None,
+                                            set: None,
+                                            enumerable: None,
+                                        }
+                                    };
+                                    let new_desc_val = interp.from_property_descriptor(&new_desc);
+                                    // §7.3.8 DefinePropertyOrThrow: throw if [[DefineOwnProperty]] returns false
+                                    match interp.proxy_define_own_property(
+                                        obj_id,
+                                        key.clone(),
+                                        &new_desc_val,
+                                    ) {
+                                        Ok(true) => {}
+                                        Ok(false) => {
+                                            return Completion::Throw(interp.create_type_error(
+                                                &format!("Cannot freeze property '{key}'"),
+                                            ));
+                                        }
+                                        Err(e) => return Completion::Throw(e),
+                                    }
+                                }
+                            } else {
+                                let keys_and_descs: Vec<(JsPropertyKey, PropertyDescriptor)> = {
+                                    let b = obj.borrow();
+                                    b.properties
+                                        .iter()
+                                        .map(|(k, d)| (k.clone(), d.clone()))
+                                        .collect()
+                                };
+                                for (key, desc) in keys_and_descs {
+                                    let new_desc = if desc.is_accessor_descriptor() {
+                                        PropertyDescriptor {
+                                            configurable: Some(false),
+                                            value: None,
+                                            writable: None,
+                                            get: None,
+                                            set: None,
+                                            enumerable: None,
+                                        }
+                                    } else {
+                                        PropertyDescriptor {
+                                            configurable: Some(false),
+                                            writable: Some(false),
+                                            value: None,
+                                            get: None,
+                                            set: None,
+                                            enumerable: None,
+                                        }
+                                    };
+                                    if !obj.borrow_mut().define_own_property(key.clone(), new_desc)
+                                    {
+                                        return Completion::Throw(interp.create_type_error(
+                                            &format!("Cannot freeze property '{key}'"),
+                                        ));
+                                    }
                                 }
                             }
                         }
@@ -5726,124 +5785,12 @@ impl Interpreter {
                     let Some(obj_id) = target.as_object_id() else {
                         return Completion::Normal(interp.create_array(Vec::new()));
                     };
-                    if let Some(obj) = interp.get_object_cell(obj_id) {
-                        // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
-                        {
-                            let is_deferred_ns = obj
-                                .borrow()
-                                .module_namespace()
-                                .as_ref()
-                                .is_some_and(|ns| ns.deferred);
-                            if is_deferred_ns
-                                && let Err(e) = interp.ensure_deferred_namespace_evaluation(obj_id)
-                            {
-                                return Completion::Throw(e);
-                            }
-                        }
-                        let obj = interp.get_object_cell(obj_id).unwrap();
-                        // Proxy ownKeys trap (getOwnPropertyNames returns all string keys)
-                        let res = {
-                            let _b = obj.borrow();
-                            _b.is_proxy() || _b.is_proxy_revoked()
-                        };
-                        if res {
-                            match interp.proxy_own_keys(obj_id) {
-                                Ok(keys) => {
-                                    let str_keys: Vec<JsValue> =
-                                        keys.into_iter().filter(|k| (k).is_string()).collect();
-                                    let arr = interp.create_array(str_keys);
-                                    return Completion::Normal(arr);
-                                }
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        }
-                        // TypedArray [[OwnPropertyKeys]]: virtual index keys
-                        {
-                            let b = obj.borrow();
-                            if let Some(ta) = b.typed_array_info() {
-                                let len = crate::interpreter::types::typed_array_length(ta);
-                                let property_order = b.property_order.clone();
-                                drop(b);
-                                let mut names: Vec<JsValue> = Vec::new();
-                                for i in 0..len {
-                                    names.push(JsValue::string(JsString::from_str(&i.to_string())));
-                                }
-                                for k in &property_order {
-                                    if k.is_symbol() {
-                                        continue;
-                                    }
-                                    if let Ok(n) = k.parse::<u64>()
-                                        && n < 0xFFFFFFFF
-                                        && k.eq_str(&n.to_string())
-                                    {
-                                        continue; // skip numeric indices
-                                    }
-                                    names.push(JsValue::string(k.to_js_string()));
-                                }
-                                let arr = interp.create_array(names);
-                                return Completion::Normal(arr);
-                            }
-                        }
-                        // String exotic: include "length" and character index keys
-                        let b = obj.borrow();
-                        let is_string_wrapper =
-                            b.primitive_value.as_ref().is_some_and(JsValue::is_string);
-                        let mut names: Vec<JsValue> = Vec::new();
-                        if is_string_wrapper
-                            && let Some(s) = b.primitive_value.as_ref().and_then(JsValue::as_string)
-                        {
-                            for i in 0..s.len() {
-                                names.push(JsValue::string(JsString::from_str(&i.to_string())));
-                            }
-                        }
-                        // Collect and sort non-symbol keys from property_order
-                        let prop_keys: Vec<JsPropertyKey> = b
-                            .property_order
-                            .iter()
-                            .filter(|k| !k.is_symbol())
-                            .cloned()
-                            .collect();
-                        drop(b);
-                        // Sort: integer indices first (already added char indices), then string keys
-                        let mut int_keys: Vec<(u64, JsPropertyKey)> = Vec::new();
-                        let mut str_keys2: Vec<JsPropertyKey> = Vec::new();
-                        for k in prop_keys {
-                            let already_added = names.iter().any(|v| {
-                                v.as_string()
-                                    .is_some_and(|s| JsPropertyKey::from_js_string(&s) == k)
-                            });
-                            if already_added {
-                                continue;
-                            }
-                            // For string wrappers, "length" is added at the end
-                            if is_string_wrapper && k.eq_str("length") {
-                                continue;
-                            }
-                            if let Ok(n) = k.parse::<u64>() {
-                                if k.eq_str(&n.to_string()) {
-                                    int_keys.push((n, k));
-                                } else {
-                                    str_keys2.push(k);
-                                }
-                            } else {
-                                str_keys2.push(k);
-                            }
-                        }
-                        int_keys.sort_by_key(|(n, _)| *n);
-                        for (_, k) in int_keys {
-                            names.push(JsValue::string(k.to_js_string()));
-                        }
-                        for k in str_keys2 {
-                            names.push(JsValue::string(k.to_js_string()));
-                        }
-                        // String exotic: "length" is always an own property
-                        if is_string_wrapper {
-                            names.push(JsValue::string(JsString::from_str("length")));
-                        }
-                        let arr = interp.create_array(names);
-                        return Completion::Normal(arr);
-                    }
-                    Completion::Normal(interp.create_array(Vec::new()))
+                    let keys = match interp.proxy_own_keys(obj_id) {
+                        Ok(keys) => keys,
+                        Err(e) => return Completion::Throw(e),
+                    };
+                    let names = keys.into_iter().filter(JsValue::is_string).collect();
+                    Completion::Normal(interp.create_array(names))
                 },
             ));
             obj_func
@@ -6192,22 +6139,52 @@ impl Interpreter {
                                     }
                                 }
                             }
-                            let keys: Vec<JsPropertyKey> = obj
-                                .borrow()
-                                .properties
-                                .keys()
-                                .cloned()
-                                .collect();
-                            for key in keys {
-                                let new_desc = PropertyDescriptor {
-                                    configurable: Some(false),
-                                    value: None,
-                                    writable: None,
-                                    get: None,
-                                    set: None,
-                                    enumerable: None,
+                            let is_array = obj.borrow().array_elements().is_some();
+                            if is_array {
+                                let keys = match interp.proxy_own_keys(obj_id) {
+                                    Ok(keys) => keys,
+                                    Err(e) => return Completion::Throw(e),
                                 };
-                                obj.borrow_mut().define_own_property(key, new_desc);
+                                for key_val in keys {
+                                    let key = to_property_key_string(&key_val);
+                                    let new_desc = PropertyDescriptor {
+                                        configurable: Some(false),
+                                        value: None,
+                                        writable: None,
+                                        get: None,
+                                        set: None,
+                                        enumerable: None,
+                                    };
+                                    let new_desc_val = interp.from_property_descriptor(&new_desc);
+                                    // §7.3.8 DefinePropertyOrThrow: throw if [[DefineOwnProperty]] returns false
+                                    match interp.proxy_define_own_property(
+                                        obj_id,
+                                        key.clone(),
+                                        &new_desc_val,
+                                    ) {
+                                        Ok(true) => {}
+                                        Ok(false) => {
+                                            return Completion::Throw(interp.create_type_error(
+                                                &format!("Cannot seal property '{key}'"),
+                                            ));
+                                        }
+                                        Err(e) => return Completion::Throw(e),
+                                    }
+                                }
+                            } else {
+                                let keys: Vec<JsPropertyKey> =
+                                    obj.borrow().properties.keys().cloned().collect();
+                                for key in keys {
+                                    let new_desc = PropertyDescriptor {
+                                        configurable: Some(false),
+                                        value: None,
+                                        writable: None,
+                                        get: None,
+                                        set: None,
+                                        enumerable: None,
+                                    };
+                                    obj.borrow_mut().define_own_property(key, new_desc);
+                                }
                             }
                         }
                     }
@@ -7044,133 +7021,12 @@ impl Interpreter {
                         interp.create_type_error("Reflect.ownKeys requires an object"),
                     );
                 }
-                if let Some(target_id) = target.as_object_id()
-                    && let Some(obj) = interp.get_object_cell(target_id)
-                {
-                    // Deferred namespace: trigger evaluation on [[OwnPropertyKeys]]
-                    {
-                        let is_deferred_ns = obj
-                            .borrow()
-                            .module_namespace()
-                            .as_ref()
-                            .is_some_and(|ns| ns.deferred);
-                        if is_deferred_ns
-                            && let Err(e) = interp.ensure_deferred_namespace_evaluation(target_id)
-                        {
-                            return Completion::Throw(e);
-                        }
-                    }
-                    let obj = interp.get_object_cell(target_id).unwrap();
-                    let res = {
-                        let _b = obj.borrow();
-                        _b.is_proxy() || _b.is_proxy_revoked()
-                    };
-                    if res {
-                        match interp.proxy_own_keys(target_id) {
-                            Ok(keys) => {
-                                let arr = interp.create_array(keys);
-                                return Completion::Normal(arr);
-                            }
-                            Err(e) => return Completion::Throw(e),
-                        }
-                    }
-                    // TypedArray [[OwnPropertyKeys]]: §10.4.5.6
-                    {
-                        let b = obj.borrow();
-                        if let Some(ta) = b.typed_array_info() {
-                            let len = crate::interpreter::types::typed_array_length(ta);
-                            let property_order = b.property_order.clone();
-                            drop(b);
-                            let mut keys: Vec<JsValue> = Vec::new();
-                            for i in 0..len {
-                                keys.push(JsValue::string(JsString::from_str(&i.to_string())));
-                            }
-                            let mut strings: Vec<(JsPropertyKey, usize)> = Vec::new();
-                            let mut symbols: Vec<(JsPropertyKey, usize)> = Vec::new();
-                            for (pos, k) in property_order.iter().enumerate() {
-                                if k.is_symbol() {
-                                    symbols.push((k.clone(), pos));
-                                } else if let Ok(n) = k.parse::<u64>()
-                                    && n < 0xFFFFFFFF
-                                    && k.eq_str(&n.to_string())
-                                {
-                                    // Skip numeric indices, already handled above
-                                } else {
-                                    strings.push((k.clone(), pos));
-                                }
-                            }
-                            for (s, _) in &strings {
-                                keys.push(JsValue::string(s.to_js_string()));
-                            }
-                            for (sym_key, _) in &symbols {
-                                keys.push(interp.symbol_key_to_jsvalue(sym_key));
-                            }
-                            let arr = interp.create_array(keys);
-                            return Completion::Normal(arr);
-                        }
-                    }
-                    // Collect virtual own keys for String exotic objects
-                    let mut virtual_indices: Vec<u32> = Vec::new();
-                    let mut has_virtual_length = false;
-                    {
-                        let b = obj.borrow();
-                        if b.class_name == "String"
-                            && let Some(s) = b.primitive_value.as_ref().and_then(JsValue::as_string)
-                        {
-                            let slen = s.code_units.len();
-                            for i in 0..slen {
-                                virtual_indices.push(i as u32);
-                            }
-                            has_virtual_length = true;
-                        }
-                    }
-                    let property_order = obj.borrow().property_order.clone();
-                    // Collect keys already in property_order into virtual_indices set for dedup
-                    let existing_keys: HashSet<JsPropertyKey> =
-                        property_order.iter().cloned().collect();
-                    // OrdinaryOwnPropertyKeys: indices ascending, then strings, then symbols
-                    let mut indices: Vec<(u32, usize)> = Vec::new();
-                    let mut strings: Vec<(JsPropertyKey, usize)> = Vec::new();
-                    let mut symbols: Vec<(JsPropertyKey, usize)> = Vec::new();
-                    // Add virtual string indices first (they have implicit position before all others)
-                    for idx in &virtual_indices {
-                        let k = idx.to_string();
-                        if !existing_keys.contains(k.as_bytes()) {
-                            indices.push((*idx, 0));
-                        }
-                    }
-                    for (pos, k) in property_order.iter().enumerate() {
-                        if k.is_symbol() {
-                            symbols.push((k.clone(), pos));
-                        } else if let Ok(n) = k.parse::<u64>()
-                            && n < 0xFFFFFFFF
-                            && k.eq_str(&n.to_string())
-                        {
-                            indices.push((n as u32, pos));
-                        } else {
-                            strings.push((k.clone(), pos));
-                        }
-                    }
-                    indices.sort_by_key(|&(n, _)| n);
-                    let mut keys: Vec<JsValue> =
-                        Vec::with_capacity(property_order.len() + virtual_indices.len() + 1);
-                    for (n, _) in &indices {
-                        keys.push(JsValue::string(JsString::from_str(&n.to_string())));
-                    }
-                    // Add "length" for String exotic objects (before other strings)
-                    if has_virtual_length && !existing_keys.contains("length".as_bytes()) {
-                        keys.push(JsValue::string(JsString::from_str("length")));
-                    }
-                    for (s, _) in &strings {
-                        keys.push(JsValue::string(s.to_js_string()));
-                    }
-                    for (sym_key, _) in &symbols {
-                        keys.push(interp.symbol_key_to_jsvalue(sym_key));
-                    }
-                    let arr = interp.create_array(keys);
-                    return Completion::Normal(arr);
-                }
-                Completion::Normal(interp.create_array(Vec::new()))
+                let target_id = target.as_object_id().unwrap();
+                let keys = match interp.proxy_own_keys(target_id) {
+                    Ok(keys) => keys,
+                    Err(e) => return Completion::Throw(e),
+                };
+                Completion::Normal(interp.create_array(keys))
             },
         ));
         self.get_object_cell_expect(reflect_obj_id)

--- a/src/interpreter/property.rs
+++ b/src/interpreter/property.rs
@@ -1684,13 +1684,10 @@ impl Interpreter {
             for k in &b.property_order {
                 if k.is_symbol() {
                     sym_keys.push(k.clone());
-                } else if let Ok(n) = k.parse::<u64>() {
-                    if k.eq_str(&n.to_string()) {
-                        // This is an integer index - add/overwrite (string char indices take precedence, but we let btreemap handle uniqueness)
-                        int_keys_set.insert(n, k.to_string());
-                    } else {
-                        str_keys.push(k.clone());
-                    }
+                } else if let Some(n) = parse_array_index(k) {
+                    // String char indices take precedence, but the BTreeMap
+                    // handles uniqueness and ascending numeric order.
+                    int_keys_set.insert(n as u64, k.to_string());
                 } else {
                     // Skip "length" for string wrappers - it's virtual, added separately
                     if is_string_wrapper && k.eq_str("length") {
@@ -1704,12 +1701,13 @@ impl Interpreter {
             for (_, k) in int_keys_set {
                 result.push(JsValue::from_str(&k));
             }
-            for k in str_keys {
-                result.push(JsValue::string(k.to_js_string()));
-            }
-            // String exotic: "length" is a virtual non-enumerable string key (after other str keys, before symbols)
+            // A String exotic's virtual "length" property exists before any
+            // subsequently created ordinary string properties.
             if is_string_wrapper {
                 result.push(JsValue::from_str("length"));
+            }
+            for k in str_keys {
+                result.push(JsValue::string(k.to_js_string()));
             }
             for k in sym_keys {
                 result.push(self.symbol_key_to_jsvalue(&k));

--- a/test262-extra/array-dynamic-elements-ownkeys-integrity.js
+++ b/test262-extra/array-dynamic-elements-ownkeys-integrity.js
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 the JSSE project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Array index properties created after the Array are included by
+  [[OwnPropertyKeys]]. SetIntegrityLevel must therefore update their property
+  descriptors when Object.freeze or Object.seal is applied.
+info: |
+  10.1.11 OrdinaryOwnPropertyKeys ( O )
+    2. For each own property key P of O such that P is an array index, in
+       ascending numeric index order, append P to keys.
+
+  7.3.16 SetIntegrityLevel ( O, level )
+    3. Let keys be ? O.[[OwnPropertyKeys]]().
+    4. If level is sealed, set every own property's [[Configurable]] to false.
+    5. If level is frozen, also set every own data property's [[Writable]] to
+       false.
+features: [Reflect, Symbol]
+includes: [propertyHelper.js]
+---*/
+
+function assertKeys(actual, expected, message) {
+  assert.sameValue(actual.length, expected.length, message + ": key count");
+  for (var i = 0; i < expected.length; i++) {
+    assert.sameValue(actual[i], expected[i], message + ": key " + i);
+  }
+}
+
+var pushed = [];
+pushed.push(1, 2);
+assertKeys(Object.getOwnPropertyNames(pushed), ["0", "1", "length"], "push names");
+assertKeys(Reflect.ownKeys(pushed), ["0", "1", "length"], "push ownKeys");
+
+var assigned = new Array(2);
+assigned[0] = 1;
+assigned[1] = 2;
+assertKeys(Object.getOwnPropertyNames(assigned), ["0", "1", "length"], "assigned names");
+assertKeys(Reflect.ownKeys(assigned), ["0", "1", "length"], "assigned ownKeys");
+
+var filled = new Array(2).fill(0);
+assertKeys(Object.getOwnPropertyNames(filled), ["0", "1", "length"], "fill names");
+assertKeys(Reflect.ownKeys(filled), ["0", "1", "length"], "fill ownKeys");
+
+var ordered = [];
+var marker = Symbol("marker");
+ordered.named = true;
+ordered[2] = "c";
+ordered[0] = "a";
+ordered[marker] = true;
+assertKeys(
+  Object.getOwnPropertyNames(ordered),
+  ["0", "2", "length", "named"],
+  "dynamic index ordering and holes"
+);
+assertKeys(
+  Reflect.ownKeys(ordered),
+  ["0", "2", "length", "named", marker],
+  "dynamic index, string, and symbol ordering"
+);
+assert.sameValue(Object.hasOwn(ordered, "1"), false, "a hole is not an own property");
+
+var frozen = [];
+frozen.push(1, 2);
+assert.sameValue(Object.freeze(frozen), frozen, "freeze returns the array");
+verifyProperty(frozen, "0", {
+  value: 1,
+  writable: false,
+  enumerable: true,
+  configurable: false,
+});
+verifyProperty(frozen, "1", {
+  value: 2,
+  writable: false,
+  enumerable: true,
+  configurable: false,
+});
+assert.sameValue(Reflect.set(frozen, "0", 99), false, "frozen element rejects writes");
+assert.sameValue(Reflect.deleteProperty(frozen, "0"), false, "frozen element rejects deletion");
+assert.sameValue(frozen[0], 1, "frozen element value is preserved");
+assert.sameValue(Object.isFrozen(frozen), true, "dynamic array is frozen");
+
+var sealed = [];
+sealed.push(1);
+assert.sameValue(Object.seal(sealed), sealed, "seal returns the array");
+verifyProperty(sealed, "0", {
+  value: 1,
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
+assert.sameValue(Reflect.deleteProperty(sealed, "0"), false, "sealed element rejects deletion");
+assert.sameValue(Reflect.set(sealed, "0", 2), true, "sealed element remains writable");
+assert.sameValue(sealed[0], 2, "sealed element accepts writes");
+assert.sameValue(Object.isSealed(sealed), true, "dynamic array is sealed");
+assert.sameValue(Object.isFrozen(sealed), false, "writable sealed array is not frozen");
+
+var sparse = new Array(2);
+sparse[1] = 1;
+Object.freeze(sparse);
+assert.sameValue(Object.hasOwn(sparse, "0"), false, "freeze does not materialize a hole");
+verifyProperty(sparse, "1", {
+  value: 1,
+  writable: false,
+  enumerable: true,
+  configurable: false,
+});


### PR DESCRIPTION
Summary:
- route Object.getOwnPropertyNames and Reflect.ownKeys through the canonical own-key walker
- include dense array backing-store elements when Object.freeze and Object.seal define integrity attributes
- preserve array-index and String-exotic key ordering while removing duplicate reflection walkers
- add strict and non-strict regression coverage for push, assignment, fill, holes, ordering, freeze, and seal

Design choice:
The generic integrity path is scoped to Array objects because extending it to every exotic exposed unrelated String descriptor gaps. Arrays already have a working descriptor path, proven by the no-trap Proxy behavior and the new regression.

Testing:
- cargo fmt --check
- cargo clippy
- cargo build --release
- cargo test --release
- ./scripts/lint.sh
- uv run python scripts/run-custom-tests.py
- affected Object and Reflect test262 directories: 590/590
- full default test262: 99,568/99,568, zero regressions

Closes #516