### PR TITLE
perf(regexp): cache converted exec subjects

### DIFF
--- a/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
+++ b/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
@@ -68,7 +68,9 @@ content rather than necessarily duplicating the full subject.
 
 The UTF-16-to-regex conversion will reserve capacity. Pure ASCII subjects take
 an exact-capacity byte conversion fast path, and the non-Unicode form aliases
-the Unicode form instead of performing another pass.
+the Unicode form instead of performing another pass. `RegexInput` also retains
+the ASCII classification so byte/UTF-16 offset conversion does not rediscover
+it by scanning the complete subject on every exec.
 
 Compiled-pattern cache key redesign and non-ASCII byte-offset maps are excluded
 from this slice. Pattern keys are normally small and do not account for the

--- a/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
+++ b/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
@@ -79,6 +79,19 @@ backend byte offsets through the retained UTF-16 subject without confusing a
 genuine U+F0000-U+F07FF scalar with the same scalar used as a lone-surrogate
 sentinel. ASCII subjects return offsets directly and never allocate the map.
 
+Both offset maps are *sampled* rather than dense: they retain one boundary every
+`BOUNDARY_SAMPLE_INTERVAL` (32) characters, and a lookup binary-searches the
+samples before walking at most one interval. A dense map is the one part of a
+cached subject whose size tracks the subject's length rather than the work asked
+of it, so a prefix-only match such as `/^é/u.test(s)` would otherwise retain a
+table several times the size of the subject that produced it — 16 bytes per
+character for the Unicode map and 8 per code unit for the non-Unicode one. The
+bounded walk keeps lookups O(1), so sampling costs no measurable time (a
+400k-character tokenizer scan is unchanged within noise) while cutting the
+retained tables by more than an order of magnitude: on a five-million-character
+non-ASCII subject, exercising both maps grows peak RSS by 15 MB rather than
+126 MB.
+
 ## Correctness and failure behavior
 
 The cache holds only immutable `JsString` storage, so there is no invalidation

--- a/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
+++ b/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
@@ -90,6 +90,15 @@ UTF-16 offsets, rather than backend byte offsets, are retained for Annex B
 contexts. This preserves lone surrogates and makes context materialization
 independent of which regex backend produced the match.
 
+Each lazy form is built from the retained UTF-16 code units, never derived from
+another form. The PUA encoding of lone surrogates is not injective: U+F0000 is a
+real assignable code point, so a genuine plane-15 scalar in U+F0000-U+F07FF is
+indistinguishable in the Unicode form from an encoded lone surrogate, and
+deriving the non-Unicode form from it silently loses one code unit of the
+subject. Aliasing is therefore confined to pure-ASCII subjects, where no
+surrogate encoding is in play. The residual divergences that the ambiguous
+encoding itself causes are tracked separately and are unchanged by this slice.
+
 ## Validation
 
 - Add unit coverage proving repeated use of the same `JsString` returns the

--- a/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
+++ b/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
@@ -1,0 +1,101 @@
+# RegExp subject conversion cache design
+
+## Context
+
+`RegExpBuiltinExec` operates on an ECMAScript String and reports match indices in
+UTF-16 code units. JSSE stores that String as an immutable `Arc<Vec<u16>>`, while
+its regex backends consume UTF-8, PUA-mapped UTF-8, or WTF-8. The current exec
+path rebuilds those representations from the full subject on every call, clones
+the complete UTF-16 vector, and eagerly copies the Annex B input and left/right
+contexts after every successful match. Repeated sticky or global exec calls on
+one large subject consequently do O(subject length) work for every token.
+
+A release-mode sticky scan confirms the scaling: 5,000, 10,000, and 20,000 ASCII
+tokens take approximately 0.12, 0.42, and 1.49 seconds respectively. Doubling
+the subject therefore costs 3.4-3.6 times as much, close to quadratic rather
+than linear growth.
+
+The specification's `RegExpBuiltinExec` algorithm treats the subject as an
+immutable String, uses its UTF-16 length and code-unit indices, and installs the
+original String as the result array's `input` property. This permits JSSE to
+retain the original `JsString` and cache backend-only representations without
+changing observable values.
+
+## Approaches considered
+
+1. Add a single-entry cache to the existing regexp-owned interpreter state,
+   keyed by the `Arc<Vec<u16>>` identity of the subject. Cache the backend input
+   forms and carry the original `JsString` through exec. This directly targets
+   tokenizer workloads, bounds retained memory to one subject, and does not
+   change the engine-wide string representation.
+2. Change `JsString` to wrap a new allocation containing UTF-16 plus lazy regex
+   representations. This would share conversions across interpreters and cache
+   churn, but it expands every string allocation and makes a regex optimization
+   part of the core value representation.
+3. Use a content-keyed LRU of converted subjects. This handles alternating
+   equal strings, but hashing or comparing a large subject on every lookup is
+   itself O(n), so it cannot remove the tokenizer scan's quadratic work.
+
+JSSE will use approach 1. String identity is an implementation cache key only;
+ECMAScript String equality remains value-based. A cache miss for a distinct but
+equal backing allocation is acceptable because avoiding that miss would require
+the full-subject operation this change removes.
+
+## Design
+
+Introduce a private `RegexInput` owned through `Rc`. It retains the original
+`JsString`, eagerly creates the normal Unicode regex string, and lazily creates
+the non-Unicode PUA form and WTF-8 byte form when a backend needs them. The
+single-entry cache retains the most recently used `RegexInput`; a cloned
+`JsValue` for the same String has the same backing `Arc` and returns the same
+`Rc` without traversing or copying its code units.
+
+Refactor the internal regexp execution seam to accept `RegexInput` rather than
+an independently allocated Rust `String` and `Vec<u16>`. The exec path selects
+the cached representation after re-reading flags, uses the original UTF-16
+length directly, and puts a clone of the original `JsString` in the match result.
+Custom `exec` calls likewise receive that original String. Existing regexp
+symbol methods use the same object, so they retain their current coercion order
+while sharing the conversion.
+
+On a successful match, store the original `JsString` and the match's UTF-16
+start/end in the Annex B state. `RegExp.input` returns the retained String;
+`leftContext` and `rightContext` copy only their requested UTF-16 ranges when
+their accessors run. Setting `RegExp.input` replaces only that property and does
+not disturb the context subject or offsets from the last match. Match text and
+capture statics remain eager because their size is bounded by match/capture
+content rather than necessarily duplicating the full subject.
+
+The UTF-16-to-regex conversion will reserve capacity. Pure ASCII subjects take
+an exact-capacity byte conversion fast path, and the non-Unicode form aliases
+the Unicode form instead of performing another pass.
+
+Compiled-pattern cache key redesign and non-ASCII byte-offset maps are excluded
+from this slice. Pattern keys are normally small and do not account for the
+full-subject O(n) passes. Offset mapping is a separate representation question
+that is unnecessary for the reported ASCII tokenizer workload.
+
+## Correctness and failure behavior
+
+The cache holds only immutable `JsString` storage, so there is no invalidation
+on JavaScript-visible mutation. Identity matching uses `Arc::ptr_eq` while the
+cached strong reference prevents allocator-address reuse. Conversion allocation
+failures have the same process-level out-of-memory behavior as the existing
+eager allocations. User-code coercion and `lastIndex` side effects still happen
+before matching in their existing order.
+
+UTF-16 offsets, rather than backend byte offsets, are retained for Annex B
+contexts. This preserves lone surrogates and makes context materialization
+independent of which regex backend produced the match.
+
+## Validation
+
+- Add unit coverage proving repeated use of the same `JsString` returns the
+  identical cached `RegexInput`, while a distinct backing allocation misses.
+- Add semantic coverage for lazy Annex B input/contexts, including an input
+  setter after a match and lone-surrogate slicing.
+- Re-run the release sticky-scan measurement and require a doubling ratio near
+  linear, with a large absolute improvement over the recorded baseline.
+- Run custom tests, the official built-in RegExp and Annex B RegExp test262
+  directories, formatting, clippy, release build/tests, and the full test262
+  suite without updating the feature-branch baseline.

--- a/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
+++ b/docs/specs/2026-08-25-regexp-subject-conversion-cache-design.md
@@ -72,10 +72,12 @@ the Unicode form instead of performing another pass. `RegexInput` also retains
 the ASCII classification so byte/UTF-16 offset conversion does not rediscover
 it by scanning the complete subject on every exec.
 
-Compiled-pattern cache key redesign and non-ASCII byte-offset maps are excluded
-from this slice. Pattern keys are normally small and do not account for the
-full-subject O(n) passes. Offset mapping is a separate representation question
-that is unnecessary for the reported ASCII tokenizer workload.
+Compiled-pattern cache key redesign is excluded from this slice. Pattern keys
+are normally small and do not account for the full-subject O(n) passes. A lazy
+non-ASCII Unicode boundary map is included for correctness: it translates
+backend byte offsets through the retained UTF-16 subject without confusing a
+genuine U+F0000-U+F07FF scalar with the same scalar used as a lone-surrogate
+sentinel. ASCII subjects return offsets directly and never allocate the map.
 
 ## Correctness and failure behavior
 
@@ -88,7 +90,9 @@ before matching in their existing order.
 
 UTF-16 offsets, rather than backend byte offsets, are retained for Annex B
 contexts. This preserves lone surrogates and makes context materialization
-independent of which regex backend produced the match.
+independent of which regex backend produced the match. Unicode-mode offsets are
+looked up in boundaries derived from the original UTF-16 subject, not inferred
+from the ambiguous converted Unicode form.
 
 Each lazy form is built from the retained UTF-16 code units, never derived from
 another form. The PUA encoding of lone surrogates is not injective: U+F0000 is a
@@ -104,7 +108,8 @@ encoding itself causes are tracked separately and are unchanged by this slice.
 - Add unit coverage proving repeated use of the same `JsString` returns the
   identical cached `RegexInput`, while a distinct backing allocation misses.
 - Add semantic coverage for lazy Annex B input/contexts, including an input
-  setter after a match and lone-surrogate slicing.
+  setter after a match, lone-surrogate slicing, and genuine supplementary PUA
+  scalars on both sides of a match.
 - Re-run the release sticky-scan measurement and require a doubling ratio near
   linear, with a large absolute improvement over the recorded baseline.
 - Run custom tests, the official built-in RegExp and Annex B RegExp test262

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -413,7 +413,11 @@ impl RegexInput {
             &self.unicode
         } else {
             self.non_unicode
-                .get_or_init(|| Rc::from(split_surrogates_for_non_unicode(&self.unicode)))
+                .get_or_init(|| {
+                    Rc::from(js_string_to_regex_input_non_unicode(
+                        &self.subject.code_units,
+                    ))
+                })
                 .as_ref()
         }
     }
@@ -7792,22 +7796,6 @@ fn get_substitution(
         }
     }
     Ok(result)
-}
-
-fn split_surrogates_for_non_unicode(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
-    for c in input.chars() {
-        if c as u32 >= 0x10000 && pua_to_surrogate(c).is_none() {
-            let cp = c as u32;
-            let hi = ((cp - 0x10000) >> 10) + 0xD800;
-            let lo = ((cp - 0x10000) & 0x3FF) + 0xDC00;
-            result.push(surrogate_to_pua(hi));
-            result.push(surrogate_to_pua(lo));
-        } else {
-            result.push(c);
-        }
-    }
-    result
 }
 
 fn resolve_named_group_matches<'a>(

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -55,22 +55,6 @@ fn encode_for_regexp_escape(c: char) -> String {
     }
 }
 
