### PR TITLE
refactor(typedarray): extract validate_typed_array receiver-validation seam

### DIFF
--- a/.architecture/backlog.md
+++ b/.architecture/backlog.md
@@ -1,0 +1,74 @@
+# Deepening backlog
+
+Persistent candidate memory for the `pm-deepen` architecture routine. Statuses:
+`proposed` (eligible, not started), `in-flight` (branch+PR exist), `landed` (merged),
+`dropped` (hard filter — reversible), `rejected` (human declined / recurring bail — human-only reopen).
+Never delete rows; they are the memory that stops re-surfacing the same work.
+
+## validate-typed-array
+
+- **Status**: in-flight
+- **Score**: 24/25 (leverage 5, locality 4, blast radius 1, heat 5)
+- **Files**: ~1 estimated — `src/interpreter/builtins/typedarray.rs`
+- **Modules**: `src/interpreter/builtins/typedarray.rs`
+- **Summary**: Collapse ~17 open-coded TypedArray receiver-validation prologues (brand check + detached/out-of-bounds check + clone + doubled `not a TypedArray` throw) behind one `validate_typed_array` seam, mirroring the existing kind-gated `validate_uint8array`.
+- **First seen**: 2026-09-01
+- **PR**: (pending)
+
+## complete-state-machine-generator-ctor
+
+- **Status**: proposed
+- **Score**: 22/25 (leverage 5, locality 4, blast radius 1, heat 3)
+- **Files**: ~2 estimated — `src/interpreter/eval/generator_runtime.rs`, `src/interpreter/types.rs`
+- **Modules**: `src/interpreter/eval/generator_runtime.rs`
+- **Summary**: Collapse ~87 byte-identical inlined "completed state-machine generator" 10-field struct literals into `completed_state_machine_generator` / `…_async_generator` constructors. Runner-up candidate this run; natural next firing.
+
+## settle-and-return-tail
+
+- **Status**: proposed
+- **Score**: 20/25 (leverage 4, locality 4, blast radius 1, heat 3)
+- **Files**: ~1 estimated — `src/interpreter/eval/generator_runtime.rs`
+- **Modules**: `src/interpreter/eval/generator_runtime.rs`
+- **Summary**: Extract `settle_and_return(settle_fn, arg, promise)` for the ~47 "call settle fn + drain microtasks + return promise" async-generator exit tails. Sequence after complete-state-machine-generator-ctor, which shrinks the same driver.
+
+## this-weak-map-set
+
+- **Status**: proposed
+- **Score**: 20/25 (leverage 4, locality 4, blast radius 1, heat 3)
+- **Files**: ~1 estimated — `src/interpreter/builtins/collections.rs`
+- **Modules**: `src/interpreter/builtins/collections.rs`
+- **Summary**: Add `this_weak_map` / `this_weak_set` sibling helpers to collapse 9 inconsistently hand-rolled WeakMap/WeakSet receiver-unwrap dances, mirroring the existing `this_map` / `this_set`.
+
+## generator-entry-guard
+
+- **Status**: proposed
+- **Score**: 19/25 (leverage 4, locality 3, blast radius 1, heat 3)
+- **Files**: ~1 estimated — `src/interpreter/eval/generator_runtime.rs`
+- **Modules**: `src/interpreter/eval/generator_runtime.rs`
+- **Summary**: Fold ~11 duplicated generator-entry "called on non-object" TypeError pairs into a `require_generator_object` guard. Ties into object-id-of.
+
+## pattern-bound-names-walker
+
+- **Status**: proposed
+- **Score**: 19/25 (leverage 3, locality 3, blast radius 1, heat 5)
+- **Files**: ~1 estimated — `src/interpreter/exec.rs`
+- **Modules**: `src/interpreter/exec.rs`
+- **Summary**: Delete `collect_pattern_bound_names` (a near-byte-identical copy of `ast::Pattern::bound_names`) from the for-of TDZ path and reuse the existing method. Low count (1 straggler) but hot file.
+
+## object-id-of
+
+- **Status**: proposed
+- **Score**: 13/25 (leverage 2, locality 2, blast radius 3, heat 4)
+- **Files**: ~3+ estimated — `src/interpreter/eval.rs`, `src/interpreter/eval/generator_runtime.rs`, `src/interpreter/exec.rs`
+- **Modules**: `src/interpreter/eval.rs`
+- **Summary**: ~130 circular `.as_object_id().map(|id| JsObject { id })` round-trips that rebuild a `JsObject` only to read `.id` back out. A `/simplify`-class cleanup, not a deepening — recorded so future runs don't re-derive it as a deep-module candidate.
+
+## unify-generator-async-drivers
+
+- **Status**: dropped
+- **Score**: n/a (blast radius 5 — too large for one unattended PR)
+- **Files**: 40+ estimated — `src/interpreter/eval/generator_runtime.rs`
+- **Modules**: `src/interpreter/eval/generator_runtime.rs`
+- **Summary**: `generator_next_state_machine_impl` and `async_generator_next_state_machine_impl` are largely parallel ~1580/~3050-line state-machine interpreters. Unifying them is a deep structural refactor for a human to schedule.
+- **First seen**: 2026-09-01
+- **Reason**: Blast radius 5 — human-scheduled. Land the generator-constructor and settle-tail candidates first to shrink both drivers.

--- a/.architecture/backlog.md
+++ b/.architecture/backlog.md
@@ -11,9 +11,9 @@ Never delete rows; they are the memory that stops re-surfacing the same work.
 - **Score**: 24/25 (leverage 5, locality 4, blast radius 1, heat 5)
 - **Files**: ~1 estimated — `src/interpreter/builtins/typedarray.rs`
 - **Modules**: `src/interpreter/builtins/typedarray.rs`
-- **Summary**: Collapse ~17 open-coded TypedArray receiver-validation prologues (brand check + detached/out-of-bounds check + clone + doubled `not a TypedArray` throw) behind one `validate_typed_array` seam, mirroring the existing kind-gated `validate_uint8array`.
+- **Summary**: Collapse open-coded TypedArray receiver-validation prologues (brand check + detached/out-of-bounds check + clone + doubled `not a TypedArray` throw) behind one `validate_typed_array` seam, mirroring the existing kind-gated `validate_uint8array`. Landed: 14 read-mode sites migrated; 3 (`slice`, `sort`, `toSorted`) kept — they hold the object borrow across their body.
 - **First seen**: 2026-09-01
-- **PR**: (pending)
+- **PR**: #543
 
 ## complete-state-machine-generator-ctor
 

