### PR TITLE
chore: switch implement stage from codex to claude

### DIFF
--- a/symphonika/workflow.yml
+++ b/symphonika/workflow.yml
@@ -30,7 +30,7 @@ workflow:
     implement:
       action:
         kind: agent
-        provider: codex
+        provider: claude
         prompt: prompts/impl.md
       transitions:
         # branch_ahead_of_base alone would be satisfied by the plan commit


### PR DESCRIPTION
## Summary
- Codex is currently out of usage credits and blocks every run it's assigned. Switch the `implement` state in `symphonika/workflow.yml` from `provider: codex` to `provider: claude` so this project's issue-driven pipeline runs entirely on claude.

## Test plan
- [x] Confirmed the YAML parses and zero `provider: codex` lines remain
- Skipped cargo build/test262/mutants: this file isn't part of the Rust build or test surface, and the change is a single-line data-only edit.