-/// Convert a byte offset in a UTF-8 string to a UTF-16 code unit offset
-fn byte_offset_to_utf16(s: &str, byte_offset: usize) -> usize {
-    if s.is_ascii() {
-        return byte_offset;
-    }
-    let mut utf16_offset = 0;
-    for c in s[..byte_offset].chars() {
-        if pua_to_surrogate(c).is_some() {
-            utf16_offset += 1;
-        } else {
-            utf16_offset += c.len_utf16();
-        }
-    }
-    utf16_offset
-}
-
 /// Convert a UTF-16 code unit offset to a byte offset in a UTF-8 string
 fn utf16_to_byte_offset(s: &str, utf16_offset: usize) -> usize {
     if s.is_ascii() {
@@ -387,7 +371,8 @@ struct RegexInput {
     ascii: bool,
     non_unicode: std::cell::OnceCell<Rc<str>>,
     unicode_boundaries: std::cell::OnceCell<Vec<RegexInputBoundary>>,
-    wtf8: std::cell::OnceCell<Rc<[u8]>>,
+    non_unicode_offsets: std::cell::OnceCell<Vec<usize>>,
+    wtf8: std::cell::OnceCell<Vec<u8>>,
 }
 
 #[derive(Clone, Copy)]
@@ -412,6 +397,7 @@ impl RegexInput {
             ascii,
             non_unicode,
             unicode_boundaries: std::cell::OnceCell::new(),
+            non_unicode_offsets: std::cell::OnceCell::new(),
             wtf8: std::cell::OnceCell::new(),
         }
     }
@@ -432,8 +418,7 @@ impl RegexInput {
 
     fn wtf8(&self) -> &[u8] {
         self.wtf8
-            .get_or_init(|| Rc::from(js_code_units_to_wtf8(&self.subject.code_units)))
-            .as_ref()
+            .get_or_init(|| js_code_units_to_wtf8(&self.subject.code_units))
     }
 
     fn unicode_boundaries(&self) -> &[RegexInputBoundary] {
@@ -487,31 +472,53 @@ impl RegexInput {
         }
     }
 
+    /// Byte offset of every UTF-16 code unit in the non-Unicode view, plus a
+    /// trailing total length. That view encodes each code unit as exactly one
+    /// character (a supplementary scalar arrives as a surrogate pair and
+    /// becomes two PUA characters), so a code-unit offset indexes this table
+    /// directly instead of rescanning the subject on every exec.
+    fn non_unicode_offsets(&self) -> &[usize] {
+        self.non_unicode_offsets.get_or_init(|| {
+            let view = self.as_str(false);
+            let mut offsets = Vec::with_capacity(self.subject.len() + 1);
+            offsets.extend(view.char_indices().map(|(byte, _)| byte));
+            offsets.push(view.len());
+            offsets
+        })
+    }
+
     /// `unicode_view` identifies the surrogate-ambiguous representation. Its
     /// offsets use boundaries derived from the original UTF-16 subject, while
-    /// the direct non-Unicode form can use PUA-aware counting safely.
-    fn utf16_to_byte_offset(&self, input: &str, unicode_view: bool, offset: usize) -> usize {
+    /// the direct non-Unicode form indexes its own one-char-per-code-unit table.
+    fn utf16_to_byte_offset(&self, unicode_view: bool, offset: usize) -> usize {
         if self.ascii {
-            offset.min(input.len())
+            offset.min(self.unicode.len())
         } else if unicode_view {
             self.unicode_utf16_to_byte_offset(offset)
         } else {
-            utf16_to_byte_offset(input, offset)
+            let offsets = self.non_unicode_offsets();
+            offsets[offset.min(offsets.len() - 1)]
         }
     }
 
-    fn byte_offset_to_utf16(&self, input: &str, unicode_view: bool, offset: usize) -> usize {
+    fn byte_offset_to_utf16(&self, unicode_view: bool, offset: usize) -> usize {
         if self.ascii {
             offset
         } else if unicode_view {
             self.unicode_byte_offset_to_utf16(offset)
         } else {
-            byte_offset_to_utf16(input, offset)
+            let offsets = self.non_unicode_offsets();
+            match offsets.binary_search(&offset) {
+                Ok(index) => index,
+                // A byte offset inside a character refers to the code unit that
+                // character starts at.
+                Err(index) => index.saturating_sub(1),
+            }
         }
     }
 }
 
-fn to_regex_input_with_units(
+fn regex_input_for_value(
     interp: &mut Interpreter,
     val: &JsValue,
 ) -> Result<Rc<RegexInput>, JsValue> {
@@ -7981,7 +7988,7 @@ fn regexp_exec_raw(
     let last_index_byte = if is_bytes_mode {
         utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
     } else {
-        regex_input.utf16_to_byte_offset(input, unicode, last_index_utf16)
+        regex_input.utf16_to_byte_offset(unicode, last_index_utf16)
     };
 
     let mut caps = if is_bytes_mode {
@@ -8026,12 +8033,12 @@ fn regexp_exec_raw(
     let match_start_utf16 = if is_bytes_mode {
         wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
     } else {
-        regex_input.byte_offset_to_utf16(input, unicode, full_match.start)
+        regex_input.byte_offset_to_utf16(unicode, full_match.start)
     };
     let match_end_utf16 = if is_bytes_mode {
         wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
     } else {
-        regex_input.byte_offset_to_utf16(input, unicode, full_match.end)
+        regex_input.byte_offset_to_utf16(unicode, full_match.end)
     };
 
     if sticky && full_match.start != last_index_byte {
@@ -8125,7 +8132,7 @@ fn regexp_exec_raw(
                 if is_bytes_mode {
                     wtf8_byte_offset_to_utf16(wtf8_bytes, offset)
                 } else {
-                    regex_input.byte_offset_to_utf16(input, unicode, offset)
+                    regex_input.byte_offset_to_utf16(unicode, offset)
                 }
             };
             let mut index_pairs: Vec<JsValue> = Vec::new();
@@ -8218,7 +8225,7 @@ impl Interpreter {
                     ));
                 }
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let input = match to_regex_input_with_units(interp, &arg) {
+                let input = match regex_input_for_value(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -8249,7 +8256,7 @@ impl Interpreter {
                     }
                 };
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let input = match to_regex_input_with_units(interp, &arg) {
+                let input = match regex_input_for_value(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -8477,7 +8484,7 @@ impl Interpreter {
                     }
                 };
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let regex_input = match to_regex_input_with_units(interp, &arg) {
+                let regex_input = match regex_input_for_value(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -8557,7 +8564,7 @@ impl Interpreter {
                         let last_index_byte = if is_bytes_mode {
                             utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
                         } else {
-                            regex_input.utf16_to_byte_offset(input, unicode, last_index_utf16)
+                            regex_input.utf16_to_byte_offset(unicode, last_index_utf16)
                         };
                         let caps = if is_bytes_mode {
                             if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
@@ -8579,7 +8586,7 @@ impl Interpreter {
                         let match_end_utf16 = if is_bytes_mode {
                             wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
                         } else {
-                            regex_input.byte_offset_to_utf16(input, unicode, full_match.end)
+                            regex_input.byte_offset_to_utf16(unicode, full_match.end)
                         };
 
                         results.push(JsValue::string(regex_output_to_js_string(match_text)));
@@ -8588,7 +8595,7 @@ impl Interpreter {
                             let match_start_utf16 = if is_bytes_mode {
                                 wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
                             } else {
-                                regex_input.byte_offset_to_utf16(input, unicode, full_match.start)
+                                regex_input.byte_offset_to_utf16(unicode, full_match.start)
                             };
                             // AdvanceStringIndex per spec operates on the original S, not the
                             // possibly-preprocessed `input` — full_unicode must be able to detect
@@ -8692,7 +8699,7 @@ impl Interpreter {
                     }
                 };
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let regex_input = match to_regex_input_with_units(interp, &arg) {
+                let regex_input = match regex_input_for_value(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -8776,7 +8783,7 @@ impl Interpreter {
 
                 // 3. Let S be ? ToString(string).
                 let string_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let regex_input = match to_regex_input_with_units(interp, &string_arg) {
+                let regex_input = match regex_input_for_value(interp, &string_arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -8886,7 +8893,7 @@ impl Interpreter {
                         let last_index_byte = if is_bytes_mode {
                             utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
                         } else {
-                            regex_input.utf16_to_byte_offset(input, unicode, last_index_utf16)
+                            regex_input.utf16_to_byte_offset(unicode, last_index_utf16)
                         };
                         let mut caps = if is_bytes_mode {
                             if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
@@ -8918,18 +8925,18 @@ impl Interpreter {
                         let match_start_utf16 = if is_bytes_mode {
                             wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
                         } else {
-                            regex_input.byte_offset_to_utf16(input, unicode, full_match.start)
+                            regex_input.byte_offset_to_utf16(unicode, full_match.start)
                         };
                         let match_end_utf16 = if is_bytes_mode {
                             wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
                         } else {
-                            regex_input.byte_offset_to_utf16(input, unicode, full_match.end)
+                            regex_input.byte_offset_to_utf16(unicode, full_match.end)
                         };
                         let match_length_utf16 =
                             regex_output_to_js_string(matched).code_units.len();
                         let position_utf16 = match_start_utf16;
                         let position = regex_input
-                            .utf16_to_byte_offset(s_slice, false, position_utf16)
+                            .utf16_to_byte_offset(false, position_utf16)
                             .min(length_s);
 
                         // Build captures as JsValues for get_substitution
@@ -9011,7 +9018,6 @@ impl Interpreter {
                             JsValue::UNDEFINED
                         };
                         let tail_pos = regex_input.utf16_to_byte_offset(
-                            s_slice,
                             false,
                             (position_utf16 + match_length_utf16).min(s_utf16_len),
                         );
@@ -9221,7 +9227,7 @@ impl Interpreter {
                         (
                             utf16_pos,
                             regex_input
-                                .utf16_to_byte_offset(s_slice, false, utf16_pos)
+                                .utf16_to_byte_offset(false, utf16_pos)
                                 .min(length_s),
                         )
                     };
@@ -9269,9 +9275,10 @@ impl Interpreter {
                         for cap in &captures {
                             replacer_args.push(cap.clone());
                         }
-                        // Pass UTF-16 position and the primitive string S (non-PUA)
+                        // Pass UTF-16 position and the primitive string S itself,
+                        // rather than re-decoding the PUA view once per match.
                         replacer_args.push(JsValue::number(position_utf16 as f64));
-                        replacer_args.push(JsValue::string(regex_output_to_js_string(s_slice)));
+                        replacer_args.push(JsValue::string(regex_input.subject.clone()));
                         if !named_captures.is_undefined() {
                             replacer_args.push(named_captures.clone());
                         }
@@ -9310,7 +9317,6 @@ impl Interpreter {
                             JsValue::UNDEFINED
                         };
                         let tail_pos = regex_input.utf16_to_byte_offset(
-                            s_slice,
                             false,
                             (position_utf16 + match_length_utf16).min(s_utf16_len),
                         );
@@ -9334,7 +9340,6 @@ impl Interpreter {
 
                     // p. If position >= nextSourcePosition, then
                     let tail_pos_final = regex_input.utf16_to_byte_offset(
-                        s_slice,
                         false,
                         (position_utf16 + match_length_utf16).min(s_utf16_len),
                     );
@@ -9378,7 +9383,7 @@ impl Interpreter {
                 };
                 // 2. Let S be ? ToString(string).
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let regex_input = match to_regex_input_with_units(interp, &arg) {
+                let regex_input = match regex_input_for_value(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -9533,8 +9538,8 @@ impl Interpreter {
 
                     //   iii. Else,
                     // Push substring from p to q (convert UTF-16 positions to byte offsets)
-                    let p_byte = regex_input.utf16_to_byte_offset(s, true, p);
-                    let q_byte = regex_input.utf16_to_byte_offset(s, true, q);
+                    let p_byte = regex_input.utf16_to_byte_offset(true, p);
+                    let q_byte = regex_input.utf16_to_byte_offset(true, q);
                     let t = &s[p_byte..q_byte];
                     a.push(JsValue::string(regex_output_to_js_string(t)));
                     length_a += 1;
@@ -9589,7 +9594,7 @@ impl Interpreter {
                 }
 
                 // 16. Push remaining substring
-                let p_byte = regex_input.utf16_to_byte_offset(s, true, p);
+                let p_byte = regex_input.utf16_to_byte_offset(true, p);
                 let t = &s[p_byte..];
                 a.push(JsValue::string(regex_output_to_js_string(t)));
                 Completion::Normal(interp.create_array(a))
@@ -9617,7 +9622,7 @@ impl Interpreter {
                 };
                 // 2. Let S be ? ToString(string).
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let regex_input = match to_regex_input_with_units(interp, &arg) {
+                let regex_input = match regex_input_for_value(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -9824,7 +9829,7 @@ impl Interpreter {
                 }
 
                 let input_value = JsValue::string(string.clone());
-                let regex_input = match to_regex_input_with_units(interp, &input_value) {
+                let regex_input = match regex_input_for_value(interp, &input_value) {
                     Ok(input) => input,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -10754,19 +10759,19 @@ mod nullable_quantifier_rewrite_tests {
 
 #[cfg(test)]
 mod regex_input_cache_tests {
-    use super::{Interpreter, JsString, JsValue, Rc, RegexInput, to_regex_input_with_units};
+    use super::{Interpreter, JsString, JsValue, Rc, RegexInput, regex_input_for_value};
 
     #[test]
     fn reuses_conversion_for_the_same_js_string_identity() {
         let mut interp = Interpreter::new();
         let subject = JsValue::string(JsString::from_str(&"a".repeat(1024)));
 
-        let first = to_regex_input_with_units(&mut interp, &subject).unwrap();
-        let second = to_regex_input_with_units(&mut interp, &subject.clone()).unwrap();
+        let first = regex_input_for_value(&mut interp, &subject).unwrap();
+        let second = regex_input_for_value(&mut interp, &subject.clone()).unwrap();
         assert!(Rc::ptr_eq(&first, &second));
 
         let equal_but_distinct = JsValue::string(JsString::from_str(&"a".repeat(1024)));
-        let third = to_regex_input_with_units(&mut interp, &equal_but_distinct).unwrap();
+        let third = regex_input_for_value(&mut interp, &equal_but_distinct).unwrap();
         assert!(!Rc::ptr_eq(&first, &third));
     }
 
@@ -10775,11 +10780,11 @@ mod regex_input_cache_tests {
         let input = RegexInput::new(JsString::from_vec(vec![0xDB80, 0xDC00, b'x' as u16]));
         let unicode = input.as_str(true);
 
-        assert_eq!(input.utf16_to_byte_offset(unicode, true, 0), 0);
-        assert_eq!(input.utf16_to_byte_offset(unicode, true, 1), 0);
-        assert_eq!(input.utf16_to_byte_offset(unicode, true, 2), 4);
-        assert_eq!(input.byte_offset_to_utf16(unicode, true, 4), 2);
-        assert_eq!(input.byte_offset_to_utf16(unicode, true, 5), 3);
+        assert_eq!(input.utf16_to_byte_offset(true, 0), 0);
+        assert_eq!(input.utf16_to_byte_offset(true, 1), 0);
+        assert_eq!(input.utf16_to_byte_offset(true, 2), 4);
+        assert_eq!(input.byte_offset_to_utf16(true, 4), 2);
+        assert_eq!(input.byte_offset_to_utf16(true, 5), 3);
 
         let mixed = RegexInput::new(JsString::from_vec(vec![
             0xD800,
@@ -10788,9 +10793,9 @@ mod regex_input_cache_tests {
             b'x' as u16,
         ]));
         let unicode = mixed.as_str(true);
-        assert_eq!(mixed.utf16_to_byte_offset(unicode, true, 2), 4);
-        assert_eq!(mixed.utf16_to_byte_offset(unicode, true, 3), 8);
-        assert_eq!(mixed.byte_offset_to_utf16(unicode, true, 8), 3);
-        assert_eq!(mixed.byte_offset_to_utf16(unicode, true, 9), 4);
+        assert_eq!(mixed.utf16_to_byte_offset(true, 2), 4);
+        assert_eq!(mixed.utf16_to_byte_offset(true, 3), 8);
+        assert_eq!(mixed.byte_offset_to_utf16(true, 8), 3);
+        assert_eq!(mixed.byte_offset_to_utf16(true, 9), 4);
     }
 }

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -376,6 +376,31 @@ impl RegexView {
     }
 }
 
+/// How many characters lie between two sampled offset boundaries.
+///
+/// The offset tables are the one part of a cached subject that is proportional
+/// to its length rather than to the work asked of it, so they are sampled: a
+/// lookup binary-searches the samples and then walks at most one interval. 32
+/// keeps that walk far cheaper than the binary search it replaces while cutting
+/// the retained table to a thirty-second of a full one — enough that the tables
+/// no longer dominate the cached subject's footprint.
+const BOUNDARY_SAMPLE_INTERVAL: usize = 32;
+
+/// UTF-16 width, in code units, of the character starting at `index`.
+///
+/// A high surrogate immediately followed by a low surrogate is one two-unit
+/// character; anything else, including an unpaired surrogate, is one unit.
+fn utf16_char_width(code_units: &[u16], index: usize) -> usize {
+    if (0xD800..=0xDBFF).contains(&code_units[index])
+        && index + 1 < code_units.len()
+        && (0xDC00..=0xDFFF).contains(&code_units[index + 1])
+    {
+        2
+    } else {
+        1
+    }
+}
+
 #[derive(Clone, Copy)]
 struct RegexInputBoundary {
     byte: usize,
@@ -416,37 +441,42 @@ impl RegexInput {
             .get_or_init(|| js_code_units_to_wtf8(&self.subject.code_units))
     }
 
+    /// Sampled boundaries: one entry per [`BOUNDARY_SAMPLE_INTERVAL`]
+    /// characters, always including the first and last. A lookup binary-searches
+    /// the samples and then walks at most `BOUNDARY_SAMPLE_INTERVAL - 1`
+    /// characters, so it stays O(1) while the table costs a fraction of an entry
+    /// per character rather than a whole one — a prefix-only match on a
+    /// multi-megabyte subject no longer retains a table larger than the subject.
     fn unicode_boundaries(&self) -> &[RegexInputBoundary] {
         self.unicode_boundaries.get_or_init(|| {
             let view = self.as_str(true);
             let code_units = &self.subject.code_units;
-            let mut boundaries = Vec::with_capacity(code_units.len() + 1);
+            let mut boundaries =
+                Vec::with_capacity(code_units.len() / BOUNDARY_SAMPLE_INTERVAL + 2);
             let mut byte = 0;
             let mut utf16 = 0;
+            let mut chars = 0usize;
             boundaries.push(RegexInputBoundary { byte, utf16 });
 
             while utf16 < code_units.len() {
-                let code_unit_count = if (0xD800..=0xDBFF).contains(&code_units[utf16])
-                    && utf16 + 1 < code_units.len()
-                    && (0xDC00..=0xDFFF).contains(&code_units[utf16 + 1])
-                {
-                    2
-                } else {
-                    1
-                };
                 let encoded = view[byte..]
                     .chars()
                     .next()
                     .expect("each UTF-16 character must have a regex input character");
                 byte += encoded.len_utf8();
-                utf16 += code_unit_count;
-                boundaries.push(RegexInputBoundary { byte, utf16 });
+                utf16 += utf16_char_width(code_units, utf16);
+                chars += 1;
+                if chars.is_multiple_of(BOUNDARY_SAMPLE_INTERVAL) {
+                    boundaries.push(RegexInputBoundary { byte, utf16 });
+                }
             }
 
             debug_assert_eq!(byte, view.len());
-            // One entry per character, not per code unit, so a surrogate-heavy
-            // subject leaves up to half the reservation unused for the life of
-            // the cache.
+            // The end of the subject must always be addressable, even when the
+            // character count is not a multiple of the sample interval.
+            if !chars.is_multiple_of(BOUNDARY_SAMPLE_INTERVAL) {
+                boundaries.push(RegexInputBoundary { byte, utf16 });
+            }
             boundaries.shrink_to_fit();
             boundaries
         })
@@ -455,36 +485,130 @@ impl RegexInput {
     fn unicode_utf16_to_byte_offset(&self, offset: usize) -> usize {
         let target = offset.min(self.subject.len());
         let boundaries = self.unicode_boundaries();
-        match boundaries.binary_search_by_key(&target, |boundary| boundary.utf16) {
-            Ok(index) => boundaries[index].byte,
-            // A UTF-16 index within a surrogate pair refers to the character
-            // that starts at the preceding code-unit boundary.
-            Err(index) => boundaries[index.saturating_sub(1)].byte,
+        let start = match boundaries.binary_search_by_key(&target, |boundary| boundary.utf16) {
+            Ok(index) => return boundaries[index].byte,
+            Err(index) => boundaries[index.saturating_sub(1)],
+        };
+
+        // Walk the sampled span. A UTF-16 index within a surrogate pair refers
+        // to the character that starts at the preceding code-unit boundary, so
+        // stop at the last character beginning at or before `target`.
+        let view = self.as_str(true);
+        let code_units = &self.subject.code_units;
+        let mut byte = start.byte;
+        let mut utf16 = start.utf16;
+        while utf16 < target {
+            let width = utf16_char_width(code_units, utf16);
+            if utf16 + width > target {
+                break;
+            }
+            byte += view[byte..]
+                .chars()
+                .next()
+                .expect("each UTF-16 character must have a regex input character")
+                .len_utf8();
+            utf16 += width;
         }
+        byte
     }
 
     fn unicode_byte_offset_to_utf16(&self, offset: usize) -> usize {
-        let target = offset.min(self.as_str(true).len());
+        let view = self.as_str(true);
+        let target = offset.min(view.len());
         let boundaries = self.unicode_boundaries();
-        match boundaries.binary_search_by_key(&target, |boundary| boundary.byte) {
-            Ok(index) => boundaries[index].utf16,
-            Err(index) => boundaries[index.saturating_sub(1)].utf16,
+        let start = match boundaries.binary_search_by_key(&target, |boundary| boundary.byte) {
+            Ok(index) => return boundaries[index].utf16,
+            Err(index) => boundaries[index.saturating_sub(1)],
+        };
+
+        let code_units = &self.subject.code_units;
+        let mut byte = start.byte;
+        let mut utf16 = start.utf16;
+        while byte < target {
+            let encoded = view[byte..]
+                .chars()
+                .next()
+                .expect("each UTF-16 character must have a regex input character");
+            if byte + encoded.len_utf8() > target {
+                break;
+            }
+            byte += encoded.len_utf8();
+            utf16 += utf16_char_width(code_units, utf16);
         }
+        utf16
     }
 
-    /// Byte offset of every UTF-16 code unit in the non-Unicode view, plus a
-    /// trailing total length. That view encodes each code unit as exactly one
-    /// character (a supplementary scalar arrives as a surrogate pair and
-    /// becomes two PUA characters), so a code-unit offset indexes this table
-    /// directly instead of rescanning the subject on every exec.
+    /// Byte offset of every [`BOUNDARY_SAMPLE_INTERVAL`]-th UTF-16 code unit in
+    /// the non-Unicode view, plus a trailing total length. That view encodes
+    /// each code unit as exactly one character (a supplementary scalar arrives
+    /// as a surrogate pair and becomes two PUA characters), so a code-unit
+    /// offset divides straight into a sample and then walks at most one
+    /// interval — no rescanning the subject on every exec, and no entry
+    /// retained per code unit.
     fn non_unicode_offsets(&self) -> &[usize] {
         self.non_unicode_offsets.get_or_init(|| {
             let view = self.as_str(false);
-            let mut offsets = Vec::with_capacity(self.subject.len() + 1);
-            offsets.extend(view.char_indices().map(|(byte, _)| byte));
+            let mut offsets = Vec::with_capacity(self.subject.len() / BOUNDARY_SAMPLE_INTERVAL + 2);
+            offsets.extend(
+                view.char_indices()
+                    .step_by(BOUNDARY_SAMPLE_INTERVAL)
+                    .map(|(byte, _)| byte),
+            );
+            // One past the final code unit, so the end of the subject is
+            // addressable whatever the code-unit count is modulo the interval.
             offsets.push(view.len());
+            offsets.shrink_to_fit();
             offsets
         })
+    }
+
+    fn non_unicode_utf16_to_byte_offset(&self, offset: usize) -> usize {
+        let view = self.as_str(false);
+        let target = offset.min(self.subject.len());
+        if target == self.subject.len() {
+            return view.len();
+        }
+        let offsets = self.non_unicode_offsets();
+        let sample = target / BOUNDARY_SAMPLE_INTERVAL;
+        let mut byte = offsets[sample];
+        let mut unit = sample * BOUNDARY_SAMPLE_INTERVAL;
+        while unit < target {
+            byte += view[byte..]
+                .chars()
+                .next()
+                .expect("each code unit must have a non-Unicode view character")
+                .len_utf8();
+            unit += 1;
+        }
+        byte
+    }
+
+    fn non_unicode_byte_offset_to_utf16(&self, offset: usize) -> usize {
+        let view = self.as_str(false);
+        let target = offset.min(view.len());
+        let offsets = self.non_unicode_offsets();
+        let sample = match offsets.binary_search(&target) {
+            // The final entry is the total length, one past the last code unit.
+            Ok(index) if index + 1 == offsets.len() => return self.subject.len(),
+            Ok(index) => return index * BOUNDARY_SAMPLE_INTERVAL,
+            Err(index) => index.saturating_sub(1),
+        };
+        let mut byte = offsets[sample];
+        let mut unit = sample * BOUNDARY_SAMPLE_INTERVAL;
+        while byte < target {
+            let encoded = view[byte..]
+                .chars()
+                .next()
+                .expect("each code unit must have a non-Unicode view character");
+            // A byte offset inside a character refers to the code unit that
+            // character starts at.
+            if byte + encoded.len_utf8() > target {
+                break;
+            }
+            byte += encoded.len_utf8();
+            unit += 1;
+        }
+        unit
     }
 
     /// Map a UTF-16 code-unit offset to a byte offset within `view`.
@@ -504,10 +628,7 @@ impl RegexInput {
             RegexView::Wtf8 => utf16_to_wtf8_byte_offset(self.wtf8(), offset),
             _ if self.ascii => offset.min(self.subject.len()),
             RegexView::Unicode => self.unicode_utf16_to_byte_offset(offset),
-            RegexView::NonUnicode => {
-                let offsets = self.non_unicode_offsets();
-                offsets[offset.min(offsets.len() - 1)]
-            }
+            RegexView::NonUnicode => self.non_unicode_utf16_to_byte_offset(offset),
         }
     }
 
@@ -520,15 +641,7 @@ impl RegexInput {
             RegexView::Wtf8 => wtf8_byte_offset_to_utf16(self.wtf8(), offset),
             _ if self.ascii => offset,
             RegexView::Unicode => self.unicode_byte_offset_to_utf16(offset),
-            RegexView::NonUnicode => {
-                let offsets = self.non_unicode_offsets();
-                match offsets.binary_search(&offset) {
-                    Ok(index) => index,
-                    // A byte offset inside a character refers to the code unit
-                    // that character starts at.
-                    Err(index) => index.saturating_sub(1),
-                }
-            }
+            RegexView::NonUnicode => self.non_unicode_byte_offset_to_utf16(offset),
         }
     }
 }

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -71,25 +71,6 @@ fn byte_offset_to_utf16(s: &str, byte_offset: usize) -> usize {
     utf16_offset
 }
 
-/// Byte offset to UTF-16 offset, counting every char by its real UTF-16 length.
-/// Correct for a Unicode-mode view whose subject holds no lone surrogate, where
-/// a char in the PUA sentinel range is a genuine supplementary scalar.
-fn byte_offset_to_utf16_scalar(s: &str, byte_offset: usize) -> usize {
-    s[..byte_offset].chars().map(char::len_utf16).sum()
-}
-
-/// The inverse of `byte_offset_to_utf16_scalar`.
-fn utf16_to_byte_offset_scalar(s: &str, utf16_offset: usize) -> usize {
-    let mut utf16_count = 0;
-    for (byte_idx, c) in s.char_indices() {
-        if utf16_count >= utf16_offset {
-            return byte_idx;
-        }
-        utf16_count += c.len_utf16();
-    }
-    s.len()
-}
-
 /// Convert a UTF-16 code unit offset to a byte offset in a UTF-8 string
 fn utf16_to_byte_offset(s: &str, utf16_offset: usize) -> usize {
     if s.is_ascii() {
@@ -115,28 +96,6 @@ fn utf16_to_byte_offset(s: &str, utf16_offset: usize) -> usize {
 const SURROGATE_START: u32 = 0xD800;
 const SURROGATE_END: u32 = 0xDFFF;
 const SURROGATE_PUA_BASE: u32 = 0xF0000;
-
-/// True when `code_units` holds a surrogate that Unicode-mode conversion maps to
-/// a PUA sentinel rather than combining into a supplementary scalar. Mirrors the
-/// pairing rule in `js_string_to_regex_input_mode`.
-fn subject_has_lone_surrogate(code_units: &[u16]) -> bool {
-    let mut i = 0;
-    while i < code_units.len() {
-        let cu = code_units[i];
-        if (0xD800..=0xDBFF).contains(&cu) {
-            if i + 1 < code_units.len() && (0xDC00..=0xDFFF).contains(&code_units[i + 1]) {
-                i += 2;
-                continue;
-            }
-            return true;
-        }
-        if (0xDC00..=0xDFFF).contains(&cu) {
-            return true;
-        }
-        i += 1;
-    }
-    false
-}
 
 fn pua_aware_utf16_len(s: &str) -> usize {
     s.chars()
@@ -426,9 +385,15 @@ struct RegexInput {
     subject: JsString,
     unicode: Rc<str>,
     ascii: bool,
-    lone_surrogate: bool,
     non_unicode: std::cell::OnceCell<Rc<str>>,
+    unicode_boundaries: std::cell::OnceCell<Vec<RegexInputBoundary>>,
     wtf8: std::cell::OnceCell<Rc<[u8]>>,
+}
+
+#[derive(Clone, Copy)]
+struct RegexInputBoundary {
+    byte: usize,
+    utf16: usize,
 }
 
 impl RegexInput {
@@ -441,13 +406,12 @@ impl RegexInput {
                 .set(Rc::clone(&unicode))
                 .expect("new OnceCell must be empty");
         }
-        let lone_surrogate = !ascii && subject_has_lone_surrogate(&subject.code_units);
         Self {
             subject,
             unicode,
             ascii,
-            lone_surrogate,
             non_unicode,
+            unicode_boundaries: std::cell::OnceCell::new(),
             wtf8: std::cell::OnceCell::new(),
         }
     }
@@ -472,17 +436,65 @@ impl RegexInput {
             .as_ref()
     }
 
-    /// `unicode_view` says which representation `input` is, because the PUA
-    /// sentinel range is only ambiguous in the Unicode one. The non-Unicode view
-    /// maps every surrogate code unit to its own sentinel char, so PUA-aware
-    /// counting is always right there. In the Unicode view a valid surrogate
-    /// pair becomes one char, so a PUA-range char is a genuine two-code-unit
-    /// scalar unless the subject also holds a lone surrogate.
+    fn unicode_boundaries(&self) -> &[RegexInputBoundary] {
+        self.unicode_boundaries.get_or_init(|| {
+            let code_units = &self.subject.code_units;
+            let mut boundaries = Vec::with_capacity(code_units.len() + 1);
+            let mut byte = 0;
+            let mut utf16 = 0;
+            boundaries.push(RegexInputBoundary { byte, utf16 });
+
+            while utf16 < code_units.len() {
+                let code_unit_count = if (0xD800..=0xDBFF).contains(&code_units[utf16])
+                    && utf16 + 1 < code_units.len()
+                    && (0xDC00..=0xDFFF).contains(&code_units[utf16 + 1])
+                {
+                    2
+                } else {
+                    1
+                };
+                let encoded = self.unicode[byte..]
+                    .chars()
+                    .next()
+                    .expect("each UTF-16 character must have a regex input character");
+                byte += encoded.len_utf8();
+                utf16 += code_unit_count;
+                boundaries.push(RegexInputBoundary { byte, utf16 });
+            }
+
+            debug_assert_eq!(byte, self.unicode.len());
+            boundaries
+        })
+    }
+
+    fn unicode_utf16_to_byte_offset(&self, offset: usize) -> usize {
+        let target = offset.min(self.subject.len());
+        let boundaries = self.unicode_boundaries();
+        match boundaries.binary_search_by_key(&target, |boundary| boundary.utf16) {
+            Ok(index) => boundaries[index].byte,
+            // A UTF-16 index within a surrogate pair refers to the character
+            // that starts at the preceding code-unit boundary.
+            Err(index) => boundaries[index.saturating_sub(1)].byte,
+        }
+    }
+
+    fn unicode_byte_offset_to_utf16(&self, offset: usize) -> usize {
+        let target = offset.min(self.unicode.len());
+        let boundaries = self.unicode_boundaries();
+        match boundaries.binary_search_by_key(&target, |boundary| boundary.byte) {
+            Ok(index) => boundaries[index].utf16,
+            Err(index) => boundaries[index.saturating_sub(1)].utf16,
+        }
+    }
+
+    /// `unicode_view` identifies the surrogate-ambiguous representation. Its
+    /// offsets use boundaries derived from the original UTF-16 subject, while
+    /// the direct non-Unicode form can use PUA-aware counting safely.
     fn utf16_to_byte_offset(&self, input: &str, unicode_view: bool, offset: usize) -> usize {
         if self.ascii {
             offset.min(input.len())
-        } else if unicode_view && !self.lone_surrogate {
-            utf16_to_byte_offset_scalar(input, offset)
+        } else if unicode_view {
+            self.unicode_utf16_to_byte_offset(offset)
         } else {
             utf16_to_byte_offset(input, offset)
         }
@@ -491,8 +503,8 @@ impl RegexInput {
     fn byte_offset_to_utf16(&self, input: &str, unicode_view: bool, offset: usize) -> usize {
         if self.ascii {
             offset
-        } else if unicode_view && !self.lone_surrogate {
-            byte_offset_to_utf16_scalar(input, offset)
+        } else if unicode_view {
+            self.unicode_byte_offset_to_utf16(offset)
         } else {
             byte_offset_to_utf16(input, offset)
         }
@@ -10742,7 +10754,7 @@ mod nullable_quantifier_rewrite_tests {
 
 #[cfg(test)]
 mod regex_input_cache_tests {
-    use super::{Interpreter, JsString, JsValue, Rc, to_regex_input_with_units};
+    use super::{Interpreter, JsString, JsValue, Rc, RegexInput, to_regex_input_with_units};
 
     #[test]
     fn reuses_conversion_for_the_same_js_string_identity() {
@@ -10756,5 +10768,29 @@ mod regex_input_cache_tests {
         let equal_but_distinct = JsValue::string(JsString::from_str(&"a".repeat(1024)));
         let third = to_regex_input_with_units(&mut interp, &equal_but_distinct).unwrap();
         assert!(!Rc::ptr_eq(&first, &third));
+    }
+
+    #[test]
+    fn maps_unicode_offsets_from_the_original_utf16_subject() {
+        let input = RegexInput::new(JsString::from_vec(vec![0xDB80, 0xDC00, b'x' as u16]));
+        let unicode = input.as_str(true);
+
+        assert_eq!(input.utf16_to_byte_offset(unicode, true, 0), 0);
+        assert_eq!(input.utf16_to_byte_offset(unicode, true, 1), 0);
+        assert_eq!(input.utf16_to_byte_offset(unicode, true, 2), 4);
+        assert_eq!(input.byte_offset_to_utf16(unicode, true, 4), 2);
+        assert_eq!(input.byte_offset_to_utf16(unicode, true, 5), 3);
+
+        let mixed = RegexInput::new(JsString::from_vec(vec![
+            0xD800,
+            0xDB80,
+            0xDC00,
+            b'x' as u16,
+        ]));
+        let unicode = mixed.as_str(true);
+        assert_eq!(mixed.utf16_to_byte_offset(unicode, true, 2), 4);
+        assert_eq!(mixed.utf16_to_byte_offset(unicode, true, 3), 8);
+        assert_eq!(mixed.byte_offset_to_utf16(unicode, true, 8), 3);
+        assert_eq!(mixed.byte_offset_to_utf16(unicode, true, 9), 4);
     }
 }

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -71,6 +71,25 @@ fn byte_offset_to_utf16(s: &str, byte_offset: usize) -> usize {
     utf16_offset
 }
 
+/// Byte offset to UTF-16 offset, counting every char by its real UTF-16 length.
+/// Correct for a Unicode-mode view whose subject holds no lone surrogate, where
+/// a char in the PUA sentinel range is a genuine supplementary scalar.
+fn byte_offset_to_utf16_scalar(s: &str, byte_offset: usize) -> usize {
+    s[..byte_offset].chars().map(char::len_utf16).sum()
+}
+
+/// The inverse of `byte_offset_to_utf16_scalar`.
+fn utf16_to_byte_offset_scalar(s: &str, utf16_offset: usize) -> usize {
+    let mut utf16_count = 0;
+    for (byte_idx, c) in s.char_indices() {
+        if utf16_count >= utf16_offset {
+            return byte_idx;
+        }
+        utf16_count += c.len_utf16();
+    }
+    s.len()
+}
+
 /// Convert a UTF-16 code unit offset to a byte offset in a UTF-8 string
 fn utf16_to_byte_offset(s: &str, utf16_offset: usize) -> usize {
     if s.is_ascii() {
@@ -96,6 +115,28 @@ fn utf16_to_byte_offset(s: &str, utf16_offset: usize) -> usize {
 const SURROGATE_START: u32 = 0xD800;
 const SURROGATE_END: u32 = 0xDFFF;
 const SURROGATE_PUA_BASE: u32 = 0xF0000;
+
+/// True when `code_units` holds a surrogate that Unicode-mode conversion maps to
+/// a PUA sentinel rather than combining into a supplementary scalar. Mirrors the
+/// pairing rule in `js_string_to_regex_input_mode`.
+fn subject_has_lone_surrogate(code_units: &[u16]) -> bool {
+    let mut i = 0;
+    while i < code_units.len() {
+        let cu = code_units[i];
+        if (0xD800..=0xDBFF).contains(&cu) {
+            if i + 1 < code_units.len() && (0xDC00..=0xDFFF).contains(&code_units[i + 1]) {
+                i += 2;
+                continue;
+            }
+            return true;
+        }
+        if (0xDC00..=0xDFFF).contains(&cu) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
 
 fn pua_aware_utf16_len(s: &str) -> usize {
     s.chars()
@@ -385,6 +426,7 @@ struct RegexInput {
     subject: JsString,
     unicode: Rc<str>,
     ascii: bool,
+    lone_surrogate: bool,
     non_unicode: std::cell::OnceCell<Rc<str>>,
     wtf8: std::cell::OnceCell<Rc<[u8]>>,
 }
@@ -399,10 +441,12 @@ impl RegexInput {
                 .set(Rc::clone(&unicode))
                 .expect("new OnceCell must be empty");
         }
+        let lone_surrogate = !ascii && subject_has_lone_surrogate(&subject.code_units);
         Self {
             subject,
             unicode,
             ascii,
+            lone_surrogate,
             non_unicode,
             wtf8: std::cell::OnceCell::new(),
         }
@@ -428,17 +472,27 @@ impl RegexInput {
             .as_ref()
     }
 
-    fn utf16_to_byte_offset(&self, input: &str, offset: usize) -> usize {
+    /// `unicode_view` says which representation `input` is, because the PUA
+    /// sentinel range is only ambiguous in the Unicode one. The non-Unicode view
+    /// maps every surrogate code unit to its own sentinel char, so PUA-aware
+    /// counting is always right there. In the Unicode view a valid surrogate
+    /// pair becomes one char, so a PUA-range char is a genuine two-code-unit
+    /// scalar unless the subject also holds a lone surrogate.
+    fn utf16_to_byte_offset(&self, input: &str, unicode_view: bool, offset: usize) -> usize {
         if self.ascii {
             offset.min(input.len())
+        } else if unicode_view && !self.lone_surrogate {
+            utf16_to_byte_offset_scalar(input, offset)
         } else {
             utf16_to_byte_offset(input, offset)
         }
     }
 
-    fn byte_offset_to_utf16(&self, input: &str, offset: usize) -> usize {
+    fn byte_offset_to_utf16(&self, input: &str, unicode_view: bool, offset: usize) -> usize {
         if self.ascii {
             offset
+        } else if unicode_view && !self.lone_surrogate {
+            byte_offset_to_utf16_scalar(input, offset)
         } else {
             byte_offset_to_utf16(input, offset)
         }
@@ -7915,7 +7969,7 @@ fn regexp_exec_raw(
     let last_index_byte = if is_bytes_mode {
         utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
     } else {
-        regex_input.utf16_to_byte_offset(input, last_index_utf16)
+        regex_input.utf16_to_byte_offset(input, unicode, last_index_utf16)
     };
 
     let mut caps = if is_bytes_mode {
@@ -7960,12 +8014,12 @@ fn regexp_exec_raw(
     let match_start_utf16 = if is_bytes_mode {
         wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
     } else {
-        regex_input.byte_offset_to_utf16(input, full_match.start)
+        regex_input.byte_offset_to_utf16(input, unicode, full_match.start)
     };
     let match_end_utf16 = if is_bytes_mode {
         wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
     } else {
-        regex_input.byte_offset_to_utf16(input, full_match.end)
+        regex_input.byte_offset_to_utf16(input, unicode, full_match.end)
     };
 
     if sticky && full_match.start != last_index_byte {
@@ -8059,7 +8113,7 @@ fn regexp_exec_raw(
                 if is_bytes_mode {
                     wtf8_byte_offset_to_utf16(wtf8_bytes, offset)
                 } else {
-                    regex_input.byte_offset_to_utf16(input, offset)
+                    regex_input.byte_offset_to_utf16(input, unicode, offset)
                 }
             };
             let mut index_pairs: Vec<JsValue> = Vec::new();
@@ -8491,7 +8545,7 @@ impl Interpreter {
                         let last_index_byte = if is_bytes_mode {
                             utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
                         } else {
-                            regex_input.utf16_to_byte_offset(input, last_index_utf16)
+                            regex_input.utf16_to_byte_offset(input, unicode, last_index_utf16)
                         };
                         let caps = if is_bytes_mode {
                             if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
@@ -8513,7 +8567,7 @@ impl Interpreter {
                         let match_end_utf16 = if is_bytes_mode {
                             wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
                         } else {
-                            regex_input.byte_offset_to_utf16(input, full_match.end)
+                            regex_input.byte_offset_to_utf16(input, unicode, full_match.end)
                         };
 
                         results.push(JsValue::string(regex_output_to_js_string(match_text)));
@@ -8522,7 +8576,7 @@ impl Interpreter {
                             let match_start_utf16 = if is_bytes_mode {
                                 wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
                             } else {
-                                regex_input.byte_offset_to_utf16(input, full_match.start)
+                                regex_input.byte_offset_to_utf16(input, unicode, full_match.start)
                             };
                             // AdvanceStringIndex per spec operates on the original S, not the
                             // possibly-preprocessed `input` — full_unicode must be able to detect
@@ -8820,7 +8874,7 @@ impl Interpreter {
                         let last_index_byte = if is_bytes_mode {
                             utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
                         } else {
-                            regex_input.utf16_to_byte_offset(input, last_index_utf16)
+                            regex_input.utf16_to_byte_offset(input, unicode, last_index_utf16)
                         };
                         let mut caps = if is_bytes_mode {
                             if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
@@ -8852,18 +8906,18 @@ impl Interpreter {
                         let match_start_utf16 = if is_bytes_mode {
                             wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
                         } else {
-                            regex_input.byte_offset_to_utf16(input, full_match.start)
+                            regex_input.byte_offset_to_utf16(input, unicode, full_match.start)
                         };
                         let match_end_utf16 = if is_bytes_mode {
                             wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
                         } else {
-                            regex_input.byte_offset_to_utf16(input, full_match.end)
+                            regex_input.byte_offset_to_utf16(input, unicode, full_match.end)
                         };
                         let match_length_utf16 =
                             regex_output_to_js_string(matched).code_units.len();
                         let position_utf16 = match_start_utf16;
                         let position = regex_input
-                            .utf16_to_byte_offset(s_slice, position_utf16)
+                            .utf16_to_byte_offset(s_slice, false, position_utf16)
                             .min(length_s);
 
                         // Build captures as JsValues for get_substitution
@@ -8946,6 +9000,7 @@ impl Interpreter {
                         };
                         let tail_pos = regex_input.utf16_to_byte_offset(
                             s_slice,
+                            false,
                             (position_utf16 + match_length_utf16).min(s_utf16_len),
                         );
                         let replacement = match get_substitution(
@@ -9154,7 +9209,7 @@ impl Interpreter {
                         (
                             utf16_pos,
                             regex_input
-                                .utf16_to_byte_offset(s_slice, utf16_pos)
+                                .utf16_to_byte_offset(s_slice, false, utf16_pos)
                                 .min(length_s),
                         )
                     };
@@ -9244,6 +9299,7 @@ impl Interpreter {
                         };
                         let tail_pos = regex_input.utf16_to_byte_offset(
                             s_slice,
+                            false,
                             (position_utf16 + match_length_utf16).min(s_utf16_len),
                         );
                         match get_substitution(
@@ -9267,6 +9323,7 @@ impl Interpreter {
                     // p. If position >= nextSourcePosition, then
                     let tail_pos_final = regex_input.utf16_to_byte_offset(
                         s_slice,
+                        false,
                         (position_utf16 + match_length_utf16).min(s_utf16_len),
                     );
                     if position >= next_source_position {
@@ -9464,8 +9521,8 @@ impl Interpreter {
 
                     //   iii. Else,
                     // Push substring from p to q (convert UTF-16 positions to byte offsets)
-                    let p_byte = regex_input.utf16_to_byte_offset(s, p);
-                    let q_byte = regex_input.utf16_to_byte_offset(s, q);
+                    let p_byte = regex_input.utf16_to_byte_offset(s, true, p);
+                    let q_byte = regex_input.utf16_to_byte_offset(s, true, q);
                     let t = &s[p_byte..q_byte];
                     a.push(JsValue::string(regex_output_to_js_string(t)));
                     length_a += 1;
@@ -9520,7 +9577,7 @@ impl Interpreter {
                 }
 
                 // 16. Push remaining substring
-                let p_byte = regex_input.utf16_to_byte_offset(s, p);
+                let p_byte = regex_input.utf16_to_byte_offset(s, true, p);
                 let t = &s[p_byte..];
                 a.push(JsValue::string(regex_output_to_js_string(t)));
                 Completion::Normal(interp.create_array(a))

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -138,7 +138,12 @@ fn js_string_to_regex_input_non_unicode(code_units: &[u16]) -> String {
 }
 
 fn js_string_to_regex_input_mode(code_units: &[u16], unicode: bool) -> String {
-    let mut result = String::new();
+    if code_units.iter().all(|&cu| cu < 0x80) {
+        let bytes: Vec<u8> = code_units.iter().map(|&cu| cu as u8).collect();
+        return String::from_utf8(bytes).expect("ASCII code units are valid UTF-8");
+    }
+
+    let mut result = String::with_capacity(code_units.len());
     let mut i = 0;
     while i < code_units.len() {
         let cu = code_units[i];
@@ -376,18 +381,80 @@ fn is_co_property(content: &str) -> bool {
     }
 }
 
+struct RegexInput {
+    subject: JsString,
+    unicode: Rc<str>,
+    ascii: bool,
+    non_unicode: std::cell::OnceCell<Rc<str>>,
+    wtf8: std::cell::OnceCell<Rc<[u8]>>,
+}
+
+impl RegexInput {
+    fn new(subject: JsString) -> Self {
+        let unicode: Rc<str> = Rc::from(js_string_to_regex_input(&subject.code_units));
+        let ascii = unicode.is_ascii();
+        let non_unicode = std::cell::OnceCell::new();
+        if ascii {
+            non_unicode
+                .set(Rc::clone(&unicode))
+                .expect("new OnceCell must be empty");
+        }
+        Self {
+            subject,
+            unicode,
+            ascii,
+            non_unicode,
+            wtf8: std::cell::OnceCell::new(),
+        }
+    }
+
+    fn as_str(&self, unicode: bool) -> &str {
+        if unicode {
+            &self.unicode
+        } else {
+            self.non_unicode
+                .get_or_init(|| Rc::from(split_surrogates_for_non_unicode(&self.unicode)))
+                .as_ref()
+        }
+    }
+
+    fn wtf8(&self) -> &[u8] {
+        self.wtf8
+            .get_or_init(|| Rc::from(js_code_units_to_wtf8(&self.subject.code_units)))
+            .as_ref()
+    }
+
+    fn utf16_to_byte_offset(&self, input: &str, offset: usize) -> usize {
+        if self.ascii {
+            offset.min(input.len())
+        } else {
+            utf16_to_byte_offset(input, offset)
+        }
+    }
+
+    fn byte_offset_to_utf16(&self, input: &str, offset: usize) -> usize {
+        if self.ascii {
+            offset
+        } else {
+            byte_offset_to_utf16(input, offset)
+        }
+    }
+}
+
 fn to_regex_input_with_units(
     interp: &mut Interpreter,
     val: &JsValue,
-) -> Result<(String, Vec<u16>), JsValue> {
-    match val.with_string(|units| (js_string_to_regex_input(units), units.to_vec())) {
-        Some(pair) => Ok(pair),
-        None => {
-            let s = interp.to_string_value(val)?;
-            let js = JsString::from_str(&s);
-            Ok((js_string_to_regex_input(&js.code_units), js.into_vec()))
-        }
+) -> Result<Rc<RegexInput>, JsValue> {
+    let subject = interp.to_js_string(val)?;
+    if let Some(cached) = interp.regexp_legacy.input_cache.as_ref()
+        && Arc::ptr_eq(&cached.subject.code_units, &subject.code_units)
+    {
+        return Ok(Rc::clone(cached));
     }
+
+    let input = Rc::new(RegexInput::new(subject));
+    interp.regexp_legacy.input_cache = Some(Rc::clone(&input));
+    Ok(input)
 }
 
 fn escape_regexp_pattern_code_units(code_units: &[u16]) -> JsString {
@@ -4864,25 +4931,40 @@ enum CompiledRegex {
         remaining_source: Option<String>,
     },
 }
-/// Annex B.1.2 legacy RegExp static state — the `RegExp.input`, `RegExp.$1`-`$9`,
-/// `RegExp.lastMatch`, `RegExp.lastParen`, `RegExp.leftContext`,
-/// `RegExp.rightContext` statics and the compiled-pattern cache.
+/// RegExp-owned interpreter state: Annex B.1.2 legacy statics plus the
+/// compiled-pattern and most-recent-subject caches.
 ///
-/// All eight legacy fields were previously flat fields on the `Interpreter`
-/// god object (mod.rs L113–119 + L137), touched only by this file. Colocating
-/// them into a single struct deepens the Interpreter: 8 fields collapse to 1,
-/// and the regexp concern gains a clean seam. See `JobScheduler` for the same
-/// pattern (embedded struct accessed via `self.scheduler`).
-#[derive(Default)]
+/// The left and right contexts retain UTF-16 offsets into `context_input` and
+/// materialize only when their JavaScript accessors run.
 pub(crate) struct RegexpLegacyState {
-    pub(crate) input: String,
+    pub(crate) input: JsString,
     pub(crate) last_match: String,
     pub(crate) last_paren: String,
-    pub(crate) left_context: String,
-    pub(crate) right_context: String,
+    context_input: JsString,
+    left_context_end: usize,
+    right_context_start: usize,
     pub(crate) parens: [String; 9],
     pub(crate) constructor_id: Option<u64>,
     pub(crate) regex_cache: HashMap<(String, String), Rc<CachedRegex>>,
+    input_cache: Option<Rc<RegexInput>>,
+}
+
+impl Default for RegexpLegacyState {
+    fn default() -> Self {
+        let empty = JsString::from_vec(Vec::new());
+        Self {
+            input: empty.clone(),
+            last_match: String::new(),
+            last_paren: String::new(),
+            context_input: empty,
+            left_context_end: 0,
+            right_context_start: 0,
+            parens: std::array::from_fn(|_| String::new()),
+            constructor_id: None,
+            regex_cache: HashMap::new(),
+            input_cache: None,
+        }
+    }
 }
 
 pub(crate) struct CachedRegex {
@@ -7498,12 +7580,7 @@ fn set_last_index_strict(interp: &mut Interpreter, obj_id: u64, val: f64) -> Res
     spec_set(interp, obj_id, "lastIndex", JsValue::number(val), true)
 }
 
-fn regexp_exec_abstract(
-    interp: &mut Interpreter,
-    rx_id: u64,
-    s: &str,
-    code_units: &[u16],
-) -> Completion {
+fn regexp_exec_abstract(interp: &mut Interpreter, rx_id: u64, input: &RegexInput) -> Completion {
     let rx_val = JsValue::object(rx_id);
     let exec_val = match interp.get_object_property(rx_id, "exec", &rx_val) {
         Completion::Normal(v) => v,
@@ -7513,7 +7590,7 @@ fn regexp_exec_abstract(
         let result = interp.call_function(
             &exec_val,
             &rx_val,
-            &[JsValue::string(JsString::from_vec(code_units.to_vec()))],
+            &[JsValue::string(input.subject.clone())],
         );
         match result {
             Completion::Normal(ref v) => {
@@ -7554,7 +7631,7 @@ fn regexp_exec_abstract(
         } else {
             return Completion::Normal(JsValue::NULL);
         };
-        regexp_exec_raw(interp, rx_id, &source, &flags, s, code_units)
+        regexp_exec_raw(interp, rx_id, &source, &flags, input)
     }
 }
 
@@ -7718,7 +7795,7 @@ fn get_substitution(
 }
 
 fn split_surrogates_for_non_unicode(input: &str) -> String {
-    let mut result = String::new();
+    let mut result = String::with_capacity(input.len());
     for c in input.chars() {
         if c as u32 >= 0x10000 && pua_to_surrogate(c).is_none() {
             let cp = c as u32;
@@ -7776,8 +7853,7 @@ fn regexp_exec_raw(
     this_id: u64,
     source: &str,
     flags: &str,
-    input: &str,
-    input_code_units: &[u16],
+    regex_input: &RegexInput,
 ) -> Completion {
     // Spec: Let lastIndex be ? ToLength(? Get(R, "lastIndex")).
     // ToLength may trigger valueOf side effects that recompile the regexp,
@@ -7821,16 +7897,10 @@ fn regexp_exec_raw(
     let has_indices = flags.contains('d');
     let unicode = flags.contains('u') || flags.contains('v');
 
-    let non_unicode_input;
-    let input = if !unicode {
-        non_unicode_input = split_surrogates_for_non_unicode(input);
-        &non_unicode_input
-    } else {
-        input
-    };
+    let input = regex_input.as_str(unicode);
 
     // lastIndex is in UTF-16 code units; convert to byte offset for string slicing
-    let input_utf16_len = pua_aware_utf16_len(input);
+    let input_utf16_len = regex_input.subject.len();
     let last_index_utf16 = if global || sticky {
         let li_int = li_length as i64;
         if li_int < 0 || li_int as usize > input_utf16_len {
@@ -7850,19 +7920,19 @@ fn regexp_exec_raw(
 
     let is_bytes_mode = matches!(cached.compiled, CompiledRegex::Bytes(_));
     let wtf8_bytes = if is_bytes_mode {
-        js_code_units_to_wtf8(input_code_units)
+        regex_input.wtf8()
     } else {
-        Vec::new()
+        &[]
     };
     let last_index_byte = if is_bytes_mode {
-        utf16_to_wtf8_byte_offset(&wtf8_bytes, last_index_utf16)
+        utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
     } else {
-        utf16_to_byte_offset(input, last_index_utf16)
+        regex_input.utf16_to_byte_offset(input, last_index_utf16)
     };
 
     let mut caps = if is_bytes_mode {
         if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
-            match bytes_regex_captures_at(bytes_re, &wtf8_bytes, last_index_byte) {
+            match bytes_regex_captures_at(bytes_re, wtf8_bytes, last_index_byte) {
                 Some(c) => c,
                 None => {
                     if (global || sticky)
@@ -7900,14 +7970,14 @@ fn regexp_exec_raw(
     let full_match = caps.get(0).unwrap();
     // Convert absolute byte offsets to UTF-16 code unit offsets
     let match_start_utf16 = if is_bytes_mode {
-        wtf8_byte_offset_to_utf16(&wtf8_bytes, full_match.start)
+        wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
     } else {
-        byte_offset_to_utf16(input, full_match.start)
+        regex_input.byte_offset_to_utf16(input, full_match.start)
     };
     let match_end_utf16 = if is_bytes_mode {
-        wtf8_byte_offset_to_utf16(&wtf8_bytes, full_match.end)
+        wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
     } else {
-        byte_offset_to_utf16(input, full_match.end)
+        regex_input.byte_offset_to_utf16(input, full_match.end)
     };
 
     if sticky && full_match.start != last_index_byte {
@@ -7925,18 +7995,11 @@ fn regexp_exec_raw(
 
     // Update Annex B legacy static properties (B.2.4)
     {
-        interp.regexp_legacy.input = input.to_string();
+        interp.regexp_legacy.input = regex_input.subject.clone();
+        interp.regexp_legacy.context_input = regex_input.subject.clone();
+        interp.regexp_legacy.left_context_end = match_start_utf16;
+        interp.regexp_legacy.right_context_start = match_end_utf16;
         interp.regexp_legacy.last_match = full_match.text.clone();
-        interp.regexp_legacy.left_context = if is_bytes_mode {
-            wtf8_slice_to_pua_string(&wtf8_bytes[..full_match.start])
-        } else {
-            input[..full_match.start].to_string()
-        };
-        interp.regexp_legacy.right_context = if is_bytes_mode {
-            wtf8_slice_to_pua_string(&wtf8_bytes[full_match.end..])
-        } else {
-            input[full_match.end..].to_string()
-        };
         let mut last_paren = String::new();
         for idx in (1..caps.len()).rev() {
             if let Some(m) = caps.get(idx) {
@@ -7998,7 +8061,7 @@ fn regexp_exec_raw(
         );
         robj.borrow_mut().insert_value(
             "input".to_string(),
-            JsValue::string(JsString::from_str(input)),
+            JsValue::string(regex_input.subject.clone()),
         );
         robj.borrow_mut()
             .insert_value("groups".to_string(), groups_val.clone());
@@ -8006,9 +8069,9 @@ fn regexp_exec_raw(
         if has_indices {
             let cap_byte_to_utf16 = |offset: usize| -> usize {
                 if is_bytes_mode {
-                    wtf8_byte_offset_to_utf16(&wtf8_bytes, offset)
+                    wtf8_byte_offset_to_utf16(wtf8_bytes, offset)
                 } else {
-                    byte_offset_to_utf16(input, offset)
+                    regex_input.byte_offset_to_utf16(input, offset)
                 }
             };
             let mut index_pairs: Vec<JsValue> = Vec::new();
@@ -8101,12 +8164,12 @@ impl Interpreter {
                     ));
                 }
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let (input, code_units) = match to_regex_input_with_units(interp, &arg) {
+                let input = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
                 if let Some((source, flags, obj_id)) = extract_source_flags(interp, this_val) {
-                    return regexp_exec_raw(interp, obj_id, &source, &flags, &input, &code_units);
+                    return regexp_exec_raw(interp, obj_id, &source, &flags, &input);
                 }
                 Completion::Normal(JsValue::NULL)
             },
@@ -8132,11 +8195,11 @@ impl Interpreter {
                     }
                 };
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let (input, input_cu) = match to_regex_input_with_units(interp, &arg) {
+                let input = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
-                let result = regexp_exec_abstract(interp, obj_id, &input, &input_cu);
+                let result = regexp_exec_abstract(interp, obj_id, &input);
                 match result {
                     Completion::Normal(v) => Completion::Normal(JsValue::boolean(!v.is_null())),
                     other => other,
@@ -8360,10 +8423,11 @@ impl Interpreter {
                     }
                 };
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let (s, s_cu) = match to_regex_input_with_units(interp, &arg) {
+                let regex_input = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
+                let s = regex_input.as_str(true);
 
                 // 4. Let flags be ? ToString(? Get(rx, "flags")).
                 // Per spec, must invoke the flags accessor chain so user overrides of
@@ -8383,7 +8447,7 @@ impl Interpreter {
                 // 5. If flags does not contain "g", then
                 if !flags_str.contains('g') {
                     // a. Return ? RegExpExec(rx, S).
-                    return regexp_exec_abstract(interp, rx_id, &s, &s_cu);
+                    return regexp_exec_abstract(interp, rx_id, &regex_input);
                 }
 
                 // 6. Let fullUnicode be flags contains "u" or "v".
@@ -8418,31 +8482,18 @@ impl Interpreter {
                     };
                     let is_bytes_mode = matches!(cached.compiled, CompiledRegex::Bytes(_));
                     let sticky = flags_owned.contains('y');
-                    let non_unicode_input;
                     let unicode = flags_owned.contains('u') || flags_owned.contains('v');
                     let input = if is_bytes_mode {
-                        &s
-                    } else if !unicode {
-                        non_unicode_input = split_surrogates_for_non_unicode(&s);
-                        &non_unicode_input
+                        s
                     } else {
-                        &s
+                        regex_input.as_str(unicode)
                     };
                     let wtf8_bytes = if is_bytes_mode {
-                        js_code_units_to_wtf8(&s_cu)
+                        regex_input.wtf8()
                     } else {
-                        Vec::new()
+                        &[]
                     };
-                    let input_utf16_len: usize = input
-                        .chars()
-                        .map(|c| {
-                            if pua_to_surrogate(c).is_some() {
-                                1
-                            } else {
-                                c.len_utf16()
-                            }
-                        })
-                        .sum();
+                    let input_utf16_len = regex_input.subject.len();
                     let mut results: Vec<JsValue> = Vec::new();
                     let mut last_index_utf16: usize = 0;
                     loop {
@@ -8450,13 +8501,13 @@ impl Interpreter {
                             break;
                         }
                         let last_index_byte = if is_bytes_mode {
-                            utf16_to_wtf8_byte_offset(&wtf8_bytes, last_index_utf16)
+                            utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
                         } else {
-                            utf16_to_byte_offset(input, last_index_utf16)
+                            regex_input.utf16_to_byte_offset(input, last_index_utf16)
                         };
                         let caps = if is_bytes_mode {
                             if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
-                                bytes_regex_captures_at(bytes_re, &wtf8_bytes, last_index_byte)
+                                bytes_regex_captures_at(bytes_re, wtf8_bytes, last_index_byte)
                             } else {
                                 unreachable!()
                             }
@@ -8472,24 +8523,24 @@ impl Interpreter {
                         }
                         let match_text = &full_match.text;
                         let match_end_utf16 = if is_bytes_mode {
-                            wtf8_byte_offset_to_utf16(&wtf8_bytes, full_match.end)
+                            wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
                         } else {
-                            byte_offset_to_utf16(input, full_match.end)
+                            regex_input.byte_offset_to_utf16(input, full_match.end)
                         };
 
                         results.push(JsValue::string(regex_output_to_js_string(match_text)));
 
                         if match_text.is_empty() {
                             let match_start_utf16 = if is_bytes_mode {
-                                wtf8_byte_offset_to_utf16(&wtf8_bytes, full_match.start)
+                                wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
                             } else {
-                                byte_offset_to_utf16(input, full_match.start)
+                                regex_input.byte_offset_to_utf16(input, full_match.start)
                             };
                             // AdvanceStringIndex per spec operates on the original S, not the
                             // possibly-preprocessed `input` — full_unicode must be able to detect
                             // real surrogate pairs in S even when the matcher runs on a split form.
                             last_index_utf16 =
-                                advance_string_index(&s, match_start_utf16, full_unicode);
+                                advance_string_index(s, match_start_utf16, full_unicode);
                         } else {
                             last_index_utf16 = match_end_utf16;
                         }
@@ -8508,7 +8559,7 @@ impl Interpreter {
                 // Slow path: go through regexp_exec_abstract
                 let mut results: Vec<JsValue> = Vec::new();
                 loop {
-                    let result = regexp_exec_abstract(interp, rx_id, &s, &s_cu);
+                    let result = regexp_exec_abstract(interp, rx_id, &regex_input);
                     match result {
                         Completion::Normal(ref v) if v.is_null() => break,
                         Completion::Normal(ref result_val) if result_val.is_object() => {
@@ -8548,7 +8599,7 @@ impl Interpreter {
                                 } else {
                                     li_num.min(9007199254740991.0).floor() as usize
                                 };
-                                let next_index = advance_string_index(&s, this_index, full_unicode);
+                                let next_index = advance_string_index(s, this_index, full_unicode);
                                 if let Err(e) =
                                     set_last_index_strict(interp, rx_id, next_index as f64)
                                 {
@@ -8587,7 +8638,7 @@ impl Interpreter {
                     }
                 };
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let (s, s_cu) = match to_regex_input_with_units(interp, &arg) {
+                let regex_input = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -8609,7 +8660,7 @@ impl Interpreter {
                 }
 
                 // 6. Let result be ? RegExpExec(rx, S).
-                let result = regexp_exec_abstract(interp, rx_id, &s, &s_cu);
+                let result = regexp_exec_abstract(interp, rx_id, &regex_input);
                 let result_val = match result {
                     Completion::Normal(v) => v,
                     other => return other,
@@ -8671,18 +8722,16 @@ impl Interpreter {
 
                 // 3. Let S be ? ToString(string).
                 let string_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let (s, s_cu) = match to_regex_input_with_units(interp, &string_arg) {
+                let regex_input = match to_regex_input_with_units(interp, &string_arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
+                let s = regex_input.as_str(true);
                 // Non-unicode version for string slicing (surrogates kept as
                 // individual PUA chars so UTF-16 indexing works correctly)
-                let s_slice = match string_arg.with_string(js_string_to_regex_input_non_unicode) {
-                    Some(sliced) => sliced,
-                    None => s.clone(),
-                };
+                let s_slice = regex_input.as_str(false);
                 let length_s = s_slice.len();
-                let s_utf16_len = pua_aware_utf16_len(&s_slice);
+                let s_utf16_len = regex_input.subject.len();
 
                 // 5. Let functionalReplace be IsCallable(replaceValue).
                 let replace_value = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
@@ -8753,37 +8802,24 @@ impl Interpreter {
                         Ok(r) => r,
                         Err(_) => {
                             return Completion::Normal(JsValue::string(regex_output_to_js_string(
-                                &s_slice,
+                                s_slice,
                             )));
                         }
                     };
                     let is_bytes_mode = matches!(cached.compiled, CompiledRegex::Bytes(_));
                     let sticky = flags_owned.contains('y');
                     let unicode = flags_owned.contains('u') || flags_owned.contains('v');
-                    let non_unicode_input;
                     let input = if is_bytes_mode {
-                        &s
-                    } else if !unicode {
-                        non_unicode_input = split_surrogates_for_non_unicode(&s);
-                        &non_unicode_input
+                        s
                     } else {
-                        &s
+                        regex_input.as_str(unicode)
                     };
                     let wtf8_bytes = if is_bytes_mode {
-                        js_code_units_to_wtf8(&s_cu)
+                        regex_input.wtf8()
                     } else {
-                        Vec::new()
+                        &[]
                     };
-                    let input_utf16_len: usize = input
-                        .chars()
-                        .map(|c| {
-                            if pua_to_surrogate(c).is_some() {
-                                1
-                            } else {
-                                c.len_utf16()
-                            }
-                        })
-                        .sum();
+                    let input_utf16_len = regex_input.subject.len();
                     let template = replace_str.as_ref().unwrap();
                     let mut accumulated_result = String::new();
                     let mut next_source_position: usize = 0;
@@ -8794,17 +8830,14 @@ impl Interpreter {
                             break;
                         }
                         let last_index_byte = if is_bytes_mode {
-                            utf16_to_wtf8_byte_offset(&wtf8_bytes, last_index_utf16)
+                            utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
                         } else {
-                            utf16_to_byte_offset(input, last_index_utf16)
+                            regex_input.utf16_to_byte_offset(input, last_index_utf16)
                         };
                         let mut caps = if is_bytes_mode {
                             if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
-                                match bytes_regex_captures_at(
-                                    bytes_re,
-                                    &wtf8_bytes,
-                                    last_index_byte,
-                                ) {
+                                match bytes_regex_captures_at(bytes_re, wtf8_bytes, last_index_byte)
+                                {
                                     Some(c) => c,
                                     None => break,
                                 }
@@ -8829,19 +8862,21 @@ impl Interpreter {
                         let full_match = caps.get(0).unwrap();
                         let matched = &full_match.text;
                         let match_start_utf16 = if is_bytes_mode {
-                            wtf8_byte_offset_to_utf16(&wtf8_bytes, full_match.start)
+                            wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
                         } else {
-                            byte_offset_to_utf16(input, full_match.start)
+                            regex_input.byte_offset_to_utf16(input, full_match.start)
                         };
                         let match_end_utf16 = if is_bytes_mode {
-                            wtf8_byte_offset_to_utf16(&wtf8_bytes, full_match.end)
+                            wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
                         } else {
-                            byte_offset_to_utf16(input, full_match.end)
+                            regex_input.byte_offset_to_utf16(input, full_match.end)
                         };
                         let match_length_utf16 =
                             regex_output_to_js_string(matched).code_units.len();
                         let position_utf16 = match_start_utf16;
-                        let position = utf16_to_byte_offset(&s_slice, position_utf16).min(length_s);
+                        let position = regex_input
+                            .utf16_to_byte_offset(s_slice, position_utf16)
+                            .min(length_s);
 
                         // Build captures as JsValues for get_substitution
                         let mut capture_vals: Vec<JsValue> = Vec::new();
@@ -8921,14 +8956,14 @@ impl Interpreter {
                         } else {
                             JsValue::UNDEFINED
                         };
-                        let tail_pos = utf16_to_byte_offset(
-                            &s_slice,
+                        let tail_pos = regex_input.utf16_to_byte_offset(
+                            s_slice,
                             (position_utf16 + match_length_utf16).min(s_utf16_len),
                         );
                         let replacement = match get_substitution(
                             interp,
                             matched,
-                            &s_slice,
+                            s_slice,
                             position,
                             tail_pos,
                             &capture_vals,
@@ -8949,7 +8984,7 @@ impl Interpreter {
                         // original S, not the possibly-preprocessed `input`.
                         if matched.is_empty() {
                             last_index_utf16 =
-                                advance_string_index(&s, match_start_utf16, full_unicode);
+                                advance_string_index(s, match_start_utf16, full_unicode);
                         } else {
                             last_index_utf16 = match_end_utf16;
                         }
@@ -8971,7 +9006,7 @@ impl Interpreter {
                 let gc_root_start = interp.gc_temp_roots.len();
                 loop {
                     // 11a. Let result be ? RegExpExec(rx, S).
-                    let result = regexp_exec_abstract(interp, rx_id, &s, &s_cu);
+                    let result = regexp_exec_abstract(interp, rx_id, &regex_input);
                     match result {
                         Completion::Normal(ref v) if v.is_null() => break,
                         Completion::Normal(ref result_val) if result_val.is_object() => {
@@ -9032,7 +9067,7 @@ impl Interpreter {
                                     };
                                     n as usize
                                 };
-                                let next_index = advance_string_index(&s, this_index, full_unicode);
+                                let next_index = advance_string_index(s, this_index, full_unicode);
                                 match set_last_index_strict(interp, rx_id, next_index as f64) {
                                     Ok(()) => {}
                                     Err(e) => {
@@ -9130,7 +9165,9 @@ impl Interpreter {
                         let utf16_pos = int.max(0.0) as usize;
                         (
                             utf16_pos,
-                            utf16_to_byte_offset(&s_slice, utf16_pos).min(length_s),
+                            regex_input
+                                .utf16_to_byte_offset(s_slice, utf16_pos)
+                                .min(length_s),
                         )
                     };
 
@@ -9179,7 +9216,7 @@ impl Interpreter {
                         }
                         // Pass UTF-16 position and the primitive string S (non-PUA)
                         replacer_args.push(JsValue::number(position_utf16 as f64));
-                        replacer_args.push(JsValue::string(regex_output_to_js_string(&s_slice)));
+                        replacer_args.push(JsValue::string(regex_output_to_js_string(s_slice)));
                         if !named_captures.is_undefined() {
                             replacer_args.push(named_captures.clone());
                         }
@@ -9217,14 +9254,14 @@ impl Interpreter {
                         } else {
                             JsValue::UNDEFINED
                         };
-                        let tail_pos = utf16_to_byte_offset(
-                            &s_slice,
+                        let tail_pos = regex_input.utf16_to_byte_offset(
+                            s_slice,
                             (position_utf16 + match_length_utf16).min(s_utf16_len),
                         );
                         match get_substitution(
                             interp,
                             &matched,
-                            &s_slice,
+                            s_slice,
                             position,
                             tail_pos,
                             &captures,
@@ -9240,8 +9277,8 @@ impl Interpreter {
                     };
 
                     // p. If position >= nextSourcePosition, then
-                    let tail_pos_final = utf16_to_byte_offset(
-                        &s_slice,
+                    let tail_pos_final = regex_input.utf16_to_byte_offset(
+                        s_slice,
                         (position_utf16 + match_length_utf16).min(s_utf16_len),
                     );
                     if position >= next_source_position {
@@ -9284,10 +9321,11 @@ impl Interpreter {
                 };
                 // 2. Let S be ? ToString(string).
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let (s, s_cu) = match to_regex_input_with_units(interp, &arg) {
+                let regex_input = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
+                let s = regex_input.as_str(true);
 
                 // 3. Let C be ? SpeciesConstructor(rx, %RegExp%).
                 let rx_val = JsValue::object(rx_id);
@@ -9362,15 +9400,15 @@ impl Interpreter {
                     return Completion::Normal(interp.create_array(a));
                 }
 
-                let size = pua_aware_utf16_len(&s);
+                let size = regex_input.subject.len();
 
                 // 12. If size = 0, then
                 if size == 0 {
                     // a. Let z be ? RegExpExec(splitter, S).
-                    let z = regexp_exec_abstract(interp, splitter_id, &s, &s_cu);
+                    let z = regexp_exec_abstract(interp, splitter_id, &regex_input);
                     match z {
                         Completion::Normal(ref v) if v.is_null() => {
-                            a.push(JsValue::string(regex_output_to_js_string(&s)));
+                            a.push(JsValue::string(regex_output_to_js_string(s)));
                         }
                         Completion::Normal(_) => {}
                         other => return other,
@@ -9397,7 +9435,7 @@ impl Interpreter {
                     }
 
                     // b. Let z be ? RegExpExec(splitter, S).
-                    let z = regexp_exec_abstract(interp, splitter_id, &s, &s_cu);
+                    let z = regexp_exec_abstract(interp, splitter_id, &regex_input);
                     let z_val = match z {
                         Completion::Normal(v) => v,
                         other => return other,
@@ -9405,7 +9443,7 @@ impl Interpreter {
 
                     // c. If z is null, set q to AdvanceStringIndex(S, q, unicodeMatching).
                     if z_val.is_null() {
-                        q = advance_string_index(&s, q, unicode_matching);
+                        q = advance_string_index(s, q, unicode_matching);
                         continue;
                     }
 
@@ -9432,14 +9470,14 @@ impl Interpreter {
 
                     //   ii. If e = p, set q to AdvanceStringIndex(S, q, unicodeMatching).
                     if e_length == p {
-                        q = advance_string_index(&s, q, unicode_matching);
+                        q = advance_string_index(s, q, unicode_matching);
                         continue;
                     }
 
                     //   iii. Else,
                     // Push substring from p to q (convert UTF-16 positions to byte offsets)
-                    let p_byte = utf16_to_byte_offset(&s, p);
-                    let q_byte = utf16_to_byte_offset(&s, q);
+                    let p_byte = regex_input.utf16_to_byte_offset(s, p);
+                    let q_byte = regex_input.utf16_to_byte_offset(s, q);
                     let t = &s[p_byte..q_byte];
                     a.push(JsValue::string(regex_output_to_js_string(t)));
                     length_a += 1;
@@ -9454,7 +9492,7 @@ impl Interpreter {
                     let z_id = match z_val.as_object_id() {
                         Some(id) => id,
                         None => {
-                            q = advance_string_index(&s, q, unicode_matching);
+                            q = advance_string_index(s, q, unicode_matching);
                             continue;
                         }
                     };
@@ -9494,7 +9532,7 @@ impl Interpreter {
                 }
 
                 // 16. Push remaining substring
-                let p_byte = utf16_to_byte_offset(&s, p);
+                let p_byte = regex_input.utf16_to_byte_offset(s, p);
                 let t = &s[p_byte..];
                 a.push(JsValue::string(regex_output_to_js_string(t)));
                 Completion::Normal(interp.create_array(a))
@@ -9522,7 +9560,7 @@ impl Interpreter {
                 };
                 // 2. Let S be ? ToString(string).
                 let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                let (s, _s_cu) = match to_regex_input_with_units(interp, &arg) {
+                let regex_input = match to_regex_input_with_units(interp, &arg) {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
@@ -9641,7 +9679,7 @@ impl Interpreter {
                         IteratorState::RegExpStringIterator {
                             source: m_source,
                             flags: m_flags,
-                            string: s,
+                            string: regex_input.subject.clone(),
                             global,
                             last_index: last_index as usize,
                             done: false,
@@ -9728,11 +9766,17 @@ impl Interpreter {
                     );
                 }
 
+                let input_value = JsValue::string(string.clone());
+                let regex_input = match to_regex_input_with_units(interp, &input_value) {
+                    Ok(input) => input,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let regex_string = regex_input.as_str(true);
+
                 // If we have a matcher object, use RegExpExec
                 if let Some(mid) = matcher_id_val.as_number() {
                     let mid = mid as u64;
-                    let string_cu = regex_output_to_js_string(&string).code_units;
-                    let result = regexp_exec_abstract(interp, mid, &string, &string_cu);
+                    let result = regexp_exec_abstract(interp, mid, &regex_input);
                     let result_val = match result {
                         Completion::Normal(v) => v,
                         other => return other,
@@ -9805,7 +9849,7 @@ impl Interpreter {
                             li_num.min(9007199254740991.0).floor() as usize
                         };
                         let next_index =
-                            advance_string_index(&string, this_index, full_unicode);
+                            advance_string_index(regex_string, this_index, full_unicode);
                         if let Err(e) = spec_set(
                             interp, mid, "lastIndex",
                             JsValue::number(next_index as f64), true,
@@ -9853,7 +9897,7 @@ impl Interpreter {
                     );
                 }
 
-                match regex_captures(&re, &string[last_index..]) {
+                match regex_captures(&re, &regex_string[last_index..]) {
                     None => {
                         if let Some(obj2) = interp.get_object_cell(o_id) {
                             obj2.borrow_mut().kind = crate::interpreter::types::ObjectKind::Iterator(IteratorState::RegExpStringIterator {
@@ -9892,7 +9936,7 @@ impl Interpreter {
                             );
                             robj.borrow_mut().insert_value(
                                 "input".to_string(),
-                                JsValue::string(JsString::from_str(&string)),
+                                JsValue::string(string.clone()),
                             );
                             robj.borrow_mut().insert_value(
                                 "groups".to_string(),
@@ -10437,9 +10481,7 @@ impl Interpreter {
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            Completion::Normal(JsValue::string(JsString::from_str(
-                                &interp.regexp_legacy.input,
-                            )))
+                            Completion::Normal(JsValue::string(interp.regexp_legacy.input.clone()))
                         },
                     ));
                 let setter =
@@ -10454,7 +10496,7 @@ impl Interpreter {
                                 )),
                             }
                             let val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                            let s = match interp.to_string_value(&val) {
+                            let s = match interp.to_js_string(&val) {
                                 Ok(s) => s,
                                 Err(e) => return Completion::Throw(e),
                             };
@@ -10553,8 +10595,12 @@ impl Interpreter {
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            Completion::Normal(JsValue::string(JsString::from_str(
-                                &interp.regexp_legacy.left_context,
+                            let legacy = &interp.regexp_legacy;
+                            let end = legacy
+                                .left_context_end
+                                .min(legacy.context_input.code_units.len());
+                            Completion::Normal(JsValue::string(JsString::from_vec(
+                                legacy.context_input.code_units[..end].to_vec(),
                             )))
                         },
                     ));
@@ -10585,8 +10631,12 @@ impl Interpreter {
                                     "RegExp legacy accessor requires RegExp constructor as this",
                                 )),
                             }
-                            Completion::Normal(JsValue::string(JsString::from_str(
-                                &interp.regexp_legacy.right_context,
+                            let legacy = &interp.regexp_legacy;
+                            let start = legacy
+                                .right_context_start
+                                .min(legacy.context_input.code_units.len());
+                            Completion::Normal(JsValue::string(JsString::from_vec(
+                                legacy.context_input.code_units[start..].to_vec(),
                             )))
                         },
                     ));
@@ -10642,5 +10692,24 @@ mod nullable_quantifier_rewrite_tests {
 
         let capture_only = fix_nullable_quantifiers("^(a*|(d)){2,3}(e)", true);
         assert!(!capture_only.sentinel_names.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod regex_input_cache_tests {
+    use super::{Interpreter, JsString, JsValue, Rc, to_regex_input_with_units};
+
+    #[test]
+    fn reuses_conversion_for_the_same_js_string_identity() {
+        let mut interp = Interpreter::new();
+        let subject = JsValue::string(JsString::from_str(&"a".repeat(1024)));
+
+        let first = to_regex_input_with_units(&mut interp, &subject).unwrap();
+        let second = to_regex_input_with_units(&mut interp, &subject.clone()).unwrap();
+        assert!(Rc::ptr_eq(&first, &second));
+
+        let equal_but_distinct = JsValue::string(JsString::from_str(&"a".repeat(1024)));
+        let third = to_regex_input_with_units(&mut interp, &equal_but_distinct).unwrap();
+        assert!(!Rc::ptr_eq(&first, &third));
     }
 }

--- a/src/interpreter/builtins/regexp.rs
+++ b/src/interpreter/builtins/regexp.rs
@@ -55,43 +55,12 @@ fn encode_for_regexp_escape(c: char) -> String {
     }
 }
 
-/// Convert a UTF-16 code unit offset to a byte offset in a UTF-8 string
-fn utf16_to_byte_offset(s: &str, utf16_offset: usize) -> usize {
-    if s.is_ascii() {
-        return utf16_offset.min(s.len());
-    }
-    let mut utf16_count = 0;
-    for (byte_idx, c) in s.char_indices() {
-        if utf16_count >= utf16_offset {
-            return byte_idx;
-        }
-        if pua_to_surrogate(c).is_some() {
-            utf16_count += 1;
-        } else {
-            utf16_count += c.len_utf16();
-        }
-    }
-    s.len()
-}
-
 // Surrogate code points (U+D800-U+DFFF) can't be represented as Rust chars.
 // We remap them to Supplementary PUA-A (U+F0000+) so regex matching works
 // on strings containing lone surrogates.
 const SURROGATE_START: u32 = 0xD800;
 const SURROGATE_END: u32 = 0xDFFF;
 const SURROGATE_PUA_BASE: u32 = 0xF0000;
-
-fn pua_aware_utf16_len(s: &str) -> usize {
-    s.chars()
-        .map(|c| {
-            if pua_to_surrogate(c).is_some() {
-                1
-            } else {
-                c.len_utf16()
-            }
-        })
-        .sum()
-}
 
 fn is_surrogate(cp: u32) -> bool {
     (SURROGATE_START..=SURROGATE_END).contains(&cp)
@@ -121,10 +90,17 @@ fn js_string_to_regex_input_non_unicode(code_units: &[u16]) -> String {
     js_string_to_regex_input_mode(code_units, false)
 }
 
+/// Both regex views encode an all-ASCII subject identically to its code units,
+/// which is what lets `RegexInput` map offsets without a boundary table. The
+/// conversion fast path and that offset shortcut must agree on "ASCII", so both
+/// ask here rather than each spelling the test their own way.
+fn code_units_are_ascii(code_units: &[u16]) -> bool {
+    code_units.iter().all(|&cu| cu < 0x80)
+}
+
 fn js_string_to_regex_input_mode(code_units: &[u16], unicode: bool) -> String {
-    if code_units.iter().all(|&cu| cu < 0x80) {
-        let bytes: Vec<u8> = code_units.iter().map(|&cu| cu as u8).collect();
-        return String::from_utf8(bytes).expect("ASCII code units are valid UTF-8");
+    if code_units_are_ascii(code_units) {
+        return code_units.iter().map(|&cu| cu as u8 as char).collect();
     }
 
     let mut result = String::with_capacity(code_units.len());
@@ -367,12 +343,37 @@ fn is_co_property(content: &str) -> bool {
 
 struct RegexInput {
     subject: JsString,
-    unicode: Rc<str>,
     ascii: bool,
-    non_unicode: std::cell::OnceCell<Rc<str>>,
+    unicode: std::cell::OnceCell<Box<str>>,
+    non_unicode: std::cell::OnceCell<Box<str>>,
     unicode_boundaries: std::cell::OnceCell<Vec<RegexInputBoundary>>,
     non_unicode_offsets: std::cell::OnceCell<Vec<usize>>,
     wtf8: std::cell::OnceCell<Vec<u8>>,
+}
+
+/// Which representation of the subject a set of byte offsets belongs to. The
+/// three are not interchangeable, so offset conversion takes this rather than a
+/// bare bool: callers that pick a view and callers that convert an offset now
+/// name the same thing, and a `@@replace` holding both text views at once
+/// cannot silently cross their offsets.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RegexView {
+    /// `u`/`v` mode: a surrogate pair became one scalar.
+    Unicode,
+    /// Default mode: exactly one character per UTF-16 code unit.
+    NonUnicode,
+    /// `\p{Cs}`/`\p{Co}` patterns, which match over raw WTF-8 bytes.
+    Wtf8,
+}
+
+impl RegexView {
+    fn select(bytes_mode: bool, unicode: bool) -> Self {
+        match (bytes_mode, unicode) {
+            (true, _) => Self::Wtf8,
+            (false, true) => Self::Unicode,
+            (false, false) => Self::NonUnicode,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -383,36 +384,30 @@ struct RegexInputBoundary {
 
 impl RegexInput {
     fn new(subject: JsString) -> Self {
-        let unicode: Rc<str> = Rc::from(js_string_to_regex_input(&subject.code_units));
-        let ascii = unicode.is_ascii();
-        let non_unicode = std::cell::OnceCell::new();
-        if ascii {
-            non_unicode
-                .set(Rc::clone(&unicode))
-                .expect("new OnceCell must be empty");
-        }
         Self {
+            ascii: code_units_are_ascii(&subject.code_units),
             subject,
-            unicode,
-            ascii,
-            non_unicode,
+            unicode: std::cell::OnceCell::new(),
+            non_unicode: std::cell::OnceCell::new(),
             unicode_boundaries: std::cell::OnceCell::new(),
             non_unicode_offsets: std::cell::OnceCell::new(),
             wtf8: std::cell::OnceCell::new(),
         }
     }
 
+    /// Every view is built from the retained UTF-16 code units, never derived
+    /// from another view: the PUA encoding of lone surrogates is not injective,
+    /// so a genuine U+F0000-U+F07FF scalar is indistinguishable from an encoded
+    /// surrogate once converted. An all-ASCII subject is the one case where the
+    /// two text views coincide, so they share a cell and convert only once.
     fn as_str(&self, unicode: bool) -> &str {
-        if unicode {
-            &self.unicode
+        if unicode || self.ascii {
+            self.unicode
+                .get_or_init(|| js_string_to_regex_input(&self.subject.code_units).into())
         } else {
-            self.non_unicode
-                .get_or_init(|| {
-                    Rc::from(js_string_to_regex_input_non_unicode(
-                        &self.subject.code_units,
-                    ))
-                })
-                .as_ref()
+            self.non_unicode.get_or_init(|| {
+                js_string_to_regex_input_non_unicode(&self.subject.code_units).into()
+            })
         }
     }
 
@@ -423,6 +418,7 @@ impl RegexInput {
 
     fn unicode_boundaries(&self) -> &[RegexInputBoundary] {
         self.unicode_boundaries.get_or_init(|| {
+            let view = self.as_str(true);
             let code_units = &self.subject.code_units;
             let mut boundaries = Vec::with_capacity(code_units.len() + 1);
             let mut byte = 0;
@@ -438,7 +434,7 @@ impl RegexInput {
                 } else {
                     1
                 };
-                let encoded = self.unicode[byte..]
+                let encoded = view[byte..]
                     .chars()
                     .next()
                     .expect("each UTF-16 character must have a regex input character");
@@ -447,7 +443,11 @@ impl RegexInput {
                 boundaries.push(RegexInputBoundary { byte, utf16 });
             }
 
-            debug_assert_eq!(byte, self.unicode.len());
+            debug_assert_eq!(byte, view.len());
+            // One entry per character, not per code unit, so a surrogate-heavy
+            // subject leaves up to half the reservation unused for the life of
+            // the cache.
+            boundaries.shrink_to_fit();
             boundaries
         })
     }
@@ -464,7 +464,7 @@ impl RegexInput {
     }
 
     fn unicode_byte_offset_to_utf16(&self, offset: usize) -> usize {
-        let target = offset.min(self.unicode.len());
+        let target = offset.min(self.as_str(true).len());
         let boundaries = self.unicode_boundaries();
         match boundaries.binary_search_by_key(&target, |boundary| boundary.byte) {
             Ok(index) => boundaries[index].utf16,
@@ -487,35 +487,62 @@ impl RegexInput {
         })
     }
 
-    /// `unicode_view` identifies the surrogate-ambiguous representation. Its
-    /// offsets use boundaries derived from the original UTF-16 subject, while
-    /// the direct non-Unicode form indexes its own one-char-per-code-unit table.
-    fn utf16_to_byte_offset(&self, unicode_view: bool, offset: usize) -> usize {
-        if self.ascii {
-            offset.min(self.unicode.len())
-        } else if unicode_view {
-            self.unicode_utf16_to_byte_offset(offset)
-        } else {
-            let offsets = self.non_unicode_offsets();
-            offsets[offset.min(offsets.len() - 1)]
+    /// Map a UTF-16 code-unit offset to a byte offset within `view`.
+    ///
+    /// The Unicode view is surrogate-ambiguous once converted, so its offsets
+    /// come from boundaries derived from the original UTF-16 subject. The
+    /// non-Unicode view encodes one character per code unit and indexes its own
+    /// table directly. An all-ASCII subject needs no table in either case.
+    fn utf16_to_byte_offset(&self, view: RegexView, offset: usize) -> usize {
+        // The start of the subject is offset 0 in every view. Worth its own
+        // arm: a non-global match reads lastIndex 0 and then never converts
+        // again, so without this a single lookup builds a whole index table.
+        if offset == 0 {
+            return 0;
         }
-    }
-
-    fn byte_offset_to_utf16(&self, unicode_view: bool, offset: usize) -> usize {
-        if self.ascii {
-            offset
-        } else if unicode_view {
-            self.unicode_byte_offset_to_utf16(offset)
-        } else {
-            let offsets = self.non_unicode_offsets();
-            match offsets.binary_search(&offset) {
-                Ok(index) => index,
-                // A byte offset inside a character refers to the code unit that
-                // character starts at.
-                Err(index) => index.saturating_sub(1),
+        match view {
+            RegexView::Wtf8 => utf16_to_wtf8_byte_offset(self.wtf8(), offset),
+            _ if self.ascii => offset.min(self.subject.len()),
+            RegexView::Unicode => self.unicode_utf16_to_byte_offset(offset),
+            RegexView::NonUnicode => {
+                let offsets = self.non_unicode_offsets();
+                offsets[offset.min(offsets.len() - 1)]
             }
         }
     }
+
+    /// Inverse of [`RegexInput::utf16_to_byte_offset`].
+    fn byte_offset_to_utf16(&self, view: RegexView, offset: usize) -> usize {
+        if offset == 0 {
+            return 0;
+        }
+        match view {
+            RegexView::Wtf8 => wtf8_byte_offset_to_utf16(self.wtf8(), offset),
+            _ if self.ascii => offset,
+            RegexView::Unicode => self.unicode_byte_offset_to_utf16(offset),
+            RegexView::NonUnicode => {
+                let offsets = self.non_unicode_offsets();
+                match offsets.binary_search(&offset) {
+                    Ok(index) => index,
+                    // A byte offset inside a character refers to the code unit
+                    // that character starts at.
+                    Err(index) => index.saturating_sub(1),
+                }
+            }
+        }
+    }
+}
+
+fn regex_input_for_subject(interp: &mut Interpreter, subject: JsString) -> Rc<RegexInput> {
+    if let Some(cached) = interp.regexp_legacy.input_cache.as_ref()
+        && Arc::ptr_eq(&cached.subject.code_units, &subject.code_units)
+    {
+        return Rc::clone(cached);
+    }
+
+    let input = Rc::new(RegexInput::new(subject));
+    interp.regexp_legacy.input_cache = Some(Rc::clone(&input));
+    input
 }
 
 fn regex_input_for_value(
@@ -523,15 +550,7 @@ fn regex_input_for_value(
     val: &JsValue,
 ) -> Result<Rc<RegexInput>, JsValue> {
     let subject = interp.to_js_string(val)?;
-    if let Some(cached) = interp.regexp_legacy.input_cache.as_ref()
-        && Arc::ptr_eq(&cached.subject.code_units, &subject.code_units)
-    {
-        return Ok(Rc::clone(cached));
-    }
-
-    let input = Rc::new(RegexInput::new(subject));
-    interp.regexp_legacy.input_cache = Some(Rc::clone(&input));
-    Ok(input)
+    Ok(regex_input_for_subject(interp, subject))
 }
 
 fn escape_regexp_pattern_code_units(code_units: &[u16]) -> JsString {
@@ -5008,11 +5027,23 @@ enum CompiledRegex {
         remaining_source: Option<String>,
     },
 }
-/// RegExp-owned interpreter state: Annex B.1.2 legacy statics plus the
-/// compiled-pattern and most-recent-subject caches.
+/// RegExp-owned interpreter state: the Annex B.1.2 legacy statics
+/// (`RegExp.input`, `RegExp.$1`-`$9`, `RegExp.lastMatch`, `RegExp.lastParen`,
+/// `RegExp.leftContext`, `RegExp.rightContext`) plus the compiled-pattern and
+/// most-recent-subject caches.
 ///
-/// The left and right contexts retain UTF-16 offsets into `context_input` and
-/// materialize only when their JavaScript accessors run.
+/// All eight legacy fields were previously flat fields on the `Interpreter`
+/// god object, touched only by this file. Colocating them into a single struct
+/// deepens the Interpreter: 8 fields collapse to 1, and the regexp concern
+/// gains a clean seam. See `JobScheduler` for the same pattern (embedded
+/// struct accessed via `self.scheduler`).
+///
+/// `input` and `context_input` are assigned the same subject after a match but
+/// are NOT redundant: the `RegExp.input` setter replaces `input` alone, and
+/// `leftContext`/`rightContext` must keep slicing the subject the last match
+/// actually ran against. Collapsing them into one field silently breaks that.
+/// They retain UTF-16 offsets and materialize only when their accessors run.
+#[derive(Default)]
 pub(crate) struct RegexpLegacyState {
     pub(crate) input: JsString,
     pub(crate) last_match: String,
@@ -5024,24 +5055,6 @@ pub(crate) struct RegexpLegacyState {
     pub(crate) constructor_id: Option<u64>,
     pub(crate) regex_cache: HashMap<(String, String), Rc<CachedRegex>>,
     input_cache: Option<Rc<RegexInput>>,
-}
-
-impl Default for RegexpLegacyState {
-    fn default() -> Self {
-        let empty = JsString::from_vec(Vec::new());
-        Self {
-            input: empty.clone(),
-            last_match: String::new(),
-            last_paren: String::new(),
-            context_input: empty,
-            left_context_end: 0,
-            right_context_start: 0,
-            parens: std::array::from_fn(|_| String::new()),
-            constructor_id: None,
-            regex_cache: HashMap::new(),
-            input_cache: None,
-        }
-    }
 }
 
 pub(crate) struct CachedRegex {
@@ -7714,23 +7727,23 @@ fn regexp_exec_abstract(interp: &mut Interpreter, rx_id: u64, input: &RegexInput
 
 /// Inner implementation of RegExp @@replace result collection and processing.
 /// Extracted so the caller can bracket it with gc_temp_roots save/restore.
-/// AdvanceStringIndex per spec. `index` is in UTF-16 code units.
-fn advance_string_index(s: &str, index: usize, unicode: bool) -> usize {
+/// AdvanceStringIndex per spec (22.2.7.3). `index` is in UTF-16 code units.
+///
+/// The spec defines this over the original String S, so it reads the retained
+/// UTF-16 code units directly. That is both exact — no PUA sentinel can be
+/// confused with a real scalar — and O(1), where scanning a converted view cost
+/// two full passes over the subject on every call.
+fn advance_string_index(input: &RegexInput, index: usize, unicode: bool) -> usize {
     if !unicode {
         return index + 1;
     }
-    let utf16_len = pua_aware_utf16_len(s);
-    if index + 1 >= utf16_len {
+    let code_units = &input.subject.code_units;
+    if index + 1 >= code_units.len() {
         return index + 1;
     }
-    let byte_offset = utf16_to_byte_offset(s, index);
-    if byte_offset >= s.len() {
-        return index + 1;
-    }
-    let c = s[byte_offset..].chars().next().unwrap_or('\0');
-    if pua_to_surrogate(c).is_some() {
-        index + 1
-    } else if c.len_utf16() == 2 {
+    if (0xD800..=0xDBFF).contains(&code_units[index])
+        && (0xDC00..=0xDFFF).contains(&code_units[index + 1])
+    {
         index + 2
     } else {
         index + 1
@@ -7958,8 +7971,6 @@ fn regexp_exec_raw(
     let has_indices = flags.contains('d');
     let unicode = flags.contains('u') || flags.contains('v');
 
-    let input = regex_input.as_str(unicode);
-
     // lastIndex is in UTF-16 code units; convert to byte offset for string slicing
     let input_utf16_len = regex_input.subject.len();
     let last_index_utf16 = if global || sticky {
@@ -7980,20 +7991,12 @@ fn regexp_exec_raw(
     };
 
     let is_bytes_mode = matches!(cached.compiled, CompiledRegex::Bytes(_));
-    let wtf8_bytes = if is_bytes_mode {
-        regex_input.wtf8()
-    } else {
-        &[]
-    };
-    let last_index_byte = if is_bytes_mode {
-        utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
-    } else {
-        regex_input.utf16_to_byte_offset(unicode, last_index_utf16)
-    };
+    let view = RegexView::select(is_bytes_mode, unicode);
+    let last_index_byte = regex_input.utf16_to_byte_offset(view, last_index_utf16);
 
     let mut caps = if is_bytes_mode {
         if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
-            match bytes_regex_captures_at(bytes_re, wtf8_bytes, last_index_byte) {
+            match bytes_regex_captures_at(bytes_re, regex_input.wtf8(), last_index_byte) {
                 Some(c) => c,
                 None => {
                     if (global || sticky)
@@ -8008,7 +8011,11 @@ fn regexp_exec_raw(
             unreachable!()
         }
     } else {
-        match regex_captures_at(&cached.compiled, input, last_index_byte) {
+        match regex_captures_at(
+            &cached.compiled,
+            regex_input.as_str(unicode),
+            last_index_byte,
+        ) {
             Some(c) => c,
             None => {
                 if (global || sticky)
@@ -8030,16 +8037,8 @@ fn regexp_exec_raw(
 
     let full_match = caps.get(0).unwrap();
     // Convert absolute byte offsets to UTF-16 code unit offsets
-    let match_start_utf16 = if is_bytes_mode {
-        wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
-    } else {
-        regex_input.byte_offset_to_utf16(unicode, full_match.start)
-    };
-    let match_end_utf16 = if is_bytes_mode {
-        wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
-    } else {
-        regex_input.byte_offset_to_utf16(unicode, full_match.end)
-    };
+    let match_start_utf16 = regex_input.byte_offset_to_utf16(view, full_match.start);
+    let match_end_utf16 = regex_input.byte_offset_to_utf16(view, full_match.end);
 
     if sticky && full_match.start != last_index_byte {
         if let Err(e) = set_last_index_strict(interp, this_id, 0.0) {
@@ -8128,13 +8127,8 @@ fn regexp_exec_raw(
             .insert_value("groups".to_string(), groups_val.clone());
 
         if has_indices {
-            let cap_byte_to_utf16 = |offset: usize| -> usize {
-                if is_bytes_mode {
-                    wtf8_byte_offset_to_utf16(wtf8_bytes, offset)
-                } else {
-                    regex_input.byte_offset_to_utf16(unicode, offset)
-                }
-            };
+            let cap_byte_to_utf16 =
+                |offset: usize| -> usize { regex_input.byte_offset_to_utf16(view, offset) };
             let mut index_pairs: Vec<JsValue> = Vec::new();
             for i in 0..caps.len() {
                 match caps.get(i) {
@@ -8488,7 +8482,6 @@ impl Interpreter {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
-                let s = regex_input.as_str(true);
 
                 // 4. Let flags be ? ToString(? Get(rx, "flags")).
                 // Per spec, must invoke the flags accessor chain so user overrides of
@@ -8544,16 +8537,7 @@ impl Interpreter {
                     let is_bytes_mode = matches!(cached.compiled, CompiledRegex::Bytes(_));
                     let sticky = flags_owned.contains('y');
                     let unicode = flags_owned.contains('u') || flags_owned.contains('v');
-                    let input = if is_bytes_mode {
-                        s
-                    } else {
-                        regex_input.as_str(unicode)
-                    };
-                    let wtf8_bytes = if is_bytes_mode {
-                        regex_input.wtf8()
-                    } else {
-                        &[]
-                    };
+                    let view = RegexView::select(is_bytes_mode, unicode);
                     let input_utf16_len = regex_input.subject.len();
                     let mut results: Vec<JsValue> = Vec::new();
                     let mut last_index_utf16: usize = 0;
@@ -8561,19 +8545,24 @@ impl Interpreter {
                         if last_index_utf16 > input_utf16_len {
                             break;
                         }
-                        let last_index_byte = if is_bytes_mode {
-                            utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
-                        } else {
-                            regex_input.utf16_to_byte_offset(unicode, last_index_utf16)
-                        };
+                        let last_index_byte =
+                            regex_input.utf16_to_byte_offset(view, last_index_utf16);
                         let caps = if is_bytes_mode {
                             if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
-                                bytes_regex_captures_at(bytes_re, wtf8_bytes, last_index_byte)
+                                bytes_regex_captures_at(
+                                    bytes_re,
+                                    regex_input.wtf8(),
+                                    last_index_byte,
+                                )
                             } else {
                                 unreachable!()
                             }
                         } else {
-                            regex_captures_at(&cached.compiled, input, last_index_byte)
+                            regex_captures_at(
+                                &cached.compiled,
+                                regex_input.as_str(unicode),
+                                last_index_byte,
+                            )
                         };
                         let Some(caps) = caps else { break };
                         let full_match = caps.get(0).unwrap();
@@ -8583,25 +8572,19 @@ impl Interpreter {
                             break;
                         }
                         let match_text = &full_match.text;
-                        let match_end_utf16 = if is_bytes_mode {
-                            wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
-                        } else {
-                            regex_input.byte_offset_to_utf16(unicode, full_match.end)
-                        };
+                        let match_end_utf16 =
+                            regex_input.byte_offset_to_utf16(view, full_match.end);
 
                         results.push(JsValue::string(regex_output_to_js_string(match_text)));
 
                         if match_text.is_empty() {
-                            let match_start_utf16 = if is_bytes_mode {
-                                wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
-                            } else {
-                                regex_input.byte_offset_to_utf16(unicode, full_match.start)
-                            };
+                            let match_start_utf16 =
+                                regex_input.byte_offset_to_utf16(view, full_match.start);
                             // AdvanceStringIndex per spec operates on the original S, not the
                             // possibly-preprocessed `input` — full_unicode must be able to detect
                             // real surrogate pairs in S even when the matcher runs on a split form.
                             last_index_utf16 =
-                                advance_string_index(s, match_start_utf16, full_unicode);
+                                advance_string_index(&regex_input, match_start_utf16, full_unicode);
                         } else {
                             last_index_utf16 = match_end_utf16;
                         }
@@ -8660,7 +8643,8 @@ impl Interpreter {
                                 } else {
                                     li_num.min(9007199254740991.0).floor() as usize
                                 };
-                                let next_index = advance_string_index(s, this_index, full_unicode);
+                                let next_index =
+                                    advance_string_index(&regex_input, this_index, full_unicode);
                                 if let Err(e) =
                                     set_last_index_strict(interp, rx_id, next_index as f64)
                                 {
@@ -8787,7 +8771,6 @@ impl Interpreter {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
-                let s = regex_input.as_str(true);
                 // Non-unicode version for string slicing (surrogates kept as
                 // individual PUA chars so UTF-16 indexing works correctly)
                 let s_slice = regex_input.as_str(false);
@@ -8870,16 +8853,7 @@ impl Interpreter {
                     let is_bytes_mode = matches!(cached.compiled, CompiledRegex::Bytes(_));
                     let sticky = flags_owned.contains('y');
                     let unicode = flags_owned.contains('u') || flags_owned.contains('v');
-                    let input = if is_bytes_mode {
-                        s
-                    } else {
-                        regex_input.as_str(unicode)
-                    };
-                    let wtf8_bytes = if is_bytes_mode {
-                        regex_input.wtf8()
-                    } else {
-                        &[]
-                    };
+                    let view = RegexView::select(is_bytes_mode, unicode);
                     let input_utf16_len = regex_input.subject.len();
                     let template = replace_str.as_ref().unwrap();
                     let mut accumulated_result = String::new();
@@ -8890,15 +8864,15 @@ impl Interpreter {
                         if last_index_utf16 > input_utf16_len {
                             break;
                         }
-                        let last_index_byte = if is_bytes_mode {
-                            utf16_to_wtf8_byte_offset(wtf8_bytes, last_index_utf16)
-                        } else {
-                            regex_input.utf16_to_byte_offset(unicode, last_index_utf16)
-                        };
+                        let last_index_byte =
+                            regex_input.utf16_to_byte_offset(view, last_index_utf16);
                         let mut caps = if is_bytes_mode {
                             if let CompiledRegex::Bytes(ref bytes_re) = cached.compiled {
-                                match bytes_regex_captures_at(bytes_re, wtf8_bytes, last_index_byte)
-                                {
+                                match bytes_regex_captures_at(
+                                    bytes_re,
+                                    regex_input.wtf8(),
+                                    last_index_byte,
+                                ) {
                                     Some(c) => c,
                                     None => break,
                                 }
@@ -8906,7 +8880,11 @@ impl Interpreter {
                                 unreachable!()
                             }
                         } else {
-                            match regex_captures_at(&cached.compiled, input, last_index_byte) {
+                            match regex_captures_at(
+                                &cached.compiled,
+                                regex_input.as_str(unicode),
+                                last_index_byte,
+                            ) {
                                 Some(c) => c,
                                 None => break,
                             }
@@ -8922,21 +8900,15 @@ impl Interpreter {
 
                         let full_match = caps.get(0).unwrap();
                         let matched = &full_match.text;
-                        let match_start_utf16 = if is_bytes_mode {
-                            wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.start)
-                        } else {
-                            regex_input.byte_offset_to_utf16(unicode, full_match.start)
-                        };
-                        let match_end_utf16 = if is_bytes_mode {
-                            wtf8_byte_offset_to_utf16(wtf8_bytes, full_match.end)
-                        } else {
-                            regex_input.byte_offset_to_utf16(unicode, full_match.end)
-                        };
+                        let match_start_utf16 =
+                            regex_input.byte_offset_to_utf16(view, full_match.start);
+                        let match_end_utf16 =
+                            regex_input.byte_offset_to_utf16(view, full_match.end);
                         let match_length_utf16 =
                             regex_output_to_js_string(matched).code_units.len();
                         let position_utf16 = match_start_utf16;
                         let position = regex_input
-                            .utf16_to_byte_offset(false, position_utf16)
+                            .utf16_to_byte_offset(RegexView::NonUnicode, position_utf16)
                             .min(length_s);
 
                         // Build captures as JsValues for get_substitution
@@ -9018,7 +8990,7 @@ impl Interpreter {
                             JsValue::UNDEFINED
                         };
                         let tail_pos = regex_input.utf16_to_byte_offset(
-                            false,
+                            RegexView::NonUnicode,
                             (position_utf16 + match_length_utf16).min(s_utf16_len),
                         );
                         let replacement = match get_substitution(
@@ -9045,7 +9017,7 @@ impl Interpreter {
                         // original S, not the possibly-preprocessed `input`.
                         if matched.is_empty() {
                             last_index_utf16 =
-                                advance_string_index(s, match_start_utf16, full_unicode);
+                                advance_string_index(&regex_input, match_start_utf16, full_unicode);
                         } else {
                             last_index_utf16 = match_end_utf16;
                         }
@@ -9128,7 +9100,8 @@ impl Interpreter {
                                     };
                                     n as usize
                                 };
-                                let next_index = advance_string_index(s, this_index, full_unicode);
+                                let next_index =
+                                    advance_string_index(&regex_input, this_index, full_unicode);
                                 match set_last_index_strict(interp, rx_id, next_index as f64) {
                                     Ok(()) => {}
                                     Err(e) => {
@@ -9227,7 +9200,7 @@ impl Interpreter {
                         (
                             utf16_pos,
                             regex_input
-                                .utf16_to_byte_offset(false, utf16_pos)
+                                .utf16_to_byte_offset(RegexView::NonUnicode, utf16_pos)
                                 .min(length_s),
                         )
                     };
@@ -9317,7 +9290,7 @@ impl Interpreter {
                             JsValue::UNDEFINED
                         };
                         let tail_pos = regex_input.utf16_to_byte_offset(
-                            false,
+                            RegexView::NonUnicode,
                             (position_utf16 + match_length_utf16).min(s_utf16_len),
                         );
                         match get_substitution(
@@ -9340,7 +9313,7 @@ impl Interpreter {
 
                     // p. If position >= nextSourcePosition, then
                     let tail_pos_final = regex_input.utf16_to_byte_offset(
-                        false,
+                        RegexView::NonUnicode,
                         (position_utf16 + match_length_utf16).min(s_utf16_len),
                     );
                     if position >= next_source_position {
@@ -9387,6 +9360,8 @@ impl Interpreter {
                     Ok(r) => r,
                     Err(e) => return Completion::Throw(e),
                 };
+                // @@split slices S itself, so it works in the Unicode view
+                // regardless of the splitter's own flags.
                 let s = regex_input.as_str(true);
 
                 // 3. Let C be ? SpeciesConstructor(rx, %RegExp%).
@@ -9505,7 +9480,7 @@ impl Interpreter {
 
                     // c. If z is null, set q to AdvanceStringIndex(S, q, unicodeMatching).
                     if z_val.is_null() {
-                        q = advance_string_index(s, q, unicode_matching);
+                        q = advance_string_index(&regex_input, q, unicode_matching);
                         continue;
                     }
 
@@ -9532,14 +9507,14 @@ impl Interpreter {
 
                     //   ii. If e = p, set q to AdvanceStringIndex(S, q, unicodeMatching).
                     if e_length == p {
-                        q = advance_string_index(s, q, unicode_matching);
+                        q = advance_string_index(&regex_input, q, unicode_matching);
                         continue;
                     }
 
                     //   iii. Else,
                     // Push substring from p to q (convert UTF-16 positions to byte offsets)
-                    let p_byte = regex_input.utf16_to_byte_offset(true, p);
-                    let q_byte = regex_input.utf16_to_byte_offset(true, q);
+                    let p_byte = regex_input.utf16_to_byte_offset(RegexView::Unicode, p);
+                    let q_byte = regex_input.utf16_to_byte_offset(RegexView::Unicode, q);
                     let t = &s[p_byte..q_byte];
                     a.push(JsValue::string(regex_output_to_js_string(t)));
                     length_a += 1;
@@ -9554,7 +9529,7 @@ impl Interpreter {
                     let z_id = match z_val.as_object_id() {
                         Some(id) => id,
                         None => {
-                            q = advance_string_index(s, q, unicode_matching);
+                            q = advance_string_index(&regex_input, q, unicode_matching);
                             continue;
                         }
                     };
@@ -9594,7 +9569,7 @@ impl Interpreter {
                 }
 
                 // 16. Push remaining substring
-                let p_byte = regex_input.utf16_to_byte_offset(true, p);
+                let p_byte = regex_input.utf16_to_byte_offset(RegexView::Unicode, p);
                 let t = &s[p_byte..];
                 a.push(JsValue::string(regex_output_to_js_string(t)));
                 Completion::Normal(interp.create_array(a))
@@ -9828,11 +9803,7 @@ impl Interpreter {
                     );
                 }
 
-                let input_value = JsValue::string(string.clone());
-                let regex_input = match regex_input_for_value(interp, &input_value) {
-                    Ok(input) => input,
-                    Err(e) => return Completion::Throw(e),
-                };
+                let regex_input = regex_input_for_subject(interp, string.clone());
                 let regex_string = regex_input.as_str(true);
 
                 // If we have a matcher object, use RegExpExec
@@ -9911,7 +9882,7 @@ impl Interpreter {
                             li_num.min(9007199254740991.0).floor() as usize
                         };
                         let next_index =
-                            advance_string_index(regex_string, this_index, full_unicode);
+                            advance_string_index(&regex_input, this_index, full_unicode);
                         if let Err(e) = spec_set(
                             interp, mid, "lastIndex",
                             JsValue::number(next_index as f64), true,
@@ -10759,7 +10730,7 @@ mod nullable_quantifier_rewrite_tests {
 
 #[cfg(test)]
 mod regex_input_cache_tests {
-    use super::{Interpreter, JsString, JsValue, Rc, RegexInput, regex_input_for_value};
+    use super::{Interpreter, JsString, JsValue, Rc, RegexInput, RegexView, regex_input_for_value};
 
     #[test]
     fn reuses_conversion_for_the_same_js_string_identity() {
@@ -10778,13 +10749,12 @@ mod regex_input_cache_tests {
     #[test]
     fn maps_unicode_offsets_from_the_original_utf16_subject() {
         let input = RegexInput::new(JsString::from_vec(vec![0xDB80, 0xDC00, b'x' as u16]));
-        let unicode = input.as_str(true);
 
-        assert_eq!(input.utf16_to_byte_offset(true, 0), 0);
-        assert_eq!(input.utf16_to_byte_offset(true, 1), 0);
-        assert_eq!(input.utf16_to_byte_offset(true, 2), 4);
-        assert_eq!(input.byte_offset_to_utf16(true, 4), 2);
-        assert_eq!(input.byte_offset_to_utf16(true, 5), 3);
+        assert_eq!(input.utf16_to_byte_offset(RegexView::Unicode, 0), 0);
+        assert_eq!(input.utf16_to_byte_offset(RegexView::Unicode, 1), 0);
+        assert_eq!(input.utf16_to_byte_offset(RegexView::Unicode, 2), 4);
+        assert_eq!(input.byte_offset_to_utf16(RegexView::Unicode, 4), 2);
+        assert_eq!(input.byte_offset_to_utf16(RegexView::Unicode, 5), 3);
 
         let mixed = RegexInput::new(JsString::from_vec(vec![
             0xD800,
@@ -10792,10 +10762,9 @@ mod regex_input_cache_tests {
             0xDC00,
             b'x' as u16,
         ]));
-        let unicode = mixed.as_str(true);
-        assert_eq!(mixed.utf16_to_byte_offset(true, 2), 4);
-        assert_eq!(mixed.utf16_to_byte_offset(true, 3), 8);
-        assert_eq!(mixed.byte_offset_to_utf16(true, 8), 3);
-        assert_eq!(mixed.byte_offset_to_utf16(true, 9), 4);
+        assert_eq!(mixed.utf16_to_byte_offset(RegexView::Unicode, 2), 4);
+        assert_eq!(mixed.utf16_to_byte_offset(RegexView::Unicode, 3), 8);
+        assert_eq!(mixed.byte_offset_to_utf16(RegexView::Unicode, 8), 3);
+        assert_eq!(mixed.byte_offset_to_utf16(RegexView::Unicode, 9), 4);
     }
 }

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -1400,7 +1400,7 @@ pub(crate) enum IteratorState {
     RegExpStringIterator {
         source: String,
         flags: String,
-        string: String,
+        string: JsString,
         global: bool,
         last_index: usize,
         done: bool,

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,7 +45,7 @@ pub(crate) enum ValueKind {
 
 // UTF-16 code unit string per spec §6.1.4
 // Uses Arc<Vec<u16>> so cloning (e.g. env.get) is O(1).
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub(crate) struct JsString {
     pub code_units: Arc<Vec<u16>>,
 }

--- a/test262-extra/RegExp-advance-string-index-supplementary-pua.js
+++ b/test262-extra/RegExp-advance-string-index-supplementary-pua.js
@@ -1,0 +1,194 @@
+/*---
+esid: sec-advancestringindex
+description: >
+  AdvanceStringIndex advances empty matches by the original UTF-16 code units,
+  so a genuine supplementary Private Use Area scalar in U+F0000-U+F07FF is
+  never mistaken for jsse's one-code-unit lone-surrogate sentinel.
+info: |
+  AdvanceStringIndex ( S, index, unicode )
+
+  3. If unicode is false, return index + 1.
+  4. If index + 1 >= the length of S, return index + 1.
+  5. Let cp be CodePointAt(S, index).
+  6. Return index + cp.[[CodeUnitCount]].
+
+  The spec defines this over the original String S. jsse matches against a
+  converted Rust view in which a *lone* surrogate is encoded as a PUA scalar in
+  U+F0000-U+F07FF, an encoding that is ambiguous with a *genuine* scalar in that
+  same range. Deriving the advance from that view makes a real U+F0000 look like
+  a one-code-unit sentinel, so a global Unicode empty match advances to UTF-16
+  index 1, the boundary map sends index 1 back to the start of the scalar, and
+  the same empty match repeats forever. AdvanceStringIndex must therefore read
+  the retained UTF-16 code units, where a high/low surrogate pair is
+  unambiguously two units wide.
+
+  Every expectation below is cross-checked against V8. The failure mode this
+  guards is a hang, so a regression shows up as a timeout rather than a
+  mismatch.
+
+  Subjects are built with String.fromCharCode rather than source literals so the
+  test exercises the RegExp conversion path only.
+---*/
+
+function codeUnits(s) {
+  var units = [];
+  for (var i = 0; i < s.length; i++) {
+    units.push(s.charCodeAt(i));
+  }
+  return units;
+}
+
+function assertSameUnits(actual, expected, label) {
+  var a = codeUnits(actual);
+  var e = codeUnits(expected);
+  if (a.length !== e.length) {
+    throw new Test262Error(
+      label + ": expected " + e.length + " code units, got " + a.length +
+      " [" + a.join(",") + "]"
+    );
+  }
+  for (var i = 0; i < e.length; i++) {
+    if (a[i] !== e[i]) {
+      throw new Test262Error(
+        label + ": code unit " + i + " should be " + e[i] + ", got " + a[i]
+      );
+    }
+  }
+}
+
+function assertIndices(actual, expected, label) {
+  if (actual.length !== expected.length) {
+    throw new Test262Error(
+      label + ": expected " + expected.length + " matches, got " +
+      actual.length + " [" + actual.join(",") + "]"
+    );
+  }
+  for (var i = 0; i < expected.length; i++) {
+    if (actual[i] !== expected[i]) {
+      throw new Test262Error(
+        label + ": match " + i + " should be at index " + expected[i] +
+        ", got " + actual[i]
+      );
+    }
+  }
+}
+
+function matchAllIndices(s, re) {
+  var indices = [];
+  var iter = s.matchAll(re);
+  var step = iter.next();
+  while (!step.done) {
+    indices.push(step.value.index);
+    step = iter.next();
+  }
+  return indices;
+}
+
+// U+F0000, the base of jsse's lone-surrogate PUA sentinel range, as a genuine
+// two-code-unit supplementary scalar.
+var pua = String.fromCharCode(0xDB80, 0xDC00);
+var lone = String.fromCharCode(0xD800);
+var emoji = String.fromCharCode(0xD83D, 0xDE00);
+
+if (pua.length !== 2 || pua.codePointAt(0) !== 0xF0000) {
+  throw new Test262Error("subject construction failed: length " + pua.length);
+}
+
+// The core repro. In Unicode mode the scalar is two code units wide, so an
+// empty match at 0 must advance past both of them and the scan must terminate
+// with exactly two matches.
+assertSameUnits(pua.replace(/(?:)/gu, "Z"), "Z" + pua + "Z", "unicode empty replace");
+assertIndices(matchAllIndices(pua, /(?:)/gu), [0, 2], "unicode empty matchAll");
+
+var m = pua.match(/(?:)/gu);
+if (m.length !== 2) {
+  throw new Test262Error("unicode empty match should yield 2 matches, got " + m.length);
+}
+
+// Without the u flag the same subject is two independent code units, so
+// AdvanceStringIndex steps one unit at a time and there are three positions.
+assertSameUnits(
+  pua.replace(/(?:)/g, "Z"),
+  "Z" + String.fromCharCode(0xDB80) + "Z" + String.fromCharCode(0xDC00) + "Z",
+  "non-unicode empty replace"
+);
+assertIndices(matchAllIndices(pua, /(?:)/g), [0, 1, 2], "non-unicode empty matchAll");
+
+// Control: what the sentinel range actually encodes. A lone surrogate is one
+// code unit wide even in Unicode mode, so it advances by one.
+assertSameUnits(lone.replace(/(?:)/gu, "Z"), "Z" + lone + "Z", "lone surrogate empty replace");
+assertIndices(matchAllIndices(lone, /(?:)/gu), [0, 1], "lone surrogate empty matchAll");
+
+// Control: an ordinary astral scalar outside the sentinel range behaves the
+// same as the PUA one, confirming the advance is driven by the surrogate pair
+// and not by the code point's value.
+assertSameUnits(emoji.replace(/(?:)/gu, "Z"), "Z" + emoji + "Z", "astral empty replace");
+assertIndices(matchAllIndices(emoji, /(?:)/gu), [0, 2], "astral empty matchAll");
+assertSameUnits(
+  emoji.replace(/(?:)/g, "Z"),
+  "Z" + String.fromCharCode(0xD83D) + "Z" + String.fromCharCode(0xDE00) + "Z",
+  "astral non-unicode empty replace"
+);
+
+// A subject holding both a real sentinel and a genuine PUA scalar: the original
+// code units disambiguate them within one scan.
+var mixed = lone + pua + "x";
+assertSameUnits(
+  mixed.replace(/(?:)/gu, "Z"),
+  "Z" + lone + "Z" + pua + "Z" + "x" + "Z",
+  "mixed empty replace"
+);
+assertIndices(matchAllIndices(mixed, /(?:)/gu), [0, 1, 3, 4], "mixed empty matchAll");
+
+// The scalar surrounded by BMP characters, so the advance is exercised from a
+// non-zero starting index rather than only at position 0.
+var padded = "a" + pua + "b";
+assertSameUnits(
+  padded.replace(/(?:)/gu, "Z"),
+  "Z" + "a" + "Z" + pua + "Z" + "b" + "Z",
+  "padded empty replace"
+);
+assertIndices(matchAllIndices(padded, /(?:)/gu), [0, 1, 3, 4], "padded empty matchAll");
+
+// Split drives the same advance through its own loop, so the scalar must stay
+// whole rather than being torn at the sentinel boundary.
+if (padded.split(/(?:)/gu).length !== 3) {
+  throw new Test262Error(
+    "unicode empty split should yield 3 elements, got " +
+    padded.split(/(?:)/gu).length
+  );
+}
+
+// A quantified pattern that can match empty must terminate too: the advance
+// only runs when the match is zero-length, and the scalar still counts as two
+// units when it does.
+assertSameUnits(pua.replace(/x*/gu, "Z"), "Z" + pua + "Z", "nullable quantifier replace");
+assertIndices(matchAllIndices(pua, /x*/gu), [0, 2], "nullable quantifier matchAll");
+
+// Driving exec directly with an explicit lastIndex covers the remaining
+// boundary edges. A lastIndex landing inside the surrogate pair is rounded down
+// to the start of the scalar in Unicode mode, so the match reports index 0 --
+// the pair is never entered at its trailing half.
+var re = /(?:)/gu;
+re.lastIndex = 1;
+var mid = re.exec(pua);
+if (mid === null || mid.index !== 0) {
+  throw new Test262Error(
+    "exec from mid-pair lastIndex should match at index 0, got " +
+    (mid === null ? "null" : mid.index)
+  );
+}
+
+re.lastIndex = 2;
+var end = re.exec(pua);
+if (end === null || end.index !== 2) {
+  throw new Test262Error(
+    "exec from end lastIndex should match at index 2, got " +
+    (end === null ? "null" : end.index)
+  );
+}
+
+re.lastIndex = 3;
+if (re.exec(pua) !== null) {
+  throw new Test262Error("exec past the end should return null");
+}

--- a/test262-extra/RegExp-legacy-statics.js
+++ b/test262-extra/RegExp-legacy-statics.js
@@ -71,6 +71,34 @@ if (RegExp.input !== "overridden") {
 if (RegExp["$_"] !== "overridden") {
   throw new Test262Error('RegExp.$_ after set should be "overridden", got: ' + RegExp["$_"]);
 }
+// Setting [[RegExpInput]] must not alter contexts retained from the last match.
+if (RegExp.leftContext !== "abc " || RegExp.rightContext !== " def") {
+  throw new Test262Error("setting RegExp.input changed the last match contexts");
+}
+
+// Retained input and lazily materialized contexts preserve raw UTF-16 code
+// units, including unpaired surrogates.
+var surrogateInput = "\ud800A\udc00";
+/A/.exec(surrogateInput);
+if (
+  RegExp.input.length !== 3 ||
+  RegExp.input.charCodeAt(0) !== 0xd800 ||
+  RegExp.input.charCodeAt(2) !== 0xdc00
+) {
+  throw new Test262Error("RegExp.input did not preserve lone surrogates");
+}
+if (
+  RegExp.leftContext.length !== 1 ||
+  RegExp.leftContext.charCodeAt(0) !== 0xd800
+) {
+  throw new Test262Error("RegExp.leftContext did not preserve the lead surrogate");
+}
+if (
+  RegExp.rightContext.length !== 1 ||
+  RegExp.rightContext.charCodeAt(0) !== 0xdc00
+) {
+  throw new Test262Error("RegExp.rightContext did not preserve the trail surrogate");
+}
 
 // --- Subclass receiver throws TypeError ---
 class MyRegExp extends RegExp {}

--- a/test262-extra/RegExp-legacy-statics.js
+++ b/test262-extra/RegExp-legacy-statics.js
@@ -100,6 +100,36 @@ if (
   throw new Test262Error("RegExp.rightContext did not preserve the trail surrogate");
 }
 
+// Unicode match offsets must be translated back through the original UTF-16
+// subject. A genuine scalar in JSSE's lone-surrogate PUA range must count as
+// its two original code units rather than as a one-unit surrogate sentinel.
+var supplementaryPua = String.fromCharCode(0xdb80, 0xdc00);
+var puaContextInput = supplementaryPua + "x" + supplementaryPua;
+
+function assertSupplementaryPuaContexts(re, label) {
+  var puaMatch = re.exec(puaContextInput);
+  if (puaMatch.index !== 2) {
+    throw new Test262Error(label + " match index should be 2, got " + puaMatch.index);
+  }
+  if (
+    RegExp.leftContext.length !== 2 ||
+    RegExp.leftContext.charCodeAt(0) !== 0xdb80 ||
+    RegExp.leftContext.charCodeAt(1) !== 0xdc00
+  ) {
+    throw new Test262Error(label + " leftContext split a supplementary PUA scalar");
+  }
+  if (
+    RegExp.rightContext.length !== 2 ||
+    RegExp.rightContext.charCodeAt(0) !== 0xdb80 ||
+    RegExp.rightContext.charCodeAt(1) !== 0xdc00
+  ) {
+    throw new Test262Error(label + " rightContext split a supplementary PUA scalar");
+  }
+}
+
+assertSupplementaryPuaContexts(/x/, "non-Unicode");
+assertSupplementaryPuaContexts(/x/u, "Unicode");
+
 // --- Subclass receiver throws TypeError ---
 class MyRegExp extends RegExp {}
 var threw = false;

--- a/test262-extra/RegExp-legacy-statics.js
+++ b/test262-extra/RegExp-legacy-statics.js
@@ -1,10 +1,17 @@
-// Tests the value behavior of legacy RegExp static properties after exec/test.
-// Spec: ECMAScript 2024, Annex B.1.2 — Legacy RegExp Features
-//
-// test262 only covers property descriptors and `this`-value validation for
-// the legacy accessors. This test fills the value-behavior gap: after a
-// successful match, the legacy statics must reflect the input, captures,
-// and context strings.
+/*---
+esid: sec-legacy-regexp-features
+description: >
+  Legacy RegExp static properties report the value of the last successful
+  match: input, lastMatch, lastParen, leftContext, rightContext and $1-$9.
+info: |
+  Annex B.1.2 Legacy RegExp Features
+
+  test262 only covers property descriptors and `this`-value validation for
+  the legacy accessors. This test fills the value-behavior gap: after a
+  successful match, the legacy statics must reflect the input, captures,
+  and context strings.
+features: [legacy-regexp]
+---*/
 
 // --- Setup: a match that exercises all legacy statics ---
 var re = /(\d+)-(\w+)/;

--- a/test262-extra/RegExp-replace-supplementary-pua-subject.js
+++ b/test262-extra/RegExp-replace-supplementary-pua-subject.js
@@ -128,6 +128,12 @@ var lone = String.fromCharCode(0xD800);
 /x/.exec(lone + "x");
 assertSameUnits(RegExp.leftContext, lone, "lone surrogate leftContext");
 
+// The original UTF-16 boundaries also disambiguate a genuine PUA scalar when
+// the same subject contains a lone surrogate sentinel.
+var mixed = lone + pua + "x";
+/x/u.exec(mixed);
+assertSameUnits(RegExp.leftContext, lone + pua, "mixed PUA and lone surrogate context");
+
 var emoji = String.fromCharCode(0xD83D, 0xDE00);
 /x/u.exec(emoji + "x");
 assertSameUnits(RegExp.leftContext, emoji, "astral unicode leftContext");

--- a/test262-extra/RegExp-replace-supplementary-pua-subject.js
+++ b/test262-extra/RegExp-replace-supplementary-pua-subject.js
@@ -1,17 +1,21 @@
-// Tests that RegExp replacement preserves subject code units that encode
-// supplementary code points in the Private Use Area plane 15 range
-// U+F0000-U+F07FF.
-// Spec: ECMAScript 2026, sec-regexp.prototype-%symbol.replace% steps 14-16
-//
-// jsse converts a UTF-16 subject into a Rust String for matching, encoding
-// lone surrogates as PUA scalars in U+F0000-U+F07FF. A *genuine* supplementary
-// code point in that same range must not be confused with that encoding: the
-// non-Unicode matching view has to be built from the original UTF-16 code
-// units, not derived from the Unicode view, or a real U+F0000 collapses into a
-// single lone surrogate and the unchanged portion of the subject is corrupted.
-//
-// Built with String.fromCharCode rather than a source literal so the test
-// exercises the RegExp conversion path only.
+/*---
+esid: sec-regexp.prototype-%symbol.replace%
+description: >
+  RegExp replacement preserves subject code units that encode supplementary
+  Private Use Area code points in the plane 15 range U+F0000-U+F07FF.
+info: |
+  RegExp.prototype [ %Symbol.replace% ] ( string, replaceValue ), steps 14-16
+
+  jsse converts a UTF-16 subject into a Rust String for matching, encoding
+  lone surrogates as PUA scalars in U+F0000-U+F07FF. A *genuine* supplementary
+  code point in that same range must not be confused with that encoding: the
+  non-Unicode matching view has to be built from the original UTF-16 code
+  units, not derived from the Unicode view, or a real U+F0000 collapses into a
+  single lone surrogate and the unchanged portion of the subject is corrupted.
+
+  Built with String.fromCharCode rather than a source literal so the test
+  exercises the RegExp conversion path only.
+---*/
 
 function codeUnits(s) {
   var units = [];

--- a/test262-extra/RegExp-replace-supplementary-pua-subject.js
+++ b/test262-extra/RegExp-replace-supplementary-pua-subject.js
@@ -100,3 +100,38 @@ if (m.index !== 3) {
   throw new Test262Error("match index should be 3, got " + m.index);
 }
 assertSameUnits(padded.match(/./)[0], "a", "non-unicode single unit match");
+
+// Offsets derived from the Unicode matching view must count such a scalar as its
+// real two code units, not as the one-code-unit surrogate sentinel. This governs
+// `.index`, the Unicode-mode replacement slice, and the Annex B lazy
+// `leftContext`/`rightContext`, which retain UTF-16 offsets into the subject.
+assertSameUnits(padded.replace(/b/u, "Z"), "a" + pua + "Z", "trailing unicode replace");
+assertSameUnits(padded.replace(/b/gu, "Z"), "a" + pua + "Z", "trailing global unicode replace");
+
+var mu = padded.match(/b/u);
+if (mu.index !== 3) {
+  throw new Test262Error("unicode match index should be 3, got " + mu.index);
+}
+
+/x/u.exec(pua + "x");
+assertSameUnits(RegExp.leftContext, pua, "unicode leftContext");
+/x/u.exec("x" + pua);
+assertSameUnits(RegExp.rightContext, pua, "unicode rightContext");
+/x/.exec(pua + "x");
+assertSameUnits(RegExp.leftContext, pua, "non-unicode leftContext");
+/x/.exec("x" + pua);
+assertSameUnits(RegExp.rightContext, pua, "non-unicode rightContext");
+
+// The sentinel range must keep working for what it actually encodes: a lone
+// surrogate stays one code unit, and an ordinary astral character stays two.
+var lone = String.fromCharCode(0xD800);
+/x/.exec(lone + "x");
+assertSameUnits(RegExp.leftContext, lone, "lone surrogate leftContext");
+
+var emoji = String.fromCharCode(0xD83D, 0xDE00);
+/x/u.exec(emoji + "x");
+assertSameUnits(RegExp.leftContext, emoji, "astral unicode leftContext");
+/x/.exec(emoji + "x");
+assertSameUnits(RegExp.leftContext, emoji, "astral non-unicode leftContext");
+assertSameUnits(emoji.replace(/x/g, "y"), emoji, "astral replace unchanged");
+assertSameUnits(lone.replace(/x/g, "y"), lone, "lone surrogate replace unchanged");

--- a/test262-extra/RegExp-replace-supplementary-pua-subject.js
+++ b/test262-extra/RegExp-replace-supplementary-pua-subject.js
@@ -1,0 +1,102 @@
+// Tests that RegExp replacement preserves subject code units that encode
+// supplementary code points in the Private Use Area plane 15 range
+// U+F0000-U+F07FF.
+// Spec: ECMAScript 2026, sec-regexp.prototype-%symbol.replace% steps 14-16
+//
+// jsse converts a UTF-16 subject into a Rust String for matching, encoding
+// lone surrogates as PUA scalars in U+F0000-U+F07FF. A *genuine* supplementary
+// code point in that same range must not be confused with that encoding: the
+// non-Unicode matching view has to be built from the original UTF-16 code
+// units, not derived from the Unicode view, or a real U+F0000 collapses into a
+// single lone surrogate and the unchanged portion of the subject is corrupted.
+//
+// Built with String.fromCharCode rather than a source literal so the test
+// exercises the RegExp conversion path only.
+
+function codeUnits(s) {
+  var units = [];
+  for (var i = 0; i < s.length; i++) {
+    units.push(s.charCodeAt(i));
+  }
+  return units;
+}
+
+function assertSameUnits(actual, expected, label) {
+  var a = codeUnits(actual);
+  var e = codeUnits(expected);
+  if (a.length !== e.length) {
+    throw new Test262Error(
+      label + ": expected " + e.length + " code units, got " + a.length +
+      " [" + a.join(",") + "]"
+    );
+  }
+  for (var i = 0; i < e.length; i++) {
+    if (a[i] !== e[i]) {
+      throw new Test262Error(
+        label + ": code unit " + i + " should be " + e[i] + ", got " + a[i]
+      );
+    }
+  }
+}
+
+// The surrogate pair encoding of U+F0000, the base of jsse's lone-surrogate
+// PUA range.
+var pua = String.fromCharCode(0xDB80, 0xDC00);
+
+if (pua.length !== 2 || pua.codePointAt(0) !== 0xF0000) {
+  throw new Test262Error("subject construction failed: length " + pua.length);
+}
+
+// A pattern that never matches must return the subject unchanged.
+assertSameUnits(pua.replace(/x/, "y"), pua, "non-matching replace");
+assertSameUnits(pua.replace(/x/g, "y"), pua, "non-matching global replace");
+assertSameUnits(pua.replace(/x/u, "y"), pua, "non-matching unicode replace");
+assertSameUnits(pua.replace(/x/gu, "y"), pua, "non-matching global unicode replace");
+
+// A match elsewhere in the subject must leave the supplementary code point
+// intact in both the leading and trailing unchanged portions.
+var padded = "a" + pua + "b";
+if (padded.length !== 4) {
+  throw new Test262Error("padded subject should be 4 code units, got " + padded.length);
+}
+
+assertSameUnits(padded.replace(/a/, "Z"), "Z" + pua + "b", "leading replace");
+assertSameUnits(padded.replace(/a/g, "Z"), "Z" + pua + "b", "leading global replace");
+assertSameUnits(padded.replace(/b/, "Z"), "a" + pua + "Z", "trailing replace");
+assertSameUnits(padded.replace(/b/g, "Z"), "a" + pua + "Z", "trailing global replace");
+assertSameUnits(padded.replace(/a/gu, "Z"), "Z" + pua + "b", "leading global unicode replace");
+
+// Functional replacement receives the intact subject as its final argument,
+// and the match position is a UTF-16 offset into that subject.
+var seenString = null;
+var seenPosition = null;
+var functional = padded.replace(/b/g, function (match, position, string) {
+  seenPosition = position;
+  seenString = string;
+  return "Z";
+});
+assertSameUnits(functional, "a" + pua + "Z", "functional replace result");
+assertSameUnits(seenString, padded, "functional replace subject argument");
+if (seenPosition !== 3) {
+  throw new Test262Error("functional replace position should be 3, got " + seenPosition);
+}
+
+// $` and $' substitutions slice the same intact subject.
+assertSameUnits(
+  padded.replace(/b/, "[$`]"),
+  "a" + pua + "[a" + pua + "]",
+  "$` substitution"
+);
+assertSameUnits(
+  padded.replace(/a/, "[$']"),
+  "[" + pua + "b]" + pua + "b",
+  "$' substitution"
+);
+
+// A non-Unicode pattern sees the subject as two individual code units, so the
+// match index of a following character reflects both of them.
+var m = padded.match(/b/);
+if (m.index !== 3) {
+  throw new Test262Error("match index should be 3, got " + m.index);
+}
+assertSameUnits(padded.match(/./)[0], "a", "non-unicode single unit match");

--- a/test262-extra/RegExp-sampled-offset-boundaries.js
+++ b/test262-extra/RegExp-sampled-offset-boundaries.js
@@ -1,0 +1,213 @@
+/*---
+esid: sec-regexpbuiltinexec
+description: >
+  Match offsets stay exact on subjects long enough to span many sampled offset
+  boundaries, in both Unicode and non-Unicode mode.
+info: |
+  RegExpBuiltinExec ( R, S ), steps 12-15
+
+  jsse matches against a converted view of the subject and maps offsets back to
+  UTF-16 with a cached table. That table is *sampled* — it stores one boundary
+  every N characters rather than one per character, so a lookup binary-searches
+  the samples and then walks at most one interval. The walk is where a sampled
+  table can diverge from a dense one, and only a subject longer than the sample
+  interval exercises it: short subjects fit inside the first interval and never
+  binary-search at all.
+
+  Each character below is deliberately a different UTF-8 width in the converted
+  view (1, 2 and 3 bytes) and a different UTF-16 width in the subject (1 and 2
+  code units), so byte offsets and code-unit offsets advance at different rates
+  and a walk that miscounts either one is caught.
+
+  Every expectation is derived from the subject's construction rather than
+  hard-coded, and cross-checked against V8.
+---*/
+
+function codeUnits(s) {
+  var units = [];
+  for (var i = 0; i < s.length; i++) {
+    units.push(s.charCodeAt(i));
+  }
+  return units;
+}
+
+function assertSameUnits(actual, expected, label) {
+  var a = codeUnits(actual);
+  var e = codeUnits(expected);
+  if (a.length !== e.length) {
+    throw new Test262Error(
+      label + ": expected " + e.length + " code units, got " + a.length
+    );
+  }
+  for (var i = 0; i < e.length; i++) {
+    if (a[i] !== e[i]) {
+      throw new Test262Error(
+        label + ": code unit " + i + " should be " + e[i] + ", got " + a[i]
+      );
+    }
+  }
+}
+
+// One repeating unit mixing every relevant width, with a marker at a known
+// position. "a" is 1 byte / 1 unit, "é" is 2 bytes / 1 unit, "€" is 3 bytes /
+// 1 unit, and the astral characters are 4 bytes / 2 units.
+var astral = String.fromCharCode(0xD83D, 0xDE00);   // U+1F600
+var pua = String.fromCharCode(0xDB80, 0xDC00);      // genuine U+F0000
+var cell = "aé€" + astral + pua;          // 7 code units per cell
+
+var CELLS = 500;
+var subject = cell.repeat(CELLS);
+var CELL_UNITS = 7;
+
+if (subject.length !== CELLS * CELL_UNITS) {
+  throw new Test262Error(
+    "subject should be " + CELLS * CELL_UNITS + " code units, got " + subject.length
+  );
+}
+
+// Well past any plausible sample interval, so lookups must binary-search the
+// samples and then walk within one.
+if (subject.length < 1024) {
+  throw new Test262Error("subject is too short to span multiple samples");
+}
+
+// Every "€" sits at a known code-unit offset. Walking all of them checks the
+// mapping at hundreds of independent points, not just the first and last.
+var euro = /€/gu;
+var seen = 0;
+var m;
+while ((m = euro.exec(subject)) !== null) {
+  var expected = seen * CELL_UNITS + 2;
+  if (m.index !== expected) {
+    throw new Test262Error(
+      "unicode match " + seen + " should be at index " + expected + ", got " + m.index
+    );
+  }
+  if (euro.lastIndex !== expected + 1) {
+    throw new Test262Error(
+      "unicode lastIndex after match " + seen + " should be " + (expected + 1) +
+      ", got " + euro.lastIndex
+    );
+  }
+  seen++;
+}
+if (seen !== CELLS) {
+  throw new Test262Error("expected " + CELLS + " unicode matches, got " + seen);
+}
+
+// The same sweep without the u flag, which uses the sibling offset table.
+var euroPlain = /€/g;
+seen = 0;
+while ((m = euroPlain.exec(subject)) !== null) {
+  if (m.index !== seen * CELL_UNITS + 2) {
+    throw new Test262Error(
+      "non-unicode match " + seen + " should be at index " + (seen * CELL_UNITS + 2) +
+      ", got " + m.index
+    );
+  }
+  seen++;
+}
+if (seen !== CELLS) {
+  throw new Test262Error("expected " + CELLS + " non-unicode matches, got " + seen);
+}
+
+// An explicit lastIndex deep in the subject must resolve to the same place the
+// sequential scan reached, in both modes.
+var probe = /€/gu;
+probe.lastIndex = 400 * CELL_UNITS;
+if (probe.exec(subject).index !== 400 * CELL_UNITS + 2) {
+  throw new Test262Error("unicode lastIndex probe resolved to the wrong offset");
+}
+
+var probePlain = /€/g;
+probePlain.lastIndex = 400 * CELL_UNITS;
+if (probePlain.exec(subject).index !== 400 * CELL_UNITS + 2) {
+  throw new Test262Error("non-unicode lastIndex probe resolved to the wrong offset");
+}
+
+// A lastIndex landing on the trailing half of a surrogate pair is rounded down
+// to the start of that character in Unicode mode. Cell offset 3 is the astral
+// character, so offset 4 is its low surrogate.
+var midPair = /[\s\S]/gu;
+midPair.lastIndex = 100 * CELL_UNITS + 4;
+var mid = midPair.exec(subject);
+if (mid.index !== 100 * CELL_UNITS + 3) {
+  throw new Test262Error(
+    "mid-pair lastIndex should resolve to " + (100 * CELL_UNITS + 3) + ", got " + mid.index
+  );
+}
+assertSameUnits(mid[0], astral, "mid-pair match text");
+
+// $` and $' slice the subject using converted offsets, so a replacement deep in
+// a long subject reconstructs it exactly.
+var single = subject.replace(/€/u, "[$`$']");
+assertSameUnits(
+  single,
+  subject.slice(0, 2) + "[" + subject.slice(0, 2) + subject.slice(3) + "]" + subject.slice(3),
+  "$` and $' over a long subject"
+);
+
+// A functional replacement reports UTF-16 positions into the original subject.
+var positions = [];
+subject.replace(/€/gu, function (match, position) {
+  positions.push(position);
+  return "z";
+});
+if (positions.length !== CELLS) {
+  throw new Test262Error("expected " + CELLS + " replacement positions");
+}
+for (var i = 0; i < CELLS; i++) {
+  if (positions[i] !== i * CELL_UNITS + 2) {
+    throw new Test262Error(
+      "replacement position " + i + " should be " + (i * CELL_UNITS + 2) +
+      ", got " + positions[i]
+    );
+  }
+}
+
+// Replacing every "€" must leave all other characters — including the astral
+// and PUA-range ones — byte-identical.
+assertSameUnits(
+  subject.replace(/€/gu, "z"),
+  ("aéz" + astral + pua).repeat(CELLS),
+  "global unicode replace over a long subject"
+);
+assertSameUnits(
+  subject.replace(/€/g, "z"),
+  ("aéz" + astral + pua).repeat(CELLS),
+  "global non-unicode replace over a long subject"
+);
+
+// Splitting yields one more piece than there are separators, and the split
+// boundaries land in the same places the scan found.
+//
+// Only the boundaries are asserted here, not the full text of a piece that ends
+// in the PUA-range scalar: %Symbol.split% still decodes such a scalar back into
+// a lone surrogate on the way out, a pre-existing decode bug tracked in #534
+// that is unrelated to offset mapping and reproduces identically on `main`.
+var parts = subject.split(/€/gu);
+if (parts.length !== CELLS + 1) {
+  throw new Test262Error("expected " + (CELLS + 1) + " split parts, got " + parts.length);
+}
+assertSameUnits(parts[0], "aé", "first split part");
+assertSameUnits(parts[CELLS].slice(0, 2), astral, "last split part starts at the right boundary");
+for (var p = 1; p < CELLS; p++) {
+  if (parts[p].slice(0, 2) !== astral) {
+    throw new Test262Error("split part " + p + " does not start at a cell boundary");
+  }
+}
+
+// The Annex B statics retain UTF-16 offsets into the subject, so a match near
+// the end must report the whole preceding text.
+/€/u.exec(subject);
+if (RegExp.leftContext.length !== 2) {
+  throw new Test262Error(
+    "leftContext should be 2 code units, got " + RegExp.leftContext.length
+  );
+}
+if (RegExp.rightContext.length !== subject.length - 3) {
+  throw new Test262Error(
+    "rightContext should be " + (subject.length - 3) + " code units, got " +
+    RegExp.rightContext.length
+  );
+}


### PR DESCRIPTION
## Summary

- cache regex backend input by immutable `JsString` identity, including Unicode, non-Unicode, WTF-8, and ASCII classification
- retain the original subject through built-in and custom exec paths instead of cloning its UTF-16 storage
- materialize Annex B input/left/right contexts lazily from the retained subject and UTF-16 match offsets
- preserve the cached subject through RegExp string iterators and cover identity reuse plus lone-surrogate legacy contexts

## Performance

The sticky ASCII scan at 20,000 tokens improved from 1.49s before the change to 0.31s on the final build under the same shared runner. A larger 20k/40k/80k probe measured 0.31/0.72/1.13s on its first run, removing the prior near-quadratic doubling behavior.

## Validation

- `./scripts/lint.sh`
- `cargo build --release`
- `cargo test --release`
- `uv run python scripts/run-custom-tests.py` (13/13)
- targeted RegExp + Annex B + test262-extra (4,103/4,103)
- full test262 (99,568/99,568, zero regressions)

Closes #522