### PR TITLE
fix(test262): stop killed runs leaving scratch files in the submodule

### DIFF
--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -28,6 +28,7 @@ import time
 from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
+from typing import NamedTuple
 
 _main_pgid = None
 
@@ -497,22 +498,31 @@ def run_single_test(
         except OSError:
             return (scenario_id, False, "harness_error", 0.0)
 
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            prefix=SCRATCH_PREFIX,
-            suffix=".js",
-            delete=False,
-            encoding="utf-8",
-            newline="",
-            dir=str(test_file.parent),
-        ) as tmp:
-            # The file exists on disk from the moment it is created, so register
-            # it before writing. `combined` can be hundreds of KB, and a signal
-            # arriving during the write or the close would otherwise find
-            # `_active_scratch_path` still unset and exit without unlinking --
-            # leaving exactly the stray file this handler exists to prevent.
+        # The file exists on disk from inside `NamedTemporaryFile`, before it
+        # returns anything we could record. A handler firing in that gap would
+        # `os._exit` with nothing to unlink, so hold the termination signals
+        # across creation *and* registration; a signal sent while they are
+        # blocked stays pending and is delivered once the mask is restored,
+        # by which point there is a path to clean up.
+        blocked = {signal.SIGTERM, signal.SIGINT}
+        previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, blocked)
+        try:
+            tmp = tempfile.NamedTemporaryFile(
+                mode="w",
+                prefix=SCRATCH_PREFIX,
+                suffix=".js",
+                delete=False,
+                encoding="utf-8",
+                newline="",
+                dir=str(test_file.parent),
+            )
             tmp_path = tmp.name
             _active_scratch_path = tmp_path
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+
+        # The write is already covered: the path is registered by now.
+        with tmp:
             tmp.write(combined)
 
     cmd = adapter.build_command(test_file, tmp_path, harness_files, is_module, flags)
@@ -750,9 +760,26 @@ def _raise_for_uncollected_mjs(paths: list[Path], test262_dir: Path) -> None:
     )
 
 
-def sweep_scratch_files(
-    roots: list[Path], min_age_s: float
-) -> tuple[int, int, list[tuple[Path, OSError]]]:
+class SweepResult(NamedTuple):
+    """Outcome of a sweep, in enough detail to never imply a false all-clear.
+
+    A bare count cannot distinguish "nothing to do" from "never looked", so
+    every way the sweep can fall short is reported separately: files left
+    because they are too recent to judge dead, files that resisted removal, and
+    directories that could not be traversed at all.
+    """
+
+    removed: int
+    skipped_too_recent: int
+    unremovable: list[tuple[Path, OSError]]
+    unreadable: list[tuple[Path, OSError]]
+
+    @property
+    def incomplete(self) -> bool:
+        return bool(self.unremovable or self.unreadable)
+
+
+def sweep_scratch_files(roots: list[Path], min_age_s: float) -> SweepResult:
     """Delete scratch files left behind by a run that was killed outright.
 
     SIGKILL runs neither the `finally` in `run_scenario` nor the worker's
@@ -768,14 +795,29 @@ def sweep_scratch_files(
     record a false failure. The caller asserts that no other run is active.
 
     `min_age_s` is defence in depth for a mistaken invocation, not a liveness
-    test. Returns (removed, skipped_too_recent, failures) so the caller can
-    distinguish "nothing to do" from "could not look" or "could not remove" --
-    reporting a count alone would let any of them read as an all-clear.
+    test. See `SweepResult` for why the outcome is more than a count.
     """
     cutoff = time.time() - min_age_s
     removed = 0
     skipped = 0
-    failures: list[tuple[Path, OSError]] = []
+    unremovable: list[tuple[Path, OSError]] = []
+    unreadable: list[tuple[Path, OSError]] = []
+
+    def _scan(directory: Path) -> list[Path]:
+        # `Path.rglob` swallows a directory it cannot read and simply omits that
+        # subtree, which would let an unreadable corner of the tree pass as
+        # swept. `os.walk` can at least tell us it happened.
+        found: list[Path] = []
+        for dirpath, _dirnames, filenames in os.walk(
+            directory, onerror=lambda e: unreadable.append((Path(e.filename), e))
+        ):
+            found.extend(
+                Path(dirpath) / name
+                for name in filenames
+                if name.startswith(SCRATCH_PREFIX) and name.endswith(".js")
+            )
+        return found
+
     for root in roots:
         # `paths` accepts individual files, and a shell glob over a directory
         # expands to them, so a file root has to be considered on its own terms
