### PR TITLE
chore(bench): enforce controlled JetStream measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,33 @@ uv run python scripts/run-jetstream.py --test OfflineAssembler --iterations 1 --
 ```
 
 The runner covers pure-JS JetStream 3 workloads and skips Wasm/Worker-dependent tests.
-Each workload is measured three times by default and reported as a median with
-its min-max range. Controlled runs refuse a one-minute load average above 1.5
-and use the maximum-frequency CPU cluster when Linux cpufreq data and `taskset`
-are available. Use `--repeats` and `--idle-threshold` to tune the protocol;
-`--no-idle-gate` is intended only for diagnostic or parallel runs. JSON output
-includes the repeat samples and a host/load/topology fingerprint.
+Each workload is measured three times by default. The reported score is derived
+from the median of the measured times, and the min-max range of the repeats is
+printed alongside it; a range above 5% is flagged `UNSTABLE`. Controlled runs
+refuse a one-minute load average above 1.5 and use the maximum-frequency CPU
+cluster when Linux cpufreq data and `taskset` are available. Use `--repeats` and
+`--idle-threshold` to tune the protocol; `--no-idle-gate` is intended only for
+diagnostic or parallel runs. JSON output includes the repeat samples and a
+host/load/topology fingerprint.
+
+A refused run exits **3** (distinct from argparse's 2) and leaves any existing
+`jetstream-results.json` untouched, so a truncated suite cannot overwrite a
+complete baseline. Because a single-threaded benchmark contributes roughly 1.0
+to the one-minute average itself, the default 1.5 threshold leaves only about
+0.5 of headroom for foreign load; raise `--idle-threshold` on a host with
+unavoidable background activity rather than disabling the gate.
+
+To confirm the gate actually fires, run the suite against a synthetic load.
+One `yes` asymptotes the one-minute average to only ~1.0, which is *below* the
+1.5 default, so use enough burners to clear the threshold:
+
+```bash
+for _ in 1 2 3; do yes > /dev/null & done
+sleep 60   # let the 1-minute average converge
+uv run python scripts/run-jetstream.py --test Air --iterations 1
+# expect: "BUSY  Air  (loadavg1 ... exceeds idle threshold 1.50)" and exit 3
+kill %1 %2 %3
+```
 
 ## Running the Node-compat library tests
 

--- a/README.md
+++ b/README.md
@@ -145,10 +145,13 @@ host/load/topology fingerprint.
 
 A refused run exits **3** (distinct from argparse's 2) and leaves any existing
 `jetstream-results.json` untouched, so a truncated suite cannot overwrite a
-complete baseline. Because a single-threaded benchmark contributes roughly 1.0
-to the one-minute average itself, the default 1.5 threshold leaves only about
-0.5 of headroom for foreign load; raise `--idle-threshold` on a host with
-unavoidable background activity rather than disabling the gate.
+complete baseline. This protection also applies when `--json` names that file
+through an equivalent absolute or symlinked path; choose a distinct output path
+to retain partial refusal evidence. Because a single-threaded benchmark
+contributes roughly 1.0 to the one-minute average itself, the default 1.5
+threshold leaves only about 0.5 of headroom for foreign load; raise
+`--idle-threshold` on a host with unavoidable background activity rather than
+disabling the gate.
 
 To confirm the gate actually fires, run the suite against a synthetic load.
 One `yes` asymptotes the one-minute average to only ~1.0, which is *below* the

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ uv run python scripts/run-jetstream.py --test OfflineAssembler --iterations 1 --
 ```
 
 The runner covers pure-JS JetStream 3 workloads and skips Wasm/Worker-dependent tests.
+Each workload is measured three times by default and reported as a median with
+its min-max range. Controlled runs refuse a one-minute load average above 1.5
+and use the maximum-frequency CPU cluster when Linux cpufreq data and `taskset`
+are available. Use `--repeats` and `--idle-threshold` to tune the protocol;
+`--no-idle-gate` is intended only for diagnostic or parallel runs. JSON output
+includes the repeat samples and a host/load/topology fingerprint.
 
 ## Running the Node-compat library tests
 

--- a/docs/specs/2026-08-25-benchmark-measurement-protocol-design.md
+++ b/docs/specs/2026-08-25-benchmark-measurement-protocol-design.md
@@ -1,0 +1,98 @@
+# Benchmark measurement protocol design
+
+## Goal
+
+Make JetStream results comparable across runs by rejecting measurements made
+under background load, avoiding heterogeneous slow-core placement, reporting
+repeat variability, and recording enough host context to audit later results.
+
+## Constraints
+
+- Preserve the existing `scripts/run-jetstream.py` benchmark selection,
+  JetStream-internal iteration counts, score calculation, comparison format,
+  and default sequential execution.
+- Keep diagnostic parallel execution available, while making it explicit when
+  the idle-window guarantee is disabled.
+- Work on Linux hosts with heterogeneous cpufreq data, uniform-frequency hosts,
+  and hosts where sysfs, `taskset`, `lscpu`, or `nproc` are unavailable.
+- Do not change ECMAScript behavior, `spec/`, `test262/`, or the test262 pass
+  baseline.
+
+## Approaches considered
+
+1. Add a shell wrapper around the unchanged runner. This is superficially
+   small, but repeating a whole suite prevents per-benchmark idle checks and
+   requires parsing human output to aggregate results.
+2. Add every probe and aggregation helper directly to `run-jetstream.py`. This
+   keeps one file, but makes the already large runner harder to test and reuse.
+3. Put host probing, idle checks, affinity selection, and repeat statistics in
+   a focused Python module, with JetStream orchestration remaining in the
+   existing runner. This is the selected approach because the operating-system
+   policy is independently testable without a JetStream checkout.
+
+## Design
+
+`scripts/benchmark_protocol.py` owns four small responsibilities:
+
+- read `/proc/loadavg` and reject a measurement when loadavg1 is greater than
+  the configured threshold;
+- inspect every CPU available to the current process under
+  `/sys/devices/system/cpu/cpu*/cpufreq/cpuinfo_max_freq`, distinguish uniform
+  and heterogeneous frequency sets, and select the complete maximum-frequency
+  cluster only when the topology is complete and `taskset` is available;
+- collect the CPU model reported by `lscpu`, the logical CPU count reported by
+  `nproc`, starting load averages, process affinity, and pinning decision for
+  JSON output;
+- summarize positive repeat values with N, median, minimum, maximum, relative
+  range, and an unstable flag when `max / min - 1` exceeds 5%.
+
+`scripts/run-jetstream.py` gains `--repeats` (default and minimum 3),
+`--idle-threshold` (default 1.5), and `--no-idle-gate`. A benchmark's complete
+JetStream harness invocation is one outer measurement. Before each outer
+measurement, including the first, the runner re-reads loadavg1. The engine
+command is prefixed with `taskset --cpu-list <fast CPUs>` when pinning is
+available. JetStream's internal iteration loop is unchanged.
+
+Reliable measurements remain sequential. `-j` greater than one requires
+`--no-idle-gate`, since concurrent benchmark workers intentionally create load
+and cannot satisfy the protocol. The disabled gate is printed prominently and
+recorded in JSON so diagnostic runs cannot be mistaken for controlled results.
+
+For passing benchmarks, the existing `scores` object remains the comparison
+interface, with each numeric field set to the median across successful outer
+measurements. The result also stores each measurement, plus a `repeat_summary`
+for overall score. Console output shows median score, N, min-max score, and an
+`UNSTABLE` marker above the 5% limit. A busy check returns a distinct result,
+stops further sequential benchmarks, writes partial JSON, and exits nonzero.
+
+The top-level JSON adds a `measurement_protocol` object and a `host` object.
+The host object includes CPU model, logical CPU count, start load averages,
+available CPU affinity, per-CPU maximum frequencies, selected fast cores, and
+whether pinning was applied. Uniform or unreadable topology is explicitly
+reported as unpinned with a reason rather than guessed.
+
+## Error handling
+
+- Invalid repeat counts, thresholds, and incompatible parallel/idle-gate
+  options fail during argument validation.
+- Missing or malformed loadavg data fails closed while the gate is enabled; it
+  is recorded as unavailable when the gate is explicitly disabled.
+- Incomplete frequency data, uniform frequencies, or missing `taskset` fall
+  back to an unpinned run with a prominent topology message.
+- An error, skip, or timeout in any outer measurement preserves the existing
+  benchmark status and stops repeats for that benchmark; no partial set is
+  presented as a valid median.
+
+## Verification
+
+- Unit-test load threshold boundaries and unreadable load data.
+- Unit-test heterogeneous, uniform, incomplete, and affinity-restricted CPU
+  topology detection using temporary sysfs trees.
+- Unit-test repeat medians, ranges, and the 5% instability boundary.
+- Use a temporary fake JetStream checkout and engine to verify CLI repeat
+  aggregation, affinity command construction, JSON host metadata, and busy
+  refusal without running the full benchmark suite.
+- Run the documented synthetic burner check and the repository quality gate.
+
+This is benchmark infrastructure only. There is no relevant ECMAScript section
+or targeted test262 directory, and the test262 pass count must remain unchanged.

