### PR TITLE
fix(iterator): reject take/drop limits above 2**53 - 1

### DIFF
--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -2024,7 +2024,16 @@ impl Interpreter {
                         .create_error("RangeError", "take limit must be a non-negative number");
                     return Completion::Throw(err);
                 }
-                // Step 5-6: integerLimit = ToIntegerOrInfinity, check < 0
+                // Step 5: If numLimit is finite and numLimit > 2**53 - 1, throw RangeError
+                if num_limit.is_finite() && num_limit > 9007199254740991.0 {
+                    let _ = iterator_close_getter(interp, this);
+                    let err = interp.create_error(
+                        "RangeError",
+                        "take limit must not exceed 2**53 - 1",
+                    );
+                    return Completion::Throw(err);
+                }
+                // Step 6-7: integerLimit = ToIntegerOrInfinity, check < 0
                 let integer_limit = if num_limit.is_infinite() {
                     num_limit
                 } else {
@@ -2175,7 +2184,16 @@ impl Interpreter {
                         .create_error("RangeError", "drop limit must be a non-negative number");
                     return Completion::Throw(err);
                 }
-                // Step 5-6: integerLimit = ToIntegerOrInfinity, check < 0
+                // Step 5: If numLimit is finite and numLimit > 2**53 - 1, throw RangeError
+                if num_limit.is_finite() && num_limit > 9007199254740991.0 {
+                    let _ = iterator_close_getter(interp, this);
+                    let err = interp.create_error(
+                        "RangeError",
+                        "drop limit must not exceed 2**53 - 1",
+                    );
+                    return Completion::Throw(err);
+                }
+                // Step 6-7: integerLimit = ToIntegerOrInfinity, check < 0
                 let integer_limit = if num_limit.is_infinite() {
                     num_limit
                 } else {

--- a/test262-extra/iterator-take-drop-limit-above-max-safe-integer.js
+++ b/test262-extra/iterator-take-drop-limit-above-max-safe-integer.js
@@ -1,0 +1,98 @@
+/*---
+description: >
+  Iterator.prototype.take and Iterator.prototype.drop throw a RangeError when
+  the limit is finite and greater than 2**53 - 1, closing the underlying
+  iterator, while accepting 2**53 - 1 itself and Infinity.
+esid: sec-iterator.prototype.take
+info: |
+  Iterator.prototype.take ( limit )
+
+  1. Let O be the this value.
+  2. If O is not an Object, throw a TypeError exception.
+  3. Let numLimit be ? ToNumber(limit).
+  4. If numLimit is NaN, then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
+  5. If numLimit is finite and numLimit > 𝔽(2**53 - 1), then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
+  6. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
+  7. If integerLimit < 0, then
+     a. Let error be ThrowCompletion(a newly created RangeError object).
+     b. Return ? IteratorClose(iterated, error).
+
+  Iterator.prototype.drop ( limit ) performs the same steps.
+
+  Step 5 distinguishes a finite limit above the safe-integer range, which is
+  rejected, from Infinity, which is not finite and so is accepted.
+features: [iterator-helpers]
+---*/
+
+var MAX_SAFE = 9007199254740991; // 2**53 - 1
+
+// Values at or below 2**53 - 1, and Infinity, are accepted.
+(function* () {})().take(MAX_SAFE);
+(function* () {})().drop(MAX_SAFE);
+(function* () {})().take(Infinity);
+(function* () {})().drop(Infinity);
+
+// A finite limit above 2**53 - 1 is a RangeError.
+assert.throws(RangeError, function () {
+  (function* () {})().take(MAX_SAFE + 1);
+}, 'take with a limit above 2**53 - 1');
+
+assert.throws(RangeError, function () {
+  (function* () {})().drop(MAX_SAFE + 1);
+}, 'drop with a limit above 2**53 - 1');
+
+assert.throws(RangeError, function () {
+  (function* () {})().take(Number.MAX_VALUE);
+}, 'take with Number.MAX_VALUE');
+
+assert.throws(RangeError, function () {
+  (function* () {})().drop(Number.MAX_VALUE);
+}, 'drop with Number.MAX_VALUE');
+
+// Step 5.b closes the underlying iterator before the RangeError propagates.
+function closingIterator() {
+  var iterator = {
+    returnCount: 0,
+    next: function () {
+      return { value: 1, done: false };
+    },
+    return: function () {
+      this.returnCount += 1;
+      return { done: true };
+    }
+  };
+  Object.setPrototypeOf(iterator, Iterator.prototype);
+  return iterator;
+}
+
+var takeIterator = closingIterator();
+assert.throws(RangeError, function () {
+  takeIterator.take(MAX_SAFE + 1);
+});
+assert.sameValue(takeIterator.returnCount, 1, 'take closed the underlying iterator');
+
+var dropIterator = closingIterator();
+assert.throws(RangeError, function () {
+  dropIterator.drop(MAX_SAFE + 1);
+});
+assert.sameValue(dropIterator.returnCount, 1, 'drop closed the underlying iterator');
+
+// The limit is coerced with ToNumber before the range check, so a valueOf that
+// returns an out-of-range value still produces a RangeError.
+var coerced = {
+  valueOf: function () {
+    return MAX_SAFE + 1;
+  }
+};
+
+assert.throws(RangeError, function () {
+  (function* () {})().take(coerced);
+}, 'take with a coerced out-of-range limit');
+
+assert.throws(RangeError, function () {
+  (function* () {})().drop(coerced);
+}, 'drop with a coerced out-of-range limit');


### PR DESCRIPTION
## Problem

`Iterator.prototype.take` and `Iterator.prototype.drop` implement the older spec steps — `ToNumber`, reject `NaN`, `ToIntegerOrInfinity`, reject negative. The current spec inserts a step between the `NaN` and negative checks:

> 5. If `numLimit` is finite and `numLimit` > 𝔽(2\*\*53 - 1), then
>    a. Let `error` be ThrowCompletion(a newly created **RangeError** object).
>    b. Return ? IteratorClose(`iterated`, `error`).

jsse skipped it, so `iter.take(2**53)` silently truncated to a limit no iterator can reach instead of throwing:

```js
(function* () {})().take(Number.MAX_SAFE_INTEGER + 1);  // before: no error
(function* () {})().drop(Number.MAX_VALUE);             // before: no error
```

`Infinity` must still be accepted, which is why the guard tests `is_finite()` rather than comparing alone.

## Fix

Adds the missing step to both methods in `src/interpreter/builtins/iterators.rs`, closing the underlying iterator before the `RangeError` propagates, matching the surrounding NaN and negative-limit branches. Uses the bare `9007199254740991.0` literal, the idiom already used for this bound throughout `array.rs`, `eval.rs`, and `typedarray.rs`.

## Testing

Upstream test262 tightened `Iterator/prototype/{take,drop}/limit-rangeerror.js` to cover this, but those assertions are not in the currently pinned submodule — so per `CLAUDE.md` this adds a `test262-extra/` case instead. It covers both methods for:

- the accepted boundary — `2**53 - 1` and `Infinity`
- the rejected values — `2**53` and `Number.MAX_VALUE`
- the underlying iterator being closed on the throw
- the range check running *after* `ToNumber`, so a `valueOf` returning an out-of-range value still throws

Verified the test is a real guard: **2/2 scenarios fail without the fix, 2/2 pass with it.**

- `test262-extra/`: 231 pass, 0 fail
- `cargo test --release`: 596 pass, 0 fail
- `./scripts/lint.sh`: all checks passed

## Note

Found while preparing the test262 submodule bump, where upstream's tightened `limit-rangeerror.js` caught it. Split out here because it is an engine fix independent of that bump.

https://claude.ai/code/session_01SWtdLjDrAqjE6YCDYaPvkH