@@ -784,7 +826,7 @@ def sweep_scratch_files(
         if root.is_file():
             candidates = [root]
         elif root.is_dir():
-            candidates = root.rglob(f"{SCRATCH_PREFIX}*.js")
+            candidates = _scan(root)
         else:
             continue
         for f in candidates:
@@ -799,10 +841,10 @@ def sweep_scratch_files(
                 # A read-only checkout or changed directory permissions leaves a
                 # known stale file in place; swallowing that would let the run
                 # report success with the file still there.
-                failures.append((f, error))
+                unremovable.append((f, error))
                 continue
             removed += 1
-    return removed, skipped, failures
+    return SweepResult(removed, skipped, unremovable, unreadable)
 
 
 def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
@@ -888,18 +930,21 @@ def main():
             for r in missing:
                 print(f"Error: cleanup path not found: {r}", file=sys.stderr)
             sys.exit(2)
-        removed, skipped, failures = sweep_scratch_files(
-            roots, min_age_s=max(args.timeout * 2, 300)
+        result = sweep_scratch_files(roots, min_age_s=max(args.timeout * 2, 300))
+        print(
+            f"Removed {result.removed} scratch file(s) left by an earlier "
+            "killed run."
         )
-        print(f"Removed {removed} scratch file(s) left by an earlier killed run.")
-        if skipped:
+        if result.skipped_too_recent:
             print(
-                f"Left {skipped} in place as too recent to be sure they are dead. "
-                "Re-run once no other invocation is active."
+                f"Left {result.skipped_too_recent} in place as too recent to be "
+                "sure they are dead. Re-run once no other invocation is active."
             )
-        for path, error in failures:
+        for path, error in result.unreadable:
+            print(f"Error: could not scan {path}: {error}", file=sys.stderr)
+        for path, error in result.unremovable:
             print(f"Error: could not remove {path}: {error}", file=sys.stderr)
-        sys.exit(1 if failures else 0)
+        sys.exit(1 if result.incomplete else 0)
 
     engine_name = args.engine
     binary = args.binary

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -41,11 +41,34 @@ def _set_pdeathsig():
         pass
 
 
+# Path of the scratch file this worker is currently running, or None. The
+# termination handler below is the only reader; workers are single-threaded and
+# run one scenario at a time, so a plain global is enough.
+_active_scratch_path = None
+
+
+def _worker_cleanup_handler(signum, frame):
+    """Remove the in-flight scratch file, then exit.
+
+    `run_scenario` unlinks in a `finally`, which covers every path the
+    interpreter itself unwinds. A signal is not one of those: the default
+    SIGTERM action terminates the process outright, so the scratch file next to
+    the test would survive as an untracked `tmp*.js` inside the read-only
+    submodule. Unlink it here before exiting.
+    """
+    if _active_scratch_path is not None:
+        try:
+            os.unlink(_active_scratch_path)
+        except OSError:
+            pass
+    os._exit(128 + signum)
+
+
 def _worker_init():
     """Initializer for pool worker processes."""
     _set_pdeathsig()
-    signal.signal(signal.SIGTERM, signal.SIG_DFL)
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGTERM, _worker_cleanup_handler)
+    signal.signal(signal.SIGINT, _worker_cleanup_handler)
 
 
 def _cleanup_handler(signum, frame):
@@ -456,6 +479,8 @@ def run_single_test(
     harness_files = get_harness_files(metadata, test262_dir, is_module, is_async)
     concat_harness = adapter.needs_harness_in_source(is_module)
 
+    global _active_scratch_path
+
     tmp_path = None
     if concat_harness or not is_module:
         try:
@@ -473,6 +498,7 @@ def run_single_test(
         ) as tmp:
             tmp.write(combined)
             tmp_path = tmp.name
+        _active_scratch_path = tmp_path
 
     cmd = adapter.build_command(test_file, tmp_path, harness_files, is_module, flags)
 
@@ -509,6 +535,7 @@ def run_single_test(
                 os.unlink(tmp_path)
             except OSError:
                 pass
+            _active_scratch_path = None
 
     stderr_text = result.stderr.decode("utf-8", errors="replace")
 
@@ -647,6 +674,18 @@ def _is_fixture(p: Path) -> bool:
     return name.endswith("_FIXTURE.js") or name.endswith("_FIXTURE.mjs")
 
 
+# `tempfile` names its files `tmp` + 8 chars drawn from this alphabet. Scratch
+# files are written next to the test they wrap, so a run killed hard enough to
+# skip cleanup leaves them among the tests. Excluding them from collection keeps
+# a leaked file from being counted as a test of its own and inflating the
+# scenario total, independently of whether the sweep below reclaimed it.
+SCRATCH_RE = re.compile(r"^tmp[a-z0-9_]{8}\.js$")
+
+
+def _is_scratch(p: Path) -> bool:
+    return SCRATCH_RE.match(p.name) is not None
+
+
 class TestCollectionError(Exception):
     """Raised when a selected path contains a test the runner would omit."""
 
@@ -680,6 +719,33 @@ def _raise_for_uncollected_mjs(paths: list[Path], test262_dir: Path) -> None:
     )
 
 
+def sweep_scratch_files(roots: list[Path], min_age_s: float) -> int:
+    """Delete scratch files left behind by a run that was killed outright.
+
+    SIGKILL runs neither the `finally` in `run_scenario` nor the worker's
+    termination handler, so nothing but a later sweep can reclaim those files.
+
+    `min_age_s` keeps a concurrent run's live scratch files out of scope: one is
+    at most a per-test timeout old, so anything older belongs to a dead run.
+    """
+    cutoff = time.time() - min_age_s
+    removed = 0
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for f in root.rglob("tmp*.js"):
+            if not _is_scratch(f):
+                continue
+            try:
+                if f.stat().st_mtime > cutoff:
+                    continue
+                f.unlink()
+            except OSError:
+                continue
+            removed += 1
+    return removed
+
+
 def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
     if paths:
         selected = [Path(p) for p in paths]
@@ -690,7 +756,9 @@ def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
                 tests.append(path)
             elif path.is_dir():
                 tests.extend(
-                    f for f in sorted(path.rglob("*.js")) if not _is_fixture(f)
+                    f
+                    for f in sorted(path.rglob("*.js"))
+                    if not _is_fixture(f) and not _is_scratch(f)
                 )
         return sorted(tests)
 
@@ -701,7 +769,9 @@ def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
     for subdir in ("language", "built-ins", "annexB", "intl402"):
         d = test_dir / subdir
         if d.is_dir():
-            tests.extend(f for f in d.rglob("*.js") if not _is_fixture(f))
+            tests.extend(
+                f for f in d.rglob("*.js") if not _is_fixture(f) and not _is_scratch(f)
+            )
     return sorted(tests)
 
 
@@ -764,6 +834,12 @@ def main():
         sys.exit(2)
 
     selected_paths = args.paths if args.paths else None
+
+    sweep_roots = [Path(p) for p in args.paths] if args.paths else [test262 / "test"]
+    swept = sweep_scratch_files(sweep_roots, min_age_s=max(args.timeout * 2, 300))
+    if swept:
+        print(f"Removed {swept} scratch file(s) left by an earlier killed run.")
+
     try:
         tests = find_tests(test262, selected_paths)
     except TestCollectionError as error:

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -41,6 +41,15 @@ def _set_pdeathsig():
         pass
 
 
+# Scratch files carry a prefix that names this runner, so the filename alone is
+# evidence that we wrote them. The startup sweep deletes what it matches, and it
+# recurses into whichever directory the caller selected, so a generic `tmp`
+# prefix would let it unlink a `tempfile` belonging to some other tool -- or a
+# real test that happened to be named that way -- inside a tree the project
+# forbids modifying at all (AGENTS.md: never modify `test262/`).
+SCRATCH_PREFIX = "jsse-scratch-"
+
+
 # Path of the scratch file this worker is currently running, or None. The
 # termination handler below is the only reader; workers are single-threaded and
 # run one scenario at a time, so a plain global is enough.
@@ -53,7 +62,7 @@ def _worker_cleanup_handler(signum, frame):
     `run_scenario` unlinks in a `finally`, which covers every path the
     interpreter itself unwinds. A signal is not one of those: the default
     SIGTERM action terminates the process outright, so the scratch file next to
-    the test would survive as an untracked `tmp*.js` inside the read-only
+    the test would survive as an untracked scratch file inside the read-only
     submodule. Unlink it here before exiting.
     """
     if _active_scratch_path is not None:
@@ -490,6 +499,7 @@ def run_single_test(
 
         with tempfile.NamedTemporaryFile(
             mode="w",
+            prefix=SCRATCH_PREFIX,
             suffix=".js",
             delete=False,
             encoding="utf-8",
@@ -674,16 +684,31 @@ def _is_fixture(p: Path) -> bool:
     return name.endswith("_FIXTURE.js") or name.endswith("_FIXTURE.mjs")
 
 
-# `tempfile` names its files `tmp` + 8 chars drawn from this alphabet. Scratch
-# files are written next to the test they wrap, so a run killed hard enough to
-# skip cleanup leaves them among the tests. Excluding them from collection keeps
-# a leaked file from being counted as a test of its own and inflating the
-# scenario total, independently of whether the sweep below reclaimed it.
-SCRATCH_RE = re.compile(r"^tmp[a-z0-9_]{8}\.js$")
+# `tempfile` composes a name as its prefix plus 8 chars drawn from this
+# alphabet. Scratch files are written next to the test they wrap, so a run
+# killed hard enough to skip cleanup leaves them among the tests.
+SCRATCH_RE = re.compile(rf"^{re.escape(SCRATCH_PREFIX)}[a-z0-9_]{{8}}\.js$")
+
+# Runs from before the prefix existed leaked plain `tempfile` names. Collection
+# still skips those, so a leftover is never counted as a test of its own and
+# cannot inflate the scenario total -- but the sweep never deletes one, because
+# the name is not evidence of who wrote it.
+LEGACY_SCRATCH_RE = re.compile(r"^tmp[a-z0-9_]{8}\.js$")
 
 
 def _is_scratch(p: Path) -> bool:
+    """True for a scratch file this runner created, which the sweep may delete."""
     return SCRATCH_RE.match(p.name) is not None
+
+
+def _is_uncollectable_scratch(p: Path) -> bool:
+    """True for anything scratch-shaped, pre-prefix leftovers included.
+
+    Collection only ever skips these, and a skip is recoverable where an unlink
+    is not, so matching the generic shape here is safe in a way that matching it
+    in `sweep_scratch_files` would not be.
+    """
+    return _is_scratch(p) or LEGACY_SCRATCH_RE.match(p.name) is not None
 
 
 class TestCollectionError(Exception):
@@ -725,6 +750,10 @@ def sweep_scratch_files(roots: list[Path], min_age_s: float) -> int:
     SIGKILL runs neither the `finally` in `run_scenario` nor the worker's
     termination handler, so nothing but a later sweep can reclaim those files.
 
+    Only names carrying `SCRATCH_PREFIX` are eligible. `roots` follows whatever
+    the caller selected, so this walks trees we do not own; unlinking there is
+    only defensible for a name that says we wrote it.
+
     `min_age_s` keeps a concurrent run's live scratch files out of scope: one is
     at most a per-test timeout old, so anything older belongs to a dead run.
     """
@@ -733,7 +762,7 @@ def sweep_scratch_files(roots: list[Path], min_age_s: float) -> int:
     for root in roots:
         if not root.is_dir():
             continue
-        for f in root.rglob("tmp*.js"):
+        for f in root.rglob(f"{SCRATCH_PREFIX}*.js"):
             if not _is_scratch(f):
                 continue
             try:
@@ -758,7 +787,7 @@ def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
                 tests.extend(
                     f
                     for f in sorted(path.rglob("*.js"))
-                    if not _is_fixture(f) and not _is_scratch(f)
+                    if not _is_fixture(f) and not _is_uncollectable_scratch(f)
                 )
         return sorted(tests)
 
@@ -770,7 +799,9 @@ def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
         d = test_dir / subdir
         if d.is_dir():
             tests.extend(
-                f for f in d.rglob("*.js") if not _is_fixture(f) and not _is_scratch(f)
+                f
+                for f in d.rglob("*.js")
+                if not _is_fixture(f) and not _is_uncollectable_scratch(f)
             )
     return sorted(tests)
 

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -689,26 +689,18 @@ def _is_fixture(p: Path) -> bool:
 # killed hard enough to skip cleanup leaves them among the tests.
 SCRATCH_RE = re.compile(rf"^{re.escape(SCRATCH_PREFIX)}[a-z0-9_]{{8}}\.js$")
 
-# Runs from before the prefix existed leaked plain `tempfile` names. Collection
-# still skips those, so a leftover is never counted as a test of its own and
-# cannot inflate the scenario total -- but the sweep never deletes one, because
-# the name is not evidence of who wrote it.
-LEGACY_SCRATCH_RE = re.compile(r"^tmp[a-z0-9_]{8}\.js$")
-
 
 def _is_scratch(p: Path) -> bool:
-    """True for a scratch file this runner created, which the sweep may delete."""
-    return SCRATCH_RE.match(p.name) is not None
+    """True for a scratch file this runner created.
 
-
-def _is_uncollectable_scratch(p: Path) -> bool:
-    """True for anything scratch-shaped, pre-prefix leftovers included.
-
-    Collection only ever skips these, and a skip is recoverable where an unlink
-    is not, so matching the generic shape here is safe in a way that matching it
-    in `sweep_scratch_files` would not be.
+    Both the collection filter and the sweep key off this, so nothing is skipped
+    or deleted on the strength of a name we cannot claim. A generic `tempfile`
+    name is deliberately not enough: excluding one silently drops whatever it
+    really was from the run, and the scenario total this guards is the same
+    number a silent omission would corrupt. Leftovers from runs predating the
+    prefix are cleaned up out of band, not guessed at here.
     """
-    return _is_scratch(p) or LEGACY_SCRATCH_RE.match(p.name) is not None
+    return SCRATCH_RE.match(p.name) is not None
 
 
 class TestCollectionError(Exception):
@@ -785,17 +777,13 @@ def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
             # directly or swept up by a shell glob, and the startup sweep skips
             # it because a file is not a directory. Filter it here too, or it is
             # counted as a test and inflates the selected run's total.
-            if (
-                path.is_file()
-                and path.suffix == ".js"
-                and not _is_uncollectable_scratch(path)
-            ):
+            if path.is_file() and path.suffix == ".js" and not _is_scratch(path):
                 tests.append(path)
             elif path.is_dir():
                 tests.extend(
                     f
                     for f in sorted(path.rglob("*.js"))
-                    if not _is_fixture(f) and not _is_uncollectable_scratch(f)
+                    if not _is_fixture(f) and not _is_scratch(f)
                 )
         return sorted(tests)
 
@@ -807,9 +795,7 @@ def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
         d = test_dir / subdir
         if d.is_dir():
             tests.extend(
-                f
-                for f in d.rglob("*.js")
-                if not _is_fixture(f) and not _is_uncollectable_scratch(f)
+                f for f in d.rglob("*.js") if not _is_fixture(f) and not _is_scratch(f)
             )
     return sorted(tests)
 

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -506,9 +506,14 @@ def run_single_test(
             newline="",
             dir=str(test_file.parent),
         ) as tmp:
-            tmp.write(combined)
+            # The file exists on disk from the moment it is created, so register
+            # it before writing. `combined` can be hundreds of KB, and a signal
+            # arriving during the write or the close would otherwise find
+            # `_active_scratch_path` still unset and exit without unlinking --
+            # leaving exactly the stray file this handler exists to prevent.
             tmp_path = tmp.name
-        _active_scratch_path = tmp_path
+            _active_scratch_path = tmp_path
+            tmp.write(combined)
 
     cmd = adapter.build_command(test_file, tmp_path, harness_files, is_module, flags)
 

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -773,9 +773,17 @@ def sweep_scratch_files(roots: list[Path], min_age_s: float) -> tuple[int, int]:
     removed = 0
     skipped = 0
     for root in roots:
-        if not root.is_dir():
+        # `paths` accepts individual files, and a shell glob over a directory
+        # expands to them, so a file root has to be considered on its own terms
+        # rather than skipped -- otherwise naming a leaked file explicitly is a
+        # silent no-op that still reports success.
+        if root.is_file():
+            candidates = [root]
+        elif root.is_dir():
+            candidates = root.rglob(f"{SCRATCH_PREFIX}*.js")
+        else:
             continue
-        for f in root.rglob(f"{SCRATCH_PREFIX}*.js"):
+        for f in candidates:
             if not _is_scratch(f):
                 continue
             try:
@@ -856,6 +864,22 @@ def main():
 
     args = parse_args()
 
+    if args.clean_scratch:
+        # Before any engine resolution: this only touches the filesystem, so it
+        # must stay usable on a checkout where the binary has not been built.
+        test262 = Path(args.test262)
+        roots = [Path(p) for p in args.paths] if args.paths else [test262 / "test"]
+        removed, skipped = sweep_scratch_files(
+            roots, min_age_s=max(args.timeout * 2, 300)
+        )
+        print(f"Removed {removed} scratch file(s) left by an earlier killed run.")
+        if skipped:
+            print(
+                f"Left {skipped} in place as too recent to be sure they are dead. "
+                "Re-run once no other invocation is active."
+            )
+        sys.exit(0)
+
     engine_name = args.engine
     binary = args.binary
     if binary is None and args.jsse_compat is not None and engine_name == "jsse":
@@ -881,19 +905,6 @@ def main():
         sys.exit(2)
 
     selected_paths = args.paths if args.paths else None
-
-    if args.clean_scratch:
-        roots = [Path(p) for p in args.paths] if args.paths else [test262 / "test"]
-        removed, skipped = sweep_scratch_files(
-            roots, min_age_s=max(args.timeout * 2, 300)
-        )
-        print(f"Removed {removed} scratch file(s) left by an earlier killed run.")
-        if skipped:
-            print(
-                f"Left {skipped} in place as too recent to be sure they are dead. "
-                "Re-run once no other invocation is active."
-            )
-        sys.exit(0)
 
     try:
         tests = find_tests(test262, selected_paths)

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -781,7 +781,15 @@ def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
         _raise_for_uncollected_mjs(selected, test262_dir)
         tests = []
         for path in selected:
-            if path.is_file() and path.suffix == ".js":
+            # A leaked scratch file reaches this branch when it is named
+            # directly or swept up by a shell glob, and the startup sweep skips
+            # it because a file is not a directory. Filter it here too, or it is
+            # counted as a test and inflates the selected run's total.
+            if (
+                path.is_file()
+                and path.suffix == ".js"
+                and not _is_uncollectable_scratch(path)
+            ):
                 tests.append(path)
             elif path.is_dir():
                 tests.extend(

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -750,7 +750,9 @@ def _raise_for_uncollected_mjs(paths: list[Path], test262_dir: Path) -> None:
     )
 
 
-def sweep_scratch_files(roots: list[Path], min_age_s: float) -> tuple[int, int]:
+def sweep_scratch_files(
+    roots: list[Path], min_age_s: float
+) -> tuple[int, int, list[tuple[Path, OSError]]]:
     """Delete scratch files left behind by a run that was killed outright.
 
     SIGKILL runs neither the `finally` in `run_scenario` nor the worker's
@@ -766,12 +768,14 @@ def sweep_scratch_files(roots: list[Path], min_age_s: float) -> tuple[int, int]:
     record a false failure. The caller asserts that no other run is active.
 
     `min_age_s` is defence in depth for a mistaken invocation, not a liveness
-    test. Returns (removed, skipped_too_recent) so the caller can say what it
-    declined to touch rather than silently doing nothing.
+    test. Returns (removed, skipped_too_recent, failures) so the caller can
+    distinguish "nothing to do" from "could not look" or "could not remove" --
+    reporting a count alone would let any of them read as an all-clear.
     """
     cutoff = time.time() - min_age_s
     removed = 0
     skipped = 0
+    failures: list[tuple[Path, OSError]] = []
     for root in roots:
         # `paths` accepts individual files, and a shell glob over a directory
         # expands to them, so a file root has to be considered on its own terms
@@ -791,10 +795,14 @@ def sweep_scratch_files(roots: list[Path], min_age_s: float) -> tuple[int, int]:
                     skipped += 1
                     continue
                 f.unlink()
-            except OSError:
+            except OSError as error:
+                # A read-only checkout or changed directory permissions leaves a
+                # known stale file in place; swallowing that would let the run
+                # report success with the file still there.
+                failures.append((f, error))
                 continue
             removed += 1
-    return removed, skipped
+    return removed, skipped, failures
 
 
 def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
@@ -880,7 +888,7 @@ def main():
             for r in missing:
                 print(f"Error: cleanup path not found: {r}", file=sys.stderr)
             sys.exit(2)
-        removed, skipped = sweep_scratch_files(
+        removed, skipped, failures = sweep_scratch_files(
             roots, min_age_s=max(args.timeout * 2, 300)
         )
         print(f"Removed {removed} scratch file(s) left by an earlier killed run.")
@@ -889,7 +897,9 @@ def main():
                 f"Left {skipped} in place as too recent to be sure they are dead. "
                 "Re-run once no other invocation is active."
             )
-        sys.exit(0)
+        for path, error in failures:
+            print(f"Error: could not remove {path}: {error}", file=sys.stderr)
+        sys.exit(1 if failures else 0)
 
     engine_name = args.engine
     binary = args.binary

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -677,6 +677,15 @@ examples:
         ),
     )
     parser.add_argument(
+        "--clean-scratch",
+        action="store_true",
+        help=(
+            "Delete scratch files left behind by an earlier killed run, then "
+            "exit. Only run this while no other invocation is active: nothing "
+            "the sweep can see proves the run that created a file has died."
+        ),
+    )
+    parser.add_argument(
         "paths",
         nargs="*",
         help="Specific test files or directories to run (default: all tests)",
@@ -741,21 +750,28 @@ def _raise_for_uncollected_mjs(paths: list[Path], test262_dir: Path) -> None:
     )
 
 
-def sweep_scratch_files(roots: list[Path], min_age_s: float) -> int:
+def sweep_scratch_files(roots: list[Path], min_age_s: float) -> tuple[int, int]:
     """Delete scratch files left behind by a run that was killed outright.
 
     SIGKILL runs neither the `finally` in `run_scenario` nor the worker's
-    termination handler, so nothing but a later sweep can reclaim those files.
+    termination handler, so nothing but an explicit sweep can reclaim those
+    files. Only names carrying `SCRATCH_PREFIX` are eligible.
 
-    Only names carrying `SCRATCH_PREFIX` are eligible. `roots` follows whatever
-    the caller selected, so this walks trees we do not own; unlinking there is
-    only defensible for a name that says we wrote it.
+    This is deliberately not part of a normal run. Nothing a sweep can see
+    establishes that the run which created a file has died: a file's age is
+    bounded by the *creating* run's `--timeout`, not this one's, and a worker
+    stalled on a loaded machine outlives any fixed cutoff. Sweeping
+    automatically would therefore let one invocation delete a live scratch file
+    out from under another, whose engine would then read a missing input and
+    record a false failure. The caller asserts that no other run is active.
 
-    `min_age_s` keeps a concurrent run's live scratch files out of scope: one is
-    at most a per-test timeout old, so anything older belongs to a dead run.
+    `min_age_s` is defence in depth for a mistaken invocation, not a liveness
+    test. Returns (removed, skipped_too_recent) so the caller can say what it
+    declined to touch rather than silently doing nothing.
     """
     cutoff = time.time() - min_age_s
     removed = 0
+    skipped = 0
     for root in roots:
         if not root.is_dir():
             continue
@@ -764,12 +780,13 @@ def sweep_scratch_files(roots: list[Path], min_age_s: float) -> int:
                 continue
             try:
                 if f.stat().st_mtime > cutoff:
+                    skipped += 1
                     continue
                 f.unlink()
             except OSError:
                 continue
             removed += 1
-    return removed
+    return removed, skipped
 
 
 def find_tests(test262_dir: Path, paths: list[str] | None) -> list[Path]:
@@ -865,10 +882,18 @@ def main():
 
     selected_paths = args.paths if args.paths else None
 
-    sweep_roots = [Path(p) for p in args.paths] if args.paths else [test262 / "test"]
-    swept = sweep_scratch_files(sweep_roots, min_age_s=max(args.timeout * 2, 300))
-    if swept:
-        print(f"Removed {swept} scratch file(s) left by an earlier killed run.")
+    if args.clean_scratch:
+        roots = [Path(p) for p in args.paths] if args.paths else [test262 / "test"]
+        removed, skipped = sweep_scratch_files(
+            roots, min_age_s=max(args.timeout * 2, 300)
+        )
+        print(f"Removed {removed} scratch file(s) left by an earlier killed run.")
+        if skipped:
+            print(
+                f"Left {skipped} in place as too recent to be sure they are dead. "
+                "Re-run once no other invocation is active."
+            )
+        sys.exit(0)
 
     try:
         tests = find_tests(test262, selected_paths)

--- a/scripts/run-test262.py
+++ b/scripts/run-test262.py
@@ -869,6 +869,17 @@ def main():
         # must stay usable on a checkout where the binary has not been built.
         test262 = Path(args.test262)
         roots = [Path(p) for p in args.paths] if args.paths else [test262 / "test"]
+        # `sweep_scratch_files` skips a root it cannot walk, so without this a
+        # mistyped path -- or a missing --test262 checkout -- would report
+        # "Removed 0" and exit 0, reading as confirmation that a tree is clean
+        # when it was never looked at. Moving this command ahead of the engine
+        # setup also moved it ahead of that directory check, so it validates its
+        # own roots.
+        missing = [r for r in roots if not r.exists()]
+        if missing:
+            for r in missing:
+                print(f"Error: cleanup path not found: {r}", file=sys.stderr)
+            sys.exit(2)
         removed, skipped = sweep_scratch_files(
             roots, min_age_s=max(args.timeout * 2, 300)
         )

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -235,6 +235,40 @@ class RunTest262ExitStatusTests(unittest.TestCase):
         self.assertFalse(stale.exists(), "naming the file must not be a no-op")
         self.assertIn("Removed 1 scratch file(s)", result.stdout)
 
+    def test_clean_scratch_rejects_a_nonexistent_path(self):
+        # Silently skipping an unwalkable root would report "Removed 0" and exit
+        # 0, which reads as "this tree is clean" when it was never examined.
+        result = self.run_runner(
+            self.write_engine(0),
+            "--clean-scratch",
+            paths=("test262/test/typo-does-not-exist",),
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("cleanup path not found", result.stderr)
+        self.assertIn("typo-does-not-exist", result.stderr)
+        self.assertNotIn("Removed 0 scratch file(s)", result.stdout)
+
+    def test_clean_scratch_rejects_a_missing_test262_checkout(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--binary",
+                str(self.root / "does-not-exist-jsse"),
+                "--test262",
+                "no-such-checkout",
+                "--clean-scratch",
+            ],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("cleanup path not found", result.stderr)
+        self.assertNotIn("Removed 0 scratch file(s)", result.stdout)
+
     def test_explicit_non_fixture_mjs_is_rejected(self):
         self.write_file("test262-extra/module-test.mjs")
 

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -291,6 +291,28 @@ class RunTest262ExitStatusTests(unittest.TestCase):
         self.assertIn("could not remove", result.stderr)
         self.assertTrue(stale.exists())
 
+    def test_clean_scratch_exits_nonzero_when_a_directory_cannot_be_scanned(self):
+        if os.geteuid() == 0:
+            self.skipTest("root ignores directory permissions")
+        locked = self.root / "test262" / "test" / "locked"
+        locked.mkdir(parents=True)
+        hidden = locked / f"{PREFIX}a0o8myw6.js"
+        hidden.write_text("// unreachable\n", encoding="utf-8")
+        old = time.time() - 10_000
+        os.utime(hidden, (old, old))
+        mode = locked.stat().st_mode
+        locked.chmod(0o000)
+        try:
+            result = self.run_runner(
+                self.write_engine(0), "--clean-scratch", paths=("test262/test",)
+            )
+        finally:
+            locked.chmod(mode)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("could not scan", result.stderr)
+        self.assertTrue(hidden.exists())
+
     def test_explicit_non_fixture_mjs_is_rejected(self):
         self.write_file("test262-extra/module-test.mjs")
 
@@ -417,11 +439,10 @@ class ScratchFileTests(unittest.TestCase):
     def test_sweep_removes_stale_scratch_files(self):
         stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
 
-        removed, skipped, failures = runner.sweep_scratch_files(
-            [self.test_dir], min_age_s=300
-        )
+        result = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
-        self.assertEqual((removed, skipped, failures), (1, 0, []))
+        self.assertEqual((result.removed, result.skipped_too_recent), (1, 0))
+        self.assertFalse(result.incomplete)
         self.assertFalse(stale.exists())
 
     def test_sweep_spares_stale_generic_tempfile_names(self):
@@ -429,23 +450,21 @@ class ScratchFileTests(unittest.TestCase):
         # real test shaped like one, is not ours to unlink.
         foreign = self.write_scratch("tmpa0o8myw6.js", age_s=10_000)
 
-        removed, skipped, failures = runner.sweep_scratch_files(
-            [self.test_dir], min_age_s=300
-        )
+        result = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
         # Not even counted as skipped: it was never a candidate.
-        self.assertEqual((removed, skipped, failures), (0, 0, []))
+        self.assertEqual((result.removed, result.skipped_too_recent), (0, 0))
+        self.assertFalse(result.incomplete)
         self.assertTrue(foreign.exists())
 
     def test_sweep_spares_scratch_files_of_a_concurrent_run(self):
         live = self.write_scratch(f"{PREFIX}a0o8myw6.js")
 
-        removed, skipped, failures = runner.sweep_scratch_files(
-            [self.test_dir], min_age_s=300
-        )
+        result = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
         # Reported as skipped so the caller can say why it deleted nothing.
-        self.assertEqual((removed, skipped, failures), (0, 1, []))
+        self.assertEqual((result.removed, result.skipped_too_recent), (0, 1))
+        self.assertFalse(result.incomplete)
         self.assertTrue(live.exists())
 
     def test_explicitly_named_scratch_file_is_not_collected(self):
@@ -478,17 +497,19 @@ class ScratchFileTests(unittest.TestCase):
         # no-op that still reports success.
         stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
 
-        removed, skipped, failures = runner.sweep_scratch_files([stale], min_age_s=300)
+        result = runner.sweep_scratch_files([stale], min_age_s=300)
 
-        self.assertEqual((removed, skipped, failures), (1, 0, []))
+        self.assertEqual((result.removed, result.skipped_too_recent), (1, 0))
+        self.assertFalse(result.incomplete)
         self.assertFalse(stale.exists())
 
     def test_sweep_spares_a_real_test_named_as_a_file_root(self):
         sample = self.test_dir / "sample.js"
 
-        removed, skipped, failures = runner.sweep_scratch_files([sample], min_age_s=300)
+        result = runner.sweep_scratch_files([sample], min_age_s=300)
 
-        self.assertEqual((removed, skipped, failures), (0, 0, []))
+        self.assertEqual((result.removed, result.skipped_too_recent), (0, 0))
+        self.assertFalse(result.incomplete)
         self.assertTrue(sample.exists())
 
     def test_sweep_reports_a_file_it_could_not_remove(self):
@@ -500,15 +521,36 @@ class ScratchFileTests(unittest.TestCase):
         mode = self.test_dir.stat().st_mode
         self.test_dir.chmod(0o500)
         try:
-            removed, skipped, failures = runner.sweep_scratch_files(
-                [self.test_dir], min_age_s=300
-            )
+            result = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
         finally:
             self.test_dir.chmod(mode)
 
-        self.assertEqual((removed, skipped), (0, 0))
-        self.assertEqual([p for p, _ in failures], [stale])
+        self.assertEqual((result.removed, result.skipped_too_recent), (0, 0))
+        self.assertEqual([p for p, _ in result.unremovable], [stale])
         self.assertTrue(stale.exists())
+
+    def test_sweep_reports_a_directory_it_could_not_scan(self):
+        # `Path.rglob` omits an unreadable subtree without a word, which would
+        # let an unscanned corner of the tree pass as swept.
+        if os.geteuid() == 0:
+            self.skipTest("root ignores directory permissions")
+        locked = self.test_dir / "locked"
+        locked.mkdir()
+        hidden = locked / f"{PREFIX}a0o8myw6.js"
+        hidden.write_text("// unreachable\n", encoding="utf-8")
+        old = time.time() - 10_000
+        os.utime(hidden, (old, old))
+        mode = locked.stat().st_mode
+        locked.chmod(0o000)
+        try:
+            result = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+        finally:
+            locked.chmod(mode)
+
+        self.assertEqual(result.removed, 0)
+        self.assertTrue(result.incomplete)
+        self.assertEqual([p for p, _ in result.unreadable], [locked])
+        self.assertTrue(hidden.exists())
 
     def test_sweep_leaves_real_tests_alone(self):
         sample = self.test_dir / "sample.js"

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -285,6 +285,30 @@ class ScratchFileTests(unittest.TestCase):
         self.assertEqual(removed, 0)
         self.assertTrue(live.exists())
 
+    def test_explicitly_named_scratch_file_is_not_collected(self):
+        scratch = self.write_scratch(f"{PREFIX}a0o8myw6.js")
+
+        tests = runner.find_tests(self.root / "test262", [str(scratch)])
+
+        self.assertEqual(tests, [])
+
+    def test_explicitly_named_legacy_scratch_file_is_not_collected(self):
+        scratch = self.write_scratch("tmpa0o8myw6.js")
+
+        tests = runner.find_tests(self.root / "test262", [str(scratch)])
+
+        self.assertEqual(tests, [])
+
+    def test_glob_expanded_selection_drops_only_the_scratch_file(self):
+        # `run-test262.py test262/test/language/*.js` reaches find_tests as a
+        # list of explicit file paths, one of which may be a leaked scratch file.
+        sample = self.test_dir / "sample.js"
+        scratch = self.write_scratch(f"{PREFIX}a0o8myw6.js")
+
+        tests = runner.find_tests(self.root / "test262", [str(sample), str(scratch)])
+
+        self.assertEqual([p.name for p in tests], ["sample.js"])
+
     def test_sweep_leaves_real_tests_alone(self):
         sample = self.test_dir / "sample.js"
         decoy = self.write_scratch(f"{PREFIX}short.js", age_s=10_000)

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -235,13 +235,12 @@ class ScratchFileTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertFalse(runner._is_scratch(Path(name)))
 
-    def test_generic_tempfile_names_are_never_sweepable(self):
-        # A bare `tempfile` name proves nothing about who wrote it, so it must
-        # never be eligible for deletion -- see _is_scratch vs _is_uncollectable.
+    def test_generic_tempfile_names_are_not_claimed(self):
+        # A bare `tempfile` name proves nothing about who wrote it, so it is
+        # neither deleted nor skipped: both would act on a file we cannot claim.
         for name in ("tmpa0o8myw6.js", "tmp_g3ol4p_.js"):
             with self.subTest(name=name):
                 self.assertFalse(runner._is_scratch(Path(name)))
-                self.assertTrue(runner._is_uncollectable_scratch(Path(name)))
 
     def test_scratch_files_are_not_collected_as_tests(self):
         self.write_scratch(f"{PREFIX}a0o8myw6.js")
@@ -250,14 +249,15 @@ class ScratchFileTests(unittest.TestCase):
 
         self.assertEqual([p.name for p in tests], ["sample.js"])
 
-    def test_legacy_scratch_files_are_not_collected_as_tests(self):
-        # Files leaked before the prefix existed must still stay out of the
-        # scenario count, even though the sweep will not delete them.
+    def test_legacy_shaped_files_are_still_collected(self):
+        # A real test may legitimately be named like a bare `tempfile`. Skipping
+        # it would silently shrink the run, corrupting the same scenario total
+        # the scratch filter exists to protect, so only prefixed names are ours.
         self.write_scratch("tmpa0o8myw6.js")
 
         tests = runner.find_tests(self.root / "test262", None)
 
-        self.assertEqual([p.name for p in tests], ["sample.js"])
+        self.assertEqual([p.name for p in tests], ["sample.js", "tmpa0o8myw6.js"])
 
     def test_sweep_removes_stale_scratch_files(self):
         stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
@@ -292,12 +292,12 @@ class ScratchFileTests(unittest.TestCase):
 
         self.assertEqual(tests, [])
 
-    def test_explicitly_named_legacy_scratch_file_is_not_collected(self):
-        scratch = self.write_scratch("tmpa0o8myw6.js")
+    def test_explicitly_named_legacy_shaped_file_is_still_collected(self):
+        legacy = self.write_scratch("tmpa0o8myw6.js")
 
-        tests = runner.find_tests(self.root / "test262", [str(scratch)])
+        tests = runner.find_tests(self.root / "test262", [str(legacy)])
 
-        self.assertEqual(tests, [])
+        self.assertEqual(tests, [legacy])
 
     def test_glob_expanded_selection_drops_only_the_scratch_file(self):
         # `run-test262.py test262/test/language/*.js` reaches find_tests as a

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -23,6 +23,7 @@ def _load_runner():
 
 
 runner = _load_runner()
+PREFIX = runner.SCRATCH_PREFIX
 
 
 def frontmatter(*lines: str) -> str:
@@ -207,24 +208,51 @@ class ScratchFileTests(unittest.TestCase):
         return path
 
     def test_scratch_names_are_recognised(self):
-        self.assertTrue(runner._is_scratch(Path("tmpa0o8myw6.js")))
-        self.assertTrue(runner._is_scratch(Path("tmp_g3ol4p_.js")))
+        self.assertTrue(runner._is_scratch(Path(f"{PREFIX}a0o8myw6.js")))
+        self.assertTrue(runner._is_scratch(Path(f"{PREFIX}_g3ol4p_.js")))
+
+    def test_created_scratch_files_match_the_sweep_pattern(self):
+        # Guards against the prefix and the regex drifting apart: a name the
+        # runner actually produces must be one the sweep recognises.
+        with tempfile.NamedTemporaryFile(
+            prefix=runner.SCRATCH_PREFIX, suffix=".js", dir=self.test_dir
+        ) as tmp:
+            created = Path(tmp.name)
+            self.assertTrue(runner._is_scratch(created))
+            self.assertIn(created, set(self.test_dir.rglob(f"{PREFIX}*.js")))
 
     def test_real_tests_are_not_mistaken_for_scratch(self):
-        # test262 has real tests whose names begin with "tmp"-like prefixes;
-        # only the exact tempfile shape (tmp + 8 chars + .js) may be swept.
+        # Only the exact shape the runner emits (prefix + 8 chars + .js) may be
+        # swept; near misses must survive.
         for name in (
-            "tmp.js",
-            "tmpshort.js",
-            "tmptoolonganame.js",
-            "tmpABCDEFGH.js",
-            "temporal-tmpa0o8myw6.js",
-            "tmpa0o8myw6.mjs",
+            f"{PREFIX}.js",
+            f"{PREFIX}short.js",
+            f"{PREFIX}toolonganame.js",
+            f"{PREFIX}ABCDEFGH.js",
+            f"temporal-{PREFIX}a0o8myw6.js",
+            f"{PREFIX}a0o8myw6.mjs",
         ):
             with self.subTest(name=name):
                 self.assertFalse(runner._is_scratch(Path(name)))
 
+    def test_generic_tempfile_names_are_never_sweepable(self):
+        # A bare `tempfile` name proves nothing about who wrote it, so it must
+        # never be eligible for deletion -- see _is_scratch vs _is_uncollectable.
+        for name in ("tmpa0o8myw6.js", "tmp_g3ol4p_.js"):
+            with self.subTest(name=name):
+                self.assertFalse(runner._is_scratch(Path(name)))
+                self.assertTrue(runner._is_uncollectable_scratch(Path(name)))
+
     def test_scratch_files_are_not_collected_as_tests(self):
+        self.write_scratch(f"{PREFIX}a0o8myw6.js")
+
+        tests = runner.find_tests(self.root / "test262", None)
+
+        self.assertEqual([p.name for p in tests], ["sample.js"])
+
+    def test_legacy_scratch_files_are_not_collected_as_tests(self):
+        # Files leaked before the prefix existed must still stay out of the
+        # scenario count, even though the sweep will not delete them.
         self.write_scratch("tmpa0o8myw6.js")
 
         tests = runner.find_tests(self.root / "test262", None)
@@ -232,15 +260,25 @@ class ScratchFileTests(unittest.TestCase):
         self.assertEqual([p.name for p in tests], ["sample.js"])
 
     def test_sweep_removes_stale_scratch_files(self):
-        stale = self.write_scratch("tmpa0o8myw6.js", age_s=10_000)
+        stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
 
         removed = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
         self.assertEqual(removed, 1)
         self.assertFalse(stale.exists())
 
+    def test_sweep_spares_stale_generic_tempfile_names(self):
+        # The whole point of the prefix: an unrelated tool's `tempfile`, or a
+        # real test shaped like one, is not ours to unlink.
+        foreign = self.write_scratch("tmpa0o8myw6.js", age_s=10_000)
+
+        removed = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+
+        self.assertEqual(removed, 0)
+        self.assertTrue(foreign.exists())
+
     def test_sweep_spares_scratch_files_of_a_concurrent_run(self):
-        live = self.write_scratch("tmpa0o8myw6.js")
+        live = self.write_scratch(f"{PREFIX}a0o8myw6.js")
 
         removed = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
@@ -249,7 +287,7 @@ class ScratchFileTests(unittest.TestCase):
 
     def test_sweep_leaves_real_tests_alone(self):
         sample = self.test_dir / "sample.js"
-        decoy = self.write_scratch("tmpshort.js", age_s=10_000)
+        decoy = self.write_scratch(f"{PREFIX}short.js", age_s=10_000)
 
         runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
@@ -260,7 +298,7 @@ class ScratchFileTests(unittest.TestCase):
 class WorkerCleanupTests(unittest.TestCase):
     def test_sigterm_handler_unlinks_the_in_flight_scratch_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            scratch = Path(tmpdir) / "tmpa0o8myw6.js"
+            scratch = Path(tmpdir) / f"{PREFIX}a0o8myw6.js"
             scratch.write_text("// in flight\n", encoding="utf-8")
 
             # The handler exits the process, so run it in a child.

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -1,15 +1,28 @@
+import importlib.util
 import os
+import signal
 import stat
 import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import unittest
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUNNER = REPO_ROOT / "scripts" / "run-test262.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("run_test262", RUNNER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_runner()
 
 
 def frontmatter(*lines: str) -> str:
@@ -164,6 +177,112 @@ class RunTest262ExitStatusTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("would not be collected", result.stderr)
+
+
+class ScratchFileTests(unittest.TestCase):
+    """Scratch files are written next to the test they wrap, inside the
+    read-only test262 checkout, so a run that dies without cleaning up leaves
+    them among the tests."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        # find_tests only walks the corpus subdirectories, so the fixture has
+        # to live in one of them for the collection test to be meaningful.
+        self.test_dir = self.root / "test262" / "test" / "language"
+        self.test_dir.mkdir(parents=True)
+        (self.test_dir / "sample.js").write_text(
+            frontmatter("flags: [raw]"), encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_scratch(self, name: str, age_s: float = 0.0) -> Path:
+        path = self.test_dir / name
+        path.write_text("// leaked scratch file\n", encoding="utf-8")
+        if age_s:
+            stamp = time.time() - age_s
+            os.utime(path, (stamp, stamp))
+        return path
+
+    def test_scratch_names_are_recognised(self):
+        self.assertTrue(runner._is_scratch(Path("tmpa0o8myw6.js")))
+        self.assertTrue(runner._is_scratch(Path("tmp_g3ol4p_.js")))
+
+    def test_real_tests_are_not_mistaken_for_scratch(self):
+        # test262 has real tests whose names begin with "tmp"-like prefixes;
+        # only the exact tempfile shape (tmp + 8 chars + .js) may be swept.
+        for name in (
+            "tmp.js",
+            "tmpshort.js",
+            "tmptoolonganame.js",
+            "tmpABCDEFGH.js",
+            "temporal-tmpa0o8myw6.js",
+            "tmpa0o8myw6.mjs",
+        ):
+            with self.subTest(name=name):
+                self.assertFalse(runner._is_scratch(Path(name)))
+
+    def test_scratch_files_are_not_collected_as_tests(self):
+        self.write_scratch("tmpa0o8myw6.js")
+
+        tests = runner.find_tests(self.root / "test262", None)
+
+        self.assertEqual([p.name for p in tests], ["sample.js"])
+
+    def test_sweep_removes_stale_scratch_files(self):
+        stale = self.write_scratch("tmpa0o8myw6.js", age_s=10_000)
+
+        removed = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+
+        self.assertEqual(removed, 1)
+        self.assertFalse(stale.exists())
+
+    def test_sweep_spares_scratch_files_of_a_concurrent_run(self):
+        live = self.write_scratch("tmpa0o8myw6.js")
+
+        removed = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+
+        self.assertEqual(removed, 0)
+        self.assertTrue(live.exists())
+
+    def test_sweep_leaves_real_tests_alone(self):
+        sample = self.test_dir / "sample.js"
+        decoy = self.write_scratch("tmpshort.js", age_s=10_000)
+
+        runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+
+        self.assertTrue(sample.exists())
+        self.assertTrue(decoy.exists())
+
+
+class WorkerCleanupTests(unittest.TestCase):
+    def test_sigterm_handler_unlinks_the_in_flight_scratch_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scratch = Path(tmpdir) / "tmpa0o8myw6.js"
+            scratch.write_text("// in flight\n", encoding="utf-8")
+
+            # The handler exits the process, so run it in a child.
+            code = textwrap.dedent(
+                f"""\
+                import os, runpy, signal, sys
+                runner = runpy.run_path({str(RUNNER)!r})
+                runner["_active_scratch_path"] = {str(scratch)!r}
+                # Rebind the module global the handler closes over.
+                handler = runner["_worker_cleanup_handler"]
+                handler.__globals__["_active_scratch_path"] = {str(scratch)!r}
+                handler(signal.SIGTERM, None)
+                """
+            )
+            result = subprocess.run(
+                [sys.executable, "-c", code], capture_output=True, text=True
+            )
+
+            self.assertEqual(result.returncode, 128 + signal.SIGTERM)
+            self.assertFalse(
+                scratch.exists(), "handler should unlink the in-flight scratch file"
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -188,6 +188,53 @@ class RunTest262ExitStatusTests(unittest.TestCase):
         self.assertIn("Removed 0 scratch file(s)", result.stdout)
         self.assertIn("Left 1 in place", result.stdout)
 
+    def test_clean_scratch_works_without_a_built_engine(self):
+        # A pure filesystem sweep must not require the engine to be built; the
+        # "Build it first" error would be misleading for an operation that never
+        # launches an engine.
+        stale = self.write_file(
+            f"test262/test/{PREFIX}a0o8myw6.js", "// leaked by a killed run\n"
+        )
+        old = time.time() - 10_000
+        os.utime(stale, (old, old))
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--binary",
+                str(self.root / "does-not-exist-jsse"),
+                "--test262",
+                "test262",
+                "--clean-scratch",
+                "test262/test",
+            ],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("Build it first", result.stderr)
+        self.assertFalse(stale.exists())
+
+    def test_clean_scratch_accepts_an_explicitly_named_file(self):
+        stale = self.write_file(
+            f"test262/test/{PREFIX}a0o8myw6.js", "// leaked by a killed run\n"
+        )
+        old = time.time() - 10_000
+        os.utime(stale, (old, old))
+
+        result = self.run_runner(
+            self.write_engine(0),
+            "--clean-scratch",
+            paths=(f"test262/test/{PREFIX}a0o8myw6.js",),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(stale.exists(), "naming the file must not be a no-op")
+        self.assertIn("Removed 1 scratch file(s)", result.stdout)
+
     def test_explicit_non_fixture_mjs_is_rejected(self):
         self.write_file("test262-extra/module-test.mjs")
 
@@ -362,6 +409,25 @@ class ScratchFileTests(unittest.TestCase):
         tests = runner.find_tests(self.root / "test262", [str(sample), str(scratch)])
 
         self.assertEqual([p.name for p in tests], ["sample.js"])
+
+    def test_sweep_handles_an_explicitly_named_file_root(self):
+        # `paths` accepts individual files, and a glob expands to them, so
+        # skipping non-directory roots would make naming a leaked file a silent
+        # no-op that still reports success.
+        stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
+
+        removed, skipped = runner.sweep_scratch_files([stale], min_age_s=300)
+
+        self.assertEqual((removed, skipped), (1, 0))
+        self.assertFalse(stale.exists())
+
+    def test_sweep_spares_a_real_test_named_as_a_file_root(self):
+        sample = self.test_dir / "sample.js"
+
+        removed, skipped = runner.sweep_scratch_files([sample], min_age_s=300)
+
+        self.assertEqual((removed, skipped), (0, 0))
+        self.assertTrue(sample.exists())
 
     def test_sweep_leaves_real_tests_alone(self):
         sample = self.test_dir / "sample.js"

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -269,6 +269,28 @@ class RunTest262ExitStatusTests(unittest.TestCase):
         self.assertIn("cleanup path not found", result.stderr)
         self.assertNotIn("Removed 0 scratch file(s)", result.stdout)
 
+    def test_clean_scratch_exits_nonzero_when_a_file_cannot_be_removed(self):
+        if os.geteuid() == 0:
+            self.skipTest("root ignores directory permissions")
+        stale = self.write_file(
+            f"test262/test/{PREFIX}a0o8myw6.js", "// leaked by a killed run\n"
+        )
+        old = time.time() - 10_000
+        os.utime(stale, (old, old))
+        target_dir = self.root / "test262" / "test"
+        mode = target_dir.stat().st_mode
+        target_dir.chmod(0o500)
+        try:
+            result = self.run_runner(
+                self.write_engine(0), "--clean-scratch", paths=("test262/test",)
+            )
+        finally:
+            target_dir.chmod(mode)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("could not remove", result.stderr)
+        self.assertTrue(stale.exists())
+
     def test_explicit_non_fixture_mjs_is_rejected(self):
         self.write_file("test262-extra/module-test.mjs")
 
@@ -395,9 +417,11 @@ class ScratchFileTests(unittest.TestCase):
     def test_sweep_removes_stale_scratch_files(self):
         stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
 
-        removed, skipped = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+        removed, skipped, failures = runner.sweep_scratch_files(
+            [self.test_dir], min_age_s=300
+        )
 
-        self.assertEqual((removed, skipped), (1, 0))
+        self.assertEqual((removed, skipped, failures), (1, 0, []))
         self.assertFalse(stale.exists())
 
     def test_sweep_spares_stale_generic_tempfile_names(self):
@@ -405,19 +429,23 @@ class ScratchFileTests(unittest.TestCase):
         # real test shaped like one, is not ours to unlink.
         foreign = self.write_scratch("tmpa0o8myw6.js", age_s=10_000)
 
-        removed, skipped = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+        removed, skipped, failures = runner.sweep_scratch_files(
+            [self.test_dir], min_age_s=300
+        )
 
         # Not even counted as skipped: it was never a candidate.
-        self.assertEqual((removed, skipped), (0, 0))
+        self.assertEqual((removed, skipped, failures), (0, 0, []))
         self.assertTrue(foreign.exists())
 
     def test_sweep_spares_scratch_files_of_a_concurrent_run(self):
         live = self.write_scratch(f"{PREFIX}a0o8myw6.js")
 
-        removed, skipped = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+        removed, skipped, failures = runner.sweep_scratch_files(
+            [self.test_dir], min_age_s=300
+        )
 
         # Reported as skipped so the caller can say why it deleted nothing.
-        self.assertEqual((removed, skipped), (0, 1))
+        self.assertEqual((removed, skipped, failures), (0, 1, []))
         self.assertTrue(live.exists())
 
     def test_explicitly_named_scratch_file_is_not_collected(self):
@@ -450,18 +478,37 @@ class ScratchFileTests(unittest.TestCase):
         # no-op that still reports success.
         stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
 
-        removed, skipped = runner.sweep_scratch_files([stale], min_age_s=300)
+        removed, skipped, failures = runner.sweep_scratch_files([stale], min_age_s=300)
 
-        self.assertEqual((removed, skipped), (1, 0))
+        self.assertEqual((removed, skipped, failures), (1, 0, []))
         self.assertFalse(stale.exists())
 
     def test_sweep_spares_a_real_test_named_as_a_file_root(self):
         sample = self.test_dir / "sample.js"
 
-        removed, skipped = runner.sweep_scratch_files([sample], min_age_s=300)
+        removed, skipped, failures = runner.sweep_scratch_files([sample], min_age_s=300)
+
+        self.assertEqual((removed, skipped, failures), (0, 0, []))
+        self.assertTrue(sample.exists())
+
+    def test_sweep_reports_a_file_it_could_not_remove(self):
+        # A read-only checkout leaves a known stale file in place; swallowing the
+        # error would let the caller report success with the file still there.
+        if os.geteuid() == 0:
+            self.skipTest("root ignores directory permissions")
+        stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
+        mode = self.test_dir.stat().st_mode
+        self.test_dir.chmod(0o500)
+        try:
+            removed, skipped, failures = runner.sweep_scratch_files(
+                [self.test_dir], min_age_s=300
+            )
+        finally:
+            self.test_dir.chmod(mode)
 
         self.assertEqual((removed, skipped), (0, 0))
-        self.assertTrue(sample.exists())
+        self.assertEqual([p for p, _ in failures], [stale])
+        self.assertTrue(stale.exists())
 
     def test_sweep_leaves_real_tests_alone(self):
         sample = self.test_dir / "sample.js"

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -320,6 +320,62 @@ class ScratchFileTests(unittest.TestCase):
 
 
 class WorkerCleanupTests(unittest.TestCase):
+    def test_signal_during_the_write_still_unlinks_the_scratch_file(self):
+        """The scratch file exists on disk from creation, not from write.
+
+        So registration cannot wait until the write finishes: `combined` can be
+        hundreds of KB, and a signal landing inside that window would otherwise
+        find no path to unlink and leave the file behind in the submodule.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            test_dir = root / "test262" / "test" / "language"
+            test_dir.mkdir(parents=True)
+            test_file = test_dir / "sample.js"
+            test_file.write_text(frontmatter("flags: [raw]"), encoding="utf-8")
+
+            # Fire SIGTERM from inside `write`, i.e. after the file exists but
+            # before anything has been written to it.
+            code = textwrap.dedent(
+                f"""\
+                import os, runpy, signal, tempfile
+                runner = runpy.run_path({str(RUNNER)!r})
+                signal.signal(signal.SIGTERM, runner["_worker_cleanup_handler"])
+
+                real_ntf = tempfile.NamedTemporaryFile
+
+                def spy(*a, **kw):
+                    handle = real_ntf(*a, **kw)
+                    real_write = handle.write
+
+                    def write(data):
+                        os.kill(os.getpid(), signal.SIGTERM)
+                        return real_write(data)
+
+                    handle.write = write
+                    return handle
+
+                tempfile.NamedTemporaryFile = spy
+                runner["run_single_test"]((
+                    "sample.js",
+                    {str(test_file)!r},
+                    "default",
+                    5,
+                    {str(root / "test262")!r},
+                    "jsse",
+                    "/nonexistent/jsse-binary",
+                    False,
+                ))
+                """
+            )
+            result = subprocess.run(
+                [sys.executable, "-c", code], capture_output=True, text=True
+            )
+
+            self.assertEqual(result.returncode, 128 + signal.SIGTERM, result.stderr)
+            leaked = sorted(p.name for p in test_dir.iterdir() if p != test_file)
+            self.assertEqual(leaked, [], f"scratch file left behind: {leaked}")
+
     def test_sigterm_handler_unlinks_the_in_flight_scratch_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             scratch = Path(tmpdir) / f"{PREFIX}a0o8myw6.js"

--- a/scripts/test_run_test262.py
+++ b/scripts/test_run_test262.py
@@ -136,6 +136,58 @@ class RunTest262ExitStatusTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0)
 
+    def test_a_normal_run_does_not_delete_scratch_files(self):
+        # Deleting on a normal run would let one invocation unlink a live
+        # scratch file belonging to another, whose engine would then read a
+        # missing input and record a false failure. Reclamation is opt-in.
+        stale = self.write_file(
+            f"test262/test/{PREFIX}a0o8myw6.js", "// leaked by a killed run\n"
+        )
+        old = time.time() - 10_000
+        os.utime(stale, (old, old))
+
+        # A directory selection, so the sweep root would have been a directory:
+        # with a single file the old automatic sweep silently did nothing.
+        result = self.run_runner(
+            self.write_engine(0), "--fail-on-failures", paths=("test262/test",)
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(stale.exists(), "a normal run must not sweep")
+        # Still kept out of the run, which is what protects the totals.
+        self.assertIn("Files:   1", result.stdout)
+
+    def test_clean_scratch_removes_stale_files_and_exits(self):
+        stale = self.write_file(
+            f"test262/test/{PREFIX}a0o8myw6.js", "// leaked by a killed run\n"
+        )
+        old = time.time() - 10_000
+        os.utime(stale, (old, old))
+
+        result = self.run_runner(
+            self.write_engine(0), "--clean-scratch", paths=("test262/test",)
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(stale.exists())
+        self.assertIn("Removed 1 scratch file(s)", result.stdout)
+        # Exited instead of running the suite.
+        self.assertNotIn("Files:", result.stdout)
+
+    def test_clean_scratch_reports_what_it_declined_to_delete(self):
+        live = self.write_file(
+            f"test262/test/{PREFIX}a0o8myw6.js", "// a concurrent run's file\n"
+        )
+
+        result = self.run_runner(
+            self.write_engine(0), "--clean-scratch", paths=("test262/test",)
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(live.exists())
+        self.assertIn("Removed 0 scratch file(s)", result.stdout)
+        self.assertIn("Left 1 in place", result.stdout)
+
     def test_explicit_non_fixture_mjs_is_rejected(self):
         self.write_file("test262-extra/module-test.mjs")
 
@@ -262,9 +314,9 @@ class ScratchFileTests(unittest.TestCase):
     def test_sweep_removes_stale_scratch_files(self):
         stale = self.write_scratch(f"{PREFIX}a0o8myw6.js", age_s=10_000)
 
-        removed = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+        removed, skipped = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
-        self.assertEqual(removed, 1)
+        self.assertEqual((removed, skipped), (1, 0))
         self.assertFalse(stale.exists())
 
     def test_sweep_spares_stale_generic_tempfile_names(self):
@@ -272,17 +324,19 @@ class ScratchFileTests(unittest.TestCase):
         # real test shaped like one, is not ours to unlink.
         foreign = self.write_scratch("tmpa0o8myw6.js", age_s=10_000)
 
-        removed = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+        removed, skipped = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
-        self.assertEqual(removed, 0)
+        # Not even counted as skipped: it was never a candidate.
+        self.assertEqual((removed, skipped), (0, 0))
         self.assertTrue(foreign.exists())
 
     def test_sweep_spares_scratch_files_of_a_concurrent_run(self):
         live = self.write_scratch(f"{PREFIX}a0o8myw6.js")
 
-        removed = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
+        removed, skipped = runner.sweep_scratch_files([self.test_dir], min_age_s=300)
 
-        self.assertEqual(removed, 0)
+        # Reported as skipped so the caller can say why it deleted nothing.
+        self.assertEqual((removed, skipped), (0, 1))
         self.assertTrue(live.exists())
 
     def test_explicitly_named_scratch_file_is_not_collected(self):


### PR DESCRIPTION
## Problem

`run_scenario` writes each scenario's scratch file **next to the test it wraps** — inside the read-only `test262/` checkout — and unlinks it in a `finally` (`scripts/run-test262.py:508`). That covers every path the interpreter unwinds, but not a signal: `_worker_init` sets `SIGTERM`/`SIGINT` to `SIG_DFL` in workers, so a terminated run leaves one scratch file per worker behind.

Measured on `built-ins/` with `-j 8` — 8 scratch files in flight at the kill, 8 left afterwards:

```
no-fix/TERM: procs=10 in-flight=8
no-fix/TERM: leaked after TERM = 8
```

Those files then look like tests. `find_tests` collects `*.js`, so the next run counts each leaked file as a test of its own and inflates the scenario total. That is exactly how a run on this branch reported **99,947 scenarios instead of 99,907** — 20 leaked files, 40 phantom scenarios, silently changing the denominator of a pass-rate number that goes into the README.

## Changes

Four, in order of what they guarantee:

1. **Workers clean up on termination.** `_worker_cleanup_handler` unlinks the in-flight scratch file before exiting, so an ordinary `kill` leaves nothing. SIGTERM and SIGINT are blocked across creation and registration (the file exists on disk from inside `NamedTemporaryFile`, before it returns anything we can record), and the path is registered before `tmp.write` — the file exists on disk from creation, and `combined` is the test plus its harness, so registering after the write would leave hundreds of KB of I/O during which a signal finds nothing to unlink. It still ends in `os._exit`, preserving the fast process-group teardown the existing parent handler is built around.
2. **Scratch files carry their own provenance.** They are created with a runner-specific `SCRATCH_PREFIX` (`jsse-scratch-`) rather than `tempfile`'s generic `tmp`, so the filename alone identifies who wrote the file. Everything below keys off that, which is what makes acting on a filename defensible at all.
3. **Collection skips scratch files**, at all three entry points — the default corpus walk, a selected directory, and an explicitly named path (including what a shell glob expands to). Nothing can clean up after `SIGKILL`, so *this* is what actually keeps a leaked file from corrupting a run's totals, and it holds regardless of the sweep.
4. **Reclaiming leftovers is opt-in**, via `--clean-scratch`, which sweeps and exits. It is deliberately *not* part of a normal run: nothing a sweep can see establishes that the run which created a file has died. A live file's age is bounded by the *creating* run's `--timeout`, not the sweeping one's, so an automatic sweep let a default-timeout run delete a live file belonging to a `--timeout 600` run, whose engine would then read a missing input and record a false failure. The caller of `--clean-scratch` asserts the precondition the code cannot verify; the age cutoff remains only as defence in depth for a mistaken invocation.

Tagging files with the creating PID was the obvious way to make the sweep safe automatically, but it only narrows the window — it still mistakes a live owner for a dead one across PID namespaces or a shared filesystem. The collection filter, not the sweep, is what actually protects the scenario total, and it needs no liveness guess; so the sweep became opt-in rather than cleverer.

A single predicate, `_is_scratch`, gates both the skip and the delete, and it matches only the prefixed shape. A bare `tempfile` name is deliberately not enough for either: deleting one is data loss, and *skipping* one silently drops whatever it really was, shrinking the very denominator this change exists to protect. Leftovers from runs predating the prefix are cleaned up out of band by the project's existing `find test262 -name 'tmp*.js' -delete` step — they are transitional, whereas misclassifying an upstream test name would not have been.

## Testing

Full before/after, driving a real run and signalling it:

| | SIGTERM | SIGKILL |
|---|---|---|
| before | 8 leaked | 8 leaked |
| after | **0 leaked** | 8 leaked, but not collected and swept once aged |

`SIGKILL` is unpreventable by construction; the point is that the leftovers are now inert.

Confirmed against the real engine over a 13,222-file corpus subset (`built-ins/Array`, `built-ins/Map`, `language/statements`, `language/module-code` — `module-code` included because that is where the scratch file's directory has to be right), with a legitimately-named `tmpa0o8myw6.js` planted to prove it is not mistaken for scratch:

```
Found 13222 test files, 25124 scenarios
Pass:    25124
Fail:    0
Rate:    100.00%

collected tmpa0o8myw6.js: True
leftover scratch files:   0
```

Collection is exact: 13,377 real files − 156 `_FIXTURE.js` + 1 planted = 13,222.

Adds 28 unit tests (`scripts/test_run_test262.py`), including that a bare `tempfile` name is never swept, that a legacy-shaped name is still collected, that real test names are never mistaken for scratch files, that the prefix and the sweep regex cannot drift apart, an end-to-end test that fires SIGTERM from inside `write` — after the file exists, before anything is written — and asserts the directory is left clean, and `main()`-level tests that a normal run deletes nothing, that `--clean-scratch` reclaims and reports what it declined to touch, that it works with no engine built, that naming a leaked file directly is not a silent no-op, that a nonexistent cleanup root is an error rather than a false all-clear, that a file the sweep cannot remove is reported with a nonzero exit, and that a directory it cannot traverse is too. `uv run python -m unittest discover -s scripts -p 'test_*.py'` (the CI command): 72 tests, all pass.

## Follow-up

`find_tests` has the same `Path.rglob` blind spot — an unreadable subtree is omitted with no diagnostic, silently dropping real tests and shrinking the denominator behind a pass rate. That predates this PR and is left untouched here rather than fixing one scan path and not the other; tracked as #559.

## Note

`delete=True` on the `NamedTemporaryFile` is not an option here: the engine subprocess runs *after* the `with` block closes the file, so the file would be unlinked before it could ever be read.

https://claude.ai/code/session_01SWtdLjDrAqjE6YCDYaPvkH