--- a/docs/specs/2026-08-25-benchmark-measurement-protocol-design.md
+++ b/docs/specs/2026-08-25-benchmark-measurement-protocol-design.md
@@ -74,9 +74,11 @@ N, the min-max range of the repeats, and an `UNSTABLE` marker above the 5%
 limit. A busy check returns a distinct result, stops further sequential
 benchmarks, and exits 3 — chosen so a CI wrapper can distinguish a busy host
 from argparse's usage-error exit 2. A refused run writes partial JSON only to an
-explicitly requested `--json` path; it deliberately does not touch the default
-`jetstream-results.json`, because overwriting a complete baseline with a
-truncated suite is the comparability hazard this work exists to remove.
+explicitly requested `--json` path that resolves to a file other than the
+default `jetstream-results.json`. Relative, absolute, and symlinked aliases of
+the default are protected as the same baseline, because overwriting a complete
+baseline with a truncated suite is the comparability hazard this work exists to
+remove.
 
 The top-level JSON adds a `measurement_protocol` object and a `host` object.
 The host object includes CPU model, logical CPU count, start load averages,
@@ -108,7 +110,8 @@ reported as unpinned with a reason rather than guessed.
 - Use a temporary fake JetStream checkout and engine to verify CLI repeat
   aggregation, affinity command construction, JSON host metadata, busy refusal
   with exit 3, and that a refusal leaves an existing `jetstream-results.json`
-  intact — all without running the full benchmark suite.
+  intact when `--json` is omitted or names the baseline through a relative,
+  absolute, or symlinked path — all without running the full benchmark suite.
 - Run the synthetic burner check documented in `README.md` under "Running
   JetStream 3", and the repository quality gate. The issue's suggested single
   `yes > /dev/null` asymptotes the one-minute average to only ~1.0, below the

--- a/docs/specs/2026-08-25-benchmark-measurement-protocol-design.md
+++ b/docs/specs/2026-08-25-benchmark-measurement-protocol-design.md
@@ -59,11 +59,24 @@ and cannot satisfy the protocol. The disabled gate is printed prominently and
 recorded in JSON so diagnostic runs cannot be mistaken for controlled results.
 
 For passing benchmarks, the existing `scores` object remains the comparison
-interface, with each numeric field set to the median across successful outer
-measurements. The result also stores each measurement, plus a `repeat_summary`
-for overall score. Console output shows median score, N, min-max score, and an
-`UNSTABLE` marker above the 5% limit. A busy check returns a distinct result,
-stops further sequential benchmarks, writes partial JSON, and exits nonzero.
+interface. Aggregation medians the measured *times* across successful outer
+measurements and re-derives every score from them through the single
+`scores_from_times` definition that `compute_scores` also uses. Medianing each
+score field independently was rejected: the median of a geometric mean is not
+the geometric mean of the medians, so it would publish an `overall_score` that
+contradicts the sub-scores printed beside it. `raw_times` and `iterations` come
+from the measurement nearest the median, so they describe one real run rather
+than a synthetic blend; `scores` is derived from median times across N and is
+therefore not re-derivable from that single `raw_times` array. Every individual
+measurement is retained under `measurements` for auditing, plus a
+`repeat_summary` of the observed overall scores. Console output shows the score,
+N, the min-max range of the repeats, and an `UNSTABLE` marker above the 5%
+limit. A busy check returns a distinct result, stops further sequential
+benchmarks, and exits 3 — chosen so a CI wrapper can distinguish a busy host
+from argparse's usage-error exit 2. A refused run writes partial JSON only to an
+explicitly requested `--json` path; it deliberately does not touch the default
+`jetstream-results.json`, because overwriting a complete baseline with a
+truncated suite is the comparability hazard this work exists to remove.
 
 The top-level JSON adds a `measurement_protocol` object and a `host` object.
 The host object includes CPU model, logical CPU count, start load averages,
@@ -89,10 +102,17 @@ reported as unpinned with a reason rather than guessed.
 - Unit-test heterogeneous, uniform, incomplete, and affinity-restricted CPU
   topology detection using temporary sysfs trees.
 - Unit-test repeat medians, ranges, and the 5% instability boundary.
+- Unit-test that aggregation keeps `overall_score` equal to the geometric mean
+  of the sub-scores beside it, including when the per-measurement first-time and
+  average-time orderings disagree, and when no worst-case window exists.
 - Use a temporary fake JetStream checkout and engine to verify CLI repeat
-  aggregation, affinity command construction, JSON host metadata, and busy
-  refusal without running the full benchmark suite.
-- Run the documented synthetic burner check and the repository quality gate.
+  aggregation, affinity command construction, JSON host metadata, busy refusal
+  with exit 3, and that a refusal leaves an existing `jetstream-results.json`
+  intact — all without running the full benchmark suite.
+- Run the synthetic burner check documented in `README.md` under "Running
+  JetStream 3", and the repository quality gate. The issue's suggested single
+  `yes > /dev/null` asymptotes the one-minute average to only ~1.0, below the
+  1.5 default, so the documented recipe uses three burners.
 
 This is benchmark infrastructure only. There is no relevant ECMAScript section
 or targeted test262 directory, and the test262 pass count must remain unchanged.

