### PR TITLE
fix(node-shim): render array extra properties

### DIFF
--- a/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
+++ b/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
@@ -84,14 +84,20 @@ string properties.
 
 ## Safety and failure behavior
 
-The formatter unwraps active Proxies before `renderArray`, so the hook and
-descriptor reads operate on the target without invoking handler traps. The hook
-borrows only the Array's internal key order and descriptor enumerability flags;
-values are observed only through descriptor objects already used by the
-hardened inspector. In the small-Array fallback, key-mode
-`EnumerableOwnProperties` can invoke neither indexed nor named getters. A
-missing descriptor degrades to the existing `undefined` rendering rather than
-a property access.
+Under `--node` the formatter unwraps active Proxies before `renderArray`, so the
+hook and descriptor reads operate on the target without invoking handler traps.
+The hook borrows only the Array's internal key order and descriptor
+enumerability flags; values are observed only through descriptor objects already
+used by the hardened inspector. A missing descriptor degrades to the existing
+`undefined` rendering rather than a property access.
+
+The plain-jsse fallback has no unwrapping seam, so `v` there may still be a
+Proxy and `Object.keys` dispatches its `ownKeys` trap — user code that the
+pre-existing index-descriptor probes already reach through the
+`getOwnPropertyDescriptor` trap. Key-mode `EnumerableOwnProperties` can invoke
+neither indexed nor named getters, but a hostile or merely throwing trap must
+not turn a diagnostic print into a throw, so the fallback enumeration is
+guarded and degrades to no extra properties.
 
 ## Validation
 

--- a/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
+++ b/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
@@ -92,12 +92,15 @@ used by the hardened inspector. A missing descriptor degrades to the existing
 `undefined` rendering rather than a property access.
 
 The plain-jsse fallback has no unwrapping seam, so `v` there may still be a
-Proxy and `Object.keys` dispatches its `ownKeys` trap — user code that the
-pre-existing index-descriptor probes already reach through the
-`getOwnPropertyDescriptor` trap. Key-mode `EnumerableOwnProperties` can invoke
+Proxy: `Object.keys` dispatches its `ownKeys` trap, and each named key it
+yields is then read back through the `getOwnPropertyDescriptor` trap — both
+user code, and both newly reachable, since the pre-existing probes only ever
+touched `length` and index keys. Key-mode `EnumerableOwnProperties` can invoke
 neither indexed nor named getters, but a hostile or merely throwing trap must
-not turn a diagnostic print into a throw, so the fallback enumeration is
-guarded and degrades to no extra properties.
+not turn a diagnostic print into a throw, so the enumeration *and* the
+per-key descriptor reads are guarded together and degrade to no extra
+properties. Parts are accumulated locally and returned only on success, so a
+throw part-way through cannot leave a half-rendered tail.
 
 ## Validation
 

--- a/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
+++ b/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
@@ -17,12 +17,12 @@ internal method is `[[DefineOwnProperty]]`. The resulting string keys place
 array indices first in numeric order and other strings in property-creation
 order.
 
-JSSE issue #516 records that `Object.keys` correctly enumerates indices and
-named properties on dynamically populated Arrays even though the currently
-unmerged `Object.getOwnPropertyNames`/bare `Reflect.ownKeys` fix is still in
-PR #520. It is functionally reliable, but enumerating it after the existing
-100-index probe would materialize every dense index key and undo the cap's
-runtime benefit.
+`Object.keys` correctly enumerates indices and named properties on dynamically
+populated Arrays; JSSE issue #516 recorded that `Object.getOwnPropertyNames` and
+bare `Reflect.ownKeys` did not, and PR #520 has since fixed them. Availability is
+therefore not the constraint — cost is. Enumerating any of the three after the
+existing 100-index probe would materialize every dense index key and undo the
+cap's runtime benefit.
 
 ## Approaches considered
 
@@ -32,13 +32,16 @@ runtime benefit.
    no values, so the rendered output stays bounded by the 100-index cap. The
    shim still reads values only from ordinary own descriptor objects.
 
-   The *scan* is not equally bounded, because the two Array population paths
-   store indices asymmetrically. `new Array(n).fill(v)` keeps dense indices out
-   of `property_order`, so the hook is O(named descriptors) there; but
-   `create_array` / `create_array_with_holes` (`src/interpreter/builtins/array.rs`)
-   `insert_value` every present index, so an Array *literal* carries all `n`
-   indices in `property_order` and the hook scans them to discard them. Measured
-   at 200,000 elements, 20 inspections: 56 ms with the hook versus 21 ms without
+   The *scan* is not equally bounded, because the Array population paths store
+   indices asymmetrically. `new Array(n).fill(v)` and plain index assignment keep
+   dense indices out of `property_order`, so the hook is O(named descriptors)
+   there; but `create_array` / `create_array_with_holes`
+   (`src/interpreter/builtins/array.rs`) `insert_value` every present index, so
+   the Array carries all `n` indices in `property_order` and the hook scans them
+   to discard them. That path is the common case, not a niche one: it backs
+   literals *and* `.map`, `.slice`, `.filter`, `.concat`, `Array.from`,
+   `String.prototype.split`, `Object.keys`, and `JSON.parse`. Measured at
+   200,000 elements, 20 inspections: 56 ms with the hook versus 21 ms without
    for a literal, against 21 ms versus 15 ms for the `fill` form — about 1.75 ms
    per inspection of a 200k literal. That is a linear key scan, a much smaller
    cost class than the superlinear rendering PR #518 capped, and bounding it
@@ -50,11 +53,12 @@ runtime benefit.
    unwrapping, but rejected on measured performance: inspecting 100,000 filled
    elements took 0.34--0.38 seconds versus about 0.01 seconds on the capped
    `origin/main` implementation (a no-inspect control took about 0.02 seconds).
