### PR TITLE
fix(iterator): keep concat current iterator GC-rooted

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,3 +53,11 @@ _Avoid_: root scope marker, gc stack pointer.
 **GC Root Scope**:
 The lexical scoping of a Temp-Root Frame behind the `with_gc_root_scope(|interp| …)` combinator: it captures the frame, runs the body, and truncates on every exit path (tail, early `return`, `?`) so the teardown cannot be forgotten on a branch. Prefer it to a hand-paired `gc_root_frame`/`gc_unroot_frame` for a whole-body, single-frame native; reach for the raw primitive only when frames nest or interleave across early exits.
 _Avoid_: root guard, unroot epilogue.
+
+**Pinned Native Root**:
+A `JsValue` attached to an anchor object's `gc_native_roots` list by `pin_native_root`, so it stays reachable for as long as the anchor is. Unlike a Temp-Root Frame it outlives the native call that created it, which is what a native closure's captures need. Pins only ever accumulate, so an anchor must be pinned to a *fixed* set of values, established once.
+_Avoid_: permanent root, closure root.
+
+**Rooted Slot**:
+A GC-traced container an anchor pins once and the owner then mutates in place, for a capture whose value is *replaced* over the anchor's lifetime. A native closure's own `Rc<RefCell<…>>` state is invisible to the tracer, and re-pinning each replacement would retain every superseded value, so the slot — not the value — is what gets pinned. `RootedPair` in `builtins/iterators.rs` is the two-slot case: the iterator an iterator helper is currently drawing from, plus that iterator's `next` method.
+_Avoid_: root cell, traced box, rooted buffer.

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -341,6 +341,48 @@ fn iterator_close_getter(interp: &mut Interpreter, iterator: &JsValue) -> Result
     }
 }
 
+// A two-slot container an iterator helper roots once and mutates in place.
+// Native-closure captures that are replaced after the helper is built cannot be
+// stored in the closure's own `Rc<RefCell<...>>` state: the collector never
+// walks it, so a replacement is unreachable and can be collected mid-iteration.
+// Pinning each replacement instead would retain every superseded value for the
+// lifetime of the helper. See `Interpreter::set_helper_gc_roots`.
+fn rooted_pair_new(interp: &mut Interpreter) -> JsValue {
+    interp.create_array(vec![JsValue::UNDEFINED, JsValue::UNDEFINED])
+}
+
+fn rooted_pair_get(interp: &Interpreter, pair: &JsValue) -> (Option<JsValue>, Option<JsValue>) {
+    let pair_id = pair
+        .as_object_id()
+        .expect("rooted pair must be an Array object");
+    let cell = interp.get_object_cell_expect(pair_id);
+    let obj = cell.borrow();
+    let elements = obj
+        .array_elements()
+        .expect("rooted pair must have Array elements");
+    (
+        elements.first().filter(|v| !v.is_undefined()).cloned(),
+        elements.get(1).filter(|v| !v.is_undefined()).cloned(),
+    )
+}
+
+fn rooted_pair_set(interp: &Interpreter, pair: &JsValue, first: JsValue, second: JsValue) {
+    let pair_id = pair
+        .as_object_id()
+        .expect("rooted pair must be an Array object");
+    let cell = interp.get_object_cell_expect(pair_id);
+    let mut obj = cell.borrow_mut();
+    let elements = obj
+        .array_elements_mut()
+        .expect("rooted pair must have Array elements");
+    elements[0] = first;
+    elements[1] = second;
+}
+
+fn rooted_pair_clear(interp: &Interpreter, pair: &JsValue) {
+    rooted_pair_set(interp, pair, JsValue::UNDEFINED, JsValue::UNDEFINED);
+}
+
 fn close_iterator_for_error(
     interp: &mut Interpreter,
     iterator: &JsValue,
@@ -2889,10 +2931,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let inner_roots = interp.create_array(vec![
-                    JsValue::UNDEFINED,
-                    JsValue::UNDEFINED,
-                ]);
+                let inner_roots = rooted_pair_new(interp);
                 // state: (outer_iter, outer_next, mapper, counter, rooted inner pair, alive, running)
                 #[allow(clippy::type_complexity)]
                 let state: Rc<
@@ -2955,26 +2994,8 @@ impl Interpreter {
                                     )
                                 };
 