--- a/.architecture/reviews/2026-09-01-validate-typed-array.md
+++ b/.architecture/reviews/2026-09-01-validate-typed-array.md
@@ -151,4 +151,62 @@ No candidate tripped a hard filter (leverage 1, blast radius 5, ADR conflict, al
 
 ## Design
 
-_Written in step 4 (design-it-twice + adjudication). Filled after this report was first committed._
+Three interfaces were designed in parallel (design-it-twice), then adjudicated by a
+fourth agent that authored none of them, against the fixed criteria depth ▸ locality
+▸ seam placement ▸ test surface ▸ blast radius.
+
+### Design A — minimal free function (WINNER)
+
+```rust
+fn validate_typed_array(
+    interp: &mut Interpreter,
+    this_val: &JsValue,
+) -> Result<TypedArrayInfo, Completion>
+```
+
+Mirrors the proven sibling `validate_uint8array` (`typedarray.rs:5879`) with the kind
+gate dropped and `check_detached_or_out_of_bounds` folded in. Each of the 17 read-mode
+Shape-A sites becomes the adapter `let ta = match validate_typed_array(interp, this_val)
+{ Ok(ta) => ta, Err(c) => return c };`. **Hides**: the `as_object_id → get_object →
+borrow → typed_array_info` chain, the borrow-scoping-then-clone discipline, the
+detached/OOB check, and the doubled `"not a TypedArray"` throw. Zero new vocabulary.
+Sites that need the object id re-derive it with an infallible
+`this_val.as_object_id().unwrap()` (validation already proved the receiver is an object).
+
+### Design B — access-mode parametric / spec-faithful (runner-up design's sibling; rejected)
+
+`enum AccessMode { Read, Write }` + `struct ValidatedTypedArray { info, object_id,
+buffer_object_id }` + `validate_typed_array(interp, this, access) -> Result<…>`. Folds
+the write-mode immutable-buffer check into the seam **in spec order** and centralizes it
+for ~6 write sites, returning a richer record. **Rejected**: it *moves* the immutability
+check ahead of argument coercion at those 6 sites — an observable throw-ordering change —
+and expands scope from 17 to ~23 sites. Both are behaviour changes the pick's
+blast-radius-1 / behaviour-preserving score did not account for, and this is an
+unattended run. It also charges every read caller an enum token and two ignored struct
+fields, lowering depth for the common caller.
+
+### Design C — control-inverting combinator (RUNNER-UP DESIGN)
+
+`fn with_typed_array<F: FnOnce(&mut Interpreter, TypedArrayInfo) -> Completion>(&mut self,
+this_val, access, body) -> Completion`, an inherent method that owns the borrow's whole
+lifetime and the throw-vs-run decision, making "held borrow across interpreter re-entry"
+unrepresentable and running `body` only on the happy path. Elegant and the strongest on
+*locality* of the borrow-bug class. **Why it lost — on Depth, the first criterion that
+separated it from A**: it hides slightly more behaviour but exports a larger interface
+and, uniquely, leaks control-flow caveats back to the caller (`return` exits only the
+closure; methods validating two typed arrays must not nest a second combinator; every
+body gains a rightward indent). Per unit of interface the common read caller must learn,
+it hides *less* than A's one-function-returning-a-known-type. It is also harder to unit
+test in isolation (needs a closure body), and blast radius is larger (every method body
+re-indents into a closure) — but Depth alone already ordered A ≻ C, so the later criteria
+were not reached.
+
+### Adjudication
+
+**Ranking A ≻ C ≻ B.** Depth alone orders all three: A hands the common read caller one
+function returning a type it already knows, hiding the entire prologue behind zero new
+vocabulary — the highest behaviour-hidden-per-interface-unit ratio. C's borrow-safety win
+is real but bundled with the heaviest interface and exported caveats; B forces write-path
+vocabulary onto every read caller and, disqualifyingly for an unattended run, changes
+observable ordering. Winner: **Design A**.
+

--- a/.architecture/reviews/2026-09-01-validate-typed-array.md
+++ b/.architecture/reviews/2026-09-01-validate-typed-array.md
@@ -1,0 +1,154 @@
+# Architecture review — jsse — 2026-09-01
+
+**Scope**: `src/interpreter/` hot spots, weighted by change frequency over the last 200 commits (`eval.rs`, `types.rs`, `builtins/typedarray.rs`, `exec.rs`, generator/async machinery). Two parallel exploration passes: statement/expression + generator/async execution, and built-in prototypes + shared prologues. A 2026-08-26 audit's unpicked candidate backlog was re-verified against current code (typed-array *codec* candidate already landed as PR #541 — distinct from this run's pick).
+**Picked**: `validate-typed-array` — see PR (to be opened) and `.architecture/backlog.md`
+**Degradations**: none — `gh` authenticated, sub-agents available, `codebase-design` vocabulary applied.
+
+In the Mermaid diagrams: **solid edges are the interface** (what a caller wires), **dashed edges are inside the implementation** (hidden behind a seam).
+
+## Candidates
+
+### validate-typed-array — collapse ~17 open-coded TypedArray receiver-validation prologues behind one seam  ·  Strong  ·  score 24/25
+
+- **Files** — `src/interpreter/builtins/typedarray.rs`. Seam belongs beside the existing partial helpers `check_detached_or_out_of_bounds` (`typedarray.rs:5940`) and the kind-gated sibling `validate_uint8array` (`typedarray.rs:5879`). Collapsible "Shape A" prologues at `typedarray.rs:1544, 1801, 1922, 1993, 2058, 2114, 2171, 2228, 2269, 2390, 2454, 2532, 2601, 2853, 2992, 3024, 3051` (17 sites). File-count estimate: **1 file** (plus an in-crate `#[cfg(test)]` module).
+- **Score** — **24/25**
+  - *Leverage 5* — 17 call sites shed an ~11-line borrow-juggling prologue each, and the validation becomes independently unit-testable for the first time (today only test262 covers it).
+  - *Locality 4* — changing what "a valid, non-detached TypedArray receiver" means becomes a one-function edit; today it is ~17 edits, and drift has already happened (several getters inline `is_detached.get() || is_typed_array_out_of_bounds(ta)` instead of the helper).
+  - *Blast radius 1* (→ contributes 5) — one file, all sites are module-private native closures, no exported/public interface crossed.
+  - *Heat 5* — `typedarray.rs` is among the hottest files in the tree (100+ touches in the 200-commit window, 40 in the last 40), last changed ~2 weeks ago.
+- **Problem** — The receiver-validation is one conceptual step ("is `this` a TypedArray whose buffer is still attached and in bounds?") but every prototype method re-expresses it as ~11 lines: `as_object_id()` → `get_object` → `borrow()` → `typed_array_info()` → `check_detached_or_out_of_bounds` → `ta.clone()`, with the `"not a TypedArray"` TypeError written **twice** (once in the `else`, once as the fall-through tail after the whole method body). The interface is far simpler than the implementation the caller is forced to hand-roll — the definition of a shallow module — and the doubled throw separated by the entire body is a live footgun (easy to drop the tail throw; getters already diverged).
+- **Deletion test** — **Concentrates.** A single `validate_typed_array(interp, this) -> Result<TypedArrayInfo, Completion>` absorbs the brand check, the detached/OOB check, the borrow scoping, the clone, and both throws. Deleting it re-scatters that invariant across 17 sites; the callers do not grow — each shrinks to one line.
+- **Solution** — Add `validate_typed_array` mirroring `validate_uint8array` with the kind gate removed and `check_detached_or_out_of_bounds` folded in. Migrate the 17 Shape-A prologues to `let ta = match validate_typed_array(interp, this_val) { Ok(ta) => ta, Err(c) => return c };`. Leave the divergent sites alone: `subarray` (`:1737`) deliberately does **not** throw on OOB and captures the backing buffer inside the borrow; the base64/hex path (`:5689`) already threads through `?`.
+- **Benefits** — *Leverage*: 17 methods lose their prologue; a future spec change to ValidateTypedArray (e.g. resizable-buffer semantics) is a one-line edit. *Locality*: the brand/detach/OOB decision lives in one place next to its siblings. *Test surface*: the validation is exercisable directly through a narrow `Result` interface — valid TA → `Ok(info)`, non-object / non-TA / detached → the exact `Err` — instead of only observably through 17 separate prototype methods.
+
+```mermaid
+graph LR
+  M1[slice] --> B1[as_object_id + borrow]
+  M1 --> B2[typed_array_info]
+  M1 --> B3[check_detached_or_out_of_bounds]
+  M1 --> B4[throw not-a-TypedArray x2]
+  M2[copyWithin] --> B1
+  M2 --> B2
+  M2 --> B3
+  M2 --> B4
+  M3[...15 more] --> B1
+```
+
+```mermaid
+graph LR
+  M1[slice] --> V[validate_typed_array]
+  M2[copyWithin] --> V
+  M3[...15 more] --> V
+  V -.-> B1[as_object_id + borrow]
+  V -.-> B2[typed_array_info]
+  V -.-> B3[check_detached_or_out_of_bounds]
+  V -.-> B4[throw not-a-TypedArray]
+```
+
+### complete-state-machine-generator-ctor — collapse ~87 inlined "completed generator" struct literals  ·  Strong  ·  score 22/25
+
+- **Files** — `src/interpreter/eval/generator_runtime.rs` (pairs at `:822`, `:846`, async at `:3645`, `:3670`, and dozens more). Enum at `src/interpreter/types.rs:1370`/`:1388`. Estimate: 1–2 files.
+- **Score** — **22/25** — *Leverage 5* (87 byte-identical 10-field literals; a constructor adds compiler help for the "cleared" invariant), *Locality 4*, *Blast radius 1* (→5), *Heat 3* (`generator_runtime.rs` changed only ~4× in the window, though last touched 7 days ago — YAGNI docks it).
+- **Problem** — The invariant "this generator is finished; clear every pending field" is copy-pasted 87 times (27 sync + 60 async). Adding a field to `StateMachineGenerator`/`StateMachineAsyncGenerator` is an 87-site edit with no compiler check for a missed field.
+- **Deletion test** — **Concentrates.** `completed_state_machine_generator(sm, env, strict)` / `…_async_generator(…)` turn each 12-line block into one call.
+- **Solution** — Two private constructors (or one with an `IsAsync` flag) returning the cleared `IteratorState`.
+- **Benefits** — *Leverage* across 87 sites; *Locality* on the completed-generator shape; *Test surface*: the cleared state becomes directly assertable.
+
+```mermaid
+graph LR
+  S1[gen.return] --> L[inline 10-field Completed literal]
+  S2[gen exhausted] --> L2[inline 10-field Completed literal]
+  S3[...85 more] --> L3[inline 10-field Completed literal]
+```
+
+```mermaid
+graph LR
+  S1[gen.return] --> C[completed_state_machine_generator]
+  S2[gen exhausted] --> C
+  S3[...85 more] --> C
+  C -.-> F[cleared 10-field IteratorState]
+```
+
+### settle-and-return-tail — ~47 copies of "call settle fn + drain microtasks + return promise"  ·  Worth exploring  ·  score 20/25
+
+- **Files** — `src/interpreter/eval/generator_runtime.rs` (canonical at `:3660`, `:3685`; `reject_with_type_error` at `:2728` is one already-extracted special case). Estimate: 1 file.
+- **Score** — **20/25** — *Leverage 4* (47 sites, but the tail is 3 lines and often fuses with a completed-writeback), *Locality 4*, *Blast radius 1* (→5), *Heat 3*.
+- **Problem** — The promise-settlement protocol (invoke settle fn with `undefined` this + one arg, `drain_microtasks()` so reactions run synchronously, return the outer promise) is re-spelled at every async-generator exit; dropping the drain is a real ordering bug.
+- **Deletion test** — **Concentrates** into `settle_and_return(settle_fn, arg, promise) -> Completion`.
+- **Solution** — One settlement helper; `reject_with_type_error` layers on top. Naturally sequenced *after* the generator-constructor candidate, which shrinks the same driver.
+
+```mermaid
+graph LR
+  E1[async gen throw] --> T1[call reject + drain + return]
+  E2[async gen return] --> T2[call resolve + drain + return]
+  E3[...45 more] --> T3[call settle + drain + return]
+```
+
+```mermaid
+graph LR
+  E1[async gen throw] --> S[settle_and_return]
+  E2[async gen return] --> S
+  E3[...45 more] --> S
+  S -.-> D1[call settle fn]
+  S -.-> D2[drain_microtasks]
+  S -.-> D3[return promise]
+```
+
+### this-weak-map / this-weak-set — 9 hand-rolled WeakMap/WeakSet receiver-unwrap dances  ·  Worth exploring  ·  score 20/25
+
+- **Files** — `src/interpreter/builtins/collections.rs` (WeakMap `:1703, 1728, 1758, 1782, 1811, 1846`; WeakSet `:2106, 2134, 2158`). Template `this_map`/`this_set` exist at `:12`/`:34`; weak variants do not. Estimate: 1 file.
+- **Score** — **20/25** — *Leverage 4* (9 sites, exact template already proven), *Locality 4*, *Blast radius 1* (→5), *Heat 3* (`collections.rs` frequently changed historically but ~5 weeks stale).
+- **Problem** — Each site re-open-codes the brand check *inconsistently* (`class_name` then `map_data().cloned()` in some, reversed in others), and retypes the per-method error string by hand — exactly the divergence `this_map`/`this_set` were introduced to kill.
+- **Deletion test** — **Concentrates** into `this_weak_map`/`this_weak_set` returning `(id, handle)` + method name for the error, verbatim siblings of `this_map`/`this_set`.
+
+```mermaid
+graph LR
+  W1[WeakMap.get] --> H1[class_name + map_data dance]
+  W2[WeakMap.set] --> H2[map_data + class_name dance]
+  W3[...7 more] --> H3[ad-hoc dance]
+```
+
+```mermaid
+graph LR
+  W1[WeakMap.get] --> T[this_weak_map]
+  W2[WeakMap.set] --> T
+  W3[...7 more] --> T
+  T -.-> D1[brand check WeakMap]
+  T -.-> D2[unwrap data slot]
+  T -.-> D3[method-named TypeError]
+```
+
+### generator-entry-guard — ~11 duplicated "called on non-object" TypeError pairs  ·  Worth exploring  ·  score 19/25
+
+- **Files** — `src/interpreter/eval/generator_runtime.rs` (`:14/:18`, `:180/:184`, `:323/:327`, `:482/:487`, `:2063/:2068`, `:2410/:2415`, async at `:3607/:3611`, `:6755/:6759`, `:7014/:7019`, `:7245/:7249`, `:7319/:7324`). Estimate: 1 file.
+- **Score** — **19/25** — *Leverage 4*, *Locality 3*, *Blast radius 1* (→5), *Heat 3*.
+- **Problem** — Every generator entry point emits the same null/undefined-check + object-id-check TypeError pair.
+- **Deletion test** — **Concentrates** into `require_generator_object(this, method) -> Result<u64, …>`. Ties into the `object-id-of` simplification below.
+
+### object-id-of — ~130 circular `.as_object_id().map(|id| JsObject { id })` round-trips  ·  Speculative  ·  score 13/25
+
+- **Files** — `generator_runtime.rs` (~44), `eval.rs` (~76), `exec.rs` (~11). Estimate: 3+ files.
+- **Score** — **13/25** — *Leverage 2* (mechanical: rebuilds a `JsObject` only to read `.id` back out; renames complexity rather than concentrating real behaviour behind a seam), *Locality 2*, *Blast radius 3* (→3), *Heat 4*.
+- **Note** — This is a `/simplify`-class cleanup, not a deepening. Recorded so the next run does not re-derive it as a deep-module candidate. Best folded into whichever generator candidate touches those files.
+
+## Dropped
+
+No candidate tripped a hard filter (leverage 1, blast radius 5, ADR conflict, already-in-backlog, or un-pinnable). `object-id-of` scores low but is retained as a low-strength candidate rather than dropped, because it fails no hard filter.
+
+| Candidate | Dropped because |
+|---|---|
+| _(none)_ | — |
+
+## Too large to automate
+
+| Candidate | Blast radius |
+|---|---|
+| `unify-generator-async-drivers` — `generator_next_state_machine_impl` (`generator_runtime.rs:470`, ~1580 lines) and `async_generator_next_state_machine_impl` (`:3592`, ~3050 lines) are largely parallel state-machine interpreters, plus `_with_promise` vs `_legacy` async splits. Unifying them is a deep structural refactor, not a narrow-interface change. Landing the generator-constructor and settle-tail candidates first shrinks both drivers and is the right sequencing. | 5 — human-scheduled |
+
+## Pick
+
+**`validate-typed-array` (24/25).** It outranks the runner-up **candidate** `complete-state-machine-generator-ctor` (22/25) on **heat**: both are single-file, `pub(crate)`, blast-radius-1 collapses of a duplicated invariant with leverage 5, but `typedarray.rs` is one of the hottest files in the tree while `generator_runtime.rs` is cold (~4 window touches), and YAGNI weights deepening toward code that keeps changing. The 2-point gap is **not** within 1 point — the pick is clear, not close. A proven deep sibling (`validate_uint8array`) already exists in the same file, so the interface shape is de-risked, and the drift already visible in the diverged getters is evidence the friction is active, not hypothetical.
+
+## Design
+
+_Written in step 4 (design-it-twice + adjudication). Filled after this report was first committed._