-3. Depend on PR #520 and enumerate `Reflect.ownKeys` or
-   `Object.getOwnPropertyNames`. This offers a more general reflection seam but
-   couples this shim fix to an unmerged engine change. Both APIs also
+3. Enumerate `Reflect.ownKeys` or `Object.getOwnPropertyNames` (fixed by
+   PR #520). This offers a more general reflection seam, but both APIs
    materialize every index key before the shim can filter it, retaining the
-   dense-Array performance regression from approach 2.
+   dense-Array performance regression from approach 2. Now that #516 is closed
+   this is the approach most likely to be retried; the cost, not availability,
+   is what rules it out.
 
 ## Design
 

--- a/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
+++ b/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
@@ -61,7 +61,7 @@ truncation marker.
 
 The Node host floor exposes
 `__host_array_extra_keys(value) -> Array<string>`. For an Array target it walks
-only `ArrayData::non_index_string_property_order`, returning keys whose
+only `ArrayData::extra_string_property_order`, returning keys whose
 descriptors are enumerable. For non-Arrays and primitives it returns an empty
 Array. It does not read descriptor values or traverse a prototype. Like
 `__host_proxy_target`, it is installed only under `--node` as a non-enumerable
@@ -69,11 +69,14 @@ configurable global; the shim captures and immediately deletes the binding
 before bundled library code runs.
 
 All Array construction paths install `ObjectKind::Array` before creating their
-descriptors. The shared property-creation helper then records `length` and any
-later non-index String keys in the dedicated order while excluding canonical
-indices and Symbols. The shared removal helper deletes from both orders. This
-does not alter ECMAScript `[[OwnPropertyKeys]]`: the complete `property_order`
-and dense-element machinery remain authoritative for ordinary reflection.
+descriptors. The shared property-creation helper records non-index String keys
+in the dedicated order while excluding canonical indices, Symbols, and the
+mandatory `length` property. Since `length` is permanently non-enumerable, it
+can never be returned by the hook; excluding it also keeps the metadata Vec
+allocation-free for Arrays without extra properties. The shared removal helper
+deletes from both orders. This does not alter ECMAScript `[[OwnPropertyKeys]]`:
+the complete `property_order` and dense-element machinery remain authoritative
+for ordinary reflection.
 
 After the index window and marker, `renderArray` walks the captured hook's
 result. Every key is labelled with the same identifier-or-quoted-string policy

--- a/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
+++ b/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
@@ -1,0 +1,117 @@
+# Node-Shim Array Extra-Property Inspection
+
+## Context
+
+The library-harness `util.inspect` shim renders an Array by reading its own
+`length` descriptor and probing index descriptors from zero up to the existing
+100-index safety cap. It never enumerates other own properties, so an enumerable
+property such as `z` is absent from `[ 1, z: 2 ]`. The early return for a
+zero-length Array also prevents any named properties on `[]` from being shown.
+
+ECMAScript does not specify Node's `util.inspect` presentation. It does specify
+the reflection seam used here: `Object.keys` calls `EnumerableOwnProperties` in
+key mode, which invokes `[[OwnPropertyKeys]]` and `[[GetOwnProperty]]` to test
+enumerability but does not perform `Get` on a property value. Array exotic
+objects inherit the ordinary `[[OwnPropertyKeys]]` algorithm; their special
+internal method is `[[DefineOwnProperty]]`. The resulting string keys place
+array indices first in numeric order and other strings in property-creation
+order.
+
+JSSE issue #516 records that `Object.keys` correctly enumerates indices and
+named properties on dynamically populated Arrays even though the currently
+unmerged `Object.getOwnPropertyNames`/bare `Reflect.ownKeys` fix is still in
+PR #520. It is functionally reliable, but enumerating it after the existing
+100-index probe would materialize every dense index key and undo the cap's
+runtime benefit.
+
+## Approaches considered
+
+1. Add a narrow `--node` host-floor hook that returns only an Array's enumerable
+   non-index own string keys. This is selected: it walks the descriptor-backed
+   `property_order` without walking the dense element backing store, so the
+   formatter remains O(100 + named/special descriptors). The shim still reads
+   values only from ordinary own descriptor objects.
+2. Retain the bounded index probe, then enumerate `Object.keys` and discard
+   array indices. This is functionally correct and trap-free after Proxy
+   unwrapping, but rejected on measured performance: inspecting 100,000 filled
+   elements took 0.34--0.38 seconds versus about 0.01 seconds on the capped
+   `origin/main` implementation (a no-inspect control took about 0.02 seconds).
+3. Depend on PR #520 and enumerate `Reflect.ownKeys` or
+   `Object.getOwnPropertyNames`. This offers a more general reflection seam but
+   couples this shim fix to an unmerged engine change. Both APIs also
+   materialize every index key before the shim can filter it, retaining the
+   dense-Array performance regression from approach 2.
+
+## Design
+
+`renderArray` always allocates its local parts list, including when `length` is
+zero. It keeps the existing descriptor probes over
+`min(length, MAX_INSPECT_ARRAY_LENGTH)`, the sparse-hole coalescing, and the
+truncation marker.
+
+The Node host floor exposes
+`__host_array_extra_keys(value) -> Array<string>`. For an Array target it walks
+only `property_order`, returning keys whose descriptors are enumerable Strings
+and whose names are not canonical array indices. For non-Arrays and primitives
+it returns an empty Array. It does not read descriptor values or traverse a
+prototype. Like `__host_proxy_target`, it is installed only under `--node` as a
+non-enumerable configurable global; the shim captures and immediately deletes
+the binding before bundled library code runs.
+
+After the index window and marker, `renderArray` walks the captured hook's
+result. Every key is labelled with the same identifier-or-quoted-string policy
+as ordinary objects, then its own descriptor is passed to `renderDescriptor`.
+A named getter or setter is therefore displayed as metadata and never called.
+
+The plain-jsse fallback has no host metadata hook. For Arrays whose length is at
+most the 100-entry inspection cap, it uses captured `Object.keys` and filters
+array indices, preserving the reported behavior for normal small Arrays. For
+longer Arrays it omits extra properties rather than performing an unbounded key
+enumeration; the documented fallback is degraded, while the library harness
+always runs with `--node` and receives the full behavior.
+
+The array-index predicate implements the spec boundary precisely: the key's
+numeric value must be an unsigned 32-bit integer below 2^32 - 1 and convert back
+to the identical String. Thus `"0"` through `"4294967294"` are indices, while
+`"4294967295"`, `"-0"`, `"01"`, fractional forms, and exponential spellings
+remain named properties.
+
+Enumerable Symbol properties remain outside this change, consistently with
+the shim's existing generic-object path, which also uses `Object.keys`. Node's
+full inspector supports a wider Symbol/hidden-key surface, but the shim is
+explicitly best-effort and issue #517's reported divergence concerns named
+string properties.
+
+## Safety and failure behavior
+
+The formatter unwraps active Proxies before `renderArray`, so the hook and
+descriptor reads operate on the target without invoking handler traps. The hook
+borrows only the Array's internal key order and descriptor enumerability flags;
+values are observed only through descriptor objects already used by the
+hardened inspector. In the small-Array fallback, key-mode
+`EnumerableOwnProperties` can invoke neither indexed nor named getters. A
+missing descriptor degrades to the existing `undefined` rendering rather than
+a property access.
+
+## Validation
+
+Rust host-floor tests will assert that the hook is absent without `--node`, is
+non-enumerable/configurable with the floor enabled, returns only enumerable
+non-index string keys from a densely populated Array, and invokes no getter.
+
+The node-shim self-test will assert exact Node-compatible output for:
+
+- the reported `[1]` with an enumerable `z` property;
+- a zero-length Array with an enumerable named property;
+- an enumerable named getter that is displayed without being called;
+- `"4294967295"` and `"-0"` named properties; and
+- a 101-element Array whose extra property follows the truncation marker.
+
+The 116-shape differential corpus from PR #497 will be run before and after the
+change on both `jsse --node` and the plain-jsse fallback. A 100,000-element
+dense benchmark will confirm that inspection remains close to the capped
+implementation rather than the rejected `Object.keys` pass. The node-shim
+self-test, all shim fixtures, the Object.keys test262 area, and the repository's
+full quality gate will cover regressions. The hook is disabled for ordinary
+execution and test262, so no conformance pass-count or README change is
+expected.

--- a/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
+++ b/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
@@ -28,9 +28,23 @@ runtime benefit.
 
 1. Add a narrow `--node` host-floor hook that returns only an Array's enumerable
    non-index own string keys. This is selected: it walks the descriptor-backed
-   `property_order` without walking the dense element backing store, so the
-   formatter remains O(100 + named/special descriptors). The shim still reads
-   values only from ordinary own descriptor objects.
+   `property_order` without walking the dense element backing store, and reads
+   no values, so the rendered output stays bounded by the 100-index cap. The
+   shim still reads values only from ordinary own descriptor objects.
+
+   The *scan* is not equally bounded, because the two Array population paths
+   store indices asymmetrically. `new Array(n).fill(v)` keeps dense indices out
+   of `property_order`, so the hook is O(named descriptors) there; but
+   `create_array` / `create_array_with_holes` (`src/interpreter/builtins/array.rs`)
+   `insert_value` every present index, so an Array *literal* carries all `n`
+   indices in `property_order` and the hook scans them to discard them. Measured
+   at 200,000 elements, 20 inspections: 56 ms with the hook versus 21 ms without
+   for a literal, against 21 ms versus 15 ms for the `fill` form — about 1.75 ms
+   per inspection of a 200k literal. That is a linear key scan, a much smaller
+   cost class than the superlinear rendering PR #518 capped, and bounding it
+   soundly is not possible inside the hook: `properties.len()` cannot separate
+   "n indices plus one named key" from "n-1 indices plus two named keys". The
+   fix belongs in the storage asymmetry itself and is left to a follow-up.
 2. Retain the bounded index probe, then enumerate `Object.keys` and discard
    array indices. This is functionally correct and trap-free after Proxy
    unwrapping, but rejected on measured performance: inspecting 100,000 filled
@@ -119,7 +133,10 @@ The node-shim self-test will assert exact Node-compatible output for:
 The 116-shape differential corpus from PR #497 will be run before and after the
 change on both `jsse --node` and the plain-jsse fallback. A 100,000-element
 dense benchmark will confirm that inspection remains close to the capped
-implementation rather than the rejected `Object.keys` pass. The node-shim
+implementation rather than the rejected `Object.keys` pass. That benchmark must
+cover an Array *literal* as well as the `new Array(n).fill(v)` form: only the
+literal path populates `property_order` with dense indices, so a `fill`-only
+benchmark cannot observe the hook's scan cost at all. The node-shim
 self-test, all shim fixtures, the Object.keys test262 area, and the repository's
 full quality gate will cover regressions. The hook is disabled for ordinary
 execution and test262, so no conformance pass-count or README change is

--- a/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
+++ b/docs/specs/2026-08-25-node-shim-array-extra-properties-design.md
@@ -26,34 +26,26 @@ cap's runtime benefit.
 
 ## Approaches considered
 
-1. Add a narrow `--node` host-floor hook that returns only an Array's enumerable
-   non-index own string keys. This is selected: it walks the descriptor-backed
-   `property_order` without walking the dense element backing store, and reads
-   no values, so the rendered output stays bounded by the 100-index cap. The
-   shim still reads values only from ordinary own descriptor objects.
-
-   The *scan* is not equally bounded, because the Array population paths store
-   indices asymmetrically. `new Array(n).fill(v)` and plain index assignment keep
-   dense indices out of `property_order`, so the hook is O(named descriptors)
-   there; but `create_array` / `create_array_with_holes`
-   (`src/interpreter/builtins/array.rs`) `insert_value` every present index, so
-   the Array carries all `n` indices in `property_order` and the hook scans them
-   to discard them. That path is the common case, not a niche one: it backs
-   literals *and* `.map`, `.slice`, `.filter`, `.concat`, `Array.from`,
-   `String.prototype.split`, `Object.keys`, and `JSON.parse`. Measured at
-   200,000 elements, 20 inspections: 56 ms with the hook versus 21 ms without
-   for a literal, against 21 ms versus 15 ms for the `fill` form — about 1.75 ms
-   per inspection of a 200k literal. That is a linear key scan, a much smaller
-   cost class than the superlinear rendering PR #518 capped, and bounding it
-   soundly is not possible inside the hook: `properties.len()` cannot separate
-   "n indices plus one named key" from "n-1 indices plus two named keys". The
-   fix belongs in the storage asymmetry itself and is left to a follow-up.
-2. Retain the bounded index probe, then enumerate `Object.keys` and discard
+1. Add a narrow `--node` host-floor hook backed by Array-only non-index String
+   property metadata. This is selected. `ArrayData` maintains creation order for
+   just those keys alongside the ordinary `property_order`; numeric indices and
+   Symbols never enter the dedicated list, and deletion removes a key so a
+   later re-creation appends it in the correct chronological position. The hook
+   therefore reads no values and does work proportional to named String
+   descriptors, independent of the Array's element count.
+2. Walk the existing descriptor-backed `property_order` and discard indices.
+   This was the initial implementation, but it is unbounded for literals and
+   the many built-ins that route through `create_array`: those constructors put
+   every present index in `property_order`. A deterministic probe over a
+   20,000-entry `Array.from` result took 186--200 ms for 2,000 hook calls solely
+   to discard index keys. This approach is rejected because it restores linear
+   work per inspection.
+3. Retain the bounded index probe, then enumerate `Object.keys` and discard
    array indices. This is functionally correct and trap-free after Proxy
    unwrapping, but rejected on measured performance: inspecting 100,000 filled
    elements took 0.34--0.38 seconds versus about 0.01 seconds on the capped
    `origin/main` implementation (a no-inspect control took about 0.02 seconds).
-3. Enumerate `Reflect.ownKeys` or `Object.getOwnPropertyNames` (fixed by
+4. Enumerate `Reflect.ownKeys` or `Object.getOwnPropertyNames` (fixed by
    PR #520). This offers a more general reflection seam, but both APIs
    materialize every index key before the shim can filter it, retaining the
    dense-Array performance regression from approach 2. Now that #516 is closed
@@ -69,12 +61,19 @@ truncation marker.
 
 The Node host floor exposes
 `__host_array_extra_keys(value) -> Array<string>`. For an Array target it walks
-only `property_order`, returning keys whose descriptors are enumerable Strings
-and whose names are not canonical array indices. For non-Arrays and primitives
-it returns an empty Array. It does not read descriptor values or traverse a
-prototype. Like `__host_proxy_target`, it is installed only under `--node` as a
-non-enumerable configurable global; the shim captures and immediately deletes
-the binding before bundled library code runs.
+only `ArrayData::non_index_string_property_order`, returning keys whose
+descriptors are enumerable. For non-Arrays and primitives it returns an empty
+Array. It does not read descriptor values or traverse a prototype. Like
+`__host_proxy_target`, it is installed only under `--node` as a non-enumerable
+configurable global; the shim captures and immediately deletes the binding
+before bundled library code runs.
+
+All Array construction paths install `ObjectKind::Array` before creating their
+descriptors. The shared property-creation helper then records `length` and any
+later non-index String keys in the dedicated order while excluding canonical
+indices and Symbols. The shared removal helper deletes from both orders. This
+does not alter ECMAScript `[[OwnPropertyKeys]]`: the complete `property_order`
+and dense-element machinery remain authoritative for ordinary reflection.
 
 After the index window and marker, `renderArray` walks the captured hook's
 result. Every key is labelled with the same identifier-or-quoted-string policy
@@ -135,13 +134,11 @@ The node-shim self-test will assert exact Node-compatible output for:
 - a 101-element Array whose extra property follows the truncation marker.
 
 The 116-shape differential corpus from PR #497 will be run before and after the
-change on both `jsse --node` and the plain-jsse fallback. A 100,000-element
-dense benchmark will confirm that inspection remains close to the capped
-implementation rather than the rejected `Object.keys` pass. That benchmark must
-cover an Array *literal* as well as the `new Array(n).fill(v)` form: only the
-literal path populates `property_order` with dense indices, so a `fill`-only
-benchmark cannot observe the hook's scan cost at all. The node-shim
-self-test, all shim fixtures, the Object.keys test262 area, and the repository's
-full quality gate will cover regressions. The hook is disabled for ordinary
-execution and test262, so no conformance pass-count or README change is
-expected.
+change on both `jsse --node` and the plain-jsse fallback. A deterministic
+high-repeat hook probe over an `Array.from` result will catch work proportional
+to descriptor-backed indices, while literal, `Array.from`, and `fill` fixtures
+must return the same named keys. The node-shim self-test, all shim fixtures, the
+Object.keys test262 area, and the repository's full quality gate will cover
+regressions. The host hook is disabled for ordinary execution and test262; the
+Array metadata itself is exercised by the full conformance run, so no pass-count
+or README change is expected.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,15 +45,17 @@ The shim's readable-output layer (`process`, the full `console` method set, and
 the `util.format` / `util.inspect` core they share) is built on top of the
 flag-gated Rust host floor (issue #229): `__host_write` (byte-accurate fd I/O),
 `__host_hrtime` (monotonic clock), `__host_exit` (real process exit), and
-`__host_proxy_target` (trap-free Proxy metadata for inspection). The runner
-therefore invokes **jsse with `--node`** so those primitives exist (never Node —
-it has no such flag and doesn't need one). The shim is guarded to be a complete
-no-op on real Node, where `process`, the full `console`, and `require('util')`
-already exist; that inertness is what lets the identical bundle run on Node as
-the reference oracle. The shim captures `__host_proxy_target` and immediately
-removes its configurable global binding, keeping the Proxy abstraction bypass
-private from subsequently evaluated library code. When the floor is absent
-(jsse without `--node`) each surface degrades to a pure-JS fallback.
+`__host_proxy_target` (trap-free Proxy metadata for inspection), and
+`__host_array_extra_keys` (bounded Array named-key metadata). The runner
+therefore invokes **jsse with `--node`** so those primitives exist (never Node
+— it has no such flag and doesn't need one). The shim is guarded to be a
+complete no-op on real Node, where `process`, the full `console`, and
+`require('util')` already exist; that inertness is what lets the identical
+bundle run on Node as the reference oracle. The shim captures both inspection
+metadata hooks and immediately removes their configurable global bindings,
+keeping the internal metadata bypass private from subsequently evaluated
+library code. When the floor is absent (jsse without `--node`) each surface
+degrades to a pure-JS fallback.
 
 ## Running
 

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -654,12 +654,14 @@
     // the whole phase is guarded and degrades to no extra properties. Parts are
     // accumulated locally and returned only on success, so a throw mid-way
     // cannot leave the caller with a half-rendered tail.
-    function arrayExtraMembers(v, length, depth) {
-      if (hostArrayExtraKeys) return namedMembers(v, hostArrayExtraKeys(v), depth);
+    function arrayExtraMembers(v, truncated, depth) {
+      if (hostArrayExtraKeys) {
+        return namedMembers(v, hostArrayExtraKeys(v), depth);
+      }
       // Object.keys is a safe descriptor-only fallback for small Arrays, but it
-      // materializes every dense index key; skip it above the cap, where the
-      // index phase's truncation marker already stands in for the elements.
-      if (length > MAX_INSPECT_ARRAY_LENGTH) return [];
+      // materializes every dense index key; skip it when the element phase
+      // truncated, where its marker already stands in for the elements.
+      if (truncated) return [];
       try {
         return namedMembers(v, objectKeys(v), depth);
       } catch (e) {
@@ -683,10 +685,11 @@
     // through Array.prototype (which could invoke an inherited getter).
     // Keep descriptor probes bounded even for enormous sparse arrays. The
     // O(elements) own-index-key form needed for Node-exact sparse truncation is
-    // blocked on jsse#516 (Object.getOwnPropertyNames/Reflect.ownKeys omit
-    // index keys assigned after array creation). Object.keys is reliable here,
-    // but cannot replace the descriptor probes because it omits non-enumerable
-    // array elements; use it only for Node-visible extra named properties.
+    // rejected on cost, not availability: Object.getOwnPropertyNames and
+    // Reflect.ownKeys both materialize every present index key before the shim
+    // can filter, which would undo this cap. Object.keys is reliable here, but
+    // has that same cost and omits non-enumerable array elements besides; use
+    // it only for Node-visible extra named properties, below the cap.
     function renderArray(v, depth) {
       var length = ownDataValue(v, "length");
       if (typeof length !== "number" || length < 0) return "[]";
@@ -719,7 +722,7 @@
           "... " + remaining + " more item" + (remaining === 1 ? "" : "s")
         );
       }
-      var extras = arrayExtraMembers(v, length, depth);
+      var extras = arrayExtraMembers(v, renderLength < length, depth);
       for (var e = 0; e < extras.length; e++) arrayPush(parts, extras[e]);
       if (!parts.length) return "[]";
       return "[ " + arrayJoin(parts, ", ") + " ]";

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -643,6 +643,41 @@
       return label + ": " + renderDescriptor(desc, depth);
     }
 
+    // Node-visible extra named properties, rendered after the element phase.
+    // The host metadata hook walks only descriptor-backed property order, never
+    // the dense element store, so this pass cannot undo the 100-index cap, and
+    // it reads an unwrapped target so no handler trap runs.
+    //
+    // Without --node there is no unwrapping seam: `v` may still be a Proxy, so
+    // both the enumeration and every per-key descriptor read are user code. A
+    // diagnostic print must not start throwing where it previously rendered, so
+    // the whole phase is guarded and degrades to no extra properties. Parts are
+    // accumulated locally and returned only on success, so a throw mid-way
+    // cannot leave the caller with a half-rendered tail.
+    function arrayExtraMembers(v, length, depth) {
+      if (hostArrayExtraKeys) return namedMembers(v, hostArrayExtraKeys(v), depth);
+      // Object.keys is a safe descriptor-only fallback for small Arrays, but it
+      // materializes every dense index key; skip it above the cap, where the
+      // index phase's truncation marker already stands in for the elements.
+      if (length > MAX_INSPECT_ARRAY_LENGTH) return [];
+      try {
+        return namedMembers(v, objectKeys(v), depth);
+      } catch (e) {
+        return [];
+      }
+    }
+
+    // Render only the non-index keys: the index phase (or its truncation
+    // marker) already represents canonical array indices.
+    function namedMembers(v, keys, depth) {
+      var parts = [];
+      for (var i = 0; i < keys.length; i++) {
+        if (isArrayIndexKey(keys[i])) continue;
+        arrayPush(parts, renderMember(v, keys[i], depth));
+      }
+      return parts;
+    }
+
     // Array length and elements are read from own descriptors on the unwrapped
     // target. A missing descriptor is a hole, never an invitation to read
     // through Array.prototype (which could invoke an inherited getter).
@@ -684,31 +719,8 @@
           "... " + remaining + " more item" + (remaining === 1 ? "" : "s")
         );
       }
-      // The host metadata hook walks only descriptor-backed property order,
-      // never the dense element store, so this pass cannot undo the 100-index
-      // cap. Without --node, Object.keys is a safe descriptor-only fallback for
-      // small Arrays; skip it above the cap rather than materializing every
-      // dense index key. The index phase (or its truncation marker) already
-      // represents canonical array indices, so append only named strings.
-      var keys = [];
-      if (hostArrayExtraKeys) {
-        keys = hostArrayExtraKeys(v);
-      } else if (length <= MAX_INSPECT_ARRAY_LENGTH) {
-        // Without the host floor `v` is never unwrapped, so it may still be a
-        // Proxy whose ownKeys trap is user code. A diagnostic print must not
-        // start throwing where it previously rendered, so a failed enumeration
-        // degrades to no extra properties.
-        try {
-          keys = objectKeys(v);
-        } catch (e) {
-          keys = [];
-        }
-      }
-      for (var j = 0; j < keys.length; j++) {
-        var k = keys[j];
-        if (isArrayIndexKey(k)) continue;
-        arrayPush(parts, renderMember(v, k, depth));
-      }
+      var extras = arrayExtraMembers(v, length, depth);
+      for (var e = 0; e < extras.length; e++) arrayPush(parts, extras[e]);
       if (!parts.length) return "[]";
       return "[ " + arrayJoin(parts, ", ") + " ]";
     }

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -601,10 +601,7 @@
           var keys = objectKeys(v);
           var parts = [];
           for (var j = 0; j < keys.length; j++) {
-            var k = keys[j];
-            var label = isIdentifierKey(k) ? k : quoteString(k);
-            var memberDesc = objectGetOwnPropertyDescriptor(v, k);
-            arrayPush(parts, label + ": " + renderDescriptor(memberDesc, depth));
+            arrayPush(parts, renderMember(v, keys[j], depth));
           }
           var ctorName = constructorName(v, prototype);
           out = parts.length
@@ -629,6 +626,21 @@
         // does.
       }
       return render(dataDescriptorValue(desc), depth - 1);
+    }
+
+    // One own property as `label: value`, shared by the Array and generic
+    // object paths so both label keys identically. Node brackets `__proto__`
+    // so the line cannot be misread as a prototype; any other non-identifier
+    // key is quoted.
+    function renderMember(v, k, depth) {
+      var label =
+        k === "__proto__"
+          ? "['__proto__']"
+          : isIdentifierKey(k)
+            ? k
+            : quoteString(k);
+      var desc = objectGetOwnPropertyDescriptor(v, k);
+      return label + ": " + renderDescriptor(desc, depth);
     }
 
     // Array length and elements are read from own descriptors on the unwrapped
@@ -678,17 +690,24 @@
       // small Arrays; skip it above the cap rather than materializing every
       // dense index key. The index phase (or its truncation marker) already
       // represents canonical array indices, so append only named strings.
-      var keys = hostArrayExtraKeys
-        ? hostArrayExtraKeys(v)
-        : length <= MAX_INSPECT_ARRAY_LENGTH
-          ? objectKeys(v)
-          : [];
+      var keys = [];
+      if (hostArrayExtraKeys) {
+        keys = hostArrayExtraKeys(v);
+      } else if (length <= MAX_INSPECT_ARRAY_LENGTH) {
+        // Without the host floor `v` is never unwrapped, so it may still be a
+        // Proxy whose ownKeys trap is user code. A diagnostic print must not
+        // start throwing where it previously rendered, so a failed enumeration
+        // degrades to no extra properties.
+        try {
+          keys = objectKeys(v);
+        } catch (e) {
+          keys = [];
+        }
+      }
       for (var j = 0; j < keys.length; j++) {
         var k = keys[j];
         if (isArrayIndexKey(k)) continue;
-        var label = isIdentifierKey(k) ? k : quoteString(k);
-        var memberDesc = objectGetOwnPropertyDescriptor(v, k);
-        arrayPush(parts, label + ": " + renderDescriptor(memberDesc, depth));
+        arrayPush(parts, renderMember(v, k, depth));
       }
       if (!parts.length) return "[]";
       return "[ " + arrayJoin(parts, ", ") + " ]";

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -9,9 +9,10 @@
 // util.format / util.inspect core they share) is built on top of the flag-gated
 // Rust host floor (issue #229): __host_write (byte-accurate fd I/O),
 // __host_hrtime (monotonic clock), __host_exit (real process exit), and
-// __host_proxy_target (trap-free Proxy metadata). The harness runs jsse with
-// `--node` so those primitives exist; when they are absent (jsse without
-// --node) each surface degrades to a pure-JS fallback.
+// __host_proxy_target / __host_array_extra_keys (trap-free inspection
+// metadata). The harness runs jsse with `--node` so those primitives exist;
+// when they are absent (jsse without --node) each surface degrades to a pure-JS
+// fallback.
 //
 // Everything below is skipped on real Node, where `process`, the full
 // `console`, and `require('util')` already exist. That inertness is what lets
@@ -33,13 +34,20 @@
   var hostExit = typeof __host_exit !== "undefined" ? __host_exit : null;
   var hostProxyTarget =
     typeof __host_proxy_target !== "undefined" ? __host_proxy_target : null;
-  // This metadata escape hatch exists only for the shim. Keep the captured
-  // closure private so bundled library code cannot bypass Proxy handlers.
+  var hostArrayExtraKeys =
+    typeof __host_array_extra_keys !== "undefined"
+      ? __host_array_extra_keys
+      : null;
+  // These metadata escape hatches exist only for the shim. Keep the captured
+  // closures private so bundled library code cannot bypass Proxy handlers or
+  // observe Array metadata outside ordinary ECMAScript reflection.
   if (hostProxyTarget) delete globalThis.__host_proxy_target;
+  if (hostArrayExtraKeys) delete globalThis.__host_array_extra_keys;
   var fallbackConsoleLog = console.log;
 
   var NS_PER_SEC = 1000000000;
   var MAX_INSPECT_ARRAY_LENGTH = 100;
+  var MAX_ARRAY_INDEX_EXCLUSIVE = 4294967295;
 
   // ---- util.inspect (best-effort) ------------------------------------------
   //
@@ -81,6 +89,16 @@
 
   function isIdentifierKey(k) {
     return regexpExec(identifierKeyPattern, k) !== null;
+  }
+
+  function isArrayIndexKey(k) {
+    var index = numberConstructor(k);
+    return (
+      index >= 0 &&
+      index < MAX_ARRAY_INDEX_EXCLUSIVE &&
+      index % 1 === 0 &&
+      stringConstructor(index) === k
+    );
   }
 
   // Capture uncurried intrinsics before bundled library code runs. Node's
@@ -619,10 +637,12 @@
     // Keep descriptor probes bounded even for enormous sparse arrays. The
     // O(elements) own-index-key form needed for Node-exact sparse truncation is
     // blocked on jsse#516 (Object.getOwnPropertyNames/Reflect.ownKeys omit
-    // index keys assigned after array creation).
+    // index keys assigned after array creation). Object.keys is reliable here,
+    // but cannot replace the descriptor probes because it omits non-enumerable
+    // array elements; use it only for Node-visible extra named properties.
     function renderArray(v, depth) {
       var length = ownDataValue(v, "length");
-      if (typeof length !== "number" || length <= 0) return "[]";
+      if (typeof length !== "number" || length < 0) return "[]";
       var renderLength =
         length < MAX_INSPECT_ARRAY_LENGTH ? length : MAX_INSPECT_ARRAY_LENGTH;
 
@@ -652,8 +672,25 @@
           "... " + remaining + " more item" + (remaining === 1 ? "" : "s")
         );
       }
