### PR TITLE
fix(parser): calibrate MAX_PARSE_DEPTH per build profile

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -390,7 +390,7 @@ pub(crate) struct Interpreter {
 
 /// Soft JS call-depth limit: crossing it throws a catchable `RangeError:
 /// Maximum call stack size exceeded`. Sits well below the native capacity of
-/// the 128 MiB execution stack the engine runs on (see `main.rs`), yet far
+/// the 128 MiB execution stack the engine runs on (see `lib.rs`), yet far
 /// above the depth any real program reaches (the old 8 MiB main stack held
 /// every passing test, i.e. depths under ~1500).
 pub(crate) const CALL_DEPTH_SOFT_LIMIT: usize = 4_000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ mod lib_tests {
         // `ast::Program` holds `Rc`s and isn't `Send`, so (matching how a real
         // fuzz target must behave) the parse result is consumed entirely
         // inside the closure; only the `bool` verdict crosses the thread.
-        let owned = "[".repeat(5000);
+        let owned = "[".repeat(parser::MAX_PARSE_DEPTH as usize * 2);
         let borrowed: &str = &owned;
         let is_err = run_on_engine_stack(move || {
             parser::Parser::new(borrowed)
@@ -116,6 +116,6 @@ mod lib_tests {
 
     #[test]
     fn fuzz_parse_bytes_deep_nesting() {
-        fuzz_parse_bytes("[".repeat(5000).as_bytes());
+        fuzz_parse_bytes("[".repeat(parser::MAX_PARSE_DEPTH as usize * 2).as_bytes());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,13 +82,6 @@ mod lib_tests {
     }
 
     #[test]
-    #[cfg_attr(
-        debug_assertions,
-        ignore = "MAX_PARSE_DEPTH's headroom below ENGINE_STACK_SIZE is calibrated \
-                  for release-mode stack frames; debug-mode recursive-descent frames \
-                  are large enough that this depth overflows the native stack well \
-                  before the depth guard fires. See jsse#599."
-    )]
     fn run_on_engine_stack_borrows_non_static_data() {
         // `ast::Program` holds `Rc`s and isn't `Send`, so (matching how a real
         // fuzz target must behave) the parse result is consumed entirely
@@ -122,13 +115,6 @@ mod lib_tests {
     }
 
     #[test]
-    #[cfg_attr(
-        debug_assertions,
-        ignore = "MAX_PARSE_DEPTH's headroom below ENGINE_STACK_SIZE is calibrated \
-                  for release-mode stack frames; debug-mode recursive-descent frames \
-                  are large enough that this depth overflows the native stack well \
-                  before the depth guard fires. See jsse#599."
-    )]
     fn fuzz_parse_bytes_deep_nesting() {
         fuzz_parse_bytes("[".repeat(5000).as_bytes());
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -91,6 +91,10 @@ pub(crate) struct Parser<'a> {
 /// raising this error in debug builds — jsse#599.
 #[cfg(not(debug_assertions))]
 const MAX_PARSE_DEPTH: u32 = 4_000;
+/// Debug counterpart of [`MAX_PARSE_DEPTH`], ~10x lower for ~10x fatter frames.
+/// Reaching either limit costs about the same ~14 MB of stack, so both assume
+/// the engine stack — a parser driven on a smaller thread can still overflow
+/// first, in either profile.
 #[cfg(debug_assertions)]
 const MAX_PARSE_DEPTH: u32 = 400;
 
@@ -1430,6 +1434,18 @@ mod tests {
         Parser::new(src).unwrap().parse_program().unwrap()
     }
 
+    /// Parses `source` on the engine stack — the stack `MAX_PARSE_DEPTH` is
+    /// calibrated against — and reduces the outcome to a `bool` inside the
+    /// closure, since `Program` is not `Send` and cannot cross the boundary.
+    fn parse_on_engine_stack(
+        source: &str,
+        verdict: fn(Result<Program, ParseError>) -> bool,
+    ) -> bool {
+        crate::run_on_engine_stack(move || {
+            verdict(Parser::new(source).and_then(|mut p| p.parse_program()))
+        })
+    }
+
     #[test]
     fn parse_empty() {
         let prog = parse("");
@@ -1550,8 +1566,12 @@ mod tests {
     }
 
     /// Source nested past `MAX_PARSE_DEPTH` must raise the catchable depth
-    /// error rather than exhausting the native stack first. The shapes are the
-    /// most stack-hungry ones the parser has, so they bound every other shape.
+    /// error rather than exhausting the native stack first. These are the
+    /// shapes that spend the most native stack per depth unit, so they bound
+    /// every other shape the guard covers — but only those: source that eats
+    /// native stack without advancing the counter (a long `a.b.b…` member
+    /// chain, a long left-associative `1+1+1…` chain) is outside this guard
+    /// entirely, in both profiles.
     ///
     /// Note this cannot fail politely: if `MAX_PARSE_DEPTH` is ever raised
     /// above what the running profile's stack holds, the process aborts
@@ -1568,15 +1588,13 @@ mod tests {
             ("object literal", "({a:".repeat(reps)),
             ("object/array mix", "({a:[".repeat(reps)),
             ("template substitution", "`${".repeat(reps)),
+            ("spread element", "[...".repeat(reps)),
             ("block statement", "{".repeat(reps)),
         ] {
-            let src: &str = &source;
-            let hit_depth_limit = crate::run_on_engine_stack(move || {
-                matches!(
-                    Parser::new(src).and_then(|mut p| p.parse_program()),
-                    Err(e) if e.message.contains("nested too deeply")
-                )
-            });
+            let hit_depth_limit = parse_on_engine_stack(
+                &source,
+                |result| matches!(result, Err(e) if e.message.contains("nested too deeply")),
+            );
             assert!(
                 hit_depth_limit,
                 "{label} nested {reps} deep should hit the parse-depth guard"
@@ -1584,16 +1602,12 @@ mod tests {
         }
     }
 
-    /// The limit must not be so tight that it rejects ordinary code: nesting
-    /// an order of magnitude past test262's deepest (64 brackets) still parses
-    /// in every profile.
+    /// The limit must not be so tight that it rejects ordinary code: test262's
+    /// deepest nesting (64 brackets, ~192 units) parses in every profile.
     #[test]
     fn nesting_below_the_limit_still_parses() {
         let source = format!("{}1{}", "[".repeat(64), "]".repeat(64));
-        let src: &str = &source;
-        let parsed = crate::run_on_engine_stack(move || {
-            Parser::new(src).and_then(|mut p| p.parse_program()).is_ok()
-        });
+        let parsed = parse_on_engine_stack(&source, |result| result.is_ok());
         assert!(parsed, "64-deep array nesting should parse");
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -76,27 +76,24 @@ pub(crate) struct Parser<'a> {
 /// Maximum parser recursion depth before a catchable parse error is raised
 /// instead of letting recursive-descent recursion overflow the native stack.
 /// Sits well below the native capacity of the 128 MiB execution stack the
-/// engine runs on (see `lib.rs`). test262's deepest nesting is 64 brackets,
-/// nowhere near either limit; the release limit is comparable to V8's own
-/// (which rejects ~5000-deep nesting). One source nesting level costs more
-/// than one unit: each `[` spends 3 (assignment, exponentiation, unary).
+/// engine runs on (see `lib.rs`) and far above anything test262 contains; the
+/// release limit is comparable to V8's own (which rejects ~5000-deep nesting).
+/// One source nesting level costs more than one unit: each `[` spends 3
+/// (assignment, exponentiation, unary).
 ///
 /// Profile-aware because the resource really being bounded is stack *bytes*,
-/// and an unoptimized frame costs ~10x an optimized one. Measured by disabling
-/// the guard and binary searching the abort point over the most stack-hungry
-/// nestings (`[`, `({a:`, `({a:[`, `` `${ ``): the engine stack holds ~37,000
-/// depth units in release but only ~3,800 in debug, so each limit sits ~9x
-/// below its own profile's capacity. A single 4,000 sat *above* debug's
-/// capacity, which is why deeply nested source aborted (SIGABRT) rather than
-/// raising this error in debug builds — jsse#599.
-#[cfg(not(debug_assertions))]
-const MAX_PARSE_DEPTH: u32 = 4_000;
-/// Debug counterpart of [`MAX_PARSE_DEPTH`], ~10x lower for ~10x fatter frames.
-/// Reaching either limit costs about the same ~14 MB of stack, so both assume
-/// the engine stack — a parser driven on a smaller thread can still overflow
-/// first, in either profile.
-#[cfg(debug_assertions)]
-const MAX_PARSE_DEPTH: u32 = 400;
+/// not units. Measured by disabling the guard and binary searching the abort
+/// point over the most stack-hungry nestings (`[`, `({a:`, `({a:[`, `` `${ ``):
+/// the engine stack holds ~37,000 depth units in release but only ~3,800 in
+/// debug, and each limit is set ~9x below its own profile's capacity. A single
+/// 4,000 sat *above* debug's capacity, which is why deeply nested source
+/// aborted (SIGABRT) rather than raising this error there — jsse#599. Reaching
+/// either limit costs ~14 MB of stack, so both assume the engine stack: a
+/// parser driven on a smaller thread can still overflow first.
+///
+/// The sibling guards in `interpreter/mod.rs` are still calibrated for release
+/// frames alone — jsse#607.
+pub(crate) const MAX_PARSE_DEPTH: u32 = if cfg!(debug_assertions) { 400 } else { 4_000 };
 
 impl<'a> Parser<'a> {
     pub(crate) fn new(source: &'a str) -> Result<Self, ParseError> {
@@ -1435,14 +1432,14 @@ mod tests {
     }
 
     /// Parses `source` on the engine stack — the stack `MAX_PARSE_DEPTH` is
-    /// calibrated against — and reduces the outcome to a `bool` inside the
-    /// closure, since `Program` is not `Send` and cannot cross the boundary.
-    fn parse_on_engine_stack(
-        source: &str,
-        verdict: fn(Result<Program, ParseError>) -> bool,
-    ) -> bool {
+    /// calibrated against — discarding the `Program`, which is not `Send` and
+    /// so cannot cross the thread boundary. `ParseError` is just a `String`,
+    /// so the failure itself comes back for the caller to assert on.
+    fn parse_on_engine_stack(source: &str) -> Result<(), ParseError> {
         crate::run_on_engine_stack(move || {
-            verdict(Parser::new(source).and_then(|mut p| p.parse_program()))
+            Parser::new(source)
+                .and_then(|mut p| p.parse_program())
+                .map(|_| ())
         })
     }
 
@@ -1566,12 +1563,15 @@ mod tests {
     }
 
     /// Source nested past `MAX_PARSE_DEPTH` must raise the catchable depth
-    /// error rather than exhausting the native stack first. These are the
-    /// shapes that spend the most native stack per depth unit, so they bound
-    /// every other shape the guard covers — but only those: source that eats
-    /// native stack without advancing the counter (a long `a.b.b…` member
-    /// chain, a long left-associative `1+1+1…` chain) is outside this guard
-    /// entirely, in both profiles.
+    /// error rather than exhausting the native stack first. The first four
+    /// shapes are the stack-hungriest measured when calibrating the constant,
+    /// so they bound every other shape the guard covers — but only those:
+    /// source that eats native stack without advancing the counter (a long
+    /// `a.b.b…` member chain, a long left-associative `1+1+1…` chain) is
+    /// outside this guard entirely, in both profiles.
+    ///
+    /// `tests/recursion-limit-parser.js` covers the same shapes from JS against
+    /// a release binary; keep the two lists in step.
     ///
     /// Note this cannot fail politely: if `MAX_PARSE_DEPTH` is ever raised
     /// above what the running profile's stack holds, the process aborts
@@ -1591,13 +1591,12 @@ mod tests {
             ("spread element", "[...".repeat(reps)),
             ("block statement", "{".repeat(reps)),
         ] {
-            let hit_depth_limit = parse_on_engine_stack(
-                &source,
-                |result| matches!(result, Err(e) if e.message.contains("nested too deeply")),
-            );
+            let err = parse_on_engine_stack(&source)
+                .expect_err("deeply nested source should be rejected");
             assert!(
-                hit_depth_limit,
-                "{label} nested {reps} deep should hit the parse-depth guard"
+                err.message.contains("nested too deeply"),
+                "{label} nested {reps} deep should hit the parse-depth guard, got: {}",
+                err.message
             );
         }
     }
@@ -1607,7 +1606,9 @@ mod tests {
     #[test]
     fn nesting_below_the_limit_still_parses() {
         let source = format!("{}1{}", "[".repeat(64), "]".repeat(64));
-        let parsed = parse_on_engine_stack(&source, |result| result.is_ok());
-        assert!(parsed, "64-deep array nesting should parse");
+        assert!(
+            parse_on_engine_stack(&source).is_ok(),
+            "64-deep array nesting should parse"
+        );
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -76,9 +76,23 @@ pub(crate) struct Parser<'a> {
 /// Maximum parser recursion depth before a catchable parse error is raised
 /// instead of letting recursive-descent recursion overflow the native stack.
 /// Sits well below the native capacity of the 128 MiB execution stack the
-/// engine runs on (see `main.rs`). test262 contains no nesting near this deep,
-/// and it is comparable to V8's own limit (which rejects ~5000-deep nesting).
+/// engine runs on (see `lib.rs`). test262's deepest nesting is 64 brackets,
+/// nowhere near either limit; the release limit is comparable to V8's own
+/// (which rejects ~5000-deep nesting). One source nesting level costs more
+/// than one unit: each `[` spends 3 (assignment, exponentiation, unary).
+///
+/// Profile-aware because the resource really being bounded is stack *bytes*,
+/// and an unoptimized frame costs ~10x an optimized one. Measured by disabling
+/// the guard and binary searching the abort point over the most stack-hungry
+/// nestings (`[`, `({a:`, `({a:[`, `` `${ ``): the engine stack holds ~37,000
+/// depth units in release but only ~3,800 in debug, so each limit sits ~9x
+/// below its own profile's capacity. A single 4,000 sat *above* debug's
+/// capacity, which is why deeply nested source aborted (SIGABRT) rather than
+/// raising this error in debug builds — jsse#599.
+#[cfg(not(debug_assertions))]
 const MAX_PARSE_DEPTH: u32 = 4_000;
+#[cfg(debug_assertions)]
+const MAX_PARSE_DEPTH: u32 = 400;
 
 impl<'a> Parser<'a> {
     pub(crate) fn new(source: &'a str) -> Result<Self, ParseError> {
@@ -1533,5 +1547,53 @@ mod tests {
             &prog.body.as_slice()[0],
             Statement::ClassDeclaration(_)
         ));
+    }
+
+    /// Source nested past `MAX_PARSE_DEPTH` must raise the catchable depth
+    /// error rather than exhausting the native stack first. The shapes are the
+    /// most stack-hungry ones the parser has, so they bound every other shape.
+    ///
+    /// Note this cannot fail politely: if `MAX_PARSE_DEPTH` is ever raised
+    /// above what the running profile's stack holds, the process aborts
+    /// (SIGABRT) instead of reporting a failed assertion — jsse#599. Runs on
+    /// the engine stack because that is the stack the limit is calibrated
+    /// against; the default test-harness stack is far smaller.
+    #[test]
+    fn deep_nesting_raises_error_before_native_overflow() {
+        // Twice the limit, so even the shape advancing the counter slowest
+        // (one unit per repetition) is guaranteed to cross it.
+        let reps = MAX_PARSE_DEPTH as usize * 2;
+        for (label, source) in [
+            ("array literal", "[".repeat(reps)),
+            ("object literal", "({a:".repeat(reps)),
+            ("object/array mix", "({a:[".repeat(reps)),
+            ("template substitution", "`${".repeat(reps)),
+            ("block statement", "{".repeat(reps)),
+        ] {
+            let src: &str = &source;
+            let hit_depth_limit = crate::run_on_engine_stack(move || {
+                matches!(
+                    Parser::new(src).and_then(|mut p| p.parse_program()),
+                    Err(e) if e.message.contains("nested too deeply")
+                )
+            });
+            assert!(
+                hit_depth_limit,
+                "{label} nested {reps} deep should hit the parse-depth guard"
+            );
+        }
+    }
+
+    /// The limit must not be so tight that it rejects ordinary code: nesting
+    /// an order of magnitude past test262's deepest (64 brackets) still parses
+    /// in every profile.
+    #[test]
+    fn nesting_below_the_limit_still_parses() {
+        let source = format!("{}1{}", "[".repeat(64), "]".repeat(64));
+        let src: &str = &source;
+        let parsed = crate::run_on_engine_stack(move || {
+            Parser::new(src).and_then(|mut p| p.parse_program()).is_ok()
+        });
+        assert!(parsed, "64-deep array nesting should parse");
     }
 }

--- a/tests/recursion-limit-parser.js
+++ b/tests/recursion-limit-parser.js
@@ -63,9 +63,10 @@ mustThrow("exponentiation chain", "2" + "**2".repeat(200000));
 mustThrow("new-expression chain", "new ".repeat(200000) + "X");
 
 // The shapes above all reach the guard cheaply. These spend the most native
-// stack per unit of parse depth, so they are the ones that reach the native
-// limit first if the guard is set too high (jsse#599) — the object literal and
-// template forms cost several depth units per nesting level.
+// stack per unit of parse depth (kept in step with the same list in
+// `parser::tests::deep_nesting_raises_error_before_native_overflow`), so they
+// are the ones that reach the native limit first if the guard is set too high
+// (jsse#599) — object literal and template forms cost several units per level.
 mustThrow("object literal nesting", "({a:".repeat(50000));
 mustThrow("object/array mix", "({a:[".repeat(50000));
 mustThrow("template substitution nesting", "`${".repeat(50000));

--- a/tests/recursion-limit-parser.js
+++ b/tests/recursion-limit-parser.js
@@ -24,7 +24,9 @@ if (!(err instanceof SyntaxError)) {
 }
 
 // Reasonable nesting must still parse AND evaluate — the limit must not reject
-// ordinary (if deep) code.
+// ordinary (if deep) code. This depth assumes the release limit, which is what
+// the custom-test runner uses; a debug build's MAX_PARSE_DEPTH is ~10x lower
+// because its stack frames are that much larger (jsse#599).
 var arr = eval(nestedArray(1000));
 if (!Array.isArray(arr)) {
   throw new Error("moderately nested array literal should parse and evaluate");
@@ -59,3 +61,12 @@ mustThrow("prefix unary chain", "!".repeat(200000) + "0");
 mustThrow("unary minus chain", "- ".repeat(200000) + "0");
 mustThrow("exponentiation chain", "2" + "**2".repeat(200000));
 mustThrow("new-expression chain", "new ".repeat(200000) + "X");
+
+// The shapes above all reach the guard cheaply. These spend the most native
+// stack per unit of parse depth, so they are the ones that reach the native
+// limit first if the guard is set too high (jsse#599) — the object literal and
+// template forms cost several depth units per nesting level.
+mustThrow("object literal nesting", "({a:".repeat(50000));
+mustThrow("object/array mix", "({a:[".repeat(50000));
+mustThrow("template substitution nesting", "`${".repeat(50000));
+mustThrow("spread nesting", "[...".repeat(50000));


### PR DESCRIPTION
## Summary

`MAX_PARSE_DEPTH` bounds recursive-descent depth in *units*, but the resource it
actually protects is native stack *bytes* — and an unoptimized frame costs ~10x
an optimized one. The single 4,000 limit was calibrated for release frames, so
on a debug build deeply nested source exhausted the 128 MiB engine stack
(SIGABRT) before the guard could raise its catchable error.

- Split the constant per profile: **4,000 release (unchanged), 400 debug**.
- Un-ignores the two deep-nesting tests in `src/lib.rs` that #598 had to gate off
  in debug, plus a new profile-agnostic parser regression test and the
  worst-case shapes in `tests/recursion-limit-parser.js`.

Fixes #599

## Calibration

Measured on the 128 MiB engine stack by disabling the guard and binary searching
the abort point over the shapes that spend the most native stack per depth unit
(`[`, `({a:`, `({a:[`, `` `${ ``, `[{a:`):

| profile | native capacity | limit | margin |
|---------|-----------------|-------|--------|
| release | ~37,000 units   | 4,000 | 9.3x   |
| debug   | ~3,800 units    | 400   | 9.4x   |

Worst shape was `[{a:` at 3,768 units in debug — i.e. debug capacity sat *below*
the old 4,000 limit, so the guard could never fire there. Each profile now sits
~9x below its own capacity.

For scale: test262's deepest nesting across all 53,690 files is 64 brackets
(~192 units), so neither limit is near real code. Note one source nesting level
costs more than one unit (each `[` spends 3).

## Notes

- **Release behaviour is unchanged.** Re-measured the guard threshold for 13
  nesting shapes against the pre-change binary — identical in every case, as
  expected since the `not(debug_assertions)` arm is still 4,000.
- The issue describes debug `cargo test` as the CI gate; CI actually runs
  `cargo nextest run --release` (`ci.yml:56`), so the `ignore` attributes were
  only suppressing *local* debug runs. Those now pass.
- `cargo-fuzz` builds are optimized *with* `debug_assertions`, so
  `parse_roundtrip` picks up the 400 limit — the conservative direction, and a
  parse error is already an expected outcome for that target. `differential`
  shells out to `target/release/jsse`, so the node cross-check is unaffected.
- **Out of scope, but found while verifying:** the interpreter's guards
  (`CALL_DEPTH_*`, `EVAL_DEPTH_LIMIT`) have the same miscalibration —
  `tests/recursion-limit-interpreter.js` and a deep left-nested expression both
  SIGABRT on a debug build today while passing in release. Filed separately.

## Test plan

- [x] `cargo test` (debug) — 647 passed, 0 failed; the two previously-ignored tests now run
- [x] `cargo test --release` — 647 passed, 0 failed (`cargo nextest` not installed locally)
- [x] `./scripts/lint.sh` — clean (fmt + clippy + clippy --features perf-counters)
- [x] `run-custom-tests.py` — 11/11
- [x] test262 — 99,568/99,568 (100%), **0 regressions**
- [x] test262-extra — 308/308 default and `--bytecode`, 0 regressions
- [x] 21 nesting shapes verified to raise the catchable error (never SIGABRT) on the debug binary