### PR TITLE
refactor(iterators): extract with_array_elements/_mut, retire 9 borrow preambles

### DIFF
--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -2675,12 +2675,9 @@ impl Interpreter {
                             Ok(Some(value)) => {
                                 let values = interp.with_array_elements_mut(&buffer, |elements| {
                                     elements.push(value);
-                                    (elements.len() == chunk_size).then(|| elements.clone())
+                                    (elements.len() == chunk_size).then(|| std::mem::take(elements))
                                 });
                                 if let Some(values) = values {
-                                    interp.with_array_elements_mut(&buffer, |elements| {
-                                        elements.clear()
-                                    });
                                     let chunk = interp.create_array(values);
                                     return Completion::Normal(
                                         interp.create_iter_result_object(chunk, false),
@@ -2689,15 +2686,13 @@ impl Interpreter {
                             }
                             Ok(None) => {
                                 state_next.borrow_mut().3 = false;
-                                let values = interp
-                                    .with_array_elements(&buffer, |elements| elements.clone());
+                                let values =
+                                    interp.with_array_elements_mut(&buffer, std::mem::take);
                                 if values.is_empty() {
                                     return Completion::Normal(
                                         interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     );
                                 }
-                                interp
-                                    .with_array_elements_mut(&buffer, |elements| elements.clear());
                                 let chunk = interp.create_array(values);
                                 return Completion::Normal(
                                     interp.create_iter_result_object(chunk, false),

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -369,31 +369,17 @@ impl RootedPair {
         self.0.clone()
     }
 
-    fn slots<'a>(&self, interp: &'a Interpreter) -> &'a ObjectHandle {
-        interp.get_object_cell_expect(
-            self.0
-                .as_object_id()
-                .expect("rooted pair must be an Array object"),
-        )
-    }
-
     fn get(&self, interp: &Interpreter) -> Option<(JsValue, JsValue)> {
-        let cell = self.slots(interp);
-        let obj = cell.borrow();
-        let elements = obj
-            .array_elements()
-            .expect("rooted pair must have Array elements");
-        (!elements[0].is_undefined()).then(|| (elements[0].clone(), elements[1].clone()))
+        interp.with_array_elements(&self.0, |elements| {
+            (!elements[0].is_undefined()).then(|| (elements[0].clone(), elements[1].clone()))
+        })
     }
 
     fn set(&self, interp: &Interpreter, iterator: JsValue, next_method: JsValue) {
-        let cell = self.slots(interp);
-        let mut obj = cell.borrow_mut();
-        let elements = obj
-            .array_elements_mut()
-            .expect("rooted pair must have Array elements");
-        elements[0] = iterator;
-        elements[1] = next_method;
+        interp.with_array_elements_mut(&self.0, |elements| {
+            elements[0] = iterator;
+            elements[1] = next_method;
+        });
     }
 
     fn clear(&self, interp: &Interpreter) {
@@ -2687,25 +2673,14 @@ impl Interpreter {
                     loop {
                         match iterator_step_value_getter(interp, &iter, &next_method) {
                             Ok(Some(value)) => {
-                                let buffer_id = buffer
-                                    .as_object_id()
-                                    .expect("chunks buffer must be an Array object");
-                                let values = {
-                                    let cell = interp.get_object_cell_expect(buffer_id);
-                                    let mut obj = cell.borrow_mut();
-                                    let elements = obj
-                                        .array_elements_mut()
-                                        .expect("chunks buffer must have Array elements");
+                                let values = interp.with_array_elements_mut(&buffer, |elements| {
                                     elements.push(value);
                                     (elements.len() == chunk_size).then(|| elements.clone())
-                                };
+                                });
                                 if let Some(values) = values {
-                                    interp
-                                        .get_object_cell_expect(buffer_id)
-                                        .borrow_mut()
-                                        .array_elements_mut()
-                                        .expect("chunks buffer must have Array elements")
-                                        .clear();
+                                    interp.with_array_elements_mut(&buffer, |elements| {
+                                        elements.clear()
+                                    });
                                     let chunk = interp.create_array(values);
                                     return Completion::Normal(
                                         interp.create_iter_result_object(chunk, false),
@@ -2714,27 +2689,15 @@ impl Interpreter {
                             }
                             Ok(None) => {
                                 state_next.borrow_mut().3 = false;
-                                let buffer_id = buffer
-                                    .as_object_id()
-                                    .expect("chunks buffer must be an Array object");
-                                let values = {
-                                    let cell = interp.get_object_cell_expect(buffer_id);
-                                    cell.borrow()
-                                        .array_elements()
-                                        .expect("chunks buffer must have Array elements")
-                                        .clone()
-                                };
+                                let values = interp
+                                    .with_array_elements(&buffer, |elements| elements.clone());
                                 if values.is_empty() {
                                     return Completion::Normal(
                                         interp.create_iter_result_object(JsValue::UNDEFINED, true),
                                     );
                                 }
                                 interp
-                                    .get_object_cell_expect(buffer_id)
-                                    .borrow_mut()
-                                    .array_elements_mut()
-                                    .expect("chunks buffer must have Array elements")
-                                    .clear();
+                                    .with_array_elements_mut(&buffer, |elements| elements.clear());
                                 let chunk = interp.create_array(values);
                                 return Completion::Normal(
                                     interp.create_iter_result_object(chunk, false),
@@ -2844,21 +2807,13 @@ impl Interpreter {
                     loop {
                         match iterator_step_value_getter(interp, &iter, &next_method) {
                             Ok(Some(value)) => {
-                                let buffer_id = buffer
-                                    .as_object_id()
-                                    .expect("windows buffer must be an Array object");
-                                let values = {
-                                    let cell = interp.get_object_cell_expect(buffer_id);
-                                    let mut obj = cell.borrow_mut();
-                                    let elements = obj
-                                        .array_elements_mut()
-                                        .expect("windows buffer must have Array elements");
+                                let values = interp.with_array_elements_mut(&buffer, |elements| {
                                     if elements.len() == window_size {
                                         elements.remove(0);
                                     }
                                     elements.push(value);
                                     (elements.len() == window_size).then(|| elements.clone())
-                                };
+                                });
                                 if let Some(values) = values {
                                     let window = interp.create_array(values);
                                     return Completion::Normal(
@@ -2868,16 +2823,8 @@ impl Interpreter {
                             }
                             Ok(None) => {
                                 state_next.borrow_mut().3 = false;
-                                let buffer_id = buffer
-                                    .as_object_id()
-                                    .expect("windows buffer must be an Array object");
-                                let values = {
-                                    let cell = interp.get_object_cell_expect(buffer_id);
-                                    cell.borrow()
-                                        .array_elements()
-                                        .expect("windows buffer must have Array elements")
-                                        .clone()
-                                };
+                                let values = interp
+                                    .with_array_elements(&buffer, |elements| elements.clone());
                                 if allow_partial && !values.is_empty() && values.len() < window_size
                                 {
                                     let window = interp.create_array(values);

--- a/src/interpreter/builtins/iterators.rs
+++ b/src/interpreter/builtins/iterators.rs
@@ -2818,8 +2818,8 @@ impl Interpreter {
                             }
                             Ok(None) => {
                                 state_next.borrow_mut().3 = false;
-                                let values = interp
-                                    .with_array_elements(&buffer, |elements| elements.clone());
+                                let values =
+                                    interp.with_array_elements_mut(&buffer, std::mem::take);
                                 if allow_partial && !values.is_empty() && values.len() < window_size
                                 {
                                     let window = interp.create_array(values);

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1974,6 +1974,42 @@ impl Interpreter {
         self.objects.get_cell_expect(id)
     }
 
+    /// Borrow `array`'s element vector immutably for the duration of `f`.
+    /// Panics if `array` is not an engine-allocated Array object.
+    pub(crate) fn with_array_elements<R>(
+        &self,
+        array: &JsValue,
+        f: impl FnOnce(&Vec<JsValue>) -> R,
+    ) -> R {
+        let id = array
+            .as_object_id()
+            .expect("with_array_elements: value must be an Array object");
+        let obj = self.get_object_cell_expect(id).borrow();
+        let elements = obj
+            .array_elements()
+            .expect("with_array_elements: object must have Array elements");
+        f(elements)
+    }
+
+    /// Borrow `array`'s element vector mutably for the duration of `f`, going
+    /// through `ObjectHandle::borrow_mut` so the generational write barrier
+    /// still runs.
+    /// Panics if `array` is not an engine-allocated Array object.
+    pub(crate) fn with_array_elements_mut<R>(
+        &self,
+        array: &JsValue,
+        f: impl FnOnce(&mut Vec<JsValue>) -> R,
+    ) -> R {
+        let id = array
+            .as_object_id()
+            .expect("with_array_elements_mut: value must be an Array object");
+        let mut obj = self.get_object_cell_expect(id).borrow_mut();
+        let elements = obj
+            .array_elements_mut()
+            .expect("with_array_elements_mut: object must have Array elements");
+        f(elements)
+    }
+
     pub(crate) fn set_function_name<K: PropertyKeyLike + ?Sized>(&self, val: &JsValue, name: &K) {
         if let Some(o) = (val).as_object_id().map(|id| crate::types::JsObject { id })
             && let Some(obj) = self.get_object_cell(o.id)


### PR DESCRIPTION
## Summary

- Add `Interpreter::with_array_elements` / `with_array_elements_mut` next to `get_object_cell_expect`, consolidating the `as_object_id -> get_object_cell_expect -> borrow(_mut) -> array_elements(_mut)` chain into a single call.
- Convert all 9 hand-written borrow preambles in `iterators.rs` to use the new helpers: 4 in `chunks()`, 2 in `windows()`, and `RootedPair::get`/`set` (its `slots()` helper is now unneeded and removed).
- `_mut` still goes through `ObjectHandle::borrow_mut()`, so the generational write barrier is unaffected; the `RefMut`/`Ref` never escapes the closure.

Fixes #610

## Test plan

- [x] `cargo build --release` — clean
- [x] `./scripts/lint.sh` — clean (rustfmt, clippy, clippy perf-counters)
- [x] `uv run python scripts/run-custom-tests.py` — 11/11 passing
- [x] `uv run python scripts/run-test262.py test262/test/built-ins/Iterator/ test262/test/staging/sm/Iterator` — 1656/1656 passing, 0 regressions
- [x] `uv run python scripts/run-test262.py` (full suite) — 99907/99907 passing, 0 regressions