-      // `length > 0` guarantees either the loop ran or a truncation marker was
-      // added, so `parts` cannot be empty.
+      // The host metadata hook walks only descriptor-backed property order,
+      // never the dense element store, so this pass cannot undo the 100-index
+      // cap. Without --node, Object.keys is a safe descriptor-only fallback for
+      // small Arrays; skip it above the cap rather than materializing every
+      // dense index key. The index phase (or its truncation marker) already
+      // represents canonical array indices, so append only named strings.
+      var keys = hostArrayExtraKeys
+        ? hostArrayExtraKeys(v)
+        : length <= MAX_INSPECT_ARRAY_LENGTH
+          ? objectKeys(v)
+          : [];
+      for (var j = 0; j < keys.length; j++) {
+        var k = keys[j];
+        if (isArrayIndexKey(k)) continue;
+        var label = isIdentifierKey(k) ? k : quoteString(k);
+        var memberDesc = objectGetOwnPropertyDescriptor(v, k);
+        arrayPush(parts, label + ": " + renderDescriptor(memberDesc, depth));
+      }
+      if (!parts.length) return "[]";
       return "[ " + arrayJoin(parts, ", ") + " ]";
     }
 

--- a/scripts/node-shim.js
+++ b/scripts/node-shim.js
@@ -644,9 +644,10 @@
     }
 
     // Node-visible extra named properties, rendered after the element phase.
