### PR TITLE
refactor(interpreter): extract propagate! + IntoAbrupt completion-propagation seam

### DIFF
--- a/.architecture/backlog.md
+++ b/.architecture/backlog.md
@@ -67,7 +67,8 @@ Never delete rows; they are the memory that stops re-surfacing the same work.
 
 ## completion-unwrap-macro
 
-- **Status**: proposed
+- **Status**: in-flight
+- **PR**: #623
 - **Score**: 23/25 (leverage 5, locality 3, blast radius 1, heat 5)
 - **Files (this firing's scope)**: ~3 estimated — hoist macros out of `src/interpreter/builtins/temporal/duration.rs:9-25` into a crate-visible home in `src/interpreter/types.rs`, re-point `duration.rs`, adopt one representative file (`array.rs`/`string.rs`/`typedarray.rs` — chosen at step 5 from the shape-3 concentrations).
 - **Modules**: `src/interpreter/types.rs`, `src/interpreter/builtins/temporal/duration.rs`

--- a/.architecture/backlog.md
+++ b/.architecture/backlog.md
@@ -7,8 +7,8 @@ Never delete rows; they are the memory that stops re-surfacing the same work.
 
 ## gc-root-scope-guard
 
-- **Status**: in-flight
-- **PR**: #595
+- **Status**: landed
+- **PR**: #595 (merged 2026-09-04; reconciled in-flight→landed by the 2026-09-10 firing)
 - **Score**: 22/25 (leverage 5, locality 4, blast radius 3, heat 5)
 - **Files (full candidate)**: ~9–12 — `src/interpreter/eval.rs` (primary), `src/interpreter/builtins/array.rs`, `src/interpreter/mod.rs` (seam home), + `iterators.rs`, `promise.rs`, `exec.rs`, `atomics.rs`, `typedarray.rs`, `property.rs`, `eval/literals.rs`, `bytecode/vm.rs`
 - **Files (this firing's scope)**: ~2 estimated — `src/interpreter/mod.rs` (new `with_gc_root_scope` seam) + `src/interpreter/builtins/array.rs`
@@ -68,10 +68,11 @@ Never delete rows; they are the memory that stops re-surfacing the same work.
 ## completion-unwrap-macro
 
 - **Status**: proposed
-- **Score**: 21/25 (leverage 4, locality 3, blast radius 1, heat 5)
-- **Files**: ~2 estimated — `src/interpreter/types.rs`, `src/interpreter/builtins/typedarray.rs`
-- **Modules**: `src/interpreter/types.rs`
-- **Summary**: A `try_completion!(expr)` macro that binds a `Completion::Normal` value and propagates any abrupt Completion, for the Completion-returning natives (typedarray 27, builtins/mod 22, eval 11, string 11, …). Distinct from `completion-into-result` (Result vs Completion return context). Scope the first step to one adopter to stay blast-radius 1. First seen 2026-09-02.
+- **Score**: 23/25 (leverage 5, locality 3, blast radius 1, heat 5)
+- **Files (this firing's scope)**: ~3 estimated — hoist macros out of `src/interpreter/builtins/temporal/duration.rs:9-25` into a crate-visible home in `src/interpreter/types.rs`, re-point `duration.rs`, adopt one representative file (`array.rs`/`string.rs`/`typedarray.rs` — chosen at step 5 from the shape-3 concentrations).
+- **Modules**: `src/interpreter/types.rs`, `src/interpreter/builtins/temporal/duration.rs`
+- **Summary**: Promote the private error-propagation macros to a crate-visible seam. **2026-09-10 re-score (leverage 4→5): fresh scan found `try_completion!` AND a sibling `try_result!` already exist but are `macro_rules!`-private to `temporal/duration.rs:9-25`, and the true footprint is ~1725 hand-rolled adapter sites** (911 `Result<_,JsValue>`→`Completion::Throw`, 598 `Result<_,Completion>`→`return c`, 216 `Completion`→bind-`Normal`) — not the ~200 last estimated. Hoist both macros to a shared home (drop `try_result!`'s vestigial unused `$interp` param), add the missing `Result<T,Completion>` arm, re-point `duration.rs`, adopt one file to prove the seam and pin behaviour. Distinct from `completion-into-result` (Result-return context, a method) and `throw-error-completion` (throw-site wrapper). Scope the first step to one adopter to stay blast-radius 1. First seen 2026-09-02.
+- **Picked**: 2026-09-10 firing (re-scored 23/25, above runner-up `gc-root-scope-guard-eval` 22/25 by 1 point on the inverted blast-radius term). Branch adopted (`sym/jsse/routine/refactor-audit/01M25W97CF`), not renamed.
 
 ## settle-and-return-tail
 
@@ -202,3 +203,49 @@ Never delete rows; they are the memory that stops re-surfacing the same work.
 - **Summary**: `generator_next_state_machine_impl` and `async_generator_next_state_machine_impl` are largely parallel ~1580/~3050-line state-machine interpreters. Unifying them is a deep structural refactor for a human to schedule.
 - **First seen**: 2026-09-01
 - **Reason**: Blast radius 5 — human-scheduled. Land the generator-constructor and settle-tail candidates first to shrink both drivers.
+
+## throw-error-completion
+
+- **Status**: proposed
+- **Score**: 18/25 (leverage 3, locality 2, blast radius 1, heat 5)
+- **Files**: ~1 estimated (one adopter file first) — all `builtins/*`; representative `src/interpreter/builtins/typedarray.rs:1426`.
+- **Modules**: `src/interpreter/mod.rs` (seam home), `src/interpreter/builtins/typedarray.rs`
+- **Summary**: `interp.throw_type_error(msg) -> Completion` / `throw_range_error` helpers collapsing the 535 `return Completion::Throw(interp.create_type_error(...))` sites (287 type, 248 range, 5 reference) that each re-spell the constructor lookup + `Completion::Throw` wrapper. Thinner than `completion-unwrap-macro` (hides one wrapper token) but large. First seen 2026-09-10.
+
+## array-typedarray-immutable-methods
+
+- **Status**: proposed
+- **Score**: 17/25 (leverage 3, locality 3, blast radius 2, heat 4)
+- **Files**: ~2 estimated — `src/interpreter/builtins/array.rs:1652/2535/2908`, `src/interpreter/builtins/typedarray.rs:2258/2315`.
+- **Modules**: `src/interpreter/builtins/array.rs`, `src/interpreter/builtins/typedarray.rs`
+- **Summary**: Two parallel implementations of `toReversed`/`toSorted`/`with` (Array vs TypedArray) that risk drifting. A shared core with thin per-kind adapters. Small (~3 method pairs) but the "parallel implementations drift" pattern the scan watches for. First seen 2026-09-10.
+
+## arg-or-undefined
+
+- **Status**: dropped
+- **Score**: n/a (leverage 2 — shallow DRY helper)
+- **Files**: ubiquitous across `builtins/*`; representative `typedarray.rs:1394`.
+- **Modules**: `src/interpreter/builtins/mod.rs`
+- **Summary**: `fn arg(args, n) -> JsValue` collapsing 943 `args.get(n).cloned().unwrap_or(JsValue::UNDEFINED)` chains (627 `.first()`, 316 `.get(N)`).
+- **First seen**: 2026-09-10
+- **Reason**: Leverage 2 — the largest raw site count in the tree, but a helper whose interface equals its implementation (shallow by definition). Pure DRY + naming, not a deep module; `/simplify`-class, same bar as `object-id-of`.
+
+## define-method-adoption
+
+- **Status**: dropped
+- **Score**: n/a (leverage 2 — finishing an existing migration)
+- **Files**: ~200–260 sites — `typedarray.rs`, `iterators.rs`, `promise.rs`, `regexp.rs`, `mod.rs`.
+- **Modules**: `src/interpreter/mod.rs`
+- **Summary**: The `define_method` seam already exists (`mod.rs:1819`, 258 adopters) but ~200 sites still register the verbose `create_function(...)` + `insert_builtin` way.
+- **First seen**: 2026-09-10
+- **Reason**: Leverage 2 — the deep seam already exists; migrating stragglers is `/simplify`-class finishing work, same reasoning as `define-accessor-adoption`.
+
+## proxy-trap-skeleton
+
+- **Status**: dropped
+- **Score**: n/a (leverage 2 — thin, deep part already factored)
+- **Files**: ~13 sites — `src/interpreter/property.rs` (`proxy_is_extensible:2016`, `proxy_prevent_extensions:2050`, …).
+- **Modules**: `src/interpreter/property.rs`
+- **Summary**: The `if proxy { trap-or-recurse } else { ordinary }` skeleton repeats across ~13 trap wrappers.
+- **First seen**: 2026-09-10
+- **Reason**: Leverage 2 — the deep part (`invoke_proxy_trap`) is already factored, and the per-trap middle validation genuinely differs, so only a thin skeleton would collapse.

--- a/.architecture/reviews/2026-09-10-completion-unwrap-macro.md
+++ b/.architecture/reviews/2026-09-10-completion-unwrap-macro.md
@@ -1,7 +1,7 @@
 # Architecture review — jsse — 2026-09-10
 
 **Scope**: `src/interpreter/` and `src/interpreter/builtins/` — the interpreter hot spots that dominate recent history and that every prior deepening firing has drawn from. A fresh sub-agent scan was run against these files, and the persistent `.architecture/backlog.md` was reconciled against `gh` first.
-**Picked**: `completion-unwrap-macro` — see [PR to be opened] and `.architecture/backlog.md`. Branch was **adopted** (the firing's `sym/jsse/routine/refactor-audit/01M25W97CF`, which met all four adoption conditions: non-default, 0 commits ahead of `origin/main`, no upstream, unpublished on origin), so it is **not** renamed to `pm-deepen/<slug>`; the slug lives here and in the backlog.
+**Picked**: `completion-unwrap-macro` — see [PR #623](https://github.com/pmatos/jsse/pull/623) and `.architecture/backlog.md`. Branch was **adopted** (the firing's `sym/jsse/routine/refactor-audit/01M25W97CF`, which met all four adoption conditions: non-default, 0 commits ahead of `origin/main`, no upstream, unpublished on origin), so it is **not** renamed to `pm-deepen/<slug>`; the slug lives here and in the backlog.
 **Degradations**: none. `gh` authenticated; sub-agent available; advisor available.
 
 **Diagram convention**: solid edges are the interface (what a caller wires up); dashed edges are inside the implementation (hidden behind the seam).

--- a/.architecture/reviews/2026-09-10-completion-unwrap-macro.md
+++ b/.architecture/reviews/2026-09-10-completion-unwrap-macro.md
@@ -164,3 +164,9 @@ Deepest conceivable interface (the `?` operator, zero import), but requires `#![
 ### Proposed ADR (carried to the PR body)
 
 > **Completion propagation is a crate-local `IntoAbrupt` + `propagate!` seam, not `impl Try for Completion`.** Making `?` work on `Completion` (`try_trait_v2`) is the deepest interface but requires nightly on the shipped binary. Adopt the trait+macro seam on stable now; revisit native `?` only if `try_trait_v2` stabilises or the crate moves to nightly. The `IntoAbrupt` impls are deliberately shaped as the `FromResidual` impls that migration would need.
+
+### Delivered
+
+`IntoAbrupt` trait + three impls + `propagate!` macro added beside `Completion` in `src/interpreter/types.rs` (crate-visible via `macro_rules!` + `pub(crate) use`, re-exported through `pub(crate) use types::*`). The two private macros were deleted from `temporal/duration.rs` and its 4 call sites re-pointed (shapes 1 & 2). Adopted **13 real sites in `string.rs` cross-module** — 5 shape-2 (`Result<_, JsValue>` → `Throw`) and 8 shape-3 (the `this_js_string` receiver prologue, `Result<_, Completion>`) — so all three `IntoAbrupt` impls have production callers. Pinned by `propagate_macro_covers_three_shapes_and_empty` in `tests.rs` (all three shapes + the non-abrupt `Empty` quirk). Broad adoption of the remaining ~1700 sites (array.rs 124 / typedarray.rs 46 / collections.rs 32 shape-3 alone) is left to follow-up firings.
+
+Net: 5 files, +136/−74. Gate green — 670 unit + full `cargo test` (incl. `test262_smoke_oracle`); test262 built-ins/String 2443, Temporal/Duration 1080, intl402/String 38, annexB/String 222 (0 regressions); 11 custom; clippy + fmt clean. CONTEXT.md gains a **Completion Propagation** term.

--- a/.architecture/reviews/2026-09-10-completion-unwrap-macro.md
+++ b/.architecture/reviews/2026-09-10-completion-unwrap-macro.md
@@ -110,4 +110,57 @@ Older drops (`object-id-of`, `proxy-blind-callable-check`, `define-accessor-adop
 
 ## Design
 
-Written at step 4 (design-it-twice + advisor adjudication); this file is amended and re-committed after the design pass.
+Three interfaces were designed in parallel (design-it-twice, 3 sub-agents) and adjudicated by the advisor against the fixed criteria (depth → locality → seam placement → test surface → blast radius). **Winner: Design B.**
+
+**Decisive toolchain fact** (verified this firing): the crate builds on **stable rustc 1.98.0, edition 2024, zero `#![feature]` attributes**; `ci.yml`/`release.yml` pin `stable`. CLAUDE.md's "nightly features (`let_chains`)" line is **stale** — `let_chains` is stable under edition 2024 — but it is not edited here (out of scope; flagged in the PR body). This fact disqualifies Design C.
+
+### Design A (runner-up) — three named macros
+
+Hoist the two existing private macros out of `temporal/duration.rs`, drop `try_result!`'s vestigial `$interp`, rename it `try_throw!`, and add `try_abrupt!` for shape 3. Interface = three intent-named macros.
+
+- **Interface**: `try_completion!(e)` (Completion → bind `Normal`, `return` any other), `try_throw!(e)` (`Result<_,JsValue>` → bind `Ok`, `return Completion::Throw(err)`), `try_abrupt!(e)` (`Result<_,Completion>` → bind `Ok`, `return err`). Crate-visible via `macro_rules!` + `pub(crate) use`.
+- **Strengths**: highest call-site auditability (the name states Throw-wrap vs pass-through); zero trait-resolution inference cost; uniquely faithful to the existing in-repo pattern; correct on the `Empty`-propagation quirk.
+- **Why it lost**: shallowest plausible design — three near-identical expansions, and the caller must pick a name that duplicates a distinction the compiler already owns (the operand's error type). Self-scored depth 2.
+
+### Design B (winner) — one `propagate!` macro + `IntoAbrupt` trait
+
+A single macro backed by a conversion trait implemented for all three source shapes, so one interface token handles every propagation site.
+
+```rust
+pub(crate) trait IntoAbrupt {
+    type Ok;
+    fn into_abrupt(self) -> Result<Self::Ok, Completion>;
+}
+impl IntoAbrupt for Completion { type Ok = JsValue;
+    fn into_abrupt(self) -> Result<JsValue, Completion> {
+        match self { Completion::Normal(v) => Ok(v), other => Err(other) } } }  // Empty still propagates
+impl<T> IntoAbrupt for Result<T, JsValue> { type Ok = T;
+    fn into_abrupt(self) -> Result<T, Completion> { self.map_err(Completion::Throw) } }
+impl<T> IntoAbrupt for Result<T, Completion> { type Ok = T;
+    fn into_abrupt(self) -> Result<T, Completion> { self } }
+macro_rules! propagate {
+    ($expr:expr) => {
+        match $crate::interpreter::IntoAbrupt::into_abrupt($expr) {  // via `pub(crate) use types::*` re-export (types mod is private)
+            Ok(v) => v, Err(c) => return c,
+        }
+    };
+}
+pub(crate) use propagate;
+```
+
+- **Depth (criterion 1, B wins)**: one token hides all three propagation policies; the correct behaviour at a propagation site is fully determined by the callee's signature, so a policy-naming macro (A) is redundant with information the reader already sees. B also makes the wrong code hard to write — you cannot forget the `Throw` wrap or mishandle `Empty`.
+- **Locality (2, B slightly)**: one `impl` per shape is the sole edit point; a fourth source shape is one new impl, zero call-site churn.
+- **Seam placement (3, B)**: `IntoAbrupt` with three adapters on the real variation axis (source shape → abrupt completion) is a textbook real seam ("two adapters = real").
+- **Test surface (4, tie)**: exercisable through the interface from a `#[cfg(test)]` module — the `Empty`-passes-through, `Err→Throw`, and `Err→pass-through` cases all pinned without reaching past the seam.
+- **Blast radius (5, tie)**: 1 — seam in `types.rs`, re-point `duration.rs`, one real adopter; net-negative diff, no published interface.
+- **Honest debts (carried to the PR body)**: (a) call-site auditability — `propagate!(x)` hides Throw-vs-pass-through, so a hostile audit must consult the impl (A's strength); (b) trait-resolution inference — a site whose callee has an unconstrained error type needs a type annotation; the firing's adopter deliberately skips such sites to keep the diff mechanical.
+
+**Why B beat the runner-up design (A)**: B leads criteria 1–3 and ties 4–5; nothing A wins on ranks above a criterion B wins on. Depth is criterion 1, and it is exactly what the deepening exercise optimises for; A's advantages (auditability, zero inference cost) rank below it. Bonus: the three `IntoAbrupt` impls are precisely the `FromResidual` impls a future `impl Try for Completion` would need, so B is a stepping-stone to native `?` if the toolchain ever allows it.
+
+### Design C (disqualified) — `impl Try for Completion` (native `?`)
+
+Deepest conceivable interface (the `?` operator, zero import), but requires `#![feature(try_trait_v2)]`, which needs **nightly** and would force the shipped release binary onto nightly — `release.yml` pins stable. Disqualified on viability, not preference. Surfaced as the Proposed ADR below.
+
+### Proposed ADR (carried to the PR body)
+
+> **Completion propagation is a crate-local `IntoAbrupt` + `propagate!` seam, not `impl Try for Completion`.** Making `?` work on `Completion` (`try_trait_v2`) is the deepest interface but requires nightly on the shipped binary. Adopt the trait+macro seam on stable now; revisit native `?` only if `try_trait_v2` stabilises or the crate moves to nightly. The `IntoAbrupt` impls are deliberately shaped as the `FromResidual` impls that migration would need.

--- a/.architecture/reviews/2026-09-10-completion-unwrap-macro.md
+++ b/.architecture/reviews/2026-09-10-completion-unwrap-macro.md
@@ -1,0 +1,113 @@
+# Architecture review — jsse — 2026-09-10
+
+**Scope**: `src/interpreter/` and `src/interpreter/builtins/` — the interpreter hot spots that dominate recent history and that every prior deepening firing has drawn from. A fresh sub-agent scan was run against these files, and the persistent `.architecture/backlog.md` was reconciled against `gh` first.
+**Picked**: `completion-unwrap-macro` — see [PR to be opened] and `.architecture/backlog.md`. Branch was **adopted** (the firing's `sym/jsse/routine/refactor-audit/01M25W97CF`, which met all four adoption conditions: non-default, 0 commits ahead of `origin/main`, no upstream, unpublished on origin), so it is **not** renamed to `pm-deepen/<slug>`; the slug lives here and in the backlog.
+**Degradations**: none. `gh` authenticated; sub-agent available; advisor available.
+
+**Diagram convention**: solid edges are the interface (what a caller wires up); dashed edges are inside the implementation (hidden behind the seam).
+
+## Reconciliation summary
+
+- `gc-root-scope-guard` → **landed** (PR #595 merged 2026-09-04). Was the last `in-flight` entry; no open architecture PR now blocks implementation.
+- All `dropped` filters re-checked (ranking step 2.4) and still apply — none reopened.
+- Fresh scan surfaced one seam (`try_completion!` / `try_result!`) that **already exists** but is trapped private in `temporal/duration.rs`, which materially enriches the backlog's `completion-unwrap-macro` candidate and is the reason it re-scores above `gc-root-scope-guard-eval` this firing.
+
+## Candidates
+
+### completion-unwrap-macro — promote the private error-propagation macros to a crate-visible seam  ·  Strong  ·  score 23/25
+
+- **Files**: seam home `src/interpreter/builtins/temporal/duration.rs:9-25` (the two macros to hoist), destination near `Completion` in `src/interpreter/types.rs`, plus one representative adopter file (chosen at step 5 from the shape-3 concentrations: `array.rs` 124 sites / `string.rs` 67 / `typedarray.rs` 46). **File-count estimate: 3** — seam definition + re-point `duration.rs` + one adopter.
+- **Score 23/25**:
+  - **Leverage 5** — the seam pays back across ~1725 hand-rolled propagation adapters tree-wide (911 `Result<_,JsValue>`→`Completion::Throw`, 598 `Result<_,Completion>`→`return c`, 216 `Completion`→bind-`Normal`) and removes a whole class of two-line match heads. Parity with the leverage-5 the just-landed `gc-root-scope-guard` earned for collapsing ~50–70 teardown epilogues; this collapses far more of the same shape of boilerplate, and the seam is already proven in-repo.
+  - **Locality 3** — the propagation direction (which error type, which return conversion) concentrates in the macro definition; adoption itself is mechanical DRY, so change concentrates but bugs do not dramatically.
+  - **Blast radius 1** — this firing touches ~3 files, no published interface (macros are `pub(crate)`), net-negative lines. Broad adoption is deliberately deferred, exactly as `gc-root-scope-guard` scoped to `array.rs` before `gc-root-scope-guard-eval`.
+  - **Heat 5** — `builtins/*` and `types.rs` are the hottest files in the tree.
+- **Problem** — the same three error-unwrap dances are re-spelled 1725 times because the two macros that already solve two of them are `macro_rules!` defined at the top of one Temporal file and invisible everywhere else. This is a *shallow* situation twice over: the propagation logic has no shared interface (every call site re-derives the direction), and where a seam *does* exist it cannot be reached. A reader must re-read a two-line match to learn "this just propagates the error".
+- **Deletion test** — deleting the private macros today would re-scatter ~50 duration.rs match blocks back inline: complexity moves, does not concentrate. Deleting the *hoisted* seam would re-scatter propagation across all adopters: it concentrates. The hoisted seam passes; the trapped one fails — which is precisely the deepening.
+- **Solution** — move `try_completion!` and `try_result!` out of `duration.rs` into a crate-visible home beside `Completion` (via `macro_rules!` + `pub(crate) use`, the `kind_accessor` convention already in `types.rs`); drop `try_result!`'s vestigial unused `$interp` parameter; add the missing third arm for `Result<T, Completion>` → bind `Ok`, `return` the `Err` completion. Re-point `duration.rs` to the shared macros and adopt them in one representative file to prove the seam and pin behaviour.
+- **Benefits** — **leverage**: one seam now reachable from every builtins/core file, ready for follow-up adoption firings across 1725 sites. **locality**: the propagation contract lives in one definition instead of being re-derived per call. **test surface**: the macro's behaviour (bind normal / propagate abrupt / wrap-or-return) is exercised through a real adopter and pinned by test262-family delta = 0 plus a unit test invoking the macros from outside `duration.rs` — impossible today, since they are file-private.
+
+```mermaid
+graph LR
+  D[duration.rs callers] --> Mp["try_completion! / try_result!<br/>(private to duration.rs)"]
+  A[array.rs sites] --> Ia["inline match{Ok/Err}"]
+  S[string.rs sites] --> Is["inline match{Normal/other}"]
+  T[typedarray.rs sites] --> It["inline match{Ok/Err→c}"]
+```
+
+```mermaid
+graph LR
+  D[duration.rs callers] --> Seam[completion-propagation seam]
+  A[array.rs sites] --> Seam
+  S[string.rs sites] --> Seam
+  T[typedarray.rs sites] --> Seam
+  Seam -.-> R1["bind Normal / return abrupt"]
+  Seam -.-> R2["bind Ok / return Throw(err)"]
+  Seam -.-> R3["bind Ok / return err completion"]
+```
+
+### gc-root-scope-guard-eval — extend `with_gc_root_scope` to eval.rs + remaining files  ·  Strong  ·  score 22/25
+
+- **Files**: `src/interpreter/eval.rs` (primary; 23 setups / 51 teardowns / 2 `gc_temp_roots.push` bypasses confirmed this firing) + ~9 more (`iterators.rs`, `promise.rs`, `exec.rs`, `atomics.rs`, `typedarray.rs`, `property.rs`, `eval/literals.rs`, `mod.rs`, `bytecode/vm.rs`). **Estimate ~10.**
+- **Score 22/25**: leverage 5 (collapses ~50 teardown epilogues in the hottest file), locality 4 (GC-root correctness concentrates behind the seam), blast radius 3 (~10 files), heat 5. The `with_gc_root_scope` seam it needs is confirmed present at `mod.rs:1358`.
+- **Problem / deletion test / solution** — as recorded in the backlog: follow-up to landed #595; the `eval_expr` `#[inline(always)]` hot path must not gain a call frame, the two `gc_temp_roots.push` bypasses must be routed or documented, and 5 existing IIFE workarounds adopt the combinator trivially. Deletion test: concentrates.
+- **Why not picked** — within 1 point of the pick; it loses only on blast radius (3 vs 1). It is a correctness-sensitive control-flow rewrite of the hottest file, exactly the kind of change the inverted blast-radius term exists to defer behind a lower-footprint, higher-confidence pick. Natural next firing.
+
+```mermaid
+graph LR
+  F1[eval fn A] --> S1[gc_root_frame]
+  F1 --> T1[gc_unroot_frame ×N exits]
+  F2[eval fn B] --> S2[gc_root_frame]
+  F2 --> T2[gc_unroot_frame ×N exits]
+```
+
+```mermaid
+graph LR
+  F1[eval fn A] --> W[with_gc_root_scope]
+  F2[eval fn B] --> W
+  W -.-> R[root frame + teardown on every exit]
+```
+
+### completion-into-result — `Completion::into_result()` for the Result-returning iterator helpers  ·  Strong  ·  score 21/25
+
+- **Files**: `src/interpreter/builtins/iterators.rs`, `src/interpreter/types.rs`. **Estimate ~2.**
+- **Score 21/25**: leverage 4 (~37 adapter heads in one file), locality 3, blast radius 1, heat 5 (195 `Completion::Normal` in iterators.rs this firing).
+- **Problem** — hand-rolled `match Completion { Normal(v)=>v, Throw(e)=>return Err(e), _=>… }` heads in the Result-returning abstract-operation helpers, with fabricated dead `_ =>` arms.
+- **Why not picked** — distinct context (Result-return vs Completion-return; a method not a macro). Complementary to the pick, not superseded by it. Runner-up-adjacent; a natural firing after the macro seam lands.
+
+### throw-error-completion — `throw_type_error` / `throw_range_error` helpers  ·  Worth exploring  ·  score 18/25
+
+- **Files**: all builtins; representative `typedarray.rs:1426`. **Estimate ~1 (one adopter file first).**
+- **Score 18/25**: leverage 3 (535 sites: 287 `Completion::Throw(create_type_error(...))`, 248 range), locality 2, blast radius 1, heat 5. Thinner than the pick — hides one wrapper token + the constructor lookup — but real and large.
+- **Deletion test** — mild concentration (the `Completion::Throw` wrapper) rather than a class of control flow. Fresh this firing.
+
+### array-typedarray-immutable-methods — unify parallel `toReversed`/`toSorted`/`with`  ·  Worth exploring  ·  score 17/25
+
+- **Files**: `src/interpreter/builtins/array.rs:1652/2535/2908`, `src/interpreter/builtins/typedarray.rs:2258/2315`. **Estimate ~2.**
+- **Score 17/25**: leverage 3 (only ~3 method pairs, but two drifting parallel implementations), locality 3, blast radius 2, heat 4. The "two parallel implementations drift apart" pattern the scan is told to watch for — small here, but genuine drift risk.
+
+## Dropped
+
+| Candidate | Dropped because |
+|---|---|
+| `arg-or-undefined` | Leverage 2 — 943 sites but a shallow helper whose interface equals its implementation; pure DRY + naming, not a deep module. `/simplify`-class, like `object-id-of`. |
+| `define-method-adoption` | Leverage 2 — the `define_method` seam already exists (`mod.rs:1819`, 258 adopters); finishing the ~200 stragglers is `/simplify`-class, same reasoning as the existing `define-accessor-adoption` drop. |
+| `proxy-trap-skeleton` | Leverage 2 — the deep part (`invoke_proxy_trap`) is already factored; only a thin ~13-site `if proxy {…} else {ordinary}` skeleton repeats and the per-trap validation genuinely differs. |
+
+Older drops (`object-id-of`, `proxy-blind-callable-check`, `define-accessor-adoption`, `typedarray-shared-equality`) are retained in `.architecture/backlog.md`; all filters re-checked and still apply.
+
+## Too large to automate
+
+| Candidate | Blast radius |
+|---|---|
+| `unify-generator-async-drivers` | 5 — two ~1580/~3050-line parallel state-machine interpreters; a human-scheduled structural refactor. Shrink both drivers first via the generator-tail candidates. |
+
+(`ordinary-create-from-constructor`, blast radius 4 / ~15–20 files, stays `proposed` in the backlog for a human-scheduled wave — implementable but too broad to outrank a blast-radius-1 pick.)
+
+## Pick
+
+**`completion-unwrap-macro`**, 23/25. It outranks the runner-up **candidate** `gc-root-scope-guard-eval` (22/25) by exactly one point, on the inverted blast-radius term alone (1 vs 3) — **the pick is close**, and `gc-root-scope-guard-eval` is the natural next firing. Both score leverage 5; the macro seam wins because it delivers that leverage while touching ~3 files with no published-interface change and a net-negative diff, where the eval.rs work is a ~10-file correctness-sensitive rewrite of the hottest file. New evidence this firing (the macros already exist and are proven; the true site count is ~1725, not the ~200 the backlog last estimated) is what lifted the macro candidate's leverage to parity and made the blast-radius term decisive — a legitimate re-score on fresh evidence, not a re-prioritization on other criteria.
+
+## Design
+
+Written at step 4 (design-it-twice + advisor adjudication); this file is amended and re-committed after the design pass.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,6 +44,12 @@ _Avoid_: boundary, layer.
 How the `differential` fuzz target (`fuzz/fuzz_targets/differential.rs`) classifies a jsse-vs-node run. Tier 1: jsse crashed (signal or the interpreter-panic exit code) while node didn't — an engine bug by definition. Tier 2: exactly one side rejects the source as a syntax error — a real coverage gap. Tier 3: both sides threw (possibly a different error class) or both timed out — expected noise (usually an unimplemented feature), recorded but not a fuzzer finding. See `docs/adr/0004-fuzz-lib-target-and-subprocess-differential.md`.
 _Avoid_: divergence class, mismatch level.
 
+## Control flow
+
+**Completion Propagation**:
+The unwrap-or-early-return of the interpreter's `Completion` type behind the `propagate!(expr)` macro and its `IntoAbrupt` trait (`src/interpreter/types.rs`): the success value (`Completion::Normal`, or a `Result` `Ok`) is bound, and any abrupt completion early-returns out of the enclosing `-> Completion` function. `IntoAbrupt` adapts the three propagation source shapes into one spelling — a `Completion`, a `Result<T, JsValue>` (a Rust `Err` is a JS throw, wrapped in `Completion::Throw`), and a `Result<T, Completion>` (passed through) — replacing the hand-rolled two-line `match` heads scattered across the natives. `Completion::Empty` is not abrupt but is still propagated verbatim, matching the sites it replaces. A new source shape is one added `IntoAbrupt` impl, with no call-site churn.
+_Avoid_: try macro, error unwrap, ReturnIfAbrupt helper.
+
 ## Memory
 
 **Temp-Root Frame**:

--- a/src/interpreter/builtins/string.rs
+++ b/src/interpreter/builtins/string.rs
@@ -125,10 +125,7 @@ impl Interpreter {
                 "charAt",
                 1,
                 Rc::new(|interp, this_val, args| {
-                    let js_str = match this_js_string(interp, this_val) {
-                        Ok(s) => s,
-                        Err(c) => return c,
-                    };
+                    let js_str = propagate!(this_js_string(interp, this_val));
                     let pos = match args.first() {
                         Some(v) => match to_int_or_inf(interp, v) {
                             Ok(n) => n,
@@ -150,10 +147,7 @@ impl Interpreter {
                 "charCodeAt",
                 1,
                 Rc::new(|interp, this_val, args| {
-                    let js_str = match this_js_string(interp, this_val) {
-                        Ok(s) => s,
-                        Err(c) => return c,
-                    };
+                    let js_str = propagate!(this_js_string(interp, this_val));
                     let pos = match args.first() {
                         Some(v) => match to_int_or_inf(interp, v) {
                             Ok(n) => n,
@@ -173,10 +167,7 @@ impl Interpreter {
                 "codePointAt",
                 1,
                 Rc::new(|interp, this_val, args| {
-                    let js_str = match this_js_string(interp, this_val) {
-                        Ok(s) => s,
-                        Err(c) => return c,
-                    };
+                    let js_str = propagate!(this_js_string(interp, this_val));
                     let pos = match args.first() {
                         Some(v) => match to_int_or_inf(interp, v) {
                             Ok(n) => n,
@@ -423,10 +414,7 @@ impl Interpreter {
                 "slice",
                 2,
                 Rc::new(|interp, this_val, args| {
-                    let js_str = match this_js_string(interp, this_val) {
-                        Ok(s) => s,
-                        Err(c) => return c,
-                    };
+                    let js_str = propagate!(this_js_string(interp, this_val));
                     let units = &js_str.code_units;
                     let from = match resolve_start_index(interp, args.first(), units.len()) {
                         Ok(v) => v,
@@ -448,10 +436,7 @@ impl Interpreter {
                 "substring",
                 2,
                 Rc::new(|interp, this_val, args| {
-                    let js_str = match this_js_string(interp, this_val) {
-                        Ok(s) => s,
-                        Err(c) => return c,
-                    };
+                    let js_str = propagate!(this_js_string(interp, this_val));
                     let units = &js_str.code_units;
                     let len = units.len() as f64;
                     let int_start = match args.first() {
@@ -511,10 +496,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let locale_list = match interp.intl_canonicalize_locale_list(&locales_arg) {
-                        Ok(list) => list,
-                        Err(e) => return Completion::Throw(e),
-                    };
+                    let locale_list =
+                        propagate!(interp.intl_canonicalize_locale_list(&locales_arg));
                     let resolved = interp.intl_resolve_locale(&locale_list);
                     let langid: icu::locale::LanguageIdentifier =
                         resolved.parse().unwrap_or_else(|_| "und".parse().unwrap());
@@ -532,10 +515,8 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let locales_arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let locale_list = match interp.intl_canonicalize_locale_list(&locales_arg) {
-                        Ok(list) => list,
-                        Err(e) => return Completion::Throw(e),
-                    };
+                    let locale_list =
+                        propagate!(interp.intl_canonicalize_locale_list(&locales_arg));
                     let resolved = interp.intl_resolve_locale(&locale_list);
                     let langid: icu::locale::LanguageIdentifier =
                         resolved.parse().unwrap_or_else(|_| "und".parse().unwrap());
@@ -955,10 +936,7 @@ impl Interpreter {
                                     Completion::Throw(e) => return Completion::Throw(e),
                                     other => return other,
                                 };
-                            let flags = match interp.to_string_value(&flags_val) {
-                                Ok(s) => s,
-                                Err(e) => return Completion::Throw(e),
-                            };
+                            let flags = propagate!(interp.to_string_value(&flags_val));
                             if !flags.contains('g') {
                                 return Completion::Throw(interp.create_type_error(
                                     "String.prototype.replaceAll called with a non-global RegExp argument",
@@ -1077,10 +1055,7 @@ impl Interpreter {
                 "at",
                 1,
                 Rc::new(|interp, this_val, args| {
-                    let js_str = match this_js_string(interp, this_val) {
-                        Ok(s) => s,
-                        Err(c) => return c,
-                    };
+                    let js_str = propagate!(this_js_string(interp, this_val));
                     let units = &js_str.code_units;
                     let idx = match args.first() {
                         Some(v) => match to_int_or_inf(interp, v) {
@@ -1260,10 +1235,7 @@ impl Interpreter {
                                     Completion::Throw(e) => return Completion::Throw(e),
                                     other => return other,
                                 };
-                            let flags = match interp.to_string_value(&flags_val) {
-                                Ok(s) => s,
-                                Err(e) => return Completion::Throw(e),
-                            };
+                            let flags = propagate!(interp.to_string_value(&flags_val));
                             if !flags.contains('g') {
                                 return Completion::Throw(interp.create_type_error(
                                     "String.prototype.matchAll called with a non-global RegExp argument",
@@ -1371,10 +1343,7 @@ impl Interpreter {
                 "isWellFormed",
                 0,
                 Rc::new(|interp, this_val, _args| {
-                    let js_str = match this_js_string(interp, this_val) {
-                        Ok(s) => s,
-                        Err(c) => return c,
-                    };
+                    let js_str = propagate!(this_js_string(interp, this_val));
                     let units = &js_str.code_units;
                     let mut i = 0;
                     while i < units.len() {
@@ -1397,10 +1366,7 @@ impl Interpreter {
                 "toWellFormed",
                 0,
                 Rc::new(|interp, this_val, _args| {
-                    let js_str = match this_js_string(interp, this_val) {
-                        Ok(s) => s,
-                        Err(c) => return c,
-                    };
+                    let js_str = propagate!(this_js_string(interp, this_val));
                     let units = &js_str.code_units;
                     let mut result = Vec::with_capacity(units.len());
                     let mut i = 0;
@@ -1543,10 +1509,7 @@ impl Interpreter {
                         Err(c) => return c,
                     };
                     let arg = args.first().cloned().unwrap_or(JsValue::UNDEFINED);
-                    let attr_val = match interp.to_string_value(&arg) {
-                        Ok(v) => v,
-                        Err(e) => return Completion::Throw(e),
-                    };
+                    let attr_val = propagate!(interp.to_string_value(&arg));
                     let escaped = attr_val.replace('"', "&quot;");
                     Completion::Normal(JsValue::string(JsString::from_str(&format!(
                         "<{tag_o} {attr_name}=\"{escaped}\">{s}</{tag_c}>"

--- a/src/interpreter/builtins/temporal/duration.rs
+++ b/src/interpreter/builtins/temporal/duration.rs
@@ -6,24 +6,6 @@ use crate::interpreter::builtins::temporal::{
     temporal_unit_singular, to_integer_if_integral,
 };
 
-macro_rules! try_completion {
-    ($expr:expr) => {
-        match $expr {
-            Completion::Normal(v) => v,
-            other => return other,
-        }
-    };
-}
-
-macro_rules! try_result {
-    ($interp:expr, $expr:expr) => {
-        match $expr {
-            Ok(v) => v,
-            Err(e) => return Completion::Throw(e),
-        }
-    };
-}
-
 /// Correctly-rounded i128 / i128 → f64 division.
 /// Uses string-based conversion for precise results: constructs a decimal
 /// string with enough digits and lets f64 parsing handle the rounding.
@@ -1804,11 +1786,11 @@ impl Interpreter {
                 }
                 macro_rules! get_field {
                     ($name:expr, $default:expr) => {{
-                        let v = try_completion!(get_prop(interp, &like, $name));
+                        let v = propagate!(get_prop(interp, &like, $name));
                         if is_undefined(&v) {
                             (false, $default)
                         } else {
-                            let n = try_result!(interp, interp.to_number_value(&v));
+                            let n = propagate!(interp.to_number_value(&v));
                             match to_integer_if_integral(n) {
                                 Some(i) => (true, i),
                                 None => {
@@ -2271,11 +2253,11 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(c) => return c,
                     };
-                    let u = try_completion!(get_prop(interp, &total_of, "unit"));
+                    let u = propagate!(get_prop(interp, &total_of, "unit"));
                     if is_undefined(&u) {
                         return Completion::Throw(interp.create_range_error("unit is required"));
                     }
-                    let us = try_result!(interp, interp.to_string_value(&u));
+                    let us = propagate!(interp.to_string_value(&u));
                     let unit = match temporal_unit_singular(&us) {
                         Some(u) => u,
                         None => {

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -4576,3 +4576,59 @@ fn with_gc_root_scope_truncates_on_every_exit() {
     // The pre-scope root is untouched.
     assert!(interp.gc_temp_roots.contains(&9_001));
 }
+
+// `propagate!` (+ the `IntoAbrupt` seam) unwraps the success value of the three
+// error-propagation source shapes inside a `-> Completion` fn, early-returning
+// the abrupt completion otherwise. Pins all three shapes plus the `Empty`
+// quirk (non-abrupt, yet propagated verbatim — matching the pre-existing
+// `other => return other` sites the seam replaces).
+#[test]
+fn propagate_macro_covers_three_shapes_and_empty() {
+    // Shape 1: Completion — bind Normal, propagate every other variant.
+    fn s1(c: Completion) -> Completion {
+        let v = propagate!(c);
+        Completion::Normal(v)
+    }
+    assert!(matches!(
+        s1(Completion::Normal(JsValue::UNDEFINED)),
+        Completion::Normal(_)
+    ));
+    // Empty is NOT abrupt, but is still propagated verbatim.
+    assert!(matches!(s1(Completion::Empty), Completion::Empty));
+    assert!(matches!(
+        s1(Completion::Throw(JsValue::UNDEFINED)),
+        Completion::Throw(_)
+    ));
+    assert!(matches!(
+        s1(Completion::Break(None, None)),
+        Completion::Break(_, _)
+    ));
+
+    // Shape 2: Result<T, JsValue> — a Rust Err is a JS throw, so it is wrapped.
+    fn s2(r: Result<JsValue, JsValue>) -> Completion {
+        let v = propagate!(r);
+        Completion::Normal(v)
+    }
+    assert!(matches!(s2(Ok(JsValue::UNDEFINED)), Completion::Normal(_)));
+    assert!(matches!(s2(Err(JsValue::UNDEFINED)), Completion::Throw(_)));
+
+    // Shape 3: Result<T, Completion> — the Err already carries the completion,
+    // so it passes through unchanged.
+    fn s3(r: Result<JsValue, Completion>) -> Completion {
+        let v = propagate!(r);
+        Completion::Normal(v)
+    }
+    assert!(matches!(s3(Ok(JsValue::UNDEFINED)), Completion::Normal(_)));
+    assert!(matches!(
+        s3(Err(Completion::Continue(None, None))),
+        Completion::Continue(_, _)
+    ));
+
+    // The success value flows through generically (not fixed to JsValue).
+    fn s2_typed(r: Result<u32, JsValue>) -> Completion {
+        let n: u32 = propagate!(r);
+        assert_eq!(n, 7);
+        Completion::Normal(JsValue::number(n as f64))
+    }
+    assert!(matches!(s2_typed(Ok(7)), Completion::Normal(_)));
+}

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -265,6 +265,61 @@ impl Completion {
     }
 }
 
+/// Convert a fallible or control-flow-carrying value into the interpreter's
+/// canonical `Result<success, abrupt Completion>`: `Ok` is the value to bind,
+/// `Err` is a [`Completion`] that must early-return from the caller. Implemented
+/// for the three error-propagation source shapes that `-> Completion` functions
+/// consume, so [`propagate!`] can unwrap any of them with one spelling.
+pub(crate) trait IntoAbrupt {
+    /// The success payload — fixed per source shape, hence an associated type
+    /// (functionally determined by `Self`) rather than a type parameter.
+    type Ok;
+    fn into_abrupt(self) -> Result<Self::Ok, Completion>;
+}
+
+impl IntoAbrupt for Completion {
+    type Ok = JsValue;
+    fn into_abrupt(self) -> Result<JsValue, Completion> {
+        match self {
+            Completion::Normal(v) => Ok(v),
+            // Every other variant early-returns — including `Empty`, which is
+            // not abrupt but was propagated verbatim by the `other => return
+            // other` sites this seam replaces.
+            other => Err(other),
+        }
+    }
+}
+
+impl<T> IntoAbrupt for Result<T, JsValue> {
+    type Ok = T;
+    fn into_abrupt(self) -> Result<T, Completion> {
+        // A Rust `Err(JsValue)` is a JS throw.
+        self.map_err(Completion::Throw)
+    }
+}
+
+impl<T> IntoAbrupt for Result<T, Completion> {
+    type Ok = T;
+    fn into_abrupt(self) -> Result<T, Completion> {
+        // The `Err` already carries the completion — pass it through.
+        self
+    }
+}
+
+/// Unwrap the success value of a [`Completion`], `Result<T, JsValue>`, or
+/// `Result<T, Completion>` (via [`IntoAbrupt`]), early-returning the abrupt
+/// completion out of the enclosing `-> Completion` function otherwise. Replaces
+/// the hand-rolled two-line `match` propagation heads across the interpreter.
+macro_rules! propagate {
+    ($expr:expr) => {
+        match $crate::interpreter::IntoAbrupt::into_abrupt($expr) {
+            Ok(v) => v,
+            Err(c) => return c,
+        }
+    };
+}
+pub(crate) use propagate;
+
 pub(crate) enum GeneratorResumeKind {
     Next,
     Return(JsValue),


### PR DESCRIPTION
## Problem

Functions returning the interpreter's `Completion` type propagate errors and abrupt control flow with hand-rolled two-line `match` heads of three shapes — ~1725 tree-wide (911 `Result<_, JsValue>` → `Completion::Throw`, 598 `Result<_, Completion>` → pass-through, 216 `Completion` → bind-`Normal`). The two macros that already solve two of these (`try_completion!`, `try_result!`) were `macro_rules!`-**private to a single file** (`temporal/duration.rs`), so every other native re-derives the propagation direction inline. This is shallow twice over: the propagation policy has no shared **interface**, and where a **seam** does exist it cannot be reached.

## What changed (in `codebase-design` terms)

Promote the propagation logic into one crate-visible **deep module**: an `IntoAbrupt` trait (three impls — `Completion`, `Result<T, JsValue>`, `Result<T, Completion>`) plus a `propagate!(expr)` macro, placed beside `Completion` in `src/interpreter/types.rs`. The **seam** is `IntoAbrupt`: the single place "source shape → abrupt completion" is decided, extensible to a fourth source shape with zero call-site churn. The **interface** is one token — `propagate!` — hiding all three propagation policies; the correct behaviour at any site is fully determined by the callee's signature, so a policy-naming macro would only duplicate what the reader already sees. **Leverage**: ~1725 hand-rolled heads become reachable from one definition. **Locality**: the propagation contract lives in one `impl` per shape instead of being re-derived per call.

**Before** — every native wires the propagation policy itself:

```mermaid
graph LR
  D[duration.rs] --> Mp["try_completion! / try_result!<br/>(private to duration.rs)"]
  A[array.rs] --> Ia["inline match heads"]
  S[string.rs] --> Is["inline match heads"]
  T[typedarray.rs] --> It["inline match heads"]
```

**After** — one seam, solid edges = interface, dashed = implementation:

```mermaid
graph LR
  D[duration.rs] --> Seam["propagate! / IntoAbrupt"]
  S[string.rs] --> Seam
  A[array.rs] --> Seam
  T[typedarray.rs] --> Seam
  Seam -.-> R1["Completion: bind Normal / return abrupt"]
  Seam -.-> R2["Result&lt;_,JsValue&gt;: bind Ok / return Throw(err)"]
  Seam -.-> R3["Result&lt;_,Completion&gt;: bind Ok / return err"]
```

## Scope of this PR

Lands the seam and proves all three shapes at real sites, keeping blast radius contained (5 files, +136/−74, no published interface):

- `types.rs` — the seam.
- `temporal/duration.rs` — private macros deleted, 4 call sites re-pointed (shapes 1 & 2). `try_result!`'s vestigial unused `$interp` param is dropped.
- `string.rs` — **13 cross-module adoptions**: 5 shape-2 + 8 shape-3 (the `this_js_string` receiver prologue).
- `tests.rs` — `propagate_macro_covers_three_shapes_and_empty`, pinning all three shapes plus the non-abrupt `Empty` quirk (propagated verbatim, matching the sites it replaces).
- `CONTEXT.md` — a **Completion Propagation** glossary term.

Broad adoption of the remaining ~1700 sites (array.rs 124 / typedarray.rs 46 / collections.rs 32 shape-3 alone) is deferred to follow-up firings, mirroring the `array.rs → eval.rs` split of the landed `gc-root-scope-guard` work.

Full review with candidate scoring and the three designs: [`.architecture/reviews/2026-09-10-completion-unwrap-macro.md`](../blob/sym/jsse/routine/refactor-audit/01M25W97CF/.architecture/reviews/2026-09-10-completion-unwrap-macro.md).

## Pick & design provenance

- **Picked candidate**: `completion-unwrap-macro`, **23/25** (leverage 5, locality 3, blast radius 1, heat 5). Re-scored up from 21 on fresh evidence (the macros already exist and are proven; ~1725 sites, not the ~200 previously estimated).
- **Runner-up candidate**: `gc-root-scope-guard-eval`, 22/25 — within 1 point; it loses only on the inverted blast-radius term (a ~10-file correctness-sensitive rewrite of the hottest file). The natural next firing.
- **Winning design (B)**: `propagate!` + `IntoAbrupt`. **Runner-up design (A)**: three intent-named macros (`try_completion!` / `try_throw!` / `try_abrupt!`). A wins call-site auditability (the name states Throw-wrap vs pass-through) and has zero trait-resolution inference cost, but is the shallowest option — the caller must pick a name that duplicates a distinction the compiler already owns. B leads criteria 1–3 (depth, locality, seam placement) and ties 4–5; depth is criterion 1 and is what the deepening optimises for.

## Proposed ADR

> **Completion propagation is a crate-local `IntoAbrupt` + `propagate!` seam, not `impl Try for Completion`.** Making `?` work natively on `Completion` (Design C, `try_trait_v2`) is the deepest possible interface but requires **nightly** — and the shipped binary builds on stable (`release.yml` pins `stable`; the crate has zero `#![feature]` attributes; edition 2024 makes `let_chains` stable). Adopt the trait+macro seam on stable now; revisit native `?` only if `try_trait_v2` stabilises or the crate moves to nightly. The `IntoAbrupt` impls are deliberately shaped as the `FromResidual` impls that migration would need.

## CONTEXT.md terms added

- **Completion Propagation** — the `propagate!` / `IntoAbrupt` unwrap-or-early-return seam.

## Known trade-offs (Design B)

- Call-site auditability: `propagate!(x)` hides whether an `Err` is Throw-wrapped or passed through; a hostile audit consults the `IntoAbrupt` impl (Design A's strength).
- Trait-resolution inference: a site whose callee has an unconstrained error type would need a type annotation; the adopted sites all have concrete error types.

_Note: `CLAUDE.md`'s "uses Rust nightly features (`let_chains`)" line is stale (edition 2024 makes `let_chains` stable). Left unedited — out of scope for this refactor; flagged for a docs pass._

🤖 Generated with Claude Code
