### PR TITLE
chore: ignore agent scratch dir and generated perf report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ scripts/.unicode_cache/
 __pycache__/
 mutants.out/
 mutants.out.old/
+.entire/
+/perf-report.md


### PR DESCRIPTION
## Summary

Adds two entries to `.gitignore` so they stop showing up as untracked noise in `git status`:

- **`.entire/`** — tool scratch directory (`metadata/`, `tmp/`; carries its own `.gitignore`).
- **`/perf-report.md`** — the regenerated handoff artifact of the `/performance-analyse` skill, consumed by `/performance-fix`. Anchored to the repo root, which is where both skills write and read it.

This matches the existing convention for the other generated perf artifacts already ignored here (`jetstream-baseline.json`, `jetstream-results.json`).

## Notes

No source or test changes — `.gitignore` only.

https://claude.ai/code/session_01SWtdLjDrAqjE6YCDYaPvkH