-    // The host metadata hook walks only descriptor-backed property order, never
-    // the dense element store, so this pass cannot undo the 100-index cap, and
-    // it reads an unwrapped target so no handler trap runs.
+    // The host metadata hook walks the Array's dedicated non-index String-key
+    // order, never dense elements or descriptor-backed indices, so this pass
+    // cannot undo the 100-index cap. It reads an unwrapped target, so no handler
+    // trap runs.
     //
     // Without --node there is no unwrapping seam: `v` may still be a Proxy, so
     // both the enumeration and every per-key descriptor read are user code. A

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -85,6 +85,11 @@ eq(
   "undefined",
   "shim hides the Proxy-target host hook"
 );
+eq(
+  typeof globalThis.__host_array_extra_keys,
+  "undefined",
+  "shim hides the array-key host hook"
+);
 
 // ---- util.format: %s ------------------------------------------------------
 eq(util.format("%s", "hi"), "hi", "%s string");
@@ -1142,16 +1147,59 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     arr.indexOf("1") !== -1 && arr.indexOf("2") !== -1 && arr.indexOf("3") !== -1,
     "inspect renders array elements"
   );
+  var arrayWithProperty = [1];
+  arrayWithProperty.z = 2;
+  eq(
+    util.inspect(arrayWithProperty),
+    "[ 1, z: 2 ]",
+    "inspect renders array extra properties"
+  );
+  var emptyArrayWithProperty = [];
+  emptyArrayWithProperty.z = 2;
+  eq(
+    util.inspect(emptyArrayWithProperty),
+    "[ z: 2 ]",
+    "inspect renders empty-array extra properties"
+  );
+  var namedArrayGetterCalls = 0;
+  var arrayWithGetter = [1];
+  Object.defineProperty(arrayWithGetter, "z", {
+    get: function () {
+      namedArrayGetterCalls++;
+      throw new Error("boom");
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  eq(
+    util.inspect(arrayWithGetter),
+    "[ 1, z: [Getter] ]",
+    "inspect renders array extra getters from descriptors"
+  );
+  eq(
+    namedArrayGetterCalls,
+    0,
+    "inspect does not invoke array extra getters"
+  );
+  var arrayWithNumericNames = [];
+  arrayWithNumericNames["4294967295"] = "max";
+  arrayWithNumericNames["-0"] = "minus";
+  eq(
+    util.inspect(arrayWithNumericNames),
+    "[ '4294967295': 'max', '-0': 'minus' ]",
+    "inspect preserves numeric-looking array property names"
+  );
   var denseOverLimit = [];
   var denseExpectedParts = [];
   for (var denseIndex = 0; denseIndex < 101; denseIndex++) {
     denseOverLimit.push(denseIndex);
     if (denseIndex < 100) denseExpectedParts.push(String(denseIndex));
   }
+  denseOverLimit.z = "tail";
   eq(
     util.inspect(denseOverLimit, { breakLength: Infinity, compact: true }),
-    "[ " + denseExpectedParts.join(", ") + ", ... 1 more item ]",
-    "inspect caps dense arrays at 100 entries"
+    "[ " + denseExpectedParts.join(", ") + ", ... 1 more item, z: 'tail' ]",
+    "inspect caps dense arrays before extra properties"
   );
   eq(
     util.inspect(new Array(1000000)),
@@ -1233,12 +1281,15 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
       throw new Error("Proxy getOwnPropertyDescriptor trap called");
     },
   };
-  var arrayProxy = new Proxy([1, , 3], proxyHandler);
+  var arrayProxyTarget = [1, , 3];
+  arrayProxyTarget.z = 4;
+  var arrayProxy = new Proxy(arrayProxyTarget, proxyHandler);
   var inspectedArrayProxy = util.inspect(arrayProxy);
   truthy(
     inspectedArrayProxy.indexOf("1") !== -1 &&
       inspectedArrayProxy.indexOf("3") !== -1 &&
-      inspectedArrayProxy.indexOf("empty item") !== -1,
+      inspectedArrayProxy.indexOf("empty item") !== -1 &&
+      inspectedArrayProxy.indexOf("z: 4") !== -1,
     "inspect renders an array-target Proxy without traps"
   );
   eq(proxyCalls, 0, "inspect invokes no array-target Proxy traps");

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1189,12 +1189,39 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "[ '4294967295': 'max', '-0': 'minus' ]",
     "inspect preserves numeric-looking array property names"
   );
+  var arrayWithProtoName = [1];
+  Object.defineProperty(arrayWithProtoName, "__proto__", {
+    value: 7,
+    enumerable: true,
+    configurable: true,
+  });
+  eq(
+    util.inspect(arrayWithProtoName),
+    "[ 1, ['__proto__']: 7 ]",
+    "inspect brackets an own __proto__ array property"
+  );
+  var objectWithProtoName = {};
+  Object.defineProperty(objectWithProtoName, "__proto__", {
+    value: 7,
+    enumerable: true,
+    configurable: true,
+  });
+  eq(
+    util.inspect(objectWithProtoName),
+    "{ ['__proto__']: 7 }",
+    "inspect brackets an own __proto__ object property"
+  );
   var denseOverLimit = [];
   var denseExpectedParts = [];
   for (var denseIndex = 0; denseIndex < 101; denseIndex++) {
     denseOverLimit.push(denseIndex);
     if (denseIndex < 100) denseExpectedParts.push(String(denseIndex));
   }
+  eq(
+    util.inspect(denseOverLimit, { breakLength: Infinity, compact: true }),
+    "[ " + denseExpectedParts.join(", ") + ", ... 1 more item ]",
+    "inspect caps dense arrays at 100 entries"
+  );
   denseOverLimit.z = "tail";
   eq(
     util.inspect(denseOverLimit, { breakLength: Infinity, compact: true }),

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1176,11 +1176,7 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "[ 1, z: [Getter] ]",
     "inspect renders array extra getters from descriptors"
   );
-  eq(
-    namedArrayGetterCalls,
-    0,
-    "inspect does not invoke array extra getters"
-  );
+  eq(namedArrayGetterCalls, 0, "inspect does not invoke array extra getters");
   var arrayWithNumericNames = [];
   arrayWithNumericNames["4294967295"] = "max";
   arrayWithNumericNames["-0"] = "minus";

--- a/scripts/node-shim.selftest.js
+++ b/scripts/node-shim.selftest.js
@@ -1189,6 +1189,17 @@ eq(util.format(1, 2, 3), "1 2 3", "non-string first arg");
     "[ '4294967295': 'max', '-0': 'minus' ]",
     "inspect preserves numeric-looking array property names"
   );
