### PR TITLE
chore(readme): stop tracking test262 pass counts in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,8 @@ A from-scratch JavaScript engine implemented in Rust. No JS parser/engine librar
 2. No importing a JS parser or engine crate. Implement everything from scratch.
 3. Dependencies for parsing utilities, math, etc. are allowed.
 4. When implementing a feature, identify relevant test262 tests to validate against.
-5. After running test262, update `README.md` with pass count and percentage.
-6. The spec is the ultimate source of truth with respect to JavaScript. Use it to determine the syntax and semantics of operations.
-7. For debugging and comparison, `node` is available as a reference engine. Authority order: (1) ECMAScript spec, (2) test262, (3) node.
+5. The spec is the ultimate source of truth with respect to JavaScript. Use it to determine the syntax and semantics of operations.
+6. For debugging and comparison, `node` is available as a reference engine. Authority order: (1) ECMAScript spec, (2) test262, (3) node.
 
 ## Source Layout
 - `src/main.rs` — CLI entry point (`jsse <file>` or `jsse -e "code"`)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An agent-coded JS engine in Rust. I didn't touch a single line of code here. Not
 
 Read more: [jsse - a JavaScript engine built by an agent](https://p.ocmatos.com/blog/jsse-a-javascript-engine-built-by-an-agent.html).
 
-Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Current default run: **99,895 / 99,907 (99.99%)**. The remaining 12 failures are tracked engine gaps; every `Iterator.prototype` proposal in the suite now passes in full.
+Per the test262 specification ([INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md)), test files without `noStrict`, `onlyStrict`, `module`, or `raw` flags must be run **twice**: once in default (sloppy) mode and once with `"use strict";` prepended. Our test runner implements this dual-mode execution. Run `uv run python scripts/run-test262.py` for the current pass rate.
 
 *ES Modules now supported with dynamic `import()` and `import.meta`. Async tests run with Promise/async-await support.*
 

--- a/symphonika/prompts/impl.md
+++ b/symphonika/prompts/impl.md
@@ -65,7 +65,6 @@ debugging, never as a justification.
    If any gate fails, fix the root cause. Do not pass `--no-verify` on a real commit, do not
    skip clippy, and do not narrow test scope to make it green.
 5. **Do not regress the baseline, and do not rewrite it.** The runner reads `test262-pass.txt` from `origin/main`. Never pass `--update-baseline` on a feature branch — rolling the baseline forward is a `main`-branch operation.
-6. **Keep `README.md`'s test262 figures current.** `CLAUDE.md` rule 5 is unconditional — "After running test262, update `README.md` with pass count and percentage" — so compare the README figure against your full-run output and correct it whenever the two disagree. In practice that means a change of yours that moves the count, or a `test262` submodule bump that moves the denominator; what the rule forbids is leaving a stale number behind.
 
 ## Commit hygiene
 


### PR DESCRIPTION
## Why

Every one of the **last 40 commits on `main` touched `README.md`** — all 40, each as a single `1+/1-` hunk rewriting the same 497-character line: the test262 pass count.

```
ae39edd: 1+/1-  hunks=1
4b38491: 1+/1-  hunks=1
fc6ffd9: 1+/1-  hunks=1
bcf04a9: 1+/1-  hunks=1
d747e3e: 1+/1-  hunks=1
...
```

Git merges line-by-line, so any two concurrent PRs conflict on that line **100% of the time**. There is no `.gitattributes` merge driver, and one wouldn't help.

It is also **semantically unresolvable, not just textually**. The pass rate is a global property of the whole tree: branch A measures its tree, branch B measures its tree, and neither number is correct for the merge. Git cannot pick a side, and a resolver can't either without re-running the full suite (~8 min) purely to write a line the next merge invalidates. PR #558 hit this **three times in one sitting** as `main` advanced under it, requiring three separate full-suite runs to keep the published figure honest.

## Root cause

`063d7ea` ("Clean up README baseline workflow") deleted the automation — `scripts/update-readme.py` — but left the manual rule in place. Every PR has been hand-maintaining the figure ever since.

## What this changes

- **`README.md`** — keeps the durable content (the dual-mode execution explanation, which is genuinely useful and never goes stale) and drops the volatile count/percentage/failure breakdown, pointing at the runner instead.
- **`CLAUDE.md`** — removes rule 5 ("After running test262, update `README.md` with pass count and percentage") and renumbers the two rules after it. `AGENTS.md` is a symlink to `CLAUDE.md`, so it follows automatically.
- **`symphonika/prompts/impl.md`** — removes the list item that enforced the figure on every orchestrated run, quoting rule 5 as "unconditional". **This one is load-bearing:** removing rule 5 alone would not have stopped the churn, because this prompt independently instructs every agent to reconcile the README against its full-run output.

## Not changed

Dated design documents under `docs/specs/` still mention updating the README. Those are records of decisions made at the time, not live instructions, so they're left alone.

## Where the number lives now

`scripts/run-test262.py` already prints `Rate:` and emits machine-readable JSON (`"percentage"`), so the current figure is one command away. Note that `nightly-test262-coverage.yml` runs the full suite but only uploads **coverage** to Codecov — it does not publish the pass rate, so this PR deliberately does not claim the README links to a live number. Publishing it from that job (badge or job summary) would be a reasonable follow-up if you want the figure visible without running anything.

## Validation

Documentation only — no code paths touched. The `AGENTS.md` symlink is intact and rule renumbering leaves no dangling cross-references (the only reference to "rule 5" anywhere in the repo was the `symphonika` prompt line removed here).