--- a/scripts/benchmark_protocol.py
+++ b/scripts/benchmark_protocol.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Shared host-control and statistics helpers for performance benchmarks."""
+
+import math
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+from statistics import median
+
+
+DEFAULT_LOADAVG_PATH = Path("/proc/loadavg")
+DEFAULT_CPU_SYSFS_ROOT = Path("/sys/devices/system/cpu")
+DEFAULT_INSTABILITY_THRESHOLD = 0.05
+
+
+class LoadAverageUnavailable(RuntimeError):
+    """Raised when the host load average cannot be measured reliably."""
+
+
+class BusyHostError(RuntimeError):
+    """Raised when the host is too busy for a controlled measurement."""
+
+    def __init__(self, loadavg1: float, threshold: float):
+        self.loadavg1 = loadavg1
+        self.threshold = threshold
+        super().__init__(
+            f"loadavg1 {loadavg1:.2f} exceeds idle threshold {threshold:.2f}"
+        )
+
+
+def read_load_averages(path: Path = DEFAULT_LOADAVG_PATH) -> tuple[float, float, float]:
+    """Read the one-, five-, and fifteen-minute load averages from procfs."""
+    try:
+        fields = path.read_text(encoding="utf-8").split()
+        values = tuple(float(field) for field in fields[:3])
+    except (OSError, ValueError) as exc:
+        raise LoadAverageUnavailable(
+            f"cannot read load averages from {path}: {exc}"
+        ) from exc
+
+    if len(values) != 3 or any(
+        value < 0 or not math.isfinite(value) for value in values
+    ):
+        raise LoadAverageUnavailable(f"invalid load averages in {path}")
+    return values
+
+
+def require_idle(
+    threshold: float, path: Path = DEFAULT_LOADAVG_PATH
+) -> tuple[float, float, float]:
+    """Return current load averages, or reject a host above the threshold."""
+    loads = read_load_averages(path)
+    if loads[0] > threshold:
+        raise BusyHostError(loads[0], threshold)
+    return loads
+
+
+def get_available_cpus() -> list[int]:
+    """Return logical CPUs on which this process is allowed to run."""
+    try:
+        return sorted(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        return list(range(os.cpu_count() or 1))
+
+
+def detect_cpu_topology(
+    sysfs_root: Path = DEFAULT_CPU_SYSFS_ROOT,
+    available_cpus: list[int] | None = None,
+) -> dict:
+    """Classify maximum CPU frequencies for every available logical CPU."""
+    cpus = sorted(
+        set(available_cpus if available_cpus is not None else get_available_cpus())
+    )
+    frequencies = {}
+    unreadable = []
+
+    for cpu in cpus:
+        path = sysfs_root / f"cpu{cpu}" / "cpufreq" / "cpuinfo_max_freq"
+        try:
+            frequency = int(path.read_text(encoding="utf-8").strip())
+            if frequency <= 0:
+                raise ValueError("frequency must be positive")
+            frequencies[cpu] = frequency
+        except (OSError, ValueError):
+            unreadable.append(cpu)
+
+    base = {
+        "available_cpus": cpus,
+        "max_frequencies_khz": frequencies,
+        "fast_cores": [],
+    }
+    if not cpus:
+        return base | {
+            "classification": "unreadable",
+            "reason": "process has no available logical CPUs",
+        }
+    if unreadable:
+        return base | {
+            "classification": "unreadable",
+            "reason": "missing maximum-frequency data for CPUs "
+            + format_cpu_list(unreadable),
+        }
+
+    distinct = sorted(set(frequencies.values()))
+    if len(distinct) == 1:
+        return base | {
+            "classification": "uniform",
+            "reason": f"all available CPUs report {distinct[0]} kHz maximum",
+        }
+
+    max_frequency = distinct[-1]
+    fast_cores = [cpu for cpu in cpus if frequencies[cpu] == max_frequency]
+    return base | {
+        "classification": "heterogeneous",
+        "fast_cores": fast_cores,
+        "max_frequency_khz": max_frequency,
+        "reason": f"selected maximum-frequency cluster at {max_frequency} kHz",
+    }
+
+
+def format_cpu_list(cpus: list[int]) -> str:
+    """Format logical CPU identifiers using taskset's compact range syntax."""
+    ordered = sorted(set(cpus))
+    if not ordered:
+        return ""
+
+    ranges = []
+    start = previous = ordered[0]
+    for cpu in ordered[1:]:
+        if cpu == previous + 1:
+            previous = cpu
+            continue
+        ranges.append(str(start) if start == previous else f"{start}-{previous}")
+        start = previous = cpu
+    ranges.append(str(start) if start == previous else f"{start}-{previous}")
+    return ",".join(ranges)
+
+
+def choose_cpu_pinning(topology: dict, taskset_path: str | None = None) -> dict:
+    """Choose a taskset prefix only for a complete heterogeneous topology."""
+    resolved_taskset = (
+        taskset_path if taskset_path is not None else shutil.which("taskset")
+    )
+    if topology["classification"] != "heterogeneous":
+        return {
+            "applied": False,
+            "command_prefix": [],
+            "cpu_list": None,
+            "reason": topology["reason"],
+        }
+    if not resolved_taskset:
+        return {
+            "applied": False,
+            "command_prefix": [],
+            "cpu_list": None,
+            "reason": "heterogeneous topology detected but taskset is unavailable",
+        }
+
+    cpu_list = format_cpu_list(topology["fast_cores"])
+    return {
+        "applied": True,
+        "command_prefix": [resolved_taskset, "--cpu-list", cpu_list],
+        "cpu_list": cpu_list,
+        "reason": f"pinned to maximum-frequency CPUs {cpu_list}",
+    }
+
+
+def summarize_repeats(
+    values: list[float], instability_threshold: float = DEFAULT_INSTABILITY_THRESHOLD
+) -> dict:
+    """Summarize repeat values and identify a greater-than-threshold range."""
+    if not values or any(value <= 0 or not math.isfinite(value) for value in values):
+        raise ValueError("repeat values must be non-empty, finite, and positive")
+
+    minimum = min(values)
+    maximum = max(values)
+    relative_range = maximum / minimum - 1
+    return {
+        "n": len(values),
+        "median": median(values),
+        "min": minimum,
+        "max": maximum,
+        "relative_range": relative_range,
+        "unstable": maximum > minimum * (1 + instability_threshold),
+        "instability_threshold": instability_threshold,
+    }
+
+
+def _command_output(command: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            env=os.environ | {"LC_ALL": "C"},
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    output = result.stdout.strip()
+    return output or None
+
+
+def read_cpu_model() -> str | None:
+    """Read lscpu's model name, with /proc/cpuinfo as a fallback."""
+    lscpu = shutil.which("lscpu")
+    if lscpu:
+        output = _command_output([lscpu])
+        if output:
+            for line in output.splitlines():
+                key, separator, value = line.partition(":")
+                if separator and key.strip() == "Model name":
+                    return value.strip() or None
+
+    try:
+        for line in Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines():
+            key, separator, value = line.partition(":")
+            if separator and key.strip() in {"model name", "Processor"}:
+                return value.strip() or None
+    except OSError:
+        pass
+    return None
+
+
+def read_nproc() -> int:
+    """Read the logical CPU count using nproc, with affinity as a fallback."""
+    nproc = shutil.which("nproc")
+    if nproc:
+        output = _command_output([nproc])
+        if output:
+            try:
+                value = int(output)
+                if value > 0:
+                    return value
+            except ValueError:
+                pass
+    return len(get_available_cpus())
+
+
+def collect_host_fingerprint(
+    topology: dict,
+    pinning: dict,
+    start_load: tuple[float, float, float] | None,
+    load_error: str | None = None,
+) -> dict:
+    """Build JSON-serializable host metadata for later comparability audits."""
+    loadavg = None
+    if start_load is not None:
+        loadavg = {
+            "one_minute": start_load[0],
+            "five_minutes": start_load[1],
+            "fifteen_minutes": start_load[2],
+        }
+
+    return {
+        "hostname": platform.node(),
+        "cpu_model": read_cpu_model(),
+        "nproc": read_nproc(),
+        "loadavg_start": loadavg,
+        "loadavg_error": load_error,
+        "available_cpus": topology["available_cpus"],
+        "cpu_topology": topology["classification"],
+        "cpu_max_freq_khz": topology["max_frequencies_khz"],
+        "fast_cores": topology["fast_cores"],
+        "pinning": {
+            "applied": pinning["applied"],
+            "cpu_list": pinning["cpu_list"],
+            "reason": pinning["reason"],
+        },
+    }

--- a/scripts/run-jetstream.py
+++ b/scripts/run-jetstream.py
@@ -22,6 +22,12 @@ Options:
     --list              List available benchmarks and exit
     -j N                Number of parallel workers (default: 1, benchmarks run sequentially)
     -v, --verbose       Verbose output
+
+Exit codes:
+    0  every selected benchmark produced a result
+    1  engine or JetStream checkout missing
+    2  invalid command-line arguments (argparse)
+    3  a busy host aborted the run before the suite finished
 """
 
 import argparse
@@ -47,6 +53,10 @@ from benchmark_protocol import (
     require_idle,
     summarize_repeats,
 )
+
+# Distinct from argparse's usage-error exit code 2, so a CI wrapper can tell
+# "host was too busy" apart from "the flags were wrong".
+EXIT_BUSY_HOST = 3
 
 # JS-only benchmarks extracted from JetStreamDriver.js BENCHMARKS array.
 # Each entry: (name, type, files, preload_dict_or_None, default_iterations, deterministic_random, worst_case_count)
@@ -580,30 +590,22 @@ def to_score(time_ms):
     return 5000.0 / max(time_ms, 1.0)
 
 
-def compute_scores(results, worst_case_count):
-    if not results:
-        return None
-    first_time = results[0]
+def scores_from_times(first_time, avg_time, worst_time):
+    """Derive every score field from the three measured times.
+
+    Sole definition of the score relationships, so single-measurement and
+    across-measurement aggregation cannot drift apart.
+    """
     first_score = to_score(first_time)
-
-    rest = sorted(results[1:], reverse=True)
-
-    worst_time = None
-    worst_score = None
-    if worst_case_count and len(rest) >= worst_case_count:
-        worst_times = rest[:worst_case_count]
-        worst_time = sum(worst_times) / len(worst_times)
-        worst_score = to_score(worst_time)
-
-    avg_time = sum(rest) / len(rest) if rest else first_time
     avg_score = to_score(avg_time)
+    worst_score = to_score(worst_time) if worst_time is not None else None
 
-    scores = [first_score, avg_score]
+    components = [first_score, avg_score]
     if worst_score is not None:
-        scores.append(worst_score)
+        components.append(worst_score)
 
     # Overall score is geometric mean of sub-scores
-    overall = math.exp(sum(math.log(s) for s in scores) / len(scores))
+    overall = math.exp(sum(math.log(s) for s in components) / len(components))
 
     return {
         "first_time": first_time,
@@ -614,6 +616,21 @@ def compute_scores(results, worst_case_count):
         "average_score": avg_score,
         "overall_score": overall,
     }
+
+
+def compute_scores(results, worst_case_count):
+    if not results:
+        return None
+    first_time = results[0]
+    rest = sorted(results[1:], reverse=True)
+
+    worst_time = None
+    if worst_case_count and len(rest) >= worst_case_count:
+        worst_times = rest[:worst_case_count]
+        worst_time = sum(worst_times) / len(worst_times)
+
+    avg_time = sum(rest) / len(rest) if rest else first_time
+    return scores_from_times(first_time, avg_time, worst_time)
 
 
 def run_benchmark_once(
@@ -749,16 +766,28 @@ def run_benchmark_once(
 
 
 def median_scores(measurements):
-    """Take the median of every numeric JetStream score component."""
-    combined = {}
-    for key in measurements[0]["scores"]:
+    """Aggregate measurements by medianing the times, then re-deriving scores.
+
+    Medianing each score field independently would leave overall_score
+    inconsistent with the sub-scores beside it, because the median of a
+    geometric mean is not the geometric mean of the medians. Medianing the
+    measured times instead keeps the emitted scores object satisfying the
+    same relationships compute_scores guarantees for a single measurement.
+    """
+
+    def median_time(key):
         values = [
             measurement["scores"][key]
             for measurement in measurements
             if measurement["scores"][key] is not None
         ]
-        combined[key] = median(values) if values else None
-    return combined
+        return median(values) if values else None
+
+    return scores_from_times(
+        median_time("first_time"),
+        median_time("average_time"),
+        median_time("worst_time"),
+    )
 
 
 def run_benchmark(
@@ -1013,7 +1042,7 @@ def main():
             if repeat_summary["unstable"]:
                 stability = f"  [UNSTABLE {repeat_summary['relative_range']:.1%} range]"
             print(
-                f"  PASS  {name:40s}  score median: {overall:8.1f}  "
+                f"  PASS  {name:40s}  score: {overall:8.1f}  "
                 f"N={repeat_summary['n']}  "
                 f"range: {repeat_summary['min']:.1f}-{repeat_summary['max']:.1f}  "
                 f"avg: {avg_ms:8.1f}ms{stability}{compare_str}"
@@ -1138,12 +1167,19 @@ def main():
             json.dump(output, f, indent=2)
         print(f"\nResults written to {args.json}")
 
-    # Always write to a default location too
-    default_path = "jetstream-results.json"
-    with open(default_path, "w") as f:
-        json.dump(output, f, indent=2)
+    # Always write to a default location too, except when a busy host aborted
+    # the run: a truncated suite must not overwrite a complete baseline.
+    if busy:
+        print(
+            "\nSkipped default jetstream-results.json write "
+            "(run aborted by busy host; existing baseline preserved)"
+        )
+    else:
+        default_path = "jetstream-results.json"
+        with open(default_path, "w") as f:
+            json.dump(output, f, indent=2)
 
-    return 2 if busy else 0
+    return EXIT_BUSY_HOST if busy else 0
 
 
 if __name__ == "__main__":

--- a/scripts/run-jetstream.py
+++ b/scripts/run-jetstream.py
@@ -1162,8 +1162,15 @@ def main():
         "results": all_results,
     }
 
-    if args.json:
-        with open(args.json, "w") as f:
+    default_path = Path("jetstream-results.json")
+    requested_path = Path(args.json) if args.json else None
+    requested_is_default = (
+        requested_path is not None
+        and requested_path.resolve() == default_path.resolve()
+    )
+
+    if requested_path is not None and not (busy and requested_is_default):
+        with requested_path.open("w") as f:
             json.dump(output, f, indent=2)
         print(f"\nResults written to {args.json}")
 
@@ -1175,8 +1182,7 @@ def main():
             "(run aborted by busy host; existing baseline preserved)"
         )
     else:
-        default_path = "jetstream-results.json"
-        with open(default_path, "w") as f:
+        with default_path.open("w") as f:
             json.dump(output, f, indent=2)
 
     return EXIT_BUSY_HOST if busy else 0

--- a/scripts/run-jetstream.py
+++ b/scripts/run-jetstream.py
@@ -12,8 +12,11 @@ Options:
     --engine PATH       Path to JS engine binary (default: target/release/jsse)
     --jetstream PATH    Path to JetStream checkout (default: /tmp/JetStream)
     --iterations N      Override iteration count (default: use benchmark default)
+    --repeats N         Outer measurements per benchmark (default: 3, minimum: 3)
+    --idle-threshold N  Maximum accepted one-minute load average (default: 1.5)
+    --no-idle-gate      Disable load checks for diagnostic runs
     --test NAME         Run a specific test (comma-separated for multiple)
-    --timeout SECS      Per-benchmark timeout in seconds (default: 300)
+    --timeout SECS      Per-measurement timeout in seconds (default: 300)
     --json FILE         Write JSON results to file
     --compare FILE      Compare results against a previous JSON run
     --list              List available benchmarks and exit
@@ -31,6 +34,19 @@ import tempfile
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
+from statistics import median
+
+from benchmark_protocol import (
+    DEFAULT_INSTABILITY_THRESHOLD,
+    BusyHostError,
+    LoadAverageUnavailable,
+    choose_cpu_pinning,
+    collect_host_fingerprint,
+    detect_cpu_topology,
+    read_load_averages,
+    require_idle,
+    summarize_repeats,
+)
 
 # JS-only benchmarks extracted from JetStreamDriver.js BENCHMARKS array.
 # Each entry: (name, type, files, preload_dict_or_None, default_iterations, deterministic_random, worst_case_count)
@@ -600,7 +616,7 @@ def compute_scores(results, worst_case_count):
     }
 
 
-def run_benchmark(
+def run_benchmark_once(
     name,
     btype,
     files,
@@ -608,7 +624,7 @@ def run_benchmark(
     iterations,
     det_random,
     worst_case,
-    engine,
+    engine_command,
     jetstream_dir,
     timeout,
     verbose,
@@ -663,7 +679,7 @@ def run_benchmark(
     try:
         start = time.time()
         result = subprocess.run(
-            [engine, tmp_path],
+            [*engine_command, tmp_path],
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -732,6 +748,100 @@ def run_benchmark(
         os.unlink(tmp_path)
 
 
+def median_scores(measurements):
+    """Take the median of every numeric JetStream score component."""
+    combined = {}
+    for key in measurements[0]["scores"]:
+        values = [
+            measurement["scores"][key]
+            for measurement in measurements
+            if measurement["scores"][key] is not None
+        ]
+        combined[key] = median(values) if values else None
+    return combined
+
+
+def run_benchmark(
+    name,
+    btype,
+    files,
+    preloads,
+    iterations,
+    det_random,
+    worst_case,
+    engine_command,
+    jetstream_dir,
+    timeout,
+    verbose,
+    iteration_override,
+    repeats,
+    idle_threshold,
+):
+    """Run controlled outer measurements and aggregate their median score."""
+    measurements = []
+    for repeat in range(1, repeats + 1):
+        load_before = None
+        if idle_threshold is not None:
+            try:
+                load_before = require_idle(idle_threshold)
+            except (BusyHostError, LoadAverageUnavailable) as exc:
+                result = {
+                    "name": name,
+                    "status": "busy",
+                    "reason": str(exc),
+                    "completed_repeats": len(measurements),
+                    "measurements": measurements,
+                }
+                if isinstance(exc, BusyHostError):
+                    result["loadavg1"] = exc.loadavg1
+                    result["idle_threshold"] = exc.threshold
+                return result
+
+        result = run_benchmark_once(
+            name,
+            btype,
+            files,
+            preloads,
+            iterations,
+            det_random,
+            worst_case,
+            engine_command,
+            jetstream_dir,
+            timeout,
+            verbose,
+            iteration_override,
+        )
+        result["repeat"] = repeat
+        result["loadavg_before"] = load_before
+        measurements.append(result)
+        if result["status"] != "pass":
+            return result | {
+                "completed_repeats": repeat - 1,
+                "measurements": measurements,
+            }
+
+    scores = median_scores(measurements)
+    summary = summarize_repeats(
+        [measurement["scores"]["overall_score"] for measurement in measurements]
+    )
+    representative = min(
+        measurements,
+        key=lambda measurement: abs(
+            measurement["scores"]["overall_score"] - summary["median"]
+        ),
+    )
+    return {
+        "name": name,
+        "status": "pass",
+        "elapsed": median([measurement["elapsed"] for measurement in measurements]),
+        "iterations": representative["iterations"],
+        "scores": scores,
+        "raw_times": representative["raw_times"],
+        "repeat_summary": summary,
+        "measurements": measurements,
+    }
+
+
 def geometric_mean(values):
     if not values:
         return 0
@@ -752,10 +862,27 @@ def main():
         "--iterations", type=int, default=None, help="Override iteration count"
     )
     parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="Outer measurements per benchmark (default: 3, minimum: 3)",
+    )
+    parser.add_argument(
+        "--idle-threshold",
+        type=float,
+        default=1.5,
+        help="Maximum one-minute load average (default: 1.5)",
+    )
+    parser.add_argument(
+        "--no-idle-gate",
+        action="store_true",
+        help="Disable load checks for diagnostic runs",
+    )
+    parser.add_argument(
         "--test", default=None, help="Run specific test(s), comma-separated"
     )
     parser.add_argument(
-        "--timeout", type=int, default=300, help="Per-benchmark timeout (seconds)"
+        "--timeout", type=int, default=300, help="Per-measurement timeout (seconds)"
     )
     parser.add_argument("--json", default=None, help="Write JSON results to file")
     parser.add_argument(
@@ -773,7 +900,16 @@ def main():
         print(f"\nSkipped benchmarks ({len(SKIPPED_BENCHMARKS)}):")
         for name in SKIPPED_BENCHMARKS:
             print(f"  {name}")
-        return
+        return 0
+
+    if args.repeats < 3:
+        parser.error("--repeats must be at least 3")
+    if args.idle_threshold < 0 or not math.isfinite(args.idle_threshold):
+        parser.error("--idle-threshold must be finite and non-negative")
+    if args.j < 1:
+        parser.error("-j must be at least 1")
+    if args.j > 1 and not args.no_idle_gate:
+        parser.error("-j greater than 1 requires --no-idle-gate")
 
     # Validate paths
     engine = os.path.abspath(args.engine)
@@ -790,6 +926,18 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
+
+    topology = detect_cpu_topology()
+    pinning = choose_cpu_pinning(topology)
+    engine_command = [*pinning["command_prefix"], engine]
+
+    start_load = None
+    load_error = None
+    try:
+        start_load = read_load_averages()
+    except LoadAverageUnavailable as exc:
+        load_error = str(exc)
+    host = collect_host_fingerprint(topology, pinning, start_load, load_error)
 
     # Filter benchmarks
     benchmarks = BENCHMARKS
@@ -811,7 +959,23 @@ def main():
 
     print(f"JetStream 3 — {len(benchmarks)} JS benchmarks")
     print(f"Engine: {engine}")
-    print(f"Timeout: {args.timeout}s per benchmark")
+    print(f"Timeout: {args.timeout}s per measurement")
+    print(f"Measurements: N={args.repeats} per benchmark")
+    if args.no_idle_gate:
+        print("WARNING: idle-window gate disabled; results are diagnostic only")
+    else:
+        print(f"Idle gate: loadavg1 <= {args.idle_threshold:.2f}")
+    if start_load is None:
+        print(f"WARNING: starting load unavailable ({load_error})")
+    else:
+        print(
+            "Starting load: "
+            f"{start_load[0]:.2f} {start_load[1]:.2f} {start_load[2]:.2f}"
+        )
+    if pinning["applied"]:
+        print(f"CPU pinning: {pinning['reason']}")
+    else:
+        print(f"WARNING: CPU pinning disabled ({pinning['reason']})")
     if args.iterations:
         print(f"Iterations: {args.iterations} (override)")
     print()
@@ -821,6 +985,8 @@ def main():
     errors = []
     skipped = []
     timeouts = []
+    busy = []
+    unstable = []
 
     def process_result(result):
         all_results.append(result)
@@ -832,6 +998,9 @@ def main():
             overall = scores["overall_score"]
             passed_scores.append(overall)
             avg_ms = scores["average_time"]
+            repeat_summary = result["repeat_summary"]
+            if repeat_summary["unstable"]:
+                unstable.append(name)
 
             compare_str = ""
             if name in compare_data:
@@ -840,8 +1009,14 @@ def main():
                 arrow = "^" if ratio > 1.01 else ("v" if ratio < 0.99 else "=")
                 compare_str = f"  [{arrow} {ratio:.2f}x vs baseline]"
 
+            stability = ""
+            if repeat_summary["unstable"]:
+                stability = f"  [UNSTABLE {repeat_summary['relative_range']:.1%} range]"
             print(
-                f"  PASS  {name:40s}  score: {overall:8.1f}  avg: {avg_ms:8.1f}ms{compare_str}"
+                f"  PASS  {name:40s}  score median: {overall:8.1f}  "
+                f"N={repeat_summary['n']}  "
+                f"range: {repeat_summary['min']:.1f}-{repeat_summary['max']:.1f}  "
+                f"avg: {avg_ms:8.1f}ms{stability}{compare_str}"
             )
         elif status == "timeout":
             timeouts.append(name)
@@ -849,6 +1024,9 @@ def main():
         elif status == "skipped":
             skipped.append(name)
             print(f"  SKIP  {name:40s}  ({result.get('reason', '')})")
+        elif status == "busy":
+            busy.append(name)
+            print(f"  BUSY  {name:40s}  ({result.get('reason', '')})")
         else:
             errors.append(name)
             print(f"  FAIL  {name:40s}  ({result.get('reason', '')})")
@@ -866,11 +1044,13 @@ def main():
                     iters,
                     det_rand,
                     worst,
-                    engine,
+                    engine_command,
                     jetstream_dir,
                     args.timeout,
                     args.verbose,
                     args.iterations,
+                    args.repeats,
+                    None,
                 )
                 futures[future] = name
             for future in as_completed(futures):
@@ -885,13 +1065,17 @@ def main():
                 iters,
                 det_rand,
                 worst,
-                engine,
+                engine_command,
                 jetstream_dir,
                 args.timeout,
                 args.verbose,
                 args.iterations,
+                args.repeats,
+                None if args.no_idle_gate else args.idle_threshold,
             )
             process_result(result)
+            if result["status"] == "busy":
+                break
 
     # Summary
     print()
@@ -900,7 +1084,8 @@ def main():
     print(f"Overall score (geometric mean): {geo_mean:.1f}")
     print(
         f"Passed: {len(passed_scores)}/{len(benchmarks)}  "
-        f"Errors: {len(errors)}  Timeouts: {len(timeouts)}  Skipped: {len(skipped)}"
+        f"Errors: {len(errors)}  Timeouts: {len(timeouts)}  "
+        f"Skipped: {len(skipped)}  Busy: {len(busy)}  Unstable: {len(unstable)}"
     )
 
     if compare_data and passed_scores:
@@ -924,12 +1109,24 @@ def main():
         print(f"\nFailed: {', '.join(errors)}")
     if timeouts:
         print(f"Timed out: {', '.join(timeouts)}")
+    if busy:
+        print(f"Busy-window refusal: {', '.join(busy)}")
+    if unstable:
+        print(f"Unstable (>5% repeat range): {', '.join(unstable)}")
 
     # Write JSON
     output = {
         "engine": engine,
         "jetstream_version": "3.0",
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "measurement_protocol": {
+            "repeats": args.repeats,
+            "idle_gate_enabled": not args.no_idle_gate,
+            "idle_threshold": args.idle_threshold,
+            "instability_threshold": DEFAULT_INSTABILITY_THRESHOLD,
+            "interrupted_by_busy_host": bool(busy),
+        },
+        "host": host,
         "overall_score": geo_mean,
         "passed": len(passed_scores),
         "total": len(benchmarks),
@@ -946,6 +1143,8 @@ def main():
     with open(default_path, "w") as f:
         json.dump(output, f, indent=2)
 
+    return 2 if busy else 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/test_benchmark_protocol.py
+++ b/scripts/test_benchmark_protocol.py
@@ -405,6 +405,51 @@ class RunnerCliTests(unittest.TestCase):
             {"overall_score": 1234.5},
         )
 
+    def test_busy_host_keeps_baseline_when_json_aliases_default(self):
+        if read_load_averages()[0] == 0.0:
+            self.skipTest("host reports zero load, so no threshold can trip")
+
+        baseline = self.root / "jetstream-results.json"
+        alias = self.root / "results-alias.json"
+        alias.symlink_to(baseline.name)
+        json_targets = [
+            "jetstream-results.json",
+            str(baseline.resolve()),
+            str(alias),
+        ]
+
+        for json_target in json_targets:
+            with self.subTest(json_target=json_target):
+                baseline.write_text('{"overall_score": 1234.5}', encoding="utf-8")
+
+                result = self.run_runner("--idle-threshold", "0", "--json", json_target)
+
+                self.assertEqual(result.returncode, 3, result.stderr)
+                self.assertIn("existing baseline preserved", result.stdout)
+                self.assertEqual(
+                    json.loads(baseline.read_text(encoding="utf-8")),
+                    {"overall_score": 1234.5},
+                )
+
+    def test_busy_host_writes_distinct_explicit_json(self):
+        if read_load_averages()[0] == 0.0:
+            self.skipTest("host reports zero load, so no threshold can trip")
+
+        baseline = self.root / "jetstream-results.json"
+        baseline.write_text('{"overall_score": 1234.5}', encoding="utf-8")
+        partial = self.root / "busy-partial.json"
+
+        result = self.run_runner("--idle-threshold", "0", "--json", str(partial))
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        self.assertEqual(
+            json.loads(baseline.read_text(encoding="utf-8")),
+            {"overall_score": 1234.5},
+        )
+        output = json.loads(partial.read_text(encoding="utf-8"))
+        self.assertTrue(output["measurement_protocol"]["interrupted_by_busy_host"])
+        self.assertEqual(output["passed"], 0)
+
     def test_repeats_below_three_are_rejected(self):
         result = self.run_runner("--repeats", "2", "--no-idle-gate")
 

--- a/scripts/test_benchmark_protocol.py
+++ b/scripts/test_benchmark_protocol.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import math
 import os
 import stat
 import subprocess
@@ -34,6 +35,32 @@ def load_runner_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def assert_scores_are_self_consistent(case, scores):
+    """Assert overall_score is the geometric mean of the sub-scores beside it.
+
+    JetStream defines the overall score that way, so any aggregation across
+    repeats has to preserve it or the published score contradicts the
+    sub-scores reported next to it.
+    """
+    components = [scores["first_score"], scores["average_score"]]
+    if scores["worst_score"] is not None:
+        components.append(scores["worst_score"])
+    expected = math.exp(sum(math.log(c) for c in components) / len(components))
+    case.assertAlmostEqual(scores["overall_score"], expected, places=9)
+
+    for time_key, score_key in (
+        ("first_time", "first_score"),
+        ("average_time", "average_score"),
+        ("worst_time", "worst_score"),
+    ):
+        if scores[time_key] is None:
+            case.assertIsNone(scores[score_key])
+            continue
+        case.assertAlmostEqual(
+            scores[score_key], 5000.0 / max(scores[time_key], 1.0), places=9
+        )
 
 
 class LoadGateTests(unittest.TestCase):
@@ -153,6 +180,58 @@ class RepeatSummaryTests(unittest.TestCase):
         for values in ([], [0.0, 1.0], [float("inf"), 1.0]):
             with self.subTest(values=values), self.assertRaises(ValueError):
                 summarize_repeats(values)
+
+
+class ScoreAggregationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = load_runner_module()
+
+    def measurement(self, results, worst_case_count=0):
+        return {"scores": self.runner.compute_scores(results, worst_case_count)}
+
+    def test_single_measurement_scores_are_self_consistent(self):
+        scores = self.runner.compute_scores([100.0, 200.0, 400.0], 1)
+
+        assert_scores_are_self_consistent(self, scores)
+        self.assertIsNotNone(scores["worst_score"])
+
+    def test_aggregate_of_divergent_measurements_stays_self_consistent(self):
+        # Chosen so a per-field median of the *scores* would contradict the
+        # geometric mean beside it: the first/average orderings disagree.
+        measurements = [
+            self.measurement([100.0, 100.0]),
+            self.measurement([200.0, 400.0]),
+            self.measurement([300.0, 200.0]),
+        ]
+
+        scores = self.runner.median_scores(measurements)
+
+        assert_scores_are_self_consistent(self, scores)
+        self.assertEqual(scores["first_time"], 200.0)
+        self.assertEqual(scores["average_time"], 200.0)
+
+    def test_aggregate_medians_the_times(self):
+        measurements = [
+            self.measurement([10.0, 30.0, 50.0], 1),
+            self.measurement([20.0, 60.0, 100.0], 1),
+            self.measurement([90.0, 270.0, 450.0], 1),
+        ]
+
+        scores = self.runner.median_scores(measurements)
+
+        self.assertEqual(scores["first_time"], 20.0)
+        self.assertEqual(scores["worst_time"], 100.0)
+        assert_scores_are_self_consistent(self, scores)
+
+    def test_absent_worst_case_stays_absent_after_aggregation(self):
+        measurements = [self.measurement([10.0, 20.0]) for _ in range(3)]
+
+        scores = self.runner.median_scores(measurements)
+
+        self.assertIsNone(scores["worst_time"])
+        self.assertIsNone(scores["worst_score"])
+        assert_scores_are_self_consistent(self, scores)
 
 
 class RunnerMeasurementTests(unittest.TestCase):
@@ -299,16 +378,32 @@ class RunnerCliTests(unittest.TestCase):
         output = json.loads(output_path.read_text(encoding="utf-8"))
         benchmark = output["results"][0]
         self.assertEqual(benchmark["repeat_summary"]["n"], 3)
-        self.assertEqual(
-            benchmark["scores"]["overall_score"],
-            benchmark["repeat_summary"]["median"],
-        )
+        assert_scores_are_self_consistent(self, benchmark["scores"])
         self.assertEqual(len(benchmark["measurements"]), 3)
         self.assertEqual(output["measurement_protocol"]["repeats"], 3)
         self.assertIn("cpu_model", output["host"])
         self.assertIn("nproc", output["host"])
         self.assertIn("loadavg_start", output["host"])
         self.assertEqual(self.counter.read_text(encoding="utf-8"), "3")
+
+    def test_busy_host_exits_distinctly_and_keeps_existing_baseline(self):
+        if read_load_averages()[0] == 0.0:
+            self.skipTest("host reports zero load, so no threshold can trip")
+
+        baseline = self.root / "jetstream-results.json"
+        baseline.write_text('{"overall_score": 1234.5}', encoding="utf-8")
+
+        # Any nonzero load exceeds a zero threshold, so the gate always trips.
+        result = self.run_runner("--idle-threshold", "0")
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        self.assertNotEqual(result.returncode, 2)
+        self.assertIn("BUSY", result.stdout)
+        self.assertIn("existing baseline preserved", result.stdout)
+        self.assertEqual(
+            json.loads(baseline.read_text(encoding="utf-8")),
+            {"overall_score": 1234.5},
+        )
 
     def test_repeats_below_three_are_rejected(self):
         result = self.run_runner("--repeats", "2", "--no-idle-gate")

--- a/scripts/test_benchmark_protocol.py
+++ b/scripts/test_benchmark_protocol.py
@@ -1,0 +1,327 @@
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+RUNNER_PATH = SCRIPTS_DIR / "run-jetstream.py"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from benchmark_protocol import (  # noqa: E402
+    BusyHostError,
+    LoadAverageUnavailable,
+    choose_cpu_pinning,
+    collect_host_fingerprint,
+    detect_cpu_topology,
+    format_cpu_list,
+    read_load_averages,
+    require_idle,
+    summarize_repeats,
+)
+
+
+def load_runner_module():
+    spec = importlib.util.spec_from_file_location("run_jetstream", RUNNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class LoadGateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.loadavg = Path(self.tmp.name) / "loadavg"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_threshold_is_inclusive(self):
+        self.loadavg.write_text("1.50 2.00 3.00 1/10 123\n", encoding="utf-8")
+
+        self.assertEqual(require_idle(1.5, self.loadavg), (1.5, 2.0, 3.0))
+
+    def test_busy_host_is_rejected(self):
+        self.loadavg.write_text("1.51 2.00 3.00 1/10 123\n", encoding="utf-8")
+
+        with self.assertRaises(BusyHostError) as raised:
+            require_idle(1.5, self.loadavg)
+
+        self.assertEqual(raised.exception.loadavg1, 1.51)
+        self.assertEqual(raised.exception.threshold, 1.5)
+
+    def test_malformed_load_average_fails_closed(self):
+        self.loadavg.write_text("not-a-load-average\n", encoding="utf-8")
+
+        with self.assertRaises(LoadAverageUnavailable):
+            read_load_averages(self.loadavg)
+
+
+class CpuTopologyTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.sysfs = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_frequency(self, cpu: int, frequency: int):
+        path = self.sysfs / f"cpu{cpu}" / "cpufreq" / "cpuinfo_max_freq"
+        path.parent.mkdir(parents=True)
+        path.write_text(f"{frequency}\n", encoding="utf-8")
+
+    def test_heterogeneous_topology_pins_complete_fast_cluster(self):
+        for cpu, frequency in enumerate([5_000_000, 3_000_000, 3_000_000, 5_000_000]):
+            self.write_frequency(cpu, frequency)
+
+        topology = detect_cpu_topology(self.sysfs, [0, 1, 2, 3])
+        pinning = choose_cpu_pinning(topology, "/usr/bin/taskset")
+
+        self.assertEqual(topology["classification"], "heterogeneous")
+        self.assertEqual(topology["fast_cores"], [0, 3])
+        self.assertEqual(
+            pinning["command_prefix"], ["/usr/bin/taskset", "--cpu-list", "0,3"]
+        )
+
+    def test_affinity_restriction_limits_topology_probe(self):
+        self.write_frequency(1, 3_000_000)
+        self.write_frequency(3, 5_000_000)
+
+        topology = detect_cpu_topology(self.sysfs, [1, 3])
+
+        self.assertEqual(topology["available_cpus"], [1, 3])
+        self.assertEqual(topology["fast_cores"], [3])
+
+    def test_uniform_topology_stays_unpinned(self):
+        self.write_frequency(0, 5_000_000)
+        self.write_frequency(1, 5_000_000)
+
+        topology = detect_cpu_topology(self.sysfs, [0, 1])
+        pinning = choose_cpu_pinning(topology, "/usr/bin/taskset")
+
+        self.assertEqual(topology["classification"], "uniform")
+        self.assertFalse(pinning["applied"])
+
+    def test_incomplete_topology_stays_unpinned(self):
+        self.write_frequency(0, 5_000_000)
+
+        topology = detect_cpu_topology(self.sysfs, [0, 1])
+        pinning = choose_cpu_pinning(topology, "/usr/bin/taskset")
+
+        self.assertEqual(topology["classification"], "unreadable")
+        self.assertIn("CPUs 1", topology["reason"])
+        self.assertFalse(pinning["applied"])
+
+    def test_missing_taskset_stays_unpinned(self):
+        self.write_frequency(0, 5_000_000)
+        self.write_frequency(1, 3_000_000)
+        topology = detect_cpu_topology(self.sysfs, [0, 1])
+
+        pinning = choose_cpu_pinning(topology, "")
+
+        self.assertFalse(pinning["applied"])
+        self.assertIn("taskset is unavailable", pinning["reason"])
+
+    def test_cpu_list_uses_compact_ranges(self):
+        self.assertEqual(format_cpu_list([15, 0, 2, 1, 12, 13]), "0-2,12-13,15")
+
+
+class RepeatSummaryTests(unittest.TestCase):
+    def test_median_and_range_are_reported(self):
+        summary = summarize_repeats([100.0, 103.0, 105.0])
+
+        self.assertEqual(summary["n"], 3)
+        self.assertEqual(summary["median"], 103.0)
+        self.assertEqual(summary["min"], 100.0)
+        self.assertEqual(summary["max"], 105.0)
+        self.assertFalse(summary["unstable"])
+
+    def test_greater_than_five_percent_is_unstable(self):
+        summary = summarize_repeats([100.0, 101.0, 105.0001])
+
+        self.assertTrue(summary["unstable"])
+
+    def test_invalid_values_are_rejected(self):
+        for values in ([], [0.0, 1.0], [float("inf"), 1.0]):
+            with self.subTest(values=values), self.assertRaises(ValueError):
+                summarize_repeats(values)
+
+
+class RunnerMeasurementTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = load_runner_module()
+
+    def test_busy_check_is_repeated_between_measurements(self):
+        passing = {
+            "name": "sample",
+            "status": "pass",
+            "elapsed": 0.1,
+            "iterations": 2,
+            "scores": {"overall_score": 100.0},
+            "raw_times": [10.0, 20.0],
+        }
+        with (
+            mock.patch.object(
+                self.runner,
+                "require_idle",
+                side_effect=[(0.1, 0.2, 0.3), BusyHostError(2.0, 1.5)],
+            ) as idle,
+            mock.patch.object(
+                self.runner, "run_benchmark_once", return_value=passing.copy()
+            ) as run_once,
+        ):
+            result = self.runner.run_benchmark(
+                "sample",
+                "sync",
+                [],
+                None,
+                2,
+                False,
+                0,
+                ["engine"],
+                "/tmp",
+                30,
+                False,
+                None,
+                3,
+                1.5,
+            )
+
+        self.assertEqual(result["status"], "busy")
+        self.assertEqual(result["completed_repeats"], 1)
+        self.assertEqual(idle.call_count, 2)
+        run_once.assert_called_once()
+
+    def test_host_fingerprint_contains_required_comparability_fields(self):
+        topology = {
+            "available_cpus": [0, 1],
+            "classification": "heterogeneous",
+            "max_frequencies_khz": {0: 5_000_000, 1: 3_000_000},
+            "fast_cores": [0],
+        }
+        pinning = {
+            "applied": True,
+            "cpu_list": "0",
+            "reason": "pinned for test",
+        }
+        with (
+            mock.patch("benchmark_protocol.read_cpu_model", return_value="Test CPU"),
+            mock.patch("benchmark_protocol.read_nproc", return_value=2),
+            mock.patch("benchmark_protocol.platform.node", return_value="test-host"),
+        ):
+            host = collect_host_fingerprint(topology, pinning, (0.1, 0.2, 0.3))
+
+        self.assertEqual(host["cpu_model"], "Test CPU")
+        self.assertEqual(host["nproc"], 2)
+        self.assertEqual(host["loadavg_start"]["one_minute"], 0.1)
+        self.assertEqual(host["fast_cores"], [0])
+        self.assertTrue(host["pinning"]["applied"])
+
+
+class RunnerCliTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.jetstream = self.root / "JetStream"
+        (self.jetstream / "simple").mkdir(parents=True)
+        (self.jetstream / "JetStreamDriver.js").touch()
+        (self.jetstream / "simple" / "hash-map.js").write_text(
+            "class Benchmark {}\n", encoding="utf-8"
+        )
+        self.counter = self.root / "counter"
+        self.engine = self.root / "fake-engine.py"
+        self.engine.write_text(
+            textwrap.dedent(
+                f"""\
+                #!{sys.executable}
+                import json
+                import os
+                from pathlib import Path
+
+                counter = Path(os.environ["FAKE_JETSTREAM_COUNTER"])
+                value = int(counter.read_text() if counter.exists() else "0") + 1
+                counter.write_text(str(value))
+                print(json.dumps({{
+                    "results": [10 + value, 20 + value],
+                    "iterations": 2,
+                    "worstCaseCount": 0,
+                }}))
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.engine.chmod(self.engine.stat().st_mode | stat.S_IXUSR)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_runner(self, *extra_args: str):
+        env = os.environ | {"FAKE_JETSTREAM_COUNTER": str(self.counter)}
+        return subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER_PATH),
+                "--engine",
+                str(self.engine),
+                "--jetstream",
+                str(self.jetstream),
+                "--test",
+                "hash-map",
+                "--iterations",
+                "2",
+                *extra_args,
+            ],
+            cwd=self.root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_cli_runs_three_measurements_and_records_host(self):
+        output_path = self.root / "results.json"
+
+        result = self.run_runner("--no-idle-gate", "--json", str(output_path))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("N=3", result.stdout)
+        self.assertIn("range:", result.stdout)
+        self.assertIn("idle-window gate disabled", result.stdout)
+        output = json.loads(output_path.read_text(encoding="utf-8"))
+        benchmark = output["results"][0]
+        self.assertEqual(benchmark["repeat_summary"]["n"], 3)
+        self.assertEqual(
+            benchmark["scores"]["overall_score"],
+            benchmark["repeat_summary"]["median"],
+        )
+        self.assertEqual(len(benchmark["measurements"]), 3)
+        self.assertEqual(output["measurement_protocol"]["repeats"], 3)
+        self.assertIn("cpu_model", output["host"])
+        self.assertIn("nproc", output["host"])
+        self.assertIn("loadavg_start", output["host"])
+        self.assertEqual(self.counter.read_text(encoding="utf-8"), "3")
+
+    def test_repeats_below_three_are_rejected(self):
+        result = self.run_runner("--repeats", "2", "--no-idle-gate")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--repeats must be at least 3", result.stderr)
+
+    def test_parallel_run_requires_idle_gate_opt_out(self):
+        result = self.run_runner("-j", "2")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("requires --no-idle-gate", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- gate every outer measurement on an idle load window and fail closed with partial JSON evidence
- detect heterogeneous cpufreq topology and pin engine subprocesses to the maximum-frequency cluster
- run N>=3 repeats with median/range/instability reporting and retain every sample
- record host, load, topology, and protocol metadata in JSON
- cover load gating, affinity selection, aggregation, CLI behavior, and host fingerprints with Python tests

## Verification

- `uv run python -m unittest discover -s scripts -p "test_*.py" -v`
- `pre-commit run --files README.md scripts/benchmark_protocol.py scripts/run-jetstream.py scripts/test_benchmark_protocol.py docs/specs/2026-08-25-benchmark-measurement-protocol-design.md`
- `cargo fmt --check`
- `cargo clippy` and `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py`
- `uv run python scripts/run-test262.py` (99,568/99,568, 0 regressions)
- live `yes > /dev/null` burner refusal (BUSY, exit 2)
- real pinned JetStream `hash-map` smoke run (N=3, range and instability reported)

Closes #528