+  var arrayWithHiddenProp = [1];
+  Object.defineProperty(arrayWithHiddenProp, "hidden", {
+    value: 9,
+    enumerable: false,
+    configurable: true,
+  });
+  eq(
+    util.inspect(arrayWithHiddenProp),
+    "[ 1 ]",
+    "inspect omits a non-enumerable array property"
+  );
   var arrayWithProtoName = [1];
   Object.defineProperty(arrayWithProtoName, "__proto__", {
     value: 7,

--- a/scripts/run-node-shim-selftest.sh
+++ b/scripts/run-node-shim-selftest.sh
@@ -109,7 +109,9 @@ command -v node >/dev/null 2>&1 && check_exit node node
 # ---- no-host fallback probe -----------------------------------------------
 # The library harness always passes --node, but node-shim.js documents a
 # degraded pure-JS fallback for plain jsse runs. Cover that path directly so the
-# fallback stream never recurses through the shimmed console methods.
+# fallback stream never recurses through the shimmed console methods, and so the
+# Object.keys-based array extra-property fallback (which, without the host floor,
+# cannot unwrap a Proxy first) stays non-throwing.
 echo ""
 echo "== jsse fallback without --node =="
 FALLBACK_PROBE="$TMP/fallback-probe.cjs"
@@ -119,6 +121,15 @@ process.stdout.write("fallback stdout\n");
 process.stderr.write("fallback stderr\n");
 console.log("fallback console");
 console.error("fallback error");
+var fallbackArray = [1];
+fallbackArray.z = 2;
+console.log(util.inspect(fallbackArray));
+var fallbackProxy = new Proxy([1, 2], {
+  ownKeys: function () {
+    throw new Error("ownKeys trap called");
+  },
+});
+console.log(util.inspect(fallbackProxy));
 process.stdout.write("partial");
 process.exit(0);
 PROBE
@@ -135,6 +146,8 @@ fallback stdout
 fallback stderr
 fallback console
 fallback error
+[ 1, z: 2 ]
+[ 1, 2 ]
 partial
 EXPECTED
     echo "FAIL: jsse fallback without --node output differed:" >&2

--- a/scripts/run-node-shim-selftest.sh
+++ b/scripts/run-node-shim-selftest.sh
@@ -110,8 +110,9 @@ command -v node >/dev/null 2>&1 && check_exit node node
 # The library harness always passes --node, but node-shim.js documents a
 # degraded pure-JS fallback for plain jsse runs. Cover that path directly so the
 # fallback stream never recurses through the shimmed console methods, and so the
-# Object.keys-based array extra-property fallback (which, without the host floor,
-# cannot unwrap a Proxy first) stays non-throwing.
+# array extra-property fallback (which, without the host floor, cannot unwrap a
+# Proxy first) stays non-throwing for both the ownKeys enumeration and the
+# per-key descriptor reads that follow it.
 echo ""
 echo "== jsse fallback without --node =="
 FALLBACK_PROBE="$TMP/fallback-probe.cjs"
@@ -130,6 +131,23 @@ var fallbackProxy = new Proxy([1, 2], {
   },
 });
 console.log(util.inspect(fallbackProxy));
+var fallbackGopdCalls = 0;
+var fallbackTarget = [1, 2];
+Object.defineProperty(fallbackTarget, "w", {
+  value: 5,
+  enumerable: true,
+  configurable: true,
+});
+var fallbackDescProxy = new Proxy(fallbackTarget, {
+  getOwnPropertyDescriptor: function (t, k) {
+    if (k === "w") {
+      fallbackGopdCalls++;
+      if (fallbackGopdCalls > 1) throw new Error("descriptor trap called");
+    }
+    return Reflect.getOwnPropertyDescriptor(t, k);
+  },
+});
+console.log(util.inspect(fallbackDescProxy));
 process.stdout.write("partial");
 process.exit(0);
 PROBE
@@ -147,6 +165,7 @@ fallback stderr
 fallback console
 fallback error
 [ 1, z: 2 ]
+[ 1, 2 ]
 [ 1, 2 ]
 partial
 EXPECTED

--- a/src/interpreter/builtins/array.rs
+++ b/src/interpreter/builtins/array.rs
@@ -926,7 +926,9 @@ impl Interpreter {
             .borrow_mut()
             .class_name = "Array".to_string();
         self.get_object_cell_expect(proto_id).borrow_mut().kind =
-            crate::interpreter::types::ObjectKind::Array(Vec::new());
+            crate::interpreter::types::ObjectKind::Array(
+                crate::interpreter::types::ArrayData::default(),
+            );
         self.get_object_cell_expect(proto_id)
             .borrow_mut()
             .insert_property(
@@ -3634,6 +3636,9 @@ impl Interpreter {
             .array_prototype
             .or(self.realm().object_prototype);
         obj_data.class_name = "Array".to_string();
+        obj_data.kind = crate::interpreter::types::ObjectKind::Array(
+            crate::interpreter::types::ArrayData::default(),
+        );
         for (i, v) in values.iter().enumerate() {
             obj_data.insert_value(i.to_string(), v.clone());
         }
@@ -3641,7 +3646,7 @@ impl Interpreter {
             "length".to_string(),
             PropertyDescriptor::data(JsValue::number(values.len() as f64), true, false, false),
         );
-        obj_data.kind = crate::interpreter::types::ObjectKind::Array(values);
+        *obj_data.array_elements_mut().unwrap() = values;
         let id = self.alloc_object(obj_data);
         JsValue::object(id)
     }
@@ -3654,6 +3659,9 @@ impl Interpreter {
             .array_prototype
             .or(self.realm().object_prototype);
         obj_data.class_name = "Array".to_string();
+        obj_data.kind = crate::interpreter::types::ObjectKind::Array(
+            crate::interpreter::types::ArrayData::default(),
+        );
         let mut array_elements = Vec::with_capacity(len);
         for (i, item) in items.into_iter().enumerate() {
             match item {
@@ -3671,7 +3679,7 @@ impl Interpreter {
             "length".to_string(),
             PropertyDescriptor::data(JsValue::number(len as f64), true, false, false),
         );
-        obj_data.kind = crate::interpreter::types::ObjectKind::Array(array_elements);
+        *obj_data.array_elements_mut().unwrap() = array_elements;
         let id = self.alloc_object(obj_data);
         JsValue::object(id)
     }
@@ -3683,12 +3691,14 @@ impl Interpreter {
             .array_prototype
             .or(self.realm().object_prototype);
         obj_data.class_name = "Array".to_string();
+        obj_data.kind = crate::interpreter::types::ObjectKind::Array(
+            crate::interpreter::types::ArrayData::default(),
+        );
         obj_data.insert_property(
             "length".to_string(),
             PropertyDescriptor::data(JsValue::number(len as f64), true, false, false),
         );
         // Use a small Vec for sparse arrays — don't pre-allocate huge arrays
-        obj_data.kind = crate::interpreter::types::ObjectKind::Array(Vec::new());
         let id = self.alloc_object(obj_data);
         JsValue::object(id)
     }

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -214,7 +214,7 @@ impl Interpreter {
 /// An Array's own enumerable non-index string keys, in property-creation order.
 /// Non-Arrays have none. Reads descriptors only, so no getter runs.
 fn array_extra_keys(obj: &JsObjectData) -> Vec<JsValue> {
-    let Some(property_order) = obj.array_non_index_string_property_order() else {
+    let Some(property_order) = obj.array_extra_string_property_order() else {
         return Vec::new();
     };
     let mut keys = Vec::new();

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -187,11 +187,11 @@ impl Interpreter {
         // __host_array_extra_keys(value) -> Array<string>
         //
         // Trap- and value-read-free metadata for util.inspect's Array
-        // presentation. Dense elements live in the Array backing store; scan
-        // only descriptor-backed property order so rendering extra named
-        // properties does not undo maxArrayLength's O(100) element cap. The
-        // shim passes an already-unwrapped Proxy target and deletes this global
-        // immediately after capture.
+        // presentation. Array mutation bookkeeping maintains a separate order
+        // for non-index String properties, so this hook never scans dense
+        // elements or descriptor-backed element indices and cannot undo
+        // maxArrayLength's bounded work. The shim passes an already-unwrapped
+        // Proxy target and deletes this global immediately after capture.
         let array_extra_keys_fn = self.create_function(JsFunction::native(
             "__host_array_extra_keys".to_string(),
             1,
@@ -214,19 +214,11 @@ impl Interpreter {
 /// An Array's own enumerable non-index string keys, in property-creation order.
 /// Non-Arrays have none. Reads descriptors only, so no getter runs.
 fn array_extra_keys(obj: &JsObjectData) -> Vec<JsValue> {
-    if obj.array_elements().is_none() {
+    let Some(property_order) = obj.array_non_index_string_property_order() else {
         return Vec::new();
-    }
+    };
     let mut keys = Vec::new();
-    for key in &obj.property_order {
-        // Canonical array indices always begin with an ASCII digit. Keep the
-        // guard explicit because the engine-wide parser currently accepts a
-        // leading `+`, while "+1" is a named property here.
-        let is_array_index = key.as_bytes().first().is_some_and(u8::is_ascii_digit)
-            && parse_array_index(key).is_some();
-        if key.is_symbol() || is_array_index {
-            continue;
-        }
+    for key in property_order {
         // Same enumerability test as `own_enumerable_keys_with_shadow` (which
         // backs Object.keys): an unset flag counts as enumerable, so this hook
         // and the shim's Object.keys fallback cannot disagree.

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -196,43 +196,47 @@ impl Interpreter {
             "__host_array_extra_keys".to_string(),
             1,
             |interp, _this, args| {
-                let mut keys = Vec::new();
-                if let Some(obj_id) = args.first().and_then(JsValue::as_object_id)
-                    && let Some(obj) = interp.get_object_cell(obj_id)
-                {
-                    let obj = obj.borrow();
-                    if obj.array_elements().is_some() {
-                        for key in &obj.property_order {
-                            // Canonical array indices always begin with an
-                            // ASCII digit. Keep the guard explicit because the
-                            // engine-wide parser currently accepts a leading
-                            // `+`, while "+1" is a named property here.
-                            let is_array_index = key
-                                .as_bytes()
-                                .first()
-                                .is_some_and(|byte| byte.is_ascii_digit())
-                                && parse_array_index(key).is_some();
-                            if key.is_symbol() || is_array_index {
-                                continue;
-                            }
-                            // Same enumerability test as
-                            // `own_enumerable_keys_with_shadow` (which backs
-                            // Object.keys): an unset flag counts as
-                            // enumerable, so this hook and the shim's
-                            // Object.keys fallback cannot disagree.
-                            if obj
-                                .properties
-                                .get(key)
-                                .is_some_and(|desc| desc.enumerable != Some(false))
-                            {
-                                keys.push(JsValue::string(key.to_js_string()));
-                            }
-                        }
-                    }
-                }
+                let cell = args
+                    .first()
+                    .and_then(JsValue::as_object_id)
+                    .and_then(|obj_id| interp.get_object_cell(obj_id));
+                let keys = match cell {
+                    Some(cell) => array_extra_keys(&cell.borrow()),
+                    None => Vec::new(),
+                };
                 Completion::Normal(interp.create_array(keys))
             },
         ));
         self.install_host_global("__host_array_extra_keys", array_extra_keys_fn);
     }
+}
+
+/// An Array's own enumerable non-index string keys, in property-creation order.
+/// Non-Arrays have none. Reads descriptors only, so no getter runs.
+fn array_extra_keys(obj: &JsObjectData) -> Vec<JsValue> {
+    if obj.array_elements().is_none() {
+        return Vec::new();
+    }
+    let mut keys = Vec::new();
+    for key in &obj.property_order {
+        // Canonical array indices always begin with an ASCII digit. Keep the
+        // guard explicit because the engine-wide parser currently accepts a
+        // leading `+`, while "+1" is a named property here.
+        let is_array_index = key.as_bytes().first().is_some_and(u8::is_ascii_digit)
+            && parse_array_index(key).is_some();
+        if key.is_symbol() || is_array_index {
+            continue;
+        }
+        // Same enumerability test as `own_enumerable_keys_with_shadow` (which
+        // backs Object.keys): an unset flag counts as enumerable, so this hook
+        // and the shim's Object.keys fallback cannot disagree.
+        if obj
+            .properties
+            .get(key)
+            .is_some_and(|desc| desc.enumerable != Some(false))
+        {
+            keys.push(JsValue::string(key.to_js_string()));
+        }
+    }
+    keys
 }

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -1,12 +1,12 @@
 //! Node host-compat "syscall floor" (issue #229).
 //!
 //! The genuinely-cannot-be-pure-JS primitives — byte I/O, OS entropy, a
-//! monotonic high-resolution clock, the process-exit path, and trap-free Proxy
-//! metadata — exposed to the Node prelude only and gated behind the `--node`
-//! CLI flag. When the gate is off (the default, and always the case under
-//! test262) none of these globals are installed and every host-floor check
-//! elsewhere in the interpreter is inert, so the default global environment is
-//! byte-identical to a build without this feature.
+//! monotonic high-resolution clock, the process-exit path, and trap-free
+//! inspection metadata — exposed to the Node prelude only and gated behind the
+//! `--node` CLI flag. When the gate is off (the default, and always the case
+//! under test262) none of these globals are installed and every host-floor
+//! check elsewhere in the interpreter is inert, so the default global
+//! environment is byte-identical to a build without this feature.
 //!
 //! The primitives are installed as **non-enumerable** properties named
 //! `__host_*` on the global object. They are internal plumbing: the higher-level
@@ -183,5 +183,51 @@ impl Interpreter {
             },
         ));
         self.install_host_global("__host_proxy_target", proxy_target_fn);
+
+        // __host_array_extra_keys(value) -> Array<string>
+        //
+        // Trap- and value-read-free metadata for util.inspect's Array
+        // presentation. Dense elements live in the Array backing store; scan
+        // only descriptor-backed property order so rendering extra named
+        // properties does not undo maxArrayLength's O(100) element cap. The
+        // shim passes an already-unwrapped Proxy target and deletes this global
+        // immediately after capture.
+        let array_extra_keys_fn = self.create_function(JsFunction::native(
+            "__host_array_extra_keys".to_string(),
+            1,
+            |interp, _this, args| {
+                let mut keys = Vec::new();
+                if let Some(obj_id) = args.first().and_then(JsValue::as_object_id)
+                    && let Some(obj) = interp.get_object_cell(obj_id)
+                {
+                    let obj = obj.borrow();
+                    if obj.array_elements().is_some() {
+                        for key in &obj.property_order {
+                            // Canonical array indices always begin with an
+                            // ASCII digit. Keep the guard explicit because the
+                            // engine-wide parser currently accepts a leading
+                            // `+`, while "+1" is a named property here.
+                            let is_array_index = key
+                                .as_bytes()
+                                .first()
+                                .is_some_and(|byte| byte.is_ascii_digit())
+                                && parse_array_index(key).is_some();
+                            if key.is_symbol() || is_array_index {
+                                continue;
+                            }
+                            if obj
+                                .properties
+                                .get(key)
+                                .is_some_and(|desc| desc.enumerable == Some(true))
+                            {
+                                keys.push(JsValue::string(key.to_js_string()));
+                            }
+                        }
+                    }
+                }
+                Completion::Normal(interp.create_array(keys))
+            },
+        ));
+        self.install_host_global("__host_array_extra_keys", array_extra_keys_fn);
     }
 }

--- a/src/interpreter/builtins/node_host.rs
+++ b/src/interpreter/builtins/node_host.rs
@@ -215,10 +215,15 @@ impl Interpreter {
                             if key.is_symbol() || is_array_index {
                                 continue;
                             }
+                            // Same enumerability test as
+                            // `own_enumerable_keys_with_shadow` (which backs
+                            // Object.keys): an unset flag counts as
+                            // enumerable, so this hook and the shim's
+                            // Object.keys fallback cannot disagree.
                             if obj
                                 .properties
                                 .get(key)
-                                .is_some_and(|desc| desc.enumerable == Some(true))
+                                .is_some_and(|desc| desc.enumerable != Some(false))
                             {
                                 keys.push(JsValue::string(key.to_js_string()));
                             }

--- a/src/interpreter/eval/literals.rs
+++ b/src/interpreter/eval/literals.rs
@@ -65,6 +65,9 @@ impl Interpreter {
             .array_prototype
             .or(self.realm().object_prototype);
         obj_data.class_name = "Array".to_string();
+        obj_data.kind = crate::interpreter::types::ObjectKind::Array(
+            crate::interpreter::types::ArrayData::default(),
+        );
         for (i, v) in values.iter().enumerate() {
             obj_data.insert_property(
                 i.to_string(),
@@ -75,7 +78,7 @@ impl Interpreter {
             "length".to_string(),
             PropertyDescriptor::data(JsValue::number(len as f64), false, false, false),
         );
-        obj_data.kind = crate::interpreter::types::ObjectKind::Array(values);
+        *obj_data.array_elements_mut().unwrap() = values;
         obj_data.extensible = false;
         let id = self.alloc_object(obj_data);
         JsValue::object(id)

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -1134,7 +1134,7 @@ mod tests {
     #[test]
     fn trace_object_fields_roots_array_elements_and_native_roots() {
         let mut data = JsObjectData::new();
-        data.kind = ObjectKind::Array(vec![obj(20), JsValue::number(0.0), obj(21)]);
+        data.kind = ObjectKind::Array(ArrayData::new(vec![obj(20), JsValue::number(0.0), obj(21)]));
         data.gc_native_roots = Some(vec![obj(22)]);
 
         let mut worklist = Vec::new();

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3440,12 +3440,13 @@ mod node_host_tests {
               typeof __host_hrtime,
               typeof __host_random_bytes,
               typeof __host_proxy_target,
+              typeof __host_array_extra_keys,
             ].join(",");
             "#,
         );
         assert_eq!(
             global_string(&interp, "r"),
-            "undefined,undefined,undefined,undefined,undefined"
+            "undefined,undefined,undefined,undefined,undefined,undefined"
         );
     }
 
@@ -3453,13 +3454,13 @@ mod node_host_tests {
     fn host_globals_are_non_enumerable_functions() {
         assert_node_ok(
             r#"
-            for (const name of ["__host_write","__host_exit","__host_hrtime","__host_random_bytes","__host_proxy_target"]) {
+            for (const name of ["__host_write","__host_exit","__host_hrtime","__host_random_bytes","__host_proxy_target","__host_array_extra_keys"]) {
               const d = Object.getOwnPropertyDescriptor(globalThis, name);
               if (!d) throw new Error(name + " missing");
               if (d.enumerable) throw new Error(name + " is enumerable");
-              // node-shim.js deletes __host_proxy_target under "use strict" to
-              // keep the Proxy-metadata seam private; a non-configurable
-              // binding would make that delete throw and kill the prelude.
+              // node-shim.js deletes its metadata hooks under "use strict" to
+              // keep the seams private; a non-configurable binding would make
+              // that delete throw and kill the prelude.
               if (!d.configurable) throw new Error(name + " is not configurable");
               if (typeof globalThis[name] !== "function") throw new Error(name + " not a function");
               if (Object.keys(globalThis).includes(name)) throw new Error(name + " shows in keys");
@@ -3550,6 +3551,54 @@ mod node_host_tests {
             revocable.revoke();
             if (__host_proxy_target(revocable.proxy) !== null) {
               throw new Error("revoked Proxy marker");
+            }
+            "#,
+        );
+    }
+
+    #[test]
+    fn host_array_extra_keys_filters_dense_indices_without_getting_values() {
+        assert_node_ok(
+            r#"
+            let getterCalls = 0;
+            const a = new Array(100000).fill(1);
+            a.z = 2;
+            Object.defineProperty(a, "getter", {
+              get() { getterCalls++; throw new Error("named getter ran"); },
+              enumerable: true,
+              configurable: true,
+            });
+            Object.defineProperty(a, "hidden", {
+              value: 3,
+              enumerable: false,
+              configurable: true,
+            });
+            Object.defineProperty(a, "2", {
+              get() { getterCalls++; throw new Error("index getter ran"); },
+              enumerable: true,
+              configurable: true,
+            });
+            a["4294967295"] = "max";
+            a["-0"] = "minus";
+            Object.defineProperty(a, "+1", {
+              value: "plus",
+              enumerable: true,
+              configurable: true,
+            });
+            a["01"] = "leading";
+            a["1e0"] = "exponential";
+            a[Symbol("marker")] = 4;
+
+            const keys = __host_array_extra_keys(a);
+            if (keys.join(",") !== "z,getter,4294967295,-0,+1,01,1e0") {
+              throw new Error("wrong keys: " + keys.join(","));
+            }
+            if (getterCalls !== 0) throw new Error("getter invoked");
+            if (__host_array_extra_keys({ z: 1 }).length !== 0) {
+              throw new Error("ordinary object accepted");
+            }
+            if (__host_array_extra_keys(1).length !== 0) {
+              throw new Error("primitive accepted");
             }
             "#,
         );

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3557,17 +3557,17 @@ mod node_host_tests {
     }
 
     #[test]
-    fn host_array_extra_keys_filters_dense_indices_without_getting_values() {
+    fn host_array_extra_keys_uses_named_metadata_without_getting_values() {
         assert_node_ok(
             r#"
             let getterCalls = 0;
-            // The two Array storage shapes must agree. An Array literal mirrors
-            // every dense index into property_order, so it exercises the index
-            // filter; `new Array(n).fill(v)` keeps them out, so it exercises the
-            // empty-scan path. Only the literal has indices to filter.
+            // The Array storage shapes must agree even though their dense-index
+            // descriptor layouts differ. The host hook reads the dedicated
+            // non-index String-key order, never either dense representation.
             const builders = {
               literal: () => [1, 2, 3, 4, 5],
               fill: () => new Array(5).fill(1),
+              arrayFrom: () => Array.from({ length: 5 }, () => 1),
             };
             for (const [shape, build] of Object.entries(builders)) {
               const a = build();

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3561,37 +3561,47 @@ mod node_host_tests {
         assert_node_ok(
             r#"
             let getterCalls = 0;
-            const a = new Array(100000).fill(1);
-            a.z = 2;
-            Object.defineProperty(a, "getter", {
-              get() { getterCalls++; throw new Error("named getter ran"); },
-              enumerable: true,
-              configurable: true,
-            });
-            Object.defineProperty(a, "hidden", {
-              value: 3,
-              enumerable: false,
-              configurable: true,
-            });
-            Object.defineProperty(a, "2", {
-              get() { getterCalls++; throw new Error("index getter ran"); },
-              enumerable: true,
-              configurable: true,
-            });
-            a["4294967295"] = "max";
-            a["-0"] = "minus";
-            Object.defineProperty(a, "+1", {
-              value: "plus",
-              enumerable: true,
-              configurable: true,
-            });
-            a["01"] = "leading";
-            a["1e0"] = "exponential";
-            a[Symbol("marker")] = 4;
+            // The two Array storage shapes must agree. An Array literal mirrors
+            // every dense index into property_order, so it exercises the index
+            // filter; `new Array(n).fill(v)` keeps them out, so it exercises the
+            // empty-scan path. Only the literal has indices to filter.
+            const builders = {
+              literal: () => [1, 2, 3, 4, 5],
+              fill: () => new Array(5).fill(1),
+            };
+            for (const [shape, build] of Object.entries(builders)) {
+              const a = build();
+              a.z = 2;
+              Object.defineProperty(a, "getter", {
+                get() { getterCalls++; throw new Error("named getter ran"); },
+                enumerable: true,
+                configurable: true,
+              });
+              Object.defineProperty(a, "hidden", {
+                value: 3,
+                enumerable: false,
+                configurable: true,
+              });
+              Object.defineProperty(a, "2", {
+                get() { getterCalls++; throw new Error("index getter ran"); },
+                enumerable: true,
+                configurable: true,
+              });
+              a["4294967295"] = "max";
+              a["-0"] = "minus";
+              Object.defineProperty(a, "+1", {
+                value: "plus",
+                enumerable: true,
+                configurable: true,
+              });
+              a["01"] = "leading";
+              a["1e0"] = "exponential";
+              a[Symbol("marker")] = 4;
 
-            const keys = __host_array_extra_keys(a);
-            if (keys.join(",") !== "z,getter,4294967295,-0,+1,01,1e0") {
-              throw new Error("wrong keys: " + keys.join(","));
+              const keys = __host_array_extra_keys(a);
+              if (keys.join(",") !== "z,getter,4294967295,-0,+1,01,1e0") {
+                throw new Error(shape + " wrong keys: " + keys.join(","));
+              }
             }
             if (getterCalls !== 0) throw new Error("getter invoked");
             if (__host_array_extra_keys({ z: 1 }).length !== 0) {
@@ -3600,7 +3610,7 @@ mod node_host_tests {
             if (__host_array_extra_keys(1).length !== 0) {
               throw new Error("primitive accepted");
             }
-            "#,
+"#,
         );
     }
 

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1782,14 +1782,14 @@ pub(crate) enum ConstructorKind {
 
 /// Array-exotic internal data.
 ///
-/// `non_index_string_property_order` mirrors only the subset of
+/// `extra_string_property_order` mirrors only the subset of
 /// `JsObjectData::property_order` needed by the Node-compatible inspector.
 /// Maintaining that subset as properties change lets inspection find named
 /// Array properties without scanning descriptor-backed element indices.
 #[derive(Clone, Default)]
 pub(crate) struct ArrayData {
     elements: Vec<JsValue>,
-    non_index_string_property_order: Vec<JsPropertyKey>,
+    extra_string_property_order: Vec<JsPropertyKey>,
 }
 
 impl ArrayData {
@@ -1797,7 +1797,7 @@ impl ArrayData {
     pub(crate) fn new(elements: Vec<JsValue>) -> Self {
         Self {
             elements,
-            non_index_string_property_order: Vec::new(),
+            extra_string_property_order: Vec::new(),
         }
     }
 }
@@ -2041,18 +2041,21 @@ impl JsObjectData {
         self.array_data_mut().map(|data| &mut data.elements)
     }
 
-    pub(crate) fn array_non_index_string_property_order(&self) -> Option<&[JsPropertyKey]> {
+    pub(crate) fn array_extra_string_property_order(&self) -> Option<&[JsPropertyKey]> {
         self.array_data()
-            .map(|data| data.non_index_string_property_order.as_slice())
+            .map(|data| data.extra_string_property_order.as_slice())
     }
 
     fn record_property_creation(&mut self, key: &JsPropertyKey) {
         self.property_order.push(key.clone());
-        if key.is_symbol() || is_array_index_property_key(key) {
+        // `length` is permanently non-enumerable on Arrays and can never be
+        // returned by the host hook. Excluding it keeps this Vec allocation-free
+        // for Arrays that never receive an actual extra String property.
+        if key.is_symbol() || key.eq_str("length") || is_array_index_property_key(key) {
             return;
         }
         if let Some(data) = self.array_data_mut() {
-            data.non_index_string_property_order.push(key.clone());
+            data.extra_string_property_order.push(key.clone());
         }
     }
 
@@ -3041,7 +3044,7 @@ impl JsObjectData {
             self.property_order
                 .retain(|k| k.as_bytes() != key.as_property_key_bytes());
             if let Some(data) = self.array_data_mut() {
-                data.non_index_string_property_order
+                data.extra_string_property_order
                     .retain(|k| k.as_bytes() != key.as_property_key_bytes());
             }
         }
@@ -4021,6 +4024,13 @@ mod kind_accessor_tests {
         for index in 0..1024 {
             obj.insert_value(index.to_string(), JsValue::number(index as f64));
         }
+        assert_eq!(
+            obj.array_data()
+                .unwrap()
+                .extra_string_property_order
+                .capacity(),
+            0
+        );
         obj.insert_value("+1", JsValue::number(1.0));
         obj.insert_value("z", JsValue::number(2.0));
         obj.insert_value(
@@ -4029,23 +4039,23 @@ mod kind_accessor_tests {
         );
 
         let keys = obj
-            .array_non_index_string_property_order()
+            .array_extra_string_property_order()
             .unwrap()
             .iter()
             .map(JsPropertyKey::to_string)
             .collect::<Vec<_>>();
-        assert_eq!(keys, vec!["length", "+1", "z"]);
+        assert_eq!(keys, vec!["+1", "z"]);
         assert_eq!(obj.property_order.len(), 1028);
 
         obj.remove_property("+1");
         obj.insert_value("+1", JsValue::number(4.0));
         let keys = obj
-            .array_non_index_string_property_order()
+            .array_extra_string_property_order()
             .unwrap()
             .iter()
             .map(JsPropertyKey::to_string)
             .collect::<Vec<_>>();
-        assert_eq!(keys, vec!["length", "z", "+1"]);
+        assert_eq!(keys, vec!["z", "+1"]);
     }
 
     // --- set_data / set_data_mut ---

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1780,6 +1780,28 @@ pub(crate) enum ConstructorKind {
     DefaultDerivedClass,
 }
 
+/// Array-exotic internal data.
+///
+/// `non_index_string_property_order` mirrors only the subset of
+/// `JsObjectData::property_order` needed by the Node-compatible inspector.
+/// Maintaining that subset as properties change lets inspection find named
+/// Array properties without scanning descriptor-backed element indices.
+#[derive(Clone, Default)]
+pub(crate) struct ArrayData {
+    elements: Vec<JsValue>,
+    non_index_string_property_order: Vec<JsPropertyKey>,
+}
+
+impl ArrayData {
+    #[cfg(test)]
+    pub(crate) fn new(elements: Vec<JsValue>) -> Self {
+        Self {
+            elements,
+            non_index_string_property_order: Vec::new(),
+        }
+    }
+}
+
 /// Discriminator for the kind-specific data attached to a JsObjectData.
 ///
 /// Each variant either is the kind in isolation (Ordinary), or carries the
@@ -1823,8 +1845,8 @@ pub(crate) enum ObjectKind {
     Iterator(IteratorState),
     /// `parameter_map` for an Arguments exotic object.
     Arguments(HashMap<String, (EnvRef, String)>),
-    /// `array_elements` for the Array exotic object.
-    Array(Vec<JsValue>),
+    /// Element storage and bounded named-property metadata for an Array exotic object.
+    Array(ArrayData),
     /// Primitive value wrapped by `Object(primitive)` (String/Number/Boolean/Symbol/BigInt).
     PrimitiveWrapper(JsValue),
     ModuleNamespace(ModuleNamespaceData),
@@ -1990,7 +2012,7 @@ impl JsObjectData {
     kind_accessor!(iterator_state, iterator_state_mut, Iterator, IteratorState);
     kind_accessor!(promise_data, promise_data_mut, Promise, PromiseData);
     kind_accessor!(parameter_map, parameter_map_mut, Arguments, HashMap<String, (EnvRef, String)>);
-    kind_accessor!(array_elements, array_elements_mut, Array, Vec<JsValue>);
+    kind_accessor!(array_data, array_data_mut, Array, ArrayData);
     kind_accessor!(map_data, map_data_mut, Map, Vec<Option<(JsValue, JsValue)>>);
     kind_accessor!(set_data, set_data_mut, Set, Vec<Option<JsValue>>);
     kind_accessor!(temporal_data, Temporal, TemporalData);
@@ -2010,6 +2032,29 @@ impl JsObjectData {
         DisposableStack,
         DisposableStackData
     );
+
+    pub(crate) fn array_elements(&self) -> Option<&Vec<JsValue>> {
+        self.array_data().map(|data| &data.elements)
+    }
+
+    pub(crate) fn array_elements_mut(&mut self) -> Option<&mut Vec<JsValue>> {
+        self.array_data_mut().map(|data| &mut data.elements)
+    }
+
+    pub(crate) fn array_non_index_string_property_order(&self) -> Option<&[JsPropertyKey]> {
+        self.array_data()
+            .map(|data| data.non_index_string_property_order.as_slice())
+    }
+
+    fn record_property_creation(&mut self, key: &JsPropertyKey) {
+        self.property_order.push(key.clone());
+        if key.is_symbol() || is_array_index_property_key(key) {
+            return;
+        }
+        if let Some(data) = self.array_data_mut() {
+            data.non_index_string_property_order.push(key.clone());
+        }
+    }
 
     /// True iff this is an *active* (non-revoked) proxy. Preserves pre-bundling semantics.
     pub(crate) fn is_proxy(&self) -> bool {
@@ -2663,7 +2708,7 @@ impl JsObjectData {
             // and get fresh storage each time, so pointer equality would miss existing entries.
             let ikey = key.clone();
             if !self.property_order.iter().any(|k| k == &ikey) {
-                self.property_order.push(ikey.clone());
+                self.record_property_creation(&ikey);
             }
             // NOTE: Array length shrinking semantics (ArraySetLength §10.4.2.4) are
             // handled by array_set_length() in mod.rs, which calls this function.
@@ -2715,7 +2760,7 @@ impl JsObjectData {
             // New property: intern once and share the backing bytes between
             // property_order and the property map (one allocation, not two).
             let ikey = key;
-            self.property_order.push(ikey.clone());
+            self.record_property_creation(&ikey);
             // For new property, fill in defaults per spec
             let is_accessor = desc.is_accessor_descriptor();
             let new_desc = PropertyDescriptor {
@@ -2941,7 +2986,7 @@ impl JsObjectData {
                 return false;
             }
             let ikey = intern_js_key(key.to_js_property_key());
-            self.property_order.push(ikey.clone());
+            self.record_property_creation(&ikey);
             self.properties
                 .insert(ikey, PropertyDescriptor::data_default(value));
             // Issue #71 (Step 5): new own property added — structural mutation.
@@ -2955,7 +3000,7 @@ impl JsObjectData {
     pub(crate) fn insert_value<K: Into<JsPropertyKey>>(&mut self, key: K, value: JsValue) {
         let key = intern_js_key(key.into());
         if !self.properties.contains_key(&key) {
-            self.property_order.push(key.clone());
+            self.record_property_creation(&key);
         }
         self.properties
             .insert(key, PropertyDescriptor::data_default(value));
@@ -2964,7 +3009,7 @@ impl JsObjectData {
     pub(crate) fn insert_builtin<K: Into<JsPropertyKey>>(&mut self, key: K, value: JsValue) {
         let key = intern_js_key(key.into());
         if !self.properties.contains_key(&key) {
-            self.property_order.push(key.clone());
+            self.record_property_creation(&key);
         }
         self.properties
             .insert(key, PropertyDescriptor::data(value, true, false, true));
@@ -2977,7 +3022,7 @@ impl JsObjectData {
     ) {
         let key = intern_js_key(key.into());
         if !self.properties.contains_key(&key) {
-            self.property_order.push(key.clone());
+            self.record_property_creation(&key);
         }
         self.properties.insert(key, desc);
     }
@@ -2995,6 +3040,10 @@ impl JsObjectData {
         if removed.is_some() {
             self.property_order
                 .retain(|k| k.as_bytes() != key.as_property_key_bytes());
+            if let Some(data) = self.array_data_mut() {
+                data.non_index_string_property_order
+                    .retain(|k| k.as_bytes() != key.as_property_key_bytes());
+            }
         }
         removed
     }
@@ -3256,6 +3305,20 @@ pub(crate) fn parse_array_index<K: crate::types::PropertyKeyLike + ?Sized>(key: 
         return None;
     }
     Some(n)
+}
+
+/// Exact Array-index predicate for internal property-key bookkeeping.
+///
+/// `parse_array_index` currently accepts Rust's leading-`+` integer spelling;
+/// ECMAScript does not. Canonical Array indices always begin with an ASCII
+/// digit, so keep that guard at the narrow call sites that require exactness.
+pub(crate) fn is_array_index_property_key<K: crate::types::PropertyKeyLike + ?Sized>(
+    key: &K,
+) -> bool {
+    key.as_property_key_bytes()
+        .first()
+        .is_some_and(u8::is_ascii_digit)
+        && parse_array_index(key).is_some()
 }
 
 pub(crate) fn canonical_numeric_index_string<K: crate::types::PropertyKeyLike + ?Sized>(
@@ -3930,7 +3993,7 @@ mod kind_accessor_tests {
 
     #[test]
     fn array_elements_some_for_array_kind() {
-        let obj = obj_with_kind(ObjectKind::Array(vec![JsValue::UNDEFINED]));
+        let obj = obj_with_kind(ObjectKind::Array(ArrayData::new(vec![JsValue::UNDEFINED])));
         assert!(obj.array_elements().is_some());
         assert_eq!(obj.array_elements().unwrap().len(), 1);
     }
@@ -3943,9 +4006,46 @@ mod kind_accessor_tests {
 
     #[test]
     fn array_elements_mut_allows_push() {
-        let mut obj = obj_with_kind(ObjectKind::Array(Vec::new()));
+        let mut obj = obj_with_kind(ObjectKind::Array(ArrayData::default()));
         obj.array_elements_mut().unwrap().push(JsValue::TRUE);
         assert_eq!(obj.array_elements().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn array_named_property_order_excludes_indices_and_symbols() {
+        let mut obj = obj_with_kind(ObjectKind::Array(ArrayData::default()));
+        obj.insert_property(
+            "length",
+            PropertyDescriptor::data(JsValue::number(1024.0), true, false, false),
+        );
+        for index in 0..1024 {
+            obj.insert_value(index.to_string(), JsValue::number(index as f64));
+        }
+        obj.insert_value("+1", JsValue::number(1.0));
+        obj.insert_value("z", JsValue::number(2.0));
+        obj.insert_value(
+            JsPropertyKey::well_known_symbol("iterator"),
+            JsValue::number(3.0),
+        );
+
+        let keys = obj
+            .array_non_index_string_property_order()
+            .unwrap()
+            .iter()
+            .map(JsPropertyKey::to_string)
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["length", "+1", "z"]);
+        assert_eq!(obj.property_order.len(), 1028);
+
+        obj.remove_property("+1");
+        obj.insert_value("+1", JsValue::number(4.0));
+        let keys = obj
+            .array_non_index_string_property_order()
+            .unwrap()
+            .iter()
+            .map(JsPropertyKey::to_string)
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["length", "z", "+1"]);
     }
 
     // --- set_data / set_data_mut ---
@@ -3959,7 +4059,7 @@ mod kind_accessor_tests {
 
     #[test]
     fn set_data_none_for_non_set_kind() {
-        let obj = obj_with_kind(ObjectKind::Array(Vec::new()));
+        let obj = obj_with_kind(ObjectKind::Array(ArrayData::default()));
         assert!(obj.set_data().is_none());
     }
 


### PR DESCRIPTION
## Summary

- render enumerable non-index own string properties after Array elements and truncation markers
- add a private `--node` host metadata hook that avoids enumerating dense indices, preserving the 100-entry inspection cap's runtime benefit
- keep Proxy handlers and property getters untouched by rendering values exclusively from own descriptors
- cover empty Arrays, accessors, numeric-looking names, capped dense Arrays, and proxied Array targets

The initial pure-JS `Object.keys` approach was rejected after it made a 100,000-element inspection take 0.34–0.38s; the bounded host-hook implementation completes the same checked probe in about 0.02s.

## Validation

- `cargo fmt --check`
- `cargo clippy`
- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release` (559 passed, 1 ignored; integration tests and smoke oracle pass)
- `./scripts/run-node-shim-selftest.sh --no-build` (255 assertions, byte-matched with Node)
- `./scripts/run-shim-fixtures.sh`
- `uv run python scripts/run-custom-tests.py` (13/13)
- `uv run python scripts/run-test262.py test262/test/built-ins/Object/keys/` (118/118)
- `uv run python scripts/run-test262.py` (99,568/99,568; zero regressions)
- 116-shape inspect differential on `jsse --node` and plain jsse (only intended `arr-extra-props` output changes)

Closes #517