-                                let (inner_iter, inner_next) = {
-                                    let roots_id = inner_roots
-                                        .as_object_id()
-                                        .expect("flatMap inner roots must be an Array object");
-                                    let roots_cell = interp.get_object_cell_expect(roots_id);
-                                    let roots = roots_cell.borrow();
-                                    let elements = roots
-                                        .array_elements()
-                                        .expect("flatMap inner roots must have Array elements");
-                                    (
-                                        elements
-                                            .first()
-                                            .filter(|value| !value.is_undefined())
-                                            .cloned(),
-                                        elements
-                                            .get(1)
-                                            .filter(|value| !value.is_undefined())
-                                            .cloned(),
-                                    )
-                                };
+                                let (inner_iter, inner_next) =
+                                    rooted_pair_get(interp, &inner_roots);
 
                                 // If we have an inner iterator, drain it
                                 if let (Some(ii), Some(in_next)) = (&inner_iter, &inner_next) {
@@ -2993,16 +3014,7 @@ impl Interpreter {
                                             );
                                         }
                                         Ok(None) => {
-                                            let roots_id = inner_roots
-                                                .as_object_id()
-                                                .expect("flatMap inner roots must be an Array object");
-                                            let roots_cell = interp.get_object_cell_expect(roots_id);
-                                            let mut roots = roots_cell.borrow_mut();
-                                            let elements = roots
-                                                .array_elements_mut()
-                                                .expect("flatMap inner roots must have Array elements");
-                                            elements[0] = JsValue::UNDEFINED;
-                                            elements[1] = JsValue::UNDEFINED;
+                                            rooted_pair_clear(interp, &inner_roots);
                                             continue;
                                         }
                                         Err(e) => {
@@ -3030,17 +3042,12 @@ impl Interpreter {
                                             Completion::Normal(mapped_val) => {
                                                 match get_iterator_flattenable(interp, &mapped_val, true) {
                                                     Ok((new_inner, inner_next_method)) => {
-                                                        let roots_id = inner_roots
-                                                            .as_object_id()
-                                                            .expect("flatMap inner roots must be an Array object");
-                                                        let roots_cell =
-                                                            interp.get_object_cell_expect(roots_id);
-                                                        let mut roots = roots_cell.borrow_mut();
-                                                        let elements = roots
-                                                            .array_elements_mut()
-                                                            .expect("flatMap inner roots must have Array elements");
-                                                        elements[0] = new_inner;
-                                                        elements[1] = inner_next_method;
+                                                        rooted_pair_set(
+                                                            interp,
+                                                            &inner_roots,
+                                                            new_inner,
+                                                            inner_next_method,
+                                                        );
                                                         continue;
                                                     }
                                                     Err(e) => {
@@ -3094,19 +3101,7 @@ impl Interpreter {
                             let s = state_ret.borrow();
                             (s.0.clone(), s.4.clone(), s.5, s.6)
                         };
-                        let inner_iter = {
-                            let roots_id = inner_roots
-                                .as_object_id()
-                                .expect("flatMap inner roots must be an Array object");
-                            let roots_cell = interp.get_object_cell_expect(roots_id);
-                            let roots = roots_cell.borrow();
-                            roots
-                                .array_elements()
-                                .expect("flatMap inner roots must have Array elements")
-                                .first()
-                                .filter(|value| !value.is_undefined())
-                                .cloned()
-                        };
+                        let (inner_iter, _) = rooted_pair_get(interp, &inner_roots);
                         if running {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
@@ -3129,16 +3124,7 @@ impl Interpreter {
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
-                        let roots_id = inner_roots
-                            .as_object_id()
-                            .expect("flatMap inner roots must be an Array object");
-                        let roots_cell = interp.get_object_cell_expect(roots_id);
-                        let mut roots = roots_cell.borrow_mut();
-                        let elements = roots
-                            .array_elements_mut()
-                            .expect("flatMap inner roots must have Array elements");
-                        elements[0] = JsValue::UNDEFINED;
-                        elements[1] = JsValue::UNDEFINED;
+                        rooted_pair_clear(interp, &inner_roots);
                         state_ret.borrow_mut().6 = false;
                         result
                     },
@@ -3345,26 +3331,20 @@ impl Interpreter {
                     }
                 }
 
-                // state: (iterables, current_index, current_iter, current_next, alive, running)
+                let current_roots = rooted_pair_new(interp);
+                // state: (iterables, current_index, rooted current pair, alive, running)
                 #[allow(clippy::type_complexity)]
                 let state: Rc<
-                    RefCell<(
-                        Vec<(JsValue, JsValue)>,
-                        usize,
-                        Option<JsValue>,
-                        Option<JsValue>,
-                        bool,
-                        bool,
-                    )>,
-                > = Rc::new(RefCell::new((iterables, 0, None, None, true, false)));
+                    RefCell<(Vec<(JsValue, JsValue)>, usize, JsValue, bool, bool)>,
+                > = Rc::new(RefCell::new((iterables, 0, current_roots, true, false)));
 
                 let state_next = state.clone();
                 let next_fn = interp.create_function(JsFunction::native(
                     "next".to_string(),
                     0,
                     move |interp, _this, _args| {
-                        let alive = state_next.borrow().4;
-                        let running = state_next.borrow().5;
+                        let alive = state_next.borrow().3;
+                        let running = state_next.borrow().4;
                         if !alive {
                             return Completion::Normal(
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
@@ -3374,18 +3354,20 @@ impl Interpreter {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
                         }
-                        state_next.borrow_mut().5 = true;
+                        state_next.borrow_mut().4 = true;
                         let result = (|| {
                         loop {
-                            let (ref iterables, idx, ref cur_iter, ref cur_next, alive, _running) = {
+                            let (ref iterables, idx, ref current_roots, alive) = {
                                 let s = state_next.borrow();
-                                (s.0.clone(), s.1, s.2.clone(), s.3.clone(), s.4, s.5)
+                                (s.0.clone(), s.1, s.2.clone(), s.3)
                             };
                             if !alive {
                                 return Completion::Normal(
                                     interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
+                            let (ref cur_iter, ref cur_next) =
+                                rooted_pair_get(interp, current_roots);
 
                             // If we have a current iterator, try getting next
                             if let (Some(ci), Some(cn)) = (cur_iter, cur_next) {
@@ -3402,12 +3384,11 @@ impl Interpreter {
                                     Ok(None) => {
                                         // Current exhausted, move to next
                                         state_next.borrow_mut().1 = idx + 1;
-                                        state_next.borrow_mut().2 = None;
-                                        state_next.borrow_mut().3 = None;
+                                        rooted_pair_clear(interp, current_roots);
                                         continue;
                                     }
                                     Err(e) => {
-                                        state_next.borrow_mut().4 = false;
+                                        state_next.borrow_mut().3 = false;
                                         return Completion::Throw(e);
                                     }
                                 }
@@ -3415,7 +3396,7 @@ impl Interpreter {
 
                             // Open next iterable
                             if idx >= iterables.len() {
-                                state_next.borrow_mut().4 = false;
+                                state_next.borrow_mut().3 = false;
                                 return Completion::Normal(
                                     interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
@@ -3425,7 +3406,7 @@ impl Interpreter {
                             match interp.call_function(iter_fn, iterable, &[]) {
                                 Completion::Normal(new_iter) => {
                                     if !new_iter.is_object() {
-                                        state_next.borrow_mut().4 = false;
+                                        state_next.borrow_mut().3 = false;
                                         let err = interp.create_type_error(
                                             "Result of Symbol.iterator is not an object",
                                         );
@@ -3435,20 +3416,24 @@ impl Interpreter {
                                         match get_iterator_direct_getter(interp, &new_iter) {
                                             Ok((_, nm)) => nm,
                                             Err(e) => {
-                                                state_next.borrow_mut().4 = false;
+                                                state_next.borrow_mut().3 = false;
                                                 return Completion::Throw(e);
                                             }
                                         };
-                                    state_next.borrow_mut().2 = Some(new_iter);
-                                    state_next.borrow_mut().3 = Some(next_method);
+                                    rooted_pair_set(
+                                        interp,
+                                        current_roots,
+                                        new_iter,
+                                        next_method,
+                                    );
                                     continue;
                                 }
                                 Completion::Throw(e) => {
-                                    state_next.borrow_mut().4 = false;
+                                    state_next.borrow_mut().3 = false;
                                     return Completion::Throw(e);
                                 }
                                 _ => {
-                                    state_next.borrow_mut().4 = false;
+                                    state_next.borrow_mut().3 = false;
                                     return Completion::Normal(
                                         interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     );
@@ -3456,7 +3441,7 @@ impl Interpreter {
                             }
                         }
                         })();
-                        state_next.borrow_mut().5 = false;
+                        state_next.borrow_mut().4 = false;
                         result
                     },
                 ));
@@ -3466,18 +3451,17 @@ impl Interpreter {
                     "return".to_string(),
                     0,
                     move |interp, _this, _args| {
-                        let (cur_iter, alive, running) = {
+                        let (current_roots, alive, running) = {
                             let s = state_ret.borrow();
-                            (s.2.clone(), s.4, s.5)
+                            (s.2.clone(), s.3, s.4)
                         };
                         if running {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
                         }
-                        state_ret.borrow_mut().5 = true; // set running
-                        state_ret.borrow_mut().4 = false;
-                        state_ret.borrow_mut().2 = None;
-                        state_ret.borrow_mut().3 = None;
+                        let (cur_iter, _) = rooted_pair_get(interp, &current_roots);
+                        state_ret.borrow_mut().4 = true; // set running
+                        state_ret.borrow_mut().3 = false;
                         let result = if alive
                             && let Some(ref ci) = cur_iter
                             && let Err(e) = iterator_close_getter(interp, ci)
@@ -3488,7 +3472,8 @@ impl Interpreter {
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
-                        state_ret.borrow_mut().5 = false; // clear running
+                        rooted_pair_clear(interp, &current_roots);
+                        state_ret.borrow_mut().4 = false; // clear running
                         result
                     },
                 ));
@@ -3496,10 +3481,9 @@ impl Interpreter {
                 let helper = interp.create_iterator_helper_object(next_fn, return_fn);
                 {
                     let b = state.borrow();
-                    let mut roots = Vec::with_capacity(b.0.len() * 2 + 2);
+                    let mut roots = Vec::with_capacity(b.0.len() * 2 + 1);
                     for (io, nm) in &b.0 { roots.push(io.clone()); roots.push(nm.clone()); }
-                    if let Some(ref v) = b.2 { roots.push(v.clone()); }
-                    if let Some(ref v) = b.3 { roots.push(v.clone()); }
+                    roots.push(b.2.clone());
                     interp.set_helper_gc_roots(&helper, roots);
                 }
                 Completion::Normal(helper)

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -341,46 +341,60 @@ fn iterator_close_getter(interp: &mut Interpreter, iterator: &JsValue) -> Result
     }
 }
 
-// A two-slot container an iterator helper roots once and mutates in place.
-// Native-closure captures that are replaced after the helper is built cannot be
-// stored in the closure's own `Rc<RefCell<...>>` state: the collector never
-// walks it, so a replacement is unreachable and can be collected mid-iteration.
-// Pinning each replacement instead would retain every superseded value for the
-// lifetime of the helper. See `Interpreter::set_helper_gc_roots`.
-fn rooted_pair_new(interp: &mut Interpreter) -> JsValue {
-    interp.create_array(vec![JsValue::UNDEFINED, JsValue::UNDEFINED])
-}
+/// The current iterator an iterator helper is drawing from, paired with that
+/// iterator's `next` method, held in a GC-traced Array so the pair can be
+/// rooted once on the helper and then replaced in place. A native closure's own
+/// `Rc<RefCell<...>>` state is invisible to the collector, so a capture that is
+/// replaced after the helper is built has to live somewhere the tracer walks.
+/// See `Interpreter::set_helper_gc_roots` for why re-pinning is not the answer.
+///
+/// Slot 0 alone decides occupancy: the spec opens an iterator before reading
+/// its `next` method and does not check that the method is callable, so slot 1
+/// is stored and returned verbatim — `undefined` included — and the resulting
+/// *TypeError* is owed later, when the helper first calls it.
+#[derive(Clone)]
+struct RootedPair(JsValue);
 
-fn rooted_pair_get(interp: &Interpreter, pair: &JsValue) -> (Option<JsValue>, Option<JsValue>) {
-    let pair_id = pair
-        .as_object_id()
-        .expect("rooted pair must be an Array object");
-    let cell = interp.get_object_cell_expect(pair_id);
-    let obj = cell.borrow();
-    let elements = obj
-        .array_elements()
-        .expect("rooted pair must have Array elements");
-    (
-        elements.first().filter(|v| !v.is_undefined()).cloned(),
-        elements.get(1).filter(|v| !v.is_undefined()).cloned(),
-    )
-}
+impl RootedPair {
+    fn new(interp: &mut Interpreter) -> Self {
+        Self(interp.create_array(vec![JsValue::UNDEFINED, JsValue::UNDEFINED]))
+    }
 
-fn rooted_pair_set(interp: &Interpreter, pair: &JsValue, first: JsValue, second: JsValue) {
-    let pair_id = pair
-        .as_object_id()
-        .expect("rooted pair must be an Array object");
-    let cell = interp.get_object_cell_expect(pair_id);
-    let mut obj = cell.borrow_mut();
-    let elements = obj
-        .array_elements_mut()
-        .expect("rooted pair must have Array elements");
-    elements[0] = first;
-    elements[1] = second;
-}
+    /// The value to hand to `set_helper_gc_roots`; rooting it roots both slots.
+    fn as_root(&self) -> &JsValue {
+        &self.0
+    }
 
-fn rooted_pair_clear(interp: &Interpreter, pair: &JsValue) {
-    rooted_pair_set(interp, pair, JsValue::UNDEFINED, JsValue::UNDEFINED);
+    fn slots<'a>(&self, interp: &'a Interpreter) -> &'a ObjectHandle {
+        interp.get_object_cell_expect(
+            self.0
+                .as_object_id()
+                .expect("rooted pair must be an Array object"),
+        )
+    }
+
+    fn get(&self, interp: &Interpreter) -> Option<(JsValue, JsValue)> {
+        let cell = self.slots(interp);
+        let obj = cell.borrow();
+        let elements = obj
+            .array_elements()
+            .expect("rooted pair must have Array elements");
+        (!elements[0].is_undefined()).then(|| (elements[0].clone(), elements[1].clone()))
+    }
+
+    fn set(&self, interp: &Interpreter, iterator: JsValue, next_method: JsValue) {
+        let cell = self.slots(interp);
+        let mut obj = cell.borrow_mut();
+        let elements = obj
+            .array_elements_mut()
+            .expect("rooted pair must have Array elements");
+        elements[0] = iterator;
+        elements[1] = next_method;
+    }
+
+    fn clear(&self, interp: &Interpreter) {
+        self.set(interp, JsValue::UNDEFINED, JsValue::UNDEFINED);
+    }
 }
 
 fn close_iterator_for_error(
@@ -2931,7 +2945,7 @@ impl Interpreter {
                     Err(e) => return Completion::Throw(e),
                 };
 
-                let inner_roots = rooted_pair_new(interp);
+                let inner_roots = RootedPair::new(interp);
                 // state: (outer_iter, outer_next, mapper, counter, rooted inner pair, alive, running)
                 #[allow(clippy::type_complexity)]
                 let state: Rc<
@@ -2940,7 +2954,7 @@ impl Interpreter {
                         JsValue,
                         JsValue,
                         f64,
-                        JsValue,
+                        RootedPair,
                         bool,
                         bool,
                     )>,
@@ -2994,11 +3008,10 @@ impl Interpreter {
                                     )
                                 };
 
-                                let (inner_iter, inner_next) =
-                                    rooted_pair_get(interp, &inner_roots);
+                                let inner = inner_roots.get(interp);
 
                                 // If we have an inner iterator, drain it
-                                if let (Some(ii), Some(in_next)) = (&inner_iter, &inner_next) {
+                                if let Some((ref ii, ref in_next)) = inner {
                                     match interp.iterator_step_direct(ii, in_next) {
                                         Ok(Some(result)) => {
                                             let value = match interp.iterator_value(&result) {
@@ -3014,7 +3027,7 @@ impl Interpreter {
                                             );
                                         }
                                         Ok(None) => {
-                                            rooted_pair_clear(interp, &inner_roots);
+                                            inner_roots.clear(interp);
                                             continue;
                                         }
                                         Err(e) => {
@@ -3042,9 +3055,8 @@ impl Interpreter {
                                             Completion::Normal(mapped_val) => {
                                                 match get_iterator_flattenable(interp, &mapped_val, true) {
                                                     Ok((new_inner, inner_next_method)) => {
-                                                        rooted_pair_set(
+                                                        inner_roots.set(
                                                             interp,
-                                                            &inner_roots,
                                                             new_inner,
                                                             inner_next_method,
                                                         );
@@ -3101,7 +3113,7 @@ impl Interpreter {
                             let s = state_ret.borrow();
                             (s.0.clone(), s.4.clone(), s.5, s.6)
                         };
-                        let (inner_iter, _) = rooted_pair_get(interp, &inner_roots);
+                        let inner_iter = inner_roots.get(interp).map(|(iter, _)| iter);
                         if running {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
@@ -3124,7 +3136,7 @@ impl Interpreter {
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
-                        rooted_pair_clear(interp, &inner_roots);
+                        inner_roots.clear(interp);
                         state_ret.borrow_mut().6 = false;
                         result
                     },
@@ -3135,7 +3147,7 @@ impl Interpreter {
                     let b = state.borrow();
                     interp.set_helper_gc_roots(
                         &helper,
-                        vec![b.0.clone(), b.1.clone(), b.2.clone(), b.4.clone()],
+                        vec![b.0.clone(), b.1.clone(), b.2.clone(), b.4.as_root().clone()],
                     );
                 }
                 Completion::Normal(helper)
@@ -3331,11 +3343,11 @@ impl Interpreter {
                     }
                 }
 
-                let current_roots = rooted_pair_new(interp);
+                let current_roots = RootedPair::new(interp);
                 // state: (iterables, current_index, rooted current pair, alive, running)
                 #[allow(clippy::type_complexity)]
                 let state: Rc<
-                    RefCell<(Vec<(JsValue, JsValue)>, usize, JsValue, bool, bool)>,
+                    RefCell<(Vec<(JsValue, JsValue)>, usize, RootedPair, bool, bool)>,
                 > = Rc::new(RefCell::new((iterables, 0, current_roots, true, false)));
 
                 let state_next = state.clone();
@@ -3366,11 +3378,8 @@ impl Interpreter {
                                     interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
                             }
-                            let (ref cur_iter, ref cur_next) =
-                                rooted_pair_get(interp, current_roots);
-
                             // If we have a current iterator, try getting next
-                            if let (Some(ci), Some(cn)) = (cur_iter, cur_next) {
+                            if let Some((ref ci, ref cn)) = current_roots.get(interp) {
                                 match interp.iterator_step_direct(ci, cn) {
                                     Ok(Some(result)) => {
                                         let value = match interp.iterator_value(&result) {
@@ -3384,7 +3393,7 @@ impl Interpreter {
                                     Ok(None) => {
                                         // Current exhausted, move to next
                                         state_next.borrow_mut().1 = idx + 1;
-                                        rooted_pair_clear(interp, current_roots);
+                                        current_roots.clear(interp);
                                         continue;
                                     }
                                     Err(e) => {
@@ -3420,12 +3429,7 @@ impl Interpreter {
                                                 return Completion::Throw(e);
                                             }
                                         };
-                                    rooted_pair_set(
-                                        interp,
-                                        current_roots,
-                                        new_iter,
-                                        next_method,
-                                    );
+                                    current_roots.set(interp, new_iter, next_method);
                                     continue;
                                 }
                                 Completion::Throw(e) => {
@@ -3459,7 +3463,7 @@ impl Interpreter {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
                         }
-                        let (cur_iter, _) = rooted_pair_get(interp, &current_roots);
+                        let cur_iter = current_roots.get(interp).map(|(iter, _)| iter);
                         state_ret.borrow_mut().4 = true; // set running
                         state_ret.borrow_mut().3 = false;
                         let result = if alive
@@ -3472,7 +3476,7 @@ impl Interpreter {
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
-                        rooted_pair_clear(interp, &current_roots);
+                        current_roots.clear(interp);
                         state_ret.borrow_mut().4 = false; // clear running
                         result
                     },
@@ -3483,7 +3487,7 @@ impl Interpreter {
                     let b = state.borrow();
                     let mut roots = Vec::with_capacity(b.0.len() * 2 + 1);
                     for (io, nm) in &b.0 { roots.push(io.clone()); roots.push(nm.clone()); }
-                    roots.push(b.2.clone());
+                    roots.push(b.2.as_root().clone());
                     interp.set_helper_gc_roots(&helper, roots);
                 }
                 Completion::Normal(helper)

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -342,11 +342,15 @@ fn iterator_close_getter(interp: &mut Interpreter, iterator: &JsValue) -> Result
 }
 
 /// The current iterator an iterator helper is drawing from, paired with that
-/// iterator's `next` method, held in a GC-traced Array so the pair can be
-/// rooted once on the helper and then replaced in place. A native closure's own
-/// `Rc<RefCell<...>>` state is invisible to the collector, so a capture that is
-/// replaced after the helper is built has to live somewhere the tracer walks.
-/// See `Interpreter::set_helper_gc_roots` for why re-pinning is not the answer.
+/// iterator's `next` method — the engine's Rooted Slot for this pair (see
+/// `CONTEXT.md`). Rooted once on the helper via
+/// `Interpreter::set_helper_gc_roots`, then replaced in place.
+///
+/// The backing store is a real arena object, not a Rust container: writes go
+/// through `ObjectHandle::borrow_mut`, which runs the generational write
+/// barrier, so an old helper that takes on a young iterator is remembered for
+/// the next minor collection. A container the arena does not own would be both
+/// untraced and unbarriered.
 ///
 /// Slot 0 alone decides occupancy: the spec opens an iterator before reading
 /// its `next` method and does not check that the method is callable, so slot 1
@@ -361,8 +365,8 @@ impl RootedPair {
     }
 
     /// The value to hand to `set_helper_gc_roots`; rooting it roots both slots.
-    fn as_root(&self) -> &JsValue {
-        &self.0
+    fn root(&self) -> JsValue {
+        self.0.clone()
     }
 
     fn slots<'a>(&self, interp: &'a Interpreter) -> &'a ObjectHandle {
@@ -2946,35 +2950,19 @@ impl Interpreter {
                 };
 
                 let inner_roots = RootedPair::new(interp);
-                // state: (outer_iter, outer_next, mapper, counter, rooted inner pair, alive, running)
+                // state: (outer_iter, outer_next, mapper, counter, alive, running)
                 #[allow(clippy::type_complexity)]
-                let state: Rc<
-                    RefCell<(
-                        JsValue,
-                        JsValue,
-                        JsValue,
-                        f64,
-                        RootedPair,
-                        bool,
-                        bool,
-                    )>,
-                > = Rc::new(RefCell::new((
-                    iter,
-                    next_method,
-                    mapper,
-                    0.0,
-                    inner_roots,
-                    true,
-                    false,
-                )));
+                let state: Rc<RefCell<(JsValue, JsValue, JsValue, f64, bool, bool)>> =
+                    Rc::new(RefCell::new((iter, next_method, mapper, 0.0, true, false)));
 
                 let state_next = state.clone();
+                let roots_next = inner_roots.clone();
                 let next_fn = interp.create_function(JsFunction::native(
                     "next".to_string(),
                     0,
                     move |interp, _this, _args| {
-                        let alive = state_next.borrow().5;
-                        let running = state_next.borrow().6;
+                        let alive = state_next.borrow().4;
+                        let running = state_next.borrow().5;
                         if !alive {
                             return Completion::Normal(
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
@@ -2984,31 +2972,15 @@ impl Interpreter {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
                         }
-                        state_next.borrow_mut().6 = true;
+                        state_next.borrow_mut().5 = true;
                         let result = (|| {
                             loop {
-                                let (
-                                    outer_iter,
-                                    outer_next,
-                                    mapper,
-                                    counter,
-                                    inner_roots,
-                                    _alive,
-                                    _running,
-                                ) = {
+                                let (outer_iter, outer_next, mapper, counter) = {
                                     let s = state_next.borrow();
-                                    (
-                                        s.0.clone(),
-                                        s.1.clone(),
-                                        s.2.clone(),
-                                        s.3,
-                                        s.4.clone(),
-                                        s.5,
-                                        s.6,
-                                    )
+                                    (s.0.clone(), s.1.clone(), s.2.clone(), s.3)
                                 };
 
-                                let inner = inner_roots.get(interp);
+                                let inner = roots_next.get(interp);
 
                                 // If we have an inner iterator, drain it
                                 if let Some((ref ii, ref in_next)) = inner {
@@ -3017,7 +2989,7 @@ impl Interpreter {
                                             let value = match interp.iterator_value(&result) {
                                                 Ok(v) => v,
                                                 Err(e) => {
-                                                    state_next.borrow_mut().5 = false;
+                                                    state_next.borrow_mut().4 = false;
                                                     let _ = iterator_close_getter(interp, &outer_iter);
                                                     return Completion::Throw(e);
                                                 }
@@ -3027,11 +2999,11 @@ impl Interpreter {
                                             );
                                         }
                                         Ok(None) => {
-                                            inner_roots.clear(interp);
+                                            roots_next.clear(interp);
                                             continue;
                                         }
                                         Err(e) => {
-                                            state_next.borrow_mut().5 = false;
+                                            state_next.borrow_mut().4 = false;
                                             let _ = iterator_close_getter(interp, &outer_iter);
                                             return Completion::Throw(e);
                                         }
@@ -3055,7 +3027,7 @@ impl Interpreter {
                                             Completion::Normal(mapped_val) => {
                                                 match get_iterator_flattenable(interp, &mapped_val, true) {
                                                     Ok((new_inner, inner_next_method)) => {
-                                                        inner_roots.set(
+                                                        roots_next.set(
                                                             interp,
                                                             new_inner,
                                                             inner_next_method,
@@ -3063,19 +3035,19 @@ impl Interpreter {
                                                         continue;
                                                     }
                                                     Err(e) => {
-                                                        state_next.borrow_mut().5 = false;
+                                                        state_next.borrow_mut().4 = false;
                                                         let _ = iterator_close_getter(interp, &outer_iter);
                                                         return Completion::Throw(e);
                                                     }
                                                 }
                                             }
                                             Completion::Throw(e) => {
-                                                state_next.borrow_mut().5 = false;
+                                                state_next.borrow_mut().4 = false;
                                                 let _ = iterator_close_getter(interp, &outer_iter);
                                                 return Completion::Throw(e);
                                             }
                                             _ => {
-                                                state_next.borrow_mut().5 = false;
+                                                state_next.borrow_mut().4 = false;
                                                 return Completion::Normal(
                                                     interp.create_iter_result_object(
                                                         JsValue::UNDEFINED,
@@ -3086,40 +3058,41 @@ impl Interpreter {
                                         }
                                     }
                                     Ok(None) => {
-                                        state_next.borrow_mut().5 = false;
+                                        state_next.borrow_mut().4 = false;
                                         return Completion::Normal(
                                             interp
                                                 .create_iter_result_object(JsValue::UNDEFINED, true),
                                         );
                                     }
                                     Err(e) => {
-                                        state_next.borrow_mut().5 = false;
+                                        state_next.borrow_mut().4 = false;
                                         return Completion::Throw(e);
                                     }
                                 }
                             }
                         })();
-                        state_next.borrow_mut().6 = false;
+                        state_next.borrow_mut().5 = false;
                         result
                     },
                 ));
 
                 let state_ret = state.clone();
+                let roots_ret = inner_roots.clone();
                 let return_fn = interp.create_function(JsFunction::native(
                     "return".to_string(),
                     0,
                     move |interp, _this, _args| {
-                        let (outer_iter, inner_roots, alive, running) = {
+                        let (outer_iter, alive, running) = {
                             let s = state_ret.borrow();
-                            (s.0.clone(), s.4.clone(), s.5, s.6)
+                            (s.0.clone(), s.4, s.5)
                         };
-                        let inner_iter = inner_roots.get(interp).map(|(iter, _)| iter);
+                        let inner_iter = roots_ret.get(interp).map(|(iter, _)| iter);
                         if running {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
                         }
-                        state_ret.borrow_mut().6 = true;
-                        state_ret.borrow_mut().5 = false;
+                        state_ret.borrow_mut().5 = true;
+                        state_ret.borrow_mut().4 = false;
                         let result = if alive {
                             if let Some(ref ii) = inner_iter {
                                 let _ = iterator_close_getter(interp, ii);
@@ -3136,8 +3109,8 @@ impl Interpreter {
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
-                        inner_roots.clear(interp);
-                        state_ret.borrow_mut().6 = false;
+                        roots_ret.clear(interp);
+                        state_ret.borrow_mut().5 = false;
                         result
                     },
                 ));
@@ -3147,7 +3120,7 @@ impl Interpreter {
                     let b = state.borrow();
                     interp.set_helper_gc_roots(
                         &helper,
-                        vec![b.0.clone(), b.1.clone(), b.2.clone(), b.4.as_root().clone()],
+                        vec![b.0.clone(), b.1.clone(), b.2.clone(), inner_roots.root()],
                     );
                 }
                 Completion::Normal(helper)
@@ -3344,19 +3317,19 @@ impl Interpreter {
                 }
 
                 let current_roots = RootedPair::new(interp);
-                // state: (iterables, current_index, rooted current pair, alive, running)
+                // state: (iterables, current_index, alive, running)
                 #[allow(clippy::type_complexity)]
-                let state: Rc<
-                    RefCell<(Vec<(JsValue, JsValue)>, usize, RootedPair, bool, bool)>,
-                > = Rc::new(RefCell::new((iterables, 0, current_roots, true, false)));
+                let state: Rc<RefCell<(Vec<(JsValue, JsValue)>, usize, bool, bool)>> =
+                    Rc::new(RefCell::new((iterables, 0, true, false)));
 
                 let state_next = state.clone();
+                let roots_next = current_roots.clone();
                 let next_fn = interp.create_function(JsFunction::native(
                     "next".to_string(),
                     0,
                     move |interp, _this, _args| {
-                        let alive = state_next.borrow().3;
-                        let running = state_next.borrow().4;
+                        let alive = state_next.borrow().2;
+                        let running = state_next.borrow().3;
                         if !alive {
                             return Completion::Normal(
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
@@ -3366,20 +3339,13 @@ impl Interpreter {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
                         }
-                        state_next.borrow_mut().4 = true;
+                        state_next.borrow_mut().3 = true;
                         let result = (|| {
                         loop {
-                            let (ref iterables, idx, ref current_roots, alive) = {
-                                let s = state_next.borrow();
-                                (s.0.clone(), s.1, s.2.clone(), s.3)
-                            };
-                            if !alive {
-                                return Completion::Normal(
-                                    interp.create_iter_result_object(JsValue::UNDEFINED, true),
-                                );
-                            }
+                            let idx = state_next.borrow().1;
+
                             // If we have a current iterator, try getting next
-                            if let Some((ref ci, ref cn)) = current_roots.get(interp) {
+                            if let Some((ref ci, ref cn)) = roots_next.get(interp) {
                                 match interp.iterator_step_direct(ci, cn) {
                                     Ok(Some(result)) => {
                                         let value = match interp.iterator_value(&result) {
@@ -3393,29 +3359,28 @@ impl Interpreter {
                                     Ok(None) => {
                                         // Current exhausted, move to next
                                         state_next.borrow_mut().1 = idx + 1;
-                                        current_roots.clear(interp);
+                                        roots_next.clear(interp);
                                         continue;
                                     }
                                     Err(e) => {
-                                        state_next.borrow_mut().3 = false;
+                                        state_next.borrow_mut().2 = false;
                                         return Completion::Throw(e);
                                     }
                                 }
                             }
 
                             // Open next iterable
-                            if idx >= iterables.len() {
-                                state_next.borrow_mut().3 = false;
+                            let Some((iterable, iter_fn)) = state_next.borrow().0.get(idx).cloned()
+                            else {
+                                state_next.borrow_mut().2 = false;
                                 return Completion::Normal(
                                     interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                 );
-                            }
-
-                            let (ref iterable, ref iter_fn) = iterables[idx];
-                            match interp.call_function(iter_fn, iterable, &[]) {
+                            };
+                            match interp.call_function(&iter_fn, &iterable, &[]) {
                                 Completion::Normal(new_iter) => {
                                     if !new_iter.is_object() {
-                                        state_next.borrow_mut().3 = false;
+                                        state_next.borrow_mut().2 = false;
                                         let err = interp.create_type_error(
                                             "Result of Symbol.iterator is not an object",
                                         );
@@ -3425,19 +3390,19 @@ impl Interpreter {
                                         match get_iterator_direct_getter(interp, &new_iter) {
                                             Ok((_, nm)) => nm,
                                             Err(e) => {
-                                                state_next.borrow_mut().3 = false;
+                                                state_next.borrow_mut().2 = false;
                                                 return Completion::Throw(e);
                                             }
                                         };
-                                    current_roots.set(interp, new_iter, next_method);
+                                    roots_next.set(interp, new_iter, next_method);
                                     continue;
                                 }
                                 Completion::Throw(e) => {
-                                    state_next.borrow_mut().3 = false;
+                                    state_next.borrow_mut().2 = false;
                                     return Completion::Throw(e);
                                 }
                                 _ => {
-                                    state_next.borrow_mut().3 = false;
+                                    state_next.borrow_mut().2 = false;
                                     return Completion::Normal(
                                         interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     );
@@ -3445,27 +3410,28 @@ impl Interpreter {
                             }
                         }
                         })();
-                        state_next.borrow_mut().4 = false;
+                        state_next.borrow_mut().3 = false;
                         result
                     },
                 ));
 
                 let state_ret = state.clone();
+                let roots_ret = current_roots.clone();
                 let return_fn = interp.create_function(JsFunction::native(
                     "return".to_string(),
                     0,
                     move |interp, _this, _args| {
-                        let (current_roots, alive, running) = {
+                        let (alive, running) = {
                             let s = state_ret.borrow();
-                            (s.2.clone(), s.3, s.4)
+                            (s.2, s.3)
                         };
                         if running {
                             let err = interp.create_type_error("Iterator helper method called while iterator is already being iterated");
                             return Completion::Throw(err);
                         }
-                        let cur_iter = current_roots.get(interp).map(|(iter, _)| iter);
-                        state_ret.borrow_mut().4 = true; // set running
-                        state_ret.borrow_mut().3 = false;
+                        let cur_iter = roots_ret.get(interp).map(|(iter, _)| iter);
+                        state_ret.borrow_mut().3 = true; // set running
+                        state_ret.borrow_mut().2 = false;
                         let result = if alive
                             && let Some(ref ci) = cur_iter
                             && let Err(e) = iterator_close_getter(interp, ci)
@@ -3476,8 +3442,8 @@ impl Interpreter {
                                 interp.create_iter_result_object(JsValue::UNDEFINED, true),
                             )
                         };
-                        current_roots.clear(interp);
-                        state_ret.borrow_mut().4 = false; // clear running
+                        roots_ret.clear(interp);
+                        state_ret.borrow_mut().3 = false; // clear running
                         result
                     },
                 ));
@@ -3487,7 +3453,7 @@ impl Interpreter {
                     let b = state.borrow();
                     let mut roots = Vec::with_capacity(b.0.len() * 2 + 1);
                     for (io, nm) in &b.0 { roots.push(io.clone()); roots.push(nm.clone()); }
-                    roots.push(b.2.as_root().clone());
+                    roots.push(current_roots.root());
                     interp.set_helper_gc_roots(&helper, roots);
                 }
                 Completion::Normal(helper)

--- a/src/interpreter/gc.rs
+++ b/src/interpreter/gc.rs
@@ -191,6 +191,12 @@ impl Interpreter {
     /// gains a young root is remembered for the next minor collection. Pins only
     /// ever accumulate: there is no unpin, so they are released when the anchor
     /// itself dies.
+    ///
+    /// That makes this the wrong tool for a capture that is *replaced* over the
+    /// anchor's lifetime — pinning each replacement retains every superseded
+    /// value. Pin one arena-backed container instead and mutate its slots in
+    /// place; `RootedPair` in `builtins/iterators.rs` is the two-slot case, and
+    /// `CONTEXT.md` calls the shape a Rooted Slot.
     pub(crate) fn pin_native_root(&self, anchor: &JsValue, value: &JsValue) {
         if value.as_object_id().is_none() {
             return;

--- a/test262-extra/iterator-concat-current-iterator-gc-rooting.js
+++ b/test262-extra/iterator-concat-current-iterator-gc-rooting.js
@@ -1,0 +1,56 @@
+/*---
+description: >
+  Iterator.concat keeps the current underlying iterator reachable across
+  garbage collection between calls to the helper's next method.
+esid: sec-iterator.concat
+info: |
+  Iterator.concat opens each iterable in turn and resumes the resulting
+  iterator until it is exhausted. That iterator is reachable only from the
+  helper, so it must stay strongly rooted while the helper is live, including
+  across separate calls to the helper's next method.
+features: [iterator-sequencing, iterator-helpers, host-gc-required]
+---*/
+
+var concat = Iterator.concat(
+  {
+    [Symbol.iterator]: function* () {
+      yield 1;
+      yield 2;
+    },
+  },
+  {
+    [Symbol.iterator]: function* () {
+      yield 3;
+      yield 4;
+    },
+  }
+);
+
+var first = concat.next();
+assert.sameValue(first.value, 1, "first value from the first iterable");
+assert.sameValue(first.done, false, "first iterator is still active");
+
+first = undefined;
+$262.gc();
+
+var second = concat.next();
+assert.sameValue(second.value, 2, "current iterator survives collection");
+assert.sameValue(second.done, false, "current iterator resumes after collection");
+
+second = undefined;
+$262.gc();
+
+var third = concat.next();
+assert.sameValue(third.value, 3, "next iterable opens after collection");
+assert.sameValue(third.done, false, "last iterator is active");
+
+third = undefined;
+$262.gc();
+
+var fourth = concat.next();
+assert.sameValue(fourth.value, 4, "last iterator survives collection");
+assert.sameValue(fourth.done, false, "last iterator resumes after collection");
+
+var done = concat.next();
+assert.sameValue(done.value, undefined, "exhausted helper has no value");
+assert.sameValue(done.done, true, "helper finishes after the last iterable");

--- a/test262-extra/iterator-concat-current-iterator-gc-rooting.js
+++ b/test262-extra/iterator-concat-current-iterator-gc-rooting.js
@@ -4,11 +4,32 @@ description: >
   garbage collection between calls to the helper's next method.
 esid: sec-iterator.concat
 info: |
-  Iterator.concat opens each iterable in turn and resumes the resulting
-  iterator until it is exhausted. That iterator is reachable only from the
-  helper, so it must stay strongly rooted while the helper is live, including
-  across separate calls to the helper's next method.
-features: [iterator-sequencing, iterator-helpers, host-gc-required]
+  Iterator.concat ( ...items )
+
+  ...
+  3. Let closure be a new Abstract Closure with no parameters that captures
+     iterables and performs the following steps when called:
+    a. For each Record iterable of iterables, do
+      i. Let iter be ? Call(iterable.[[OpenMethod]], iterable.[[Iterable]]).
+      ii. If iter is not an Object, throw a TypeError exception.
+      iii. Let iteratorRecord be ? GetIteratorDirect(iter).
+      iv. Let innerAlive be true.
+      v. Repeat, while innerAlive is true,
+        1. Let innerValue be ? IteratorStepValue(iteratorRecord).
+        2. If innerValue is done, then
+          a. Set innerAlive to false.
+        3. Else,
+          a. Let completion be Completion(Yield(innerValue)).
+    b. Return ReturnCompletion(undefined).
+  4. Let gen be CreateIteratorFromClosure(closure, "Iterator Helper",
+     %IteratorHelperPrototype%, << [[UnderlyingIterators]] >>).
+  ...
+
+  The Abstract Closure resumes the same iteratorRecord across every suspension
+  of the generator, so the iterator opened at step 3.a.i must stay strongly
+  reachable for as long as the helper is live -- including across separate
+  calls to the helper's next method, when it is otherwise ephemeral.
+features: [iterator-sequencing, host-gc-required]
 ---*/
 
 var concat = Iterator.concat(

--- a/test262-extra/iterator-concat-current-iterator-gc-rooting.js
+++ b/test262-extra/iterator-concat-current-iterator-gc-rooting.js
@@ -7,28 +7,18 @@ info: |
   Iterator.concat ( ...items )
 
   ...
-  3. Let closure be a new Abstract Closure with no parameters that captures
-     iterables and performs the following steps when called:
+  3. Let closure be a new Abstract Closure ... :
     a. For each Record iterable of iterables, do
       i. Let iter be ? Call(iterable.[[OpenMethod]], iterable.[[Iterable]]).
-      ii. If iter is not an Object, throw a TypeError exception.
       iii. Let iteratorRecord be ? GetIteratorDirect(iter).
-      iv. Let innerAlive be true.
       v. Repeat, while innerAlive is true,
         1. Let innerValue be ? IteratorStepValue(iteratorRecord).
-        2. If innerValue is done, then
-          a. Set innerAlive to false.
-        3. Else,
-          a. Let completion be Completion(Yield(innerValue)).
-    b. Return ReturnCompletion(undefined).
-  4. Let gen be CreateIteratorFromClosure(closure, "Iterator Helper",
-     %IteratorHelperPrototype%, << [[UnderlyingIterators]] >>).
   ...
 
-  The Abstract Closure resumes the same iteratorRecord across every suspension
-  of the generator, so the iterator opened at step 3.a.i must stay strongly
-  reachable for as long as the helper is live -- including across separate
-  calls to the helper's next method, when it is otherwise ephemeral.
+  The closure resumes the same iteratorRecord across every suspension of the
+  generator, so the iterator opened at step 3.a.i must stay strongly reachable
+  while the helper is live -- including across separate calls to its next
+  method, when it is otherwise ephemeral.
 features: [iterator-sequencing, host-gc-required]
 ---*/
 

--- a/test262-extra/iterator-concat-non-callable-next-method.js
+++ b/test262-extra/iterator-concat-non-callable-next-method.js
@@ -1,0 +1,48 @@
+/*---
+description: >
+  Iterator.concat opens each iterable exactly once and defers the TypeError for
+  a non-callable next method to the step that calls it.
+esid: sec-iterator.concat
+info: |
+  Iterator.concat ( ...items )
+
+  ...
+  3. Let closure be a new Abstract Closure with no parameters that captures
+     iterables and performs the following steps when called:
+    a. For each Record iterable of iterables, do
+      i. Let iter be ? Call(iterable.[[OpenMethod]], iterable.[[Iterable]]).
+      ii. If iter is not an Object, throw a TypeError exception.
+      iii. Let iteratorRecord be ? GetIteratorDirect(iter).
+      iv. Let innerAlive be true.
+      v. Repeat, while innerAlive is true,
+        1. Let innerValue be ? IteratorStepValue(iteratorRecord).
+        ...
+
+  GetIteratorDirect ( obj )
+
+  1. Let nextMethod be ? Get(obj, "next").
+  2. Let iteratorRecord be the Iterator Record { [[Iterator]]: obj,
+     [[NextMethod]]: nextMethod, [[Done]]: false }.
+  3. Return iteratorRecord.
+
+  GetIteratorDirect does not check that nextMethod is callable, so an opened
+  iterator with no next method is a valid Iterator Record. The TypeError is
+  owed by IteratorStepValue, which calls it. In particular the helper must not
+  treat the absent method as "no iterator open" and re-run step 3.a.i.
+features: [iterator-sequencing]
+---*/
+
+var opened = 0;
+
+var concat = Iterator.concat({
+  [Symbol.iterator]: function () {
+    opened += 1;
+    return {};
+  },
+});
+
+assert.throws(TypeError, function () {
+  concat.next();
+}, "calling the absent next method throws a TypeError");
+
+assert.sameValue(opened, 1, "the iterable is opened exactly once");

--- a/test262-extra/iterator-concat-non-callable-next-method.js
+++ b/test262-extra/iterator-concat-non-callable-next-method.js
@@ -7,28 +7,20 @@ info: |
   Iterator.concat ( ...items )
 
   ...
-  3. Let closure be a new Abstract Closure with no parameters that captures
-     iterables and performs the following steps when called:
-    a. For each Record iterable of iterables, do
-      i. Let iter be ? Call(iterable.[[OpenMethod]], iterable.[[Iterable]]).
-      ii. If iter is not an Object, throw a TypeError exception.
       iii. Let iteratorRecord be ? GetIteratorDirect(iter).
-      iv. Let innerAlive be true.
       v. Repeat, while innerAlive is true,
         1. Let innerValue be ? IteratorStepValue(iteratorRecord).
-        ...
+  ...
 
   GetIteratorDirect ( obj )
 
   1. Let nextMethod be ? Get(obj, "next").
-  2. Let iteratorRecord be the Iterator Record { [[Iterator]]: obj,
-     [[NextMethod]]: nextMethod, [[Done]]: false }.
-  3. Return iteratorRecord.
+  ...
 
   GetIteratorDirect does not check that nextMethod is callable, so an opened
-  iterator with no next method is a valid Iterator Record. The TypeError is
-  owed by IteratorStepValue, which calls it. In particular the helper must not
-  treat the absent method as "no iterator open" and re-run step 3.a.i.
+  iterator with no next method is a valid Iterator Record and the TypeError is
+  owed by IteratorStepValue. In particular the helper must not read the absent
+  method as "no iterator open" and re-open the same iterable.
 features: [iterator-sequencing]
 ---*/
 

--- a/test262-extra/iterator-concat-return-closes-current-iterator-after-gc.js
+++ b/test262-extra/iterator-concat-return-closes-current-iterator-after-gc.js
@@ -7,14 +7,9 @@ info: |
   Iterator.concat ( ...items )
 
   ...
-  3. Let closure be a new Abstract Closure with no parameters that captures
-     iterables and performs the following steps when called:
+  3. Let closure be a new Abstract Closure ... :
     a. For each Record iterable of iterables, do
-      i. Let iter be ? Call(iterable.[[OpenMethod]], iterable.[[Iterable]]).
-      ...
       v. Repeat, while innerAlive is true,
-        1. Let innerValue be ? IteratorStepValue(iteratorRecord).
-        ...
         3. Else,
           a. Let completion be Completion(Yield(innerValue)).
           b. If completion is an abrupt completion, then
@@ -22,10 +17,9 @@ info: |
   ...
 
   Calling the helper's return method resumes the generator with an abrupt
-  completion, so step 3.a.v.3.b.i closes the iteratorRecord the helper is
-  currently drawing from. That iterator is reachable only through the helper,
-  so a collection between opening it and closing it must not lose it -- and it
-  must be closed exactly once.
+  completion, so step 3.a.v.3.b.i closes the iteratorRecord it is currently
+  drawing from. A collection between opening that iterator and closing it must
+  not lose it, and it must be closed exactly once.
 features: [iterator-sequencing, host-gc-required]
 ---*/
 

--- a/test262-extra/iterator-concat-return-closes-current-iterator-after-gc.js
+++ b/test262-extra/iterator-concat-return-closes-current-iterator-after-gc.js
@@ -1,0 +1,40 @@
+/*---
+description: >
+  Iterator.concat's return method closes the current underlying iterator even
+  when a garbage collection happened since it was opened.
+esid: sec-iterator.concat
+info: |
+  The iterator produced by Iterator.concat closes the iterator it is currently
+  drawing values from. That iterator is reachable only from the helper, so a
+  collection between opening it and closing it must not lose it.
+features: [iterator-sequencing, iterator-helpers, host-gc-required]
+---*/
+
+var closed = 0;
+
+var concat = Iterator.concat({
+  [Symbol.iterator]: function* () {
+    try {
+      yield 1;
+      yield 2;
+    } finally {
+      closed += 1;
+    }
+  },
+});
+
+var first = concat.next();
+assert.sameValue(first.value, 1, "first value from the current iterator");
+assert.sameValue(closed, 0, "current iterator is still open");
+
+first = undefined;
+$262.gc();
+
+var result = concat.return();
+assert.sameValue(result.value, undefined, "return result has no value");
+assert.sameValue(result.done, true, "return result is done");
+assert.sameValue(closed, 1, "current iterator was closed after collection");
+
+var after = concat.next();
+assert.sameValue(after.done, true, "helper stays exhausted after return");
+assert.sameValue(closed, 1, "current iterator is not closed twice");

--- a/test262-extra/iterator-concat-return-closes-current-iterator-after-gc.js
+++ b/test262-extra/iterator-concat-return-closes-current-iterator-after-gc.js
@@ -4,10 +4,29 @@ description: >
   when a garbage collection happened since it was opened.
 esid: sec-iterator.concat
 info: |
-  The iterator produced by Iterator.concat closes the iterator it is currently
-  drawing values from. That iterator is reachable only from the helper, so a
-  collection between opening it and closing it must not lose it.
-features: [iterator-sequencing, iterator-helpers, host-gc-required]
+  Iterator.concat ( ...items )
+
+  ...
+  3. Let closure be a new Abstract Closure with no parameters that captures
+     iterables and performs the following steps when called:
+    a. For each Record iterable of iterables, do
+      i. Let iter be ? Call(iterable.[[OpenMethod]], iterable.[[Iterable]]).
+      ...
+      v. Repeat, while innerAlive is true,
+        1. Let innerValue be ? IteratorStepValue(iteratorRecord).
+        ...
+        3. Else,
+          a. Let completion be Completion(Yield(innerValue)).
+          b. If completion is an abrupt completion, then
+            i. Return ? IteratorClose(iteratorRecord, completion).
+  ...
+
+  Calling the helper's return method resumes the generator with an abrupt
+  completion, so step 3.a.v.3.b.i closes the iteratorRecord the helper is
+  currently drawing from. That iterator is reachable only through the helper,
+  so a collection between opening it and closing it must not lose it -- and it
+  must be closed exactly once.
+features: [iterator-sequencing, host-gc-required]
 ---*/
 
 var closed = 0;

--- a/test262-extra/iterator-flatMap-non-callable-next-method.js
+++ b/test262-extra/iterator-flatMap-non-callable-next-method.js
@@ -9,17 +9,14 @@ info: |
   ...
     vi. Let innerIterator be Completion(GetIteratorFlattenable(mapped,
         reject-primitives)).
-    ...
     ix. Repeat, while innerAlive is true,
       1. Let innerValue be Completion(IteratorStepValue(innerIterator)).
-      ...
+  ...
 
   GetIteratorDirect ( obj )
 
   1. Let nextMethod be ? Get(obj, "next").
-  2. Let iteratorRecord be the Iterator Record { [[Iterator]]: obj,
-     [[NextMethod]]: nextMethod, [[Done]]: false }.
-  3. Return iteratorRecord.
+  ...
 
   GetIteratorFlattenable does not check that nextMethod is callable, so the
   inner iterator is a valid Iterator Record and the TypeError is owed by

--- a/test262-extra/iterator-flatMap-non-callable-next-method.js
+++ b/test262-extra/iterator-flatMap-non-callable-next-method.js
@@ -1,0 +1,41 @@
+/*---
+description: >
+  Iterator.prototype.flatMap throws a TypeError when the inner iterator has no
+  callable next method, rather than treating it as exhausted.
+esid: sec-iterator.prototype.flatmap
+info: |
+  Iterator.prototype.flatMap ( mapper )
+
+  ...
+    vi. Let innerIterator be Completion(GetIteratorFlattenable(mapped,
+        reject-primitives)).
+    ...
+    ix. Repeat, while innerAlive is true,
+      1. Let innerValue be Completion(IteratorStepValue(innerIterator)).
+      ...
+
+  GetIteratorDirect ( obj )
+
+  1. Let nextMethod be ? Get(obj, "next").
+  2. Let iteratorRecord be the Iterator Record { [[Iterator]]: obj,
+     [[NextMethod]]: nextMethod, [[Done]]: false }.
+  3. Return iteratorRecord.
+
+  GetIteratorFlattenable does not check that nextMethod is callable, so the
+  inner iterator is a valid Iterator Record and the TypeError is owed by
+  IteratorStepValue. The helper must not read the absent method as "no inner
+  iterator open" and silently move on to the next outer value.
+features: [iterator-helpers]
+---*/
+
+var flat = [1, 2].values().flatMap(function () {
+  return {
+    [Symbol.iterator]: function () {
+      return {};
+    },
+  };
+});
+
+assert.throws(TypeError, function () {
+  flat.next();
+}, "calling the absent next method throws a TypeError");


### PR DESCRIPTION
## Summary

- hold `Iterator.concat`'s current underlying iterator and its `next` method in one traced two-slot container (`RootedPair`) rooted on the helper, instead of in the native closure's own `Rc<RefCell<...>>` state that the collector never walks
- mutate and clear that fixed container in place, so a replacement stays visible to the collector without accumulating a permanent pin per iterable opened
- factor the container into a newtype shared with `flatMap` (fixed in #585), so the pattern has one implementation rather than two copies of the same inline block

Before this change, a collection between two `next()` calls could reclaim an otherwise ephemeral current iterator and leave the helper resuming a stale object id:

```js
var it = Iterator.concat([1, 2, 3], [4, 5]);
it.next();     // { value: 1, done: false }
$262.gc();
it.next();     // TypeError: Iterator result is not an object
```

Fixes #584

## Also in this PR: a flatMap behaviour change

Keying the container's occupancy on slot 0 alone (the iterator) rather than on both slots also corrects `Iterator.prototype.flatMap`. Since #585 it has *silently skipped* an inner iterator whose `next` method is not callable; per `GetIteratorFlattenable` -> `GetIteratorDirect` there is no callability check, so the *TypeError* is owed by the first `IteratorStepValue`. Node agrees:

```js
[1, 2].values().flatMap(x => ({ [Symbol.iterator]: () => ({}) })).next();
// origin/main: { done: true }      node & this PR: TypeError: undefined is not a function
```

It is the same line of the shared helper, so it is corrected here rather than deferred — but it is outside #584's stated scope, hence this note.

Full review notes, including the findings applied and declined, are in the [review comment](https://github.com/pmatos/jsse/pull/604#issuecomment-5554904603).

## Test plan

Four regression tests under `test262-extra/`:

- `iterator-concat-current-iterator-gc-rooting.js` — resumes the current iterator, and opens the next iterable, across collections (fails on `origin/main`: `TypeError: Generator.prototype.next called on non-object`)
- `iterator-concat-return-closes-current-iterator-after-gc.js` — `return()` still closes the current iterator after a collection (fails on `origin/main`: the iterator is never closed)
- `iterator-flatMap-non-callable-next-method.js` — the absent `next` throws instead of ending the helper (fails on `origin/main`: `{done:true}`)
- `iterator-concat-non-callable-next-method.js` — the absent `next` throws and `[Symbol.iterator]` runs exactly once. **Passes on `origin/main`**; it guards a regression introduced and fixed during review, which never shipped.

- [x] `./scripts/lint.sh` — clean
- [x] `cargo build --release`
- [x] `cargo test --release` — 645 unit + integration tests, 0 failed
- [x] `uv run python scripts/run-test262.py --fail-on-failures test262/test/built-ins/Iterator/ -j 32` — 1,028/1,028
- [x] `uv run python scripts/run-test262.py --fail-on-failures test262-extra/ -j 32` — 316/316
- [x] `uv run python scripts/run-custom-tests.py` — 11/11
- [x] `uv run python scripts/run-test262.py -j 32` — 99,568/99,568, 0 regressions against `origin/main`