--- a/.architecture/reviews/2026-09-01-validate-typed-array.md
+++ b/.architecture/reviews/2026-09-01-validate-typed-array.md
@@ -210,3 +210,22 @@ is real but bundled with the heaviest interface and exported caveats; B forces w
 vocabulary onto every read caller and, disqualifyingly for an unattended run, changes
 observable ordering. Winner: **Design A**.
 
+### As landed — PR #543
+
+`validate_typed_array` added beside `validate_uint8array`. **14** read-mode sites migrated:
+`at`, `copyWithin`, `fill`, `indexOf`, `lastIndexOf`, `includes`, `reverse`, `join`,
+`toLocaleString`, `toReversed`, `with`, `values`, `entries`, `keys`. **3** of the scored
+~17 (`slice`, `sort`, `toSorted`) resolved on inspection to a borrow-holding shape — they
+reference the object handle/borrow across their body — and were **kept** to preserve borrow
+granularity and keep the change behaviour-preserving. Two mechanical, behaviour-preserving
+deviations forced by clippy `-D warnings`: validate-only sites (`values`/`entries`/`keys`)
+use `if let Err(c) = validate_typed_array(...)` since they don't bind `ta`; trailing
+`return X;` became a tail expression `X` once the wrapper was removed.
+
+Test-first: 4 unit tests in `mod validate_typed_array_tests` pinned the seam and were seen
+to fail before the helper existed. Gate: `cargo build --release` clean; `cargo test --bin
+jsse --release` 600 passed; `./scripts/lint.sh` clean; **test262
+`built-ins/TypedArray/prototype/` 2792/2792, 0 regressions, +2 new passes** (the uniform
+`check_detached_or_out_of_bounds` fold-in fixed two previously-diverged getter cases);
+custom tests 13/13. Blast radius held at 1 file, as scored.
+

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1535,36 +1535,27 @@ impl Interpreter {
             "at".to_string(),
             1,
             |interp, this_val, args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    // Capture len BEFORE argument coercion (may resize buffer)
-                    let len = typed_array_length(&ta);
-                    let idx_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let idx = match interp.to_integer_or_infinity_value(&idx_val) {
-                        Ok(n) => n,
-                        Err(e) => return Completion::Throw(e),
-                    };
-                    let actual = match resolve_element_index(idx, len) {
-                        Some(k) => k,
-                        None => return Completion::Normal(JsValue::UNDEFINED),
-                    };
-                    // Use Get semantics (checks OOB post-resize via is_valid_integer_index)
-                    let key = actual.to_string();
-                    return interp.get_object_property(o, &key, this_val);
-                }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                let o = this_val
+                    .as_object_id()
+                    .expect("validated: receiver is a TypedArray object");
+                // Capture len BEFORE argument coercion (may resize buffer)
+                let len = typed_array_length(&ta);
+                let idx_val = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let idx = match interp.to_integer_or_infinity_value(&idx_val) {
+                    Ok(n) => n,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let actual = match resolve_element_index(idx, len) {
+                    Some(k) => k,
+                    None => return Completion::Normal(JsValue::UNDEFINED),
+                };
+                // Use Get semantics (checks OOB post-resize via is_valid_integer_index)
+                let key = actual.to_string();
+                interp.get_object_property(o, &key, this_val)
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1913,66 +1904,53 @@ impl Interpreter {
             "copyWithin".to_string(),
             2,
             |interp, this_val, args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    if let Err(c) = check_ta_buffer_writable(interp, &ta) {
-                        return c;
-                    }
-                    let len = typed_array_length(&ta) as i64;
-                    let target = match resolve_start_index(interp, args.first(), len as usize) {
-                        Ok(v) => v,
-                        Err(c) => return c,
-                    };
-                    let start = match resolve_start_index(interp, args.get(1), len as usize) {
-                        Ok(v) => v,
-                        Err(c) => return c,
-                    };
-                    let end = match resolve_end_index(interp, args.get(2), len as usize) {
-                        Ok(v) => v,
-                        Err(c) => return c,
-                    };
-                    // Re-check detach and OOB after coercion
-                    if let Err(c) = check_detached_or_out_of_bounds(interp, &ta) {
-                        return c;
-                    }
-                    // Use original len for count (per spec), but bound copy by actual buffer
-                    let _cur_len = typed_array_length(&ta);
-                    let count = if end <= start || target >= len as usize {
-                        0
-                    } else {
-                        (end - start).min(len as usize - target)
-                    };
-                    if count > 0 {
-                        let bpe = ta.kind.bytes_per_element();
-                        with_buffer_write(&ta.buffer, |buf| {
-                            let buf_len = buf.len();
-                            let src_byte_start = ta.byte_offset + start * bpe;
-                            let dst_byte_start = ta.byte_offset + target * bpe;
-                            let max_src_bytes = buf_len.saturating_sub(src_byte_start);
-                            let max_dst_bytes = buf_len.saturating_sub(dst_byte_start);
-                            let byte_count = (count * bpe).min(max_src_bytes).min(max_dst_bytes);
-                            if byte_count > 0 {
-                                let src = buf[src_byte_start..src_byte_start + byte_count].to_vec();
-                                buf[dst_byte_start..dst_byte_start + byte_count]
-                                    .copy_from_slice(&src);
-                            }
-                        });
-                    }
-                    return Completion::Normal(this_val.clone());
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                    return c;
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let len = typed_array_length(&ta) as i64;
+                let target = match resolve_start_index(interp, args.first(), len as usize) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                let start = match resolve_start_index(interp, args.get(1), len as usize) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                let end = match resolve_end_index(interp, args.get(2), len as usize) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                // Re-check detach and OOB after coercion
+                if let Err(c) = check_detached_or_out_of_bounds(interp, &ta) {
+                    return c;
+                }
+                // Use original len for count (per spec), but bound copy by actual buffer
+                let _cur_len = typed_array_length(&ta);
+                let count = if end <= start || target >= len as usize {
+                    0
+                } else {
+                    (end - start).min(len as usize - target)
+                };
+                if count > 0 {
+                    let bpe = ta.kind.bytes_per_element();
+                    with_buffer_write(&ta.buffer, |buf| {
+                        let buf_len = buf.len();
+                        let src_byte_start = ta.byte_offset + start * bpe;
+                        let dst_byte_start = ta.byte_offset + target * bpe;
+                        let max_src_bytes = buf_len.saturating_sub(src_byte_start);
+                        let max_dst_bytes = buf_len.saturating_sub(dst_byte_start);
+                        let byte_count = (count * bpe).min(max_src_bytes).min(max_dst_bytes);
+                        if byte_count > 0 {
+                            let src = buf[src_byte_start..src_byte_start + byte_count].to_vec();
+                            buf[dst_byte_start..dst_byte_start + byte_count].copy_from_slice(&src);
+                        }
+                    });
+                }
+                Completion::Normal(this_val.clone())
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -1984,60 +1962,46 @@ impl Interpreter {
             "fill".to_string(),
             1,
             |interp, this_val, args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    // ValidateTypedArray(..., ~write~): immutability check fires before any
-                    // argument coercion so callers observe no side effects on TypeError.
-                    if let Err(c) = check_ta_buffer_writable(interp, &ta) {
-                        return c;
-                    }
-                    // Step 3: compute len BEFORE coercion
-                    let len = typed_array_length(&ta);
-                    // Per spec: coerce value BEFORE start/end
-                    let raw_value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let coerced = match interp.typed_array_coerce_value(ta.kind, &raw_value) {
-                        Ok(v) => v,
-                        Err(e) => return Completion::Throw(e),
-                    };
-                    let start = match resolve_start_index(interp, args.get(1), len) {
-                        Ok(v) => v,
-                        Err(c) => return c,
-                    };
-                    let end = match resolve_end_index(interp, args.get(2), len) {
-                        Ok(v) => v,
-                        Err(c) => return c,
-                    };
-                    // Re-check detach and OOB after coercion (buffer may have been resized)
-                    if ta.is_detached.get() {
-                        return Completion::Throw(
-                            interp.create_type_error("typed array is detached"),
-                        );
-                    }
-                    if is_typed_array_out_of_bounds(&ta) {
-                        return Completion::Throw(
-                            interp.create_type_error("typed array is out of bounds"),
-                        );
-                    }
-                    let new_len = typed_array_length(&ta);
-                    let end = end.min(new_len);
-                    for i in start..end {
-                        typed_array_set_index(&ta, i, &coerced);
-                    }
-                    return Completion::Normal(this_val.clone());
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                // ValidateTypedArray(..., ~write~): immutability check fires before any
+                // argument coercion so callers observe no side effects on TypeError.
+                if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                    return c;
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                // Step 3: compute len BEFORE coercion
+                let len = typed_array_length(&ta);
+                // Per spec: coerce value BEFORE start/end
+                let raw_value = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let coerced = match interp.typed_array_coerce_value(ta.kind, &raw_value) {
+                    Ok(v) => v,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let start = match resolve_start_index(interp, args.get(1), len) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                let end = match resolve_end_index(interp, args.get(2), len) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                // Re-check detach and OOB after coercion (buffer may have been resized)
+                if ta.is_detached.get() {
+                    return Completion::Throw(interp.create_type_error("typed array is detached"));
+                }
+                if is_typed_array_out_of_bounds(&ta) {
+                    return Completion::Throw(
+                        interp.create_type_error("typed array is out of bounds"),
+                    );
+                }
+                let new_len = typed_array_length(&ta);
+                let end = end.min(new_len);
+                for i in start..end {
+                    typed_array_set_index(&ta, i, &coerced);
+                }
+                Completion::Normal(this_val.clone())
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2049,51 +2013,39 @@ impl Interpreter {
             "indexOf".to_string(),
             1,
             |interp, this_val, args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    let len = typed_array_length(&ta) as i64;
-                    if len == 0 {
-                        return Completion::Normal(JsValue::number(-1.0));
-                    }
-                    let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let from = if args.len() > 1 {
-                        (match interp.to_integer_or_infinity_value(&args[1]) {
-                            Ok(n) => n,
-                            Err(e) => return Completion::Throw(e),
-                        }) as i64
-                    } else {
-                        0
-                    };
-                    let start = if from < 0 {
-                        (len + from).max(0) as usize
-                    } else {
-                        from as usize
-                    };
-                    for i in start..len as usize {
-                        // indexOf uses HasProperty semantics: skip elements that are not valid
-                        if !is_valid_integer_index(&ta, i as f64) {
-                            continue;
-                        }
-                        let elem = typed_array_get_index(&ta, i);
-                        if strict_eq(&elem, &search) {
-                            return Completion::Normal(JsValue::number(i as f64));
-                        }
-                    }
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                let len = typed_array_length(&ta) as i64;
+                if len == 0 {
                     return Completion::Normal(JsValue::number(-1.0));
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let from = if args.len() > 1 {
+                    (match interp.to_integer_or_infinity_value(&args[1]) {
+                        Ok(n) => n,
+                        Err(e) => return Completion::Throw(e),
+                    }) as i64
+                } else {
+                    0
+                };
+                let start = if from < 0 {
+                    (len + from).max(0) as usize
+                } else {
+                    from as usize
+                };
+                for i in start..len as usize {
+                    // indexOf uses HasProperty semantics: skip elements that are not valid
+                    if !is_valid_integer_index(&ta, i as f64) {
+                        continue;
+                    }
+                    let elem = typed_array_get_index(&ta, i);
+                    if strict_eq(&elem, &search) {
+                        return Completion::Normal(JsValue::number(i as f64));
+                    }
+                }
+                Completion::Normal(JsValue::number(-1.0))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2105,52 +2057,40 @@ impl Interpreter {
             "lastIndexOf".to_string(),
             1,
             |interp, this_val, args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    let len = typed_array_length(&ta) as i64;
-                    if len == 0 {
-                        return Completion::Normal(JsValue::number(-1.0));
-                    }
-                    let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let from = if args.len() > 1 {
-                        (match interp.to_integer_or_infinity_value(&args[1]) {
-                            Ok(n) => n,
-                            Err(e) => return Completion::Throw(e),
-                        }) as i64
-                    } else {
-                        len - 1
-                    };
-                    let start = if from < 0 {
-                        (len + from).max(-1)
-                    } else {
-                        from.min(len - 1)
-                    };
-                    let mut i = start;
-                    while i >= 0 {
-                        // lastIndexOf uses HasProperty semantics: skip elements that are not valid
-                        if is_valid_integer_index(&ta, i as f64) {
-                            let elem = typed_array_get_index(&ta, i as usize);
-                            if strict_eq(&elem, &search) {
-                                return Completion::Normal(JsValue::number(i as f64));
-                            }
-                        }
-                        i -= 1;
-                    }
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                let len = typed_array_length(&ta) as i64;
+                if len == 0 {
                     return Completion::Normal(JsValue::number(-1.0));
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let from = if args.len() > 1 {
+                    (match interp.to_integer_or_infinity_value(&args[1]) {
+                        Ok(n) => n,
+                        Err(e) => return Completion::Throw(e),
+                    }) as i64
+                } else {
+                    len - 1
+                };
+                let start = if from < 0 {
+                    (len + from).max(-1)
+                } else {
+                    from.min(len - 1)
+                };
+                let mut i = start;
+                while i >= 0 {
+                    // lastIndexOf uses HasProperty semantics: skip elements that are not valid
+                    if is_valid_integer_index(&ta, i as f64) {
+                        let elem = typed_array_get_index(&ta, i as usize);
+                        if strict_eq(&elem, &search) {
+                            return Completion::Normal(JsValue::number(i as f64));
+                        }
+                    }
+                    i -= 1;
+                }
+                Completion::Normal(JsValue::number(-1.0))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2162,47 +2102,35 @@ impl Interpreter {
             "includes".to_string(),
             1,
             |interp, this_val, args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    let len = typed_array_length(&ta) as i64;
-                    if len == 0 {
-                        return Completion::Normal(JsValue::boolean(false));
-                    }
-                    let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let from = if args.len() > 1 {
-                        (match interp.to_integer_or_infinity_value(&args[1]) {
-                            Ok(n) => n,
-                            Err(e) => return Completion::Throw(e),
-                        }) as i64
-                    } else {
-                        0
-                    };
-                    let start = if from < 0 {
-                        (len + from).max(0) as usize
-                    } else {
-                        from as usize
-                    };
-                    for i in start..len as usize {
-                        let elem = typed_array_get_index(&ta, i);
-                        if same_value_zero(&elem, &search) {
-                            return Completion::Normal(JsValue::boolean(true));
-                        }
-                    }
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                let len = typed_array_length(&ta) as i64;
+                if len == 0 {
                     return Completion::Normal(JsValue::boolean(false));
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let search = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let from = if args.len() > 1 {
+                    (match interp.to_integer_or_infinity_value(&args[1]) {
+                        Ok(n) => n,
+                        Err(e) => return Completion::Throw(e),
+                    }) as i64
+                } else {
+                    0
+                };
+                let start = if from < 0 {
+                    (len + from).max(0) as usize
+                } else {
+                    from as usize
+                };
+                for i in start..len as usize {
+                    let elem = typed_array_get_index(&ta, i);
+                    if same_value_zero(&elem, &search) {
+                        return Completion::Normal(JsValue::boolean(true));
+                    }
+                }
+                Completion::Normal(JsValue::boolean(false))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2219,36 +2147,24 @@ impl Interpreter {
             "reverse".to_string(),
             0,
             |interp, this_val, _args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    if let Err(c) = check_ta_buffer_writable(interp, &ta) {
-                        return c;
-                    }
-                    let mut lo = 0usize;
-                    let mut hi = typed_array_length(&ta);
-                    while lo < hi {
-                        hi -= 1;
-                        let a = typed_array_get_index(&ta, lo);
-                        let b = typed_array_get_index(&ta, hi);
-                        typed_array_set_index(&ta, lo, &b);
-                        typed_array_set_index(&ta, hi, &a);
-                        lo += 1;
-                    }
-                    return Completion::Normal(this_val.clone());
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                if let Err(c) = check_ta_buffer_writable(interp, &ta) {
+                    return c;
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let mut lo = 0usize;
+                let mut hi = typed_array_length(&ta);
+                while lo < hi {
+                    hi -= 1;
+                    let a = typed_array_get_index(&ta, lo);
+                    let b = typed_array_get_index(&ta, hi);
+                    typed_array_set_index(&ta, lo, &b);
+                    typed_array_set_index(&ta, hi, &a);
+                    lo += 1;
+                }
+                Completion::Normal(this_val.clone())
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2381,46 +2297,33 @@ impl Interpreter {
             "join".to_string(),
             1,
             |interp, this_val, args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    let len = typed_array_length(&ta);
-                    let sep = if args.is_empty() || args[0].is_undefined() {
-                        ",".to_string()
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                let len = typed_array_length(&ta);
+                let sep = if args.is_empty() || args[0].is_undefined() {
+                    ",".to_string()
+                } else {
+                    match interp.to_string_value(&args[0]) {
+                        Ok(s) => s,
+                        Err(e) => return Completion::Throw(e),
+                    }
+                };
+                let mut parts: Vec<String> = Vec::with_capacity(len);
+                for i in 0..len {
+                    let elem = typed_array_get_index(&ta, i);
+                    let s = if elem.is_nullish() {
+                        String::new()
                     } else {
-                        match interp.to_string_value(&args[0]) {
+                        match interp.to_string_value(&elem) {
                             Ok(s) => s,
                             Err(e) => return Completion::Throw(e),
                         }
                     };
-                    let mut parts: Vec<String> = Vec::with_capacity(len);
-                    for i in 0..len {
-                        let elem = typed_array_get_index(&ta, i);
-                        let s = if elem.is_nullish() {
-                            String::new()
-                        } else {
-                            match interp.to_string_value(&elem) {
-                                Ok(s) => s,
-                                Err(e) => return Completion::Throw(e),
-                            }
-                        };
-                        parts.push(s);
-                    }
-                    Completion::Normal(JsValue::from_str(&parts.join(&sep)))
-                } else {
-                    Completion::Throw(interp.create_type_error("not a TypedArray"))
+                    parts.push(s);
                 }
+                Completion::Normal(JsValue::from_str(&parts.join(&sep)))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2445,73 +2348,59 @@ impl Interpreter {
                 if !this_val.is_object() {
                     return Completion::Throw(interp.create_type_error("not a TypedArray"));
                 }
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            // ValidateTypedArray: Must have [[TypedArrayName]] slot
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    let separator = ",";
-                    let locales = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
-                    let pass_args = vec![locales, options];
-                    let len = typed_array_length(&ta);
-                    let mut parts: Vec<String> = Vec::with_capacity(len);
-                    for k in 0..len {
-                        let next_element = typed_array_get_index(&ta, k);
-                        if next_element.is_nullish() {
-                            parts.push(String::new());
-                        } else {
-                            // Convert to object to get toLocaleString method
-                            let element_obj = match interp.to_object(&next_element) {
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                let separator = ",";
+                let locales = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let options = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                let pass_args = vec![locales, options];
+                let len = typed_array_length(&ta);
+                let mut parts: Vec<String> = Vec::with_capacity(len);
+                for k in 0..len {
+                    let next_element = typed_array_get_index(&ta, k);
+                    if next_element.is_nullish() {
+                        parts.push(String::new());
+                    } else {
+                        // Convert to object to get toLocaleString method
+                        let element_obj = match interp.to_object(&next_element) {
+                            Completion::Normal(v) => v,
+                            other => return other,
+                        };
+                        if let Some(elem_ref) = element_obj.as_object_id() {
+                            let to_locale_str_method = match interp.get_object_property(
+                                elem_ref,
+                                "toLocaleString",
+                                &element_obj,
+                            ) {
                                 Completion::Normal(v) => v,
                                 other => return other,
                             };
-                            if let Some(elem_ref) = element_obj.as_object_id() {
-                                let to_locale_str_method = match interp.get_object_property(
-                                    elem_ref,
-                                    "toLocaleString",
-                                    &element_obj,
+                            if interp.is_callable(&to_locale_str_method) {
+                                match interp.call_function(
+                                    &to_locale_str_method,
+                                    &next_element,
+                                    &pass_args,
                                 ) {
-                                    Completion::Normal(v) => v,
-                                    other => return other,
-                                };
-                                if interp.is_callable(&to_locale_str_method) {
-                                    match interp.call_function(
-                                        &to_locale_str_method,
-                                        &next_element,
-                                        &pass_args,
-                                    ) {
-                                        Completion::Normal(v) => {
-                                            let s = match interp.to_string_value(&v) {
-                                                Ok(s) => s,
-                                                Err(e) => return Completion::Throw(e),
-                                            };
-                                            parts.push(s);
-                                        }
-                                        other => return other,
+                                    Completion::Normal(v) => {
+                                        let s = match interp.to_string_value(&v) {
+                                            Ok(s) => s,
+                                            Err(e) => return Completion::Throw(e),
+                                        };
+                                        parts.push(s);
                                     }
-                                } else {
-                                    let err = interp
-                                        .create_type_error("toLocaleString is not a function");
-                                    return Completion::Throw(err);
+                                    other => return other,
                                 }
+                            } else {
+                                let err =
+                                    interp.create_type_error("toLocaleString is not a function");
+                                return Completion::Throw(err);
                             }
                         }
                     }
-                    Completion::Normal(JsValue::from_str(&parts.join(separator)))
-                } else {
-                    Completion::Throw(interp.create_type_error("not a TypedArray"))
                 }
+                Completion::Normal(JsValue::from_str(&parts.join(separator)))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2523,64 +2412,52 @@ impl Interpreter {
             "toReversed".to_string(),
             0,
             |interp, this_val, _args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    let len = typed_array_length(&ta);
-                    let bpe = ta.kind.bytes_per_element();
-                    let buf_byte_len = len * bpe;
-                    let new_buf = vec![0u8; buf_byte_len];
-                    let new_buf_rc = Rc::new(RefCell::new(BufferData::Owned(new_buf)));
-                    let new_detached = Rc::new(Cell::new(false));
-                    let new_ta = TypedArrayInfo {
-                        kind: ta.kind,
-                        buffer: new_buf_rc.clone(),
-                        byte_offset: 0,
-                        byte_length: buf_byte_len,
-                        array_length: len,
-                        is_detached: new_detached.clone(),
-                        is_length_tracking: false,
-                        buffer_object_id: None,
-                    };
-                    for i in 0..len {
-                        let val = typed_array_get_index(&ta, len - 1 - i);
-                        typed_array_set_index(&new_ta, i, &val);
-                    }
-                    let ab_obj_id = interp.create_object_id();
-                    let ab_proto = interp.realm().arraybuffer_prototype;
-                    {
-                        let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
-                        ab.class_name = "ArrayBuffer".to_string();
-                        ab.prototype_id = ab_proto;
-                        ab.kind = crate::interpreter::types::ObjectKind::ArrayBuffer(
-                            crate::interpreter::types::ArrayBufferData {
-                                data: new_buf_rc,
-                                detached: Some(new_detached),
-                                max_byte_length: None,
-                                is_shared: false,
-                                is_immutable: false,
-                                sab_shared: None,
-                            },
-                        );
-                    }
-                    interp.gc_track_external_bytes(buf_byte_len);
-                    let ab_id = ab_obj_id;
-                    let buf_val = JsValue::object(ab_id);
-                    let id = interp.create_typed_array_object(new_ta, buf_val);
-                    return Completion::Normal(JsValue::object(id));
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                let len = typed_array_length(&ta);
+                let bpe = ta.kind.bytes_per_element();
+                let buf_byte_len = len * bpe;
+                let new_buf = vec![0u8; buf_byte_len];
+                let new_buf_rc = Rc::new(RefCell::new(BufferData::Owned(new_buf)));
+                let new_detached = Rc::new(Cell::new(false));
+                let new_ta = TypedArrayInfo {
+                    kind: ta.kind,
+                    buffer: new_buf_rc.clone(),
+                    byte_offset: 0,
+                    byte_length: buf_byte_len,
+                    array_length: len,
+                    is_detached: new_detached.clone(),
+                    is_length_tracking: false,
+                    buffer_object_id: None,
+                };
+                for i in 0..len {
+                    let val = typed_array_get_index(&ta, len - 1 - i);
+                    typed_array_set_index(&new_ta, i, &val);
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let ab_obj_id = interp.create_object_id();
+                let ab_proto = interp.realm().arraybuffer_prototype;
+                {
+                    let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
+                    ab.class_name = "ArrayBuffer".to_string();
+                    ab.prototype_id = ab_proto;
+                    ab.kind = crate::interpreter::types::ObjectKind::ArrayBuffer(
+                        crate::interpreter::types::ArrayBufferData {
+                            data: new_buf_rc,
+                            detached: Some(new_detached),
+                            max_byte_length: None,
+                            is_shared: false,
+                            is_immutable: false,
+                            sab_shared: None,
+                        },
+                    );
+                }
+                interp.gc_track_external_bytes(buf_byte_len);
+                let ab_id = ab_obj_id;
+                let buf_val = JsValue::object(ab_id);
+                let id = interp.create_typed_array_object(new_ta, buf_val);
+                Completion::Normal(JsValue::object(id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2844,103 +2721,90 @@ impl Interpreter {
                     }
                 }
 
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    let ta = {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                            ta.clone()
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    };
-                    let len = typed_array_length(&ta) as i64;
+                let ta = match validate_typed_array(interp, this_val) {
+                    Ok(ta) => ta,
+                    Err(c) => return c,
+                };
+                let len = typed_array_length(&ta) as i64;
 
-                    // Step 4: ToIntegerOrInfinity(index) - must call valueOf on objects
-                    let index_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let relative_index = match to_number_throwing(interp, &index_arg) {
-                        Ok(n) => to_integer_or_infinity(n) as i64,
+                // Step 4: ToIntegerOrInfinity(index) - must call valueOf on objects
+                let index_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
+                let relative_index = match to_number_throwing(interp, &index_arg) {
+                    Ok(n) => to_integer_or_infinity(n) as i64,
+                    Err(e) => return Completion::Throw(e),
+                };
+                let actual_index = if relative_index >= 0 {
+                    relative_index
+                } else {
+                    len + relative_index
+                };
+
+                // Steps 7-8: Coerce value BEFORE checking index bounds
+                let value_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
+                let numeric_value = if ta.kind.is_bigint() {
+                    match to_bigint_throwing(interp, &value_arg) {
+                        Ok(v) => v,
                         Err(e) => return Completion::Throw(e),
-                    };
-                    let actual_index = if relative_index >= 0 {
-                        relative_index
-                    } else {
-                        len + relative_index
-                    };
-
-                    // Steps 7-8: Coerce value BEFORE checking index bounds
-                    let value_arg = args.get(1).cloned().unwrap_or(JsValue::UNDEFINED);
-                    let numeric_value = if ta.kind.is_bigint() {
-                        match to_bigint_throwing(interp, &value_arg) {
-                            Ok(v) => v,
-                            Err(e) => return Completion::Throw(e),
-                        }
-                    } else {
-                        match to_number_throwing(interp, &value_arg) {
-                            Ok(n) => JsValue::number(n),
-                            Err(e) => return Completion::Throw(e),
-                        }
-                    };
-
-                    // Step 9: Check IsValidIntegerIndex after coercions (uses current TA state)
-                    if !is_valid_integer_index(&ta, actual_index as f64) {
-                        return Completion::Throw(
-                            interp
-                                .create_range_error("Invalid index for TypedArray.prototype.with"),
-                        );
                     }
+                } else {
+                    match to_number_throwing(interp, &value_arg) {
+                        Ok(n) => JsValue::number(n),
+                        Err(e) => return Completion::Throw(e),
+                    }
+                };
 
-                    let bpe = ta.kind.bytes_per_element();
-                    let buf_byte_len = len as usize * bpe;
-                    let new_buf = vec![0u8; buf_byte_len];
-                    let new_buf_rc = Rc::new(RefCell::new(BufferData::Owned(new_buf)));
-                    let new_detached = Rc::new(Cell::new(false));
-                    let new_ta = TypedArrayInfo {
-                        kind: ta.kind,
-                        buffer: new_buf_rc.clone(),
-                        byte_offset: 0,
-                        byte_length: buf_byte_len,
-                        array_length: len as usize,
-                        is_detached: new_detached.clone(),
-                        is_length_tracking: false,
-                        buffer_object_id: None,
-                    };
-                    for k in 0..len as usize {
-                        let elem = if k == actual_index as usize {
-                            numeric_value.clone()
-                        } else {
-                            typed_array_get_index(&ta, k)
-                        };
-                        typed_array_set_index(&new_ta, k, &elem);
-                    }
-                    let ab_obj_id = interp.create_object_id();
-                    let ab_proto = interp.realm().arraybuffer_prototype;
-                    {
-                        let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
-                        ab.class_name = "ArrayBuffer".to_string();
-                        ab.prototype_id = ab_proto;
-                        ab.kind = crate::interpreter::types::ObjectKind::ArrayBuffer(
-                            crate::interpreter::types::ArrayBufferData {
-                                data: new_buf_rc,
-                                detached: Some(new_detached),
-                                max_byte_length: None,
-                                is_shared: false,
-                                is_immutable: false,
-                                sab_shared: None,
-                            },
-                        );
-                    }
-                    interp.gc_track_external_bytes(buf_byte_len);
-                    let ab_id = ab_obj_id;
-                    let buf_val = JsValue::object(ab_id);
-                    let id = interp.create_typed_array_object(new_ta, buf_val);
-                    return Completion::Normal(JsValue::object(id));
+                // Step 9: Check IsValidIntegerIndex after coercions (uses current TA state)
+                if !is_valid_integer_index(&ta, actual_index as f64) {
+                    return Completion::Throw(
+                        interp.create_range_error("Invalid index for TypedArray.prototype.with"),
+                    );
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+
+                let bpe = ta.kind.bytes_per_element();
+                let buf_byte_len = len as usize * bpe;
+                let new_buf = vec![0u8; buf_byte_len];
+                let new_buf_rc = Rc::new(RefCell::new(BufferData::Owned(new_buf)));
+                let new_detached = Rc::new(Cell::new(false));
+                let new_ta = TypedArrayInfo {
+                    kind: ta.kind,
+                    buffer: new_buf_rc.clone(),
+                    byte_offset: 0,
+                    byte_length: buf_byte_len,
+                    array_length: len as usize,
+                    is_detached: new_detached.clone(),
+                    is_length_tracking: false,
+                    buffer_object_id: None,
+                };
+                for k in 0..len as usize {
+                    let elem = if k == actual_index as usize {
+                        numeric_value.clone()
+                    } else {
+                        typed_array_get_index(&ta, k)
+                    };
+                    typed_array_set_index(&new_ta, k, &elem);
+                }
+                let ab_obj_id = interp.create_object_id();
+                let ab_proto = interp.realm().arraybuffer_prototype;
+                {
+                    let mut ab = interp.get_object_cell_expect(ab_obj_id).borrow_mut();
+                    ab.class_name = "ArrayBuffer".to_string();
+                    ab.prototype_id = ab_proto;
+                    ab.kind = crate::interpreter::types::ObjectKind::ArrayBuffer(
+                        crate::interpreter::types::ArrayBufferData {
+                            data: new_buf_rc,
+                            detached: Some(new_detached),
+                            max_byte_length: None,
+                            is_shared: false,
+                            is_immutable: false,
+                            sab_shared: None,
+                        },
+                    );
+                }
+                interp.gc_track_external_bytes(buf_byte_len);
+                let ab_id = ab_obj_id;
+                let buf_val = JsValue::object(ab_id);
+                let id = interp.create_typed_array_object(new_ta, buf_val);
+                Completion::Normal(JsValue::object(id))
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -2983,23 +2847,14 @@ impl Interpreter {
             "values".to_string(),
             0,
             |interp, this_val, _args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    }
-                    let iter = interp.create_typed_array_iterator(o, IteratorKind::Value);
-                    return Completion::Normal(iter);
+                if let Err(c) = validate_typed_array(interp, this_val) {
+                    return c;
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let o = this_val
+                    .as_object_id()
+                    .expect("validated: receiver is a TypedArray object");
+                let iter = interp.create_typed_array_iterator(o, IteratorKind::Value);
+                Completion::Normal(iter)
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3015,23 +2870,14 @@ impl Interpreter {
             "entries".to_string(),
             0,
             |interp, this_val, _args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    }
-                    let iter = interp.create_typed_array_iterator(o, IteratorKind::KeyValue);
-                    return Completion::Normal(iter);
+                if let Err(c) = validate_typed_array(interp, this_val) {
+                    return c;
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let o = this_val
+                    .as_object_id()
+                    .expect("validated: receiver is a TypedArray object");
+                let iter = interp.create_typed_array_iterator(o, IteratorKind::KeyValue);
+                Completion::Normal(iter)
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -3042,23 +2888,14 @@ impl Interpreter {
             "keys".to_string(),
             0,
             |interp, this_val, _args| {
-                if let Some(o) = this_val.as_object_id()
-                    && let Some(obj) = interp.get_object(o)
-                {
-                    {
-                        let obj_ref = obj.borrow();
-                        if let Some(ta) = obj_ref.typed_array_info() {
-                            if let Err(c) = check_detached_or_out_of_bounds(interp, ta) {
-                                return c;
-                            }
-                        } else {
-                            return Completion::Throw(interp.create_type_error("not a TypedArray"));
-                        }
-                    }
-                    let iter = interp.create_typed_array_iterator(o, IteratorKind::Key);
-                    return Completion::Normal(iter);
+                if let Err(c) = validate_typed_array(interp, this_val) {
+                    return c;
                 }
-                Completion::Throw(interp.create_type_error("not a TypedArray"))
+                let o = this_val
+                    .as_object_id()
+                    .expect("validated: receiver is a TypedArray object");
+                let iter = interp.create_typed_array_iterator(o, IteratorKind::Key);
+                Completion::Normal(iter)
             },
         ));
         self.get_object_cell_expect(proto_id)
@@ -5876,6 +5713,29 @@ fn strict_eq(x: &JsValue, y: &JsValue) -> bool {
     }
 }
 
+/// Spec ValidateTypedArray(this, accessMode=~read~): the receiver-validation
+/// prologue shared by the TypedArray prototype methods. Throws TypeError
+/// "not a TypedArray" for a non-TypedArray receiver, otherwise runs the
+/// detached / out-of-bounds check and returns a clone of its `TypedArrayInfo`.
+/// The kind-gated `validate_uint8array` below is the same shape for one kind.
+fn validate_typed_array(
+    interp: &mut Interpreter,
+    this_val: &JsValue,
+) -> Result<TypedArrayInfo, Completion> {
+    if let Some(o) = this_val.as_object_id()
+        && let Some(obj) = interp.get_object(o)
+    {
+        let ta = obj.borrow().typed_array_info().cloned();
+        if let Some(ta) = ta {
+            check_detached_or_out_of_bounds(interp, &ta)?;
+            return Ok(ta);
+        }
+    }
+    Err(Completion::Throw(
+        interp.create_type_error("not a TypedArray"),
+    ))
+}
+
 fn validate_uint8array(
     interp: &mut Interpreter,
     this_val: &JsValue,
@@ -6558,4 +6418,86 @@ fn make_read_written_result(interp: &mut Interpreter, read: usize, written: usiz
         .set_property_value("written", JsValue::number(written as f64));
     let id = obj_id;
     Completion::Normal(JsValue::object(id))
+}
+
+#[cfg(test)]
+mod validate_typed_array_tests {
+    //! Pins the `validate_typed_array` seam — the receiver-validation prologue
+    //! shared by the TypedArray prototype methods. A live, attached TypedArray
+    //! receiver yields its `TypedArrayInfo`; anything else throws the same
+    //! TypeError the open-coded prologues throw ("not a TypedArray" for a
+    //! non-TypedArray receiver, "typed array is detached" for a detached one).
+    use super::validate_typed_array;
+    use crate::interpreter::{Completion, Interpreter, TypedArrayKind};
+    use crate::parser::Parser;
+    use crate::types::JsValue;
+
+    fn interp_with(source: &str) -> Interpreter {
+        let mut parser = Parser::new(source).expect("parser init");
+        let program = parser.parse_program().expect("parse program");
+        let mut interp = Interpreter::new();
+        let result = interp.run(&program);
+        assert!(
+            matches!(result, Completion::Normal(_) | Completion::Empty),
+            "unexpected completion: {result:?}"
+        );
+        interp
+    }
+
+    fn global(interp: &Interpreter, name: &str) -> JsValue {
+        interp
+            .get_global_var_ref(name)
+            .unwrap_or_else(|| panic!("expected global {name}"))
+    }
+
+    #[test]
+    fn accepts_a_live_typed_array_and_returns_its_info() {
+        let mut interp = interp_with("var ta = new Uint8Array([10, 20, 30, 40]);");
+        let ta = global(&interp, "ta");
+        let info = validate_typed_array(&mut interp, &ta).expect("valid TypedArray");
+        assert_eq!(info.kind, TypedArrayKind::Uint8);
+        assert_eq!(info.array_length, 4);
+    }
+
+    #[test]
+    fn rejects_a_non_object_receiver_as_not_a_typed_array() {
+        let mut interp = interp_with("");
+        let err = match validate_typed_array(&mut interp, &JsValue::UNDEFINED) {
+            Ok(_) => panic!("expected undefined receiver to be rejected"),
+            Err(Completion::Throw(e)) => interp.format_value(&e),
+            Err(other) => panic!("expected Throw, got {other:?}"),
+        };
+        assert!(err.contains("not a TypedArray"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_a_plain_object_as_not_a_typed_array() {
+        let mut interp = interp_with("var o = {};");
+        let o = global(&interp, "o");
+        let err = match validate_typed_array(&mut interp, &o) {
+            Ok(_) => panic!("expected plain object to be rejected"),
+            Err(Completion::Throw(e)) => interp.format_value(&e),
+            Err(other) => panic!("expected Throw, got {other:?}"),
+        };
+        assert!(err.contains("not a TypedArray"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_a_detached_typed_array() {
+        let mut interp =
+            interp_with("var buf = new ArrayBuffer(8); var dta = new Uint8Array(buf);");
+        let buf = global(&interp, "buf");
+        let dta = global(&interp, "dta");
+        // Detach through the same MOP the spec's DetachArrayBuffer uses.
+        interp.detach_arraybuffer(&buf);
+        let err = match validate_typed_array(&mut interp, &dta) {
+            Ok(_) => panic!("expected detached TypedArray to be rejected"),
+            Err(Completion::Throw(e)) => interp.format_value(&e),
+            Err(other) => panic!("expected Throw, got {other:?}"),
+        };
+        assert!(
+            err.contains("typed array is detached"),
+            "unexpected error: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## What

Extract a `validate_typed_array` **seam** in `src/interpreter/builtins/typedarray.rs` and collapse the receiver-validation **prologue** that 14 TypedArray prototype methods each open-coded.

Autonomous `pm-deepen` architecture-deepening run. Full review, scoring, and design record: `.architecture/reviews/2026-09-01-validate-typed-array.md`. Backlog: `.architecture/backlog.md`.

## Problem — a shallow module

Every TypedArray prototype method re-expressed one conceptual step ("is `this` a TypedArray whose buffer is still attached and in bounds?") as an ~11-line prologue: `as_object_id → get_object → borrow → typed_array_info → check_detached_or_out_of_bounds → clone`, with the `"not a TypedArray"` TypeError written **twice** — once in the `else`, once as a fall-through after the whole method body. The **interface** the caller wants is far narrower than the implementation it was forced to hand-roll — the definition of a shallow module — and the doubled throw separated by the entire body was a live footgun. Several getters had already **drifted**, inlining `is_detached.get() || is_typed_array_out_of_bounds(ta)` instead of the shared helper.

## Solution — one deep seam

```rust
fn validate_typed_array(interp: &mut Interpreter, this_val: &JsValue)
    -> Result<TypedArrayInfo, Completion>
```

Mirrors the proven kind-gated sibling `validate_uint8array`, with the kind gate dropped and `check_detached_or_out_of_bounds` folded in. Each migrated site shrinks to:

```rust
let ta = match validate_typed_array(interp, this_val) {
    Ok(ta) => ta,
    Err(c) => return c,
};
```

**Before**: 14 callers each wire `as_object_id`, the `RefCell` borrow-scope-then-clone discipline, the detached/OOB check, and two identical throws.
**After**: those steps sit behind one seam; callers hold a validated `TypedArrayInfo` or have already returned.

- **Leverage**: 14 methods lose their prologue; a future ValidateTypedArray spec change is a one-function edit.
- **Locality**: the brand/detach/OOB decision lives in one place beside its `check_*` siblings; the drift is eliminated.
- **Test surface**: the validation is now exercisable directly through a narrow `Result` interface (4 new unit tests in `mod validate_typed_array_tests`) — previously only test262 reached it.

**Migrated (14):** `at`, `copyWithin`, `fill`, `indexOf`, `lastIndexOf`, `includes`, `reverse`, `join`, `toLocaleString`, `toReversed`, `with`, `values`, `entries`, `keys`.
**Deliberately kept (3):** `slice`, `sort`, `toSorted` hold the object handle/borrow across their body; migrating them would restructure borrow granularity, so they retain their prologue to keep the change behaviour-preserving. (The report scored ~17; three resolved on inspection to the borrow-holding shape.)

## Test-first & quality gate

- 4 unit tests pinning the seam (`Ok(info)` for a live TypedArray; `"not a TypedArray"` for a non-object and a plain object; `"typed array is detached"` for a detached one) were written and seen to fail before the helper existed.
- `cargo build --release`: clean · `cargo test --bin jsse --release`: **600 passed** · `./scripts/lint.sh` (rustfmt + clippy `-D warnings`, incl. perf-counters): clean.
- **test262 `built-ins/TypedArray/prototype/`: 2792/2792, 0 regressions, +2 new passes** — the uniform `check_detached_or_out_of_bounds` fold-in fixed two previously-diverged getter cases.
- Custom tests: 13/13.

## Pick & runners-up

- **Picked**: `validate-typed-array` — **24/25** (leverage 5, locality 4, blast radius 1, heat 5). Chosen deterministically over the **runner-up candidate** `complete-state-machine-generator-ctor` (**22/25**) on heat: both are single-file, `pub(crate)`, blast-radius-1 collapses of a duplicated invariant, but `typedarray.rs` is one of the hottest files in the tree while `generator_runtime.rs` is cold. 2-point gap — not close.
- **Runner-up design** (design-it-twice): a control-inverting combinator `with_typed_array(this, access, |i, ta| …)`. It lost to the minimal free function on **Depth** — it hides slightly more but exports a larger interface and leaks control-flow caveats back to the caller (`return` exits only the closure; two-TypedArray methods must not nest it). A spec-faithful access-mode-parametric design was rejected outright for an unattended run: it would have *moved* the immutable-buffer check ahead of argument coercion at ~6 write sites (an observable throw-ordering change) and expanded scope beyond the picked candidate.

## Proposed ADR

None — this is a localized seam extraction that re-litigates no recorded decision.

## CONTEXT.md terms added

None — the existing **Seam** glossary entry already covers the architectural concept; `validate_typed_array` is an implementation seam, not a new domain term.

---
🤖 Autonomous `pm-deepen` run. Do not merge without human review.
