### PR TITLE
refactor(interpreter): migrate yield* delegation to with_gc_root_scope

### DIFF
--- a/docs/adr/2026-09-10-2014-gc-root-scope-guard.md
+++ b/docs/adr/2026-09-10-2014-gc-root-scope-guard.md
@@ -40,8 +40,8 @@ zero real adapters in `array.rs`).
   `gc_frame_next` held simultaneously), which correctly keep the raw
   primitive.
 - **`eval.rs`'s `yield*` delegation** (this change): the concrete first slice
-  of the `gc-root-scope-guard-eval` follow-up PR #595 proposed. This is also
-  the control-flow-heavy path #331 itself named as the prototype target — 11
+  of the `gc-root-scope-guard-eval` follow-up PR #595 proposed, and the
+  control-flow-heavy path #331 itself named as the prototype target — 10
   `gc_unroot_frame` call sites across the iterator-protocol loop, one per
   abrupt exit (`IteratorNext` throwing, an awaited rejection, `done`/`value`
   getters throwing, and each of `next`/`return`/`throw` resume kinds)
@@ -49,6 +49,28 @@ zero real adapters in `array.rs`).
   `if let Some(o) = iterator.as_object_id() { self.gc_temp_roots.push(o.id) }`
   bypass at this site is replaced with `gc_root_value(&iterator)`, retiring
   one of the two seam bypasses PR #595 flagged (`eval.rs:1066`/`:4324`).
+
+  **Reachability caveat, found during review of this ADR.** #331 described
+  this loop as *the* control-flow-heavy `yield*` path when it was filed.
+  Today, ordinary `yield*` execution goes through `generator_runtime.rs`'s
+  state-machine `StateTerminator::Yield { is_delegate: true, .. }` arm
+  instead — a separate, independently-suspending implementation (spec
+  §14.4.14) that stores `delegated_iterator` on the generator object rather
+  than calling back into `eval_expr`. This `eval.rs` loop is reached only
+  through the documented `InlineYield` fallback
+  (`generator_runtime.rs:4301-4304`: "any `Completion::Yield` from
+  `exec_statements` ... came from a loop body or complex control flow that
+  isn't decomposed by the state machine transformer"). Direct instrumentation
+  of this exact branch found zero hits across a bare `yield*`, `while`/
+  `do-while`/nested-`while` loops, `try`/`finally`, `switch`, `for-in`,
+  labeled `continue`, `yield*` as a binary/call/ternary/array-literal operand,
+  and an async generator — so no construction found so far exercises it. The
+  migration is still correct and harmless (identical behavior on every exit
+  path, full test262 green), but its practical value is unconfirmed rather
+  than the "control-flow-heavy path" framing alone would suggest; see
+  jsse#625 for the open question of whether/when this fallback fires and
+  whether the legacy `self.generator_context`-driven branch is still load-
+  bearing.
 
 ## Deliberately not migrated
 

--- a/docs/adr/2026-09-10-2014-gc-root-scope-guard.md
+++ b/docs/adr/2026-09-10-2014-gc-root-scope-guard.md
@@ -17,9 +17,13 @@ whole-body, single-frame native temp-root scoping. It is not a Drop-guard:
 `gc_temp_roots` stays a plain `Vec<u64>`, so there is no interior-mutability
 borrow tax (`RefCell`) on the GC hot path (`gc_root_value`, called from every
 allocation-adjacent site in the interpreter). The raw `gc_root_frame`/
-`gc_unroot_frame` primitive is retained for frames that genuinely nest or
-interleave across early exits — the one case the combinator structurally
-cannot express, since it owns exactly one depth marker.
+`gc_unroot_frame` primitive is retained for the one shape the combinator
+cannot express: two frames alive at once where an *inner* one must truncate
+independently while the *outer* one stays open across repeated early exits
+(`Array.from`'s nested `gc_frame`/`gc_frame_next`, see below). Plain LIFO
+nesting — one `with_gc_root_scope` call inside another, each owning its own
+local frame marker on the same stack — composes fine and is not what this
+primitive is reserved for.
 
 An RAII `Drop`-guard is added only if a genuinely interleaved case with two
 or more real adapters later surfaces, decided where the variation is

--- a/docs/adr/2026-09-10-2014-gc-root-scope-guard.md
+++ b/docs/adr/2026-09-10-2014-gc-root-scope-guard.md
@@ -1,0 +1,95 @@
+# GC temp-root scoping: a closure combinator, not an RAII guard
+
+Issue #331 asked whether the GC temp-root frame idiom — `let f =
+self.gc_root_frame(); … self.gc_unroot_frame(f);`, paired and placed by hand
+on every exit path — should become an RAII `Drop`-guard, so a forgotten
+teardown (premature collection or a root leak) can no longer happen by
+omission. #290 first reconciled the one-line `gc_root_value(&x)` idiom; this
+records the decision for the frame-scoping half of that question, now that
+`with_gc_root_scope` has a second call site beyond its `array.rs` origin.
+
+## Decision
+
+`Interpreter::with_gc_root_scope(|interp| …)` — a closure combinator that
+captures the current temp-root depth, runs `body`, and bulk-unroots on every
+exit path the closure takes (tail, early `return`, `?`) — is the seam for
+whole-body, single-frame native temp-root scoping. It is not a Drop-guard:
+`gc_temp_roots` stays a plain `Vec<u64>`, so there is no interior-mutability
+borrow tax (`RefCell`) on the GC hot path (`gc_root_value`, called from every
+allocation-adjacent site in the interpreter). The raw `gc_root_frame`/
+`gc_unroot_frame` primitive is retained for frames that genuinely nest or
+interleave across early exits — the one case the combinator structurally
+cannot express, since it owns exactly one depth marker.
+
+An RAII `Drop`-guard is added only if a genuinely interleaved case with two
+or more real adapters later surfaces, decided where the variation is
+observed rather than pre-committed here. PR #595's design-it-twice review
+(`.architecture/reviews/2026-09-04-gc-root-scope-guard.md`) scored this
+against an RAII guard (Design B, rejected: forces `Rc<RefCell<Vec<u64>>>`,
+touches `gc.rs` and ~15 functions across six files for a capability
+`array.rs` never used) and a value-taking `with_gc_rooted(&[&JsValue], …)`
+variant (Design C, runner-up: its slice seals a ≥2-root variation that had
+zero real adapters in `array.rs`).
+
+## Applied so far
+
+- **`array.rs`** (PR #595): 8 whole-body natives — `concat`, `slice`, `map`,
+  `filter`, `splice`, `flat`, `flatMap`, `Array.from`'s array-like path —
+  collapsing 71 hand-threaded `gc_unroot_frame` teardowns to 9. The 9
+  remaining are `Array.from`'s nested iterator frames (`gc_frame` +
+  `gc_frame_next` held simultaneously), which correctly keep the raw
+  primitive.
+- **`eval.rs`'s `yield*` delegation** (this change): the concrete first slice
+  of the `gc-root-scope-guard-eval` follow-up PR #595 proposed. This is also
+  the control-flow-heavy path #331 itself named as the prototype target — 11
+  `gc_unroot_frame` call sites across the iterator-protocol loop, one per
+  abrupt exit (`IteratorNext` throwing, an awaited rejection, `done`/`value`
+  getters throwing, and each of `next`/`return`/`throw` resume kinds)
+  collapse to plain `return`s inside `with_gc_root_scope`. The manual
+  `if let Some(o) = iterator.as_object_id() { self.gc_temp_roots.push(o.id) }`
+  bypass at this site is replaced with `gc_root_value(&iterator)`, retiring
+  one of the two seam bypasses PR #595 flagged (`eval.rs:1066`/`:4324`).
+
+## Deliberately not migrated
+
+- **`eval.rs`'s `destructure_array_assignment`** (the other flagged bypass,
+  `:4324`) **and `exec.rs`'s `bind_pattern`** array-destructuring path root
+  their iterator the same way, but unroot it with `gc_unroot_value` — a
+  per-value identity removal, not a blanket frame truncation. Array pattern
+  binding can hold other, unrelated temp roots live across its own body (a
+  bound value that itself triggers rooting), so collapsing it into
+  `with_gc_root_scope`'s single bulk-truncating frame risks unrooting a
+  value a sibling branch still needs. These stay on the raw primitive until
+  that interaction is worked out on its own, not bundled into this slice.
+- **`array.rs`'s `from_async_gc_root`/`from_async_gc_unroot`** (`Array.fromAsync`)
+  pin a `FromAsyncState`'s object fields for the life of a multi-tick async
+  continuation, which spans suspend points `with_gc_root_scope`'s single
+  synchronous closure cannot cover. `pin_native_root`/`gc_native_roots` (the
+  anchor-object pinning PR #473 introduced, and `RootedPair` in
+  `iterators.rs` already builds on) is the right target mechanism for this
+  case — but migrating `from_async_gc_root` onto it is #331's item 3 (split
+  frame-roots from independently-registered roots) applied to a specific
+  call site, not this ADR's concern. Left as follow-up.
+- **`exec.rs`'s destructuring-pattern iterator root**, **`array.rs`'s
+  `from_async_gc_root`** loop (see above), and **`regexp.rs`'s global-match
+  result loop** still use the raw `gc_temp_roots.push(id)` / manual-frame
+  idiom #290 and #331 catalogued as remaining mechanical-sweep sites. None
+  are touched here; they are unrelated to the `with_gc_root_scope` seam
+  decision and remain future opportunistic cleanup.
+
+## Consequences
+
+- `gc-root-scope-guard-eval`'s remaining scope — the rest of `eval.rs` and
+  ~9 other files PR #595 estimated — is unchanged by this slice; each
+  future site is evaluated individually against the same criterion applied
+  here (single frame, no cross-branch identity removal, no continuation
+  spanning multiple ticks).
+- #331's item 4 (root-stack balance assertions at evaluation boundaries) is
+  **not** unblocked by this change. `gc_temp_roots` still conflates
+  frame-scoped roots (what this ADR's combinator manages) with
+  independently-registered ones — the exact hazard #465 found and fixed for
+  promise-resolver roots sharing the same truncatable stack as an enclosing
+  `eval_call` frame. Until #331's item 3 separates the two root kinds,
+  neither `==` nor `>=` holds at a call boundary while `Array.fromAsync` or
+  an `Atomics.waitAsync`-style continuation is pending, so balance
+  assertions would false-positive. Revisit once item 3 lands.

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1083,7 +1083,7 @@ impl Interpreter {
                                 Err(e) => return Completion::Throw(e),
                             };
                             if done {
-                                break Completion::Normal(value);
+                                return Completion::Normal(value);
                             }
                             if let Some(ref mut ctx) = this.generator_context {
                                 let current = ctx.current_yield;

--- a/src/interpreter/eval.rs
+++ b/src/interpreter/eval.rs
@@ -1058,83 +1058,58 @@ impl Interpreter {
                             Err(e) => return Completion::Throw(e),
                         }
                     };
-                    let gc_frame = self.gc_root_frame();
-                    if let Some(o) = iterator
-                        .as_object_id()
-                        .map(|id| crate::types::JsObject { id })
-                    {
-                        self.gc_temp_roots.push(o.id);
-                    }
-                    let result = loop {
-                        let next_result = match self.iterator_next(&iterator) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                self.gc_unroot_frame(gc_frame);
-                                return Completion::Throw(e);
-                            }
-                        };
-                        let next_result = if is_async_gen {
-                            match self.await_value(&next_result) {
-                                Completion::Normal(v) => v,
-                                Completion::Throw(e) => {
-                                    self.gc_unroot_frame(gc_frame);
-                                    return Completion::Throw(e);
+                    self.with_gc_root_scope(|this| {
+                        this.gc_root_value(&iterator);
+                        loop {
+                            let next_result = match this.iterator_next(&iterator) {
+                                Ok(v) => v,
+                                Err(e) => return Completion::Throw(e),
+                            };
+                            let next_result = if is_async_gen {
+                                match this.await_value(&next_result) {
+                                    Completion::Normal(v) => v,
+                                    Completion::Throw(e) => return Completion::Throw(e),
+                                    other => return other,
                                 }
-                                other => {
-                                    self.gc_unroot_frame(gc_frame);
-                                    return other;
+                            } else {
+                                next_result
+                            };
+                            let done = match this.iterator_complete(&next_result) {
+                                Ok(d) => d,
+                                Err(e) => return Completion::Throw(e),
+                            };
+                            let value = match this.iterator_value(&next_result) {
+                                Ok(v) => v,
+                                Err(e) => return Completion::Throw(e),
+                            };
+                            if done {
+                                break Completion::Normal(value);
+                            }
+                            if let Some(ref mut ctx) = this.generator_context {
+                                let current = ctx.current_yield;
+                                ctx.current_yield += 1;
+                                if current < ctx.target_yield {
+                                    continue;
+                                }
+                                if current == ctx.target_yield {
+                                    match &ctx.resume_kind {
+                                        GeneratorResumeKind::Next => {
+                                            return Completion::Yield(value);
+                                        }
+                                        GeneratorResumeKind::Return(v) => {
+                                            let v = v.clone();
+                                            return Completion::Return(v);
+                                        }
+                                        GeneratorResumeKind::Throw(e) => {
+                                            let e = e.clone();
+                                            return Completion::Throw(e);
+                                        }
+                                    }
                                 }
                             }
-                        } else {
-                            next_result
-                        };
-                        let done = match self.iterator_complete(&next_result) {
-                            Ok(d) => d,
-                            Err(e) => {
-                                self.gc_unroot_frame(gc_frame);
-                                return Completion::Throw(e);
-                            }
-                        };
-                        let value = match self.iterator_value(&next_result) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                self.gc_unroot_frame(gc_frame);
-                                return Completion::Throw(e);
-                            }
-                        };
-                        if done {
-                            break Completion::Normal(value);
+                            return Completion::Yield(value);
                         }
-                        if let Some(ref mut ctx) = self.generator_context {
-                            let current = ctx.current_yield;
-                            ctx.current_yield += 1;
-                            if current < ctx.target_yield {
-                                continue;
-                            }
-                            if current == ctx.target_yield {
-                                match &ctx.resume_kind {
-                                    GeneratorResumeKind::Next => {
-                                        self.gc_unroot_frame(gc_frame);
-                                        return Completion::Yield(value);
-                                    }
-                                    GeneratorResumeKind::Return(v) => {
-                                        let v = v.clone();
-                                        self.gc_unroot_frame(gc_frame);
-                                        return Completion::Return(v);
-                                    }
-                                    GeneratorResumeKind::Throw(e) => {
-                                        let e = e.clone();
-                                        self.gc_unroot_frame(gc_frame);
-                                        return Completion::Throw(e);
-                                    }
-                                }
-                            }
-                        }
-                        self.gc_unroot_frame(gc_frame);
-                        return Completion::Yield(value);
-                    };
-                    self.gc_unroot_frame(gc_frame);
-                    result
+                    })
                 } else {
                     let value = if let Some(e) = expr {
                         match self.eval_expr(e, env) {


### PR DESCRIPTION
## Summary

- Migrates the `yield*` delegation loop in `eval.rs` (`Expression::Yield` with `delegate == true`) to `with_gc_root_scope`, collapsing 10 hand-threaded `gc_unroot_frame` teardowns (one per abrupt exit across `IteratorNext` throwing, an awaited rejection, `done`/`value` getters throwing, and each of the `next`/`return`/`throw` resume kinds) into the combinator's single bulk-unroot. Replaces the raw `gc_temp_roots.push(o.id)` bypass with `gc_root_value(&iterator)`, retiring one of the two seam bypasses PR #595 flagged (`eval.rs:1066`/`:4324`).
- This is the concrete first slice of PR #595's proposed `gc-root-scope-guard-eval` follow-up, and #331 (filed before the generator state-machine transform existed) named it as the prototype target. **Reachability update, added after review**: as of this branch, ordinary `yield*` execution goes through `generator_runtime.rs`'s independently-implemented, already-correctly-GC-rooted `delegated_iterator` state machine instead of this loop — see "Notes for reviewers" below and jsse#625. The migration itself is still correct, tested, and harmless; treat it as hygiene on a legacy/fallback path rather than a fix to code most `yield*` calls execute today.
- Adds `docs/adr/2026-09-10-2014-gc-root-scope-guard.md`, formalizing PR #595's "Proposed ADR" (closure combinator, not an RAII `Drop`-guard) now that it has a second real call site, and recording why the remaining raw-rooting sites (`destructure_array_assignment`/`bind_pattern`'s identity-based unrooting, `Array.fromAsync`'s `from_async_gc_root`, and the `exec.rs`/`regexp.rs` mechanical-sweep stragglers) are deliberately not touched here.

Refs #331 — this is one slice of a larger staged backlog (RAII-vs-combinator was decided by #595; splitting frame-scoped from identity-scoped roots, and root-stack balance assertions, remain open). Not closing the issue.

## Notes for reviewers

- **A prior autonomous run on this issue cited issue #465 / commit `03df6fe`** as the documented reason `destructure_array_assignment`/`bind_pattern` are excluded from this migration. I verified that citation while writing the ADR: #465 (closed) is unrelated — it's about promise-resolver roots (`Atomics.waitAsync`/`$262.agent.getReportAsync`) being dropped by an enclosing frame's bulk truncation, not about destructuring. The underlying technical claim (those sites use per-value `gc_unroot_value` identity removal, not frame truncation, so migrating them risks unrooting a value a sibling branch still needs) checks out from reading the code directly, so the exclusion stands — the ADR just doesn't repeat the wrong citation.
- **A `/code-review xhigh --fix --comment` pass raised, then largely resolved through its own back-and-forth, a substantive question: is the loop this PR touches reachable at all?** Short answer, confirmed independently with direct instrumentation (a temporary `eprintln!` in the exact branch, not part of this diff): **no construct I could build reaches it.** Ordinary `yield*` — bare, inside `while`/`do-while`/nested-`while` loops, `try/finally`, `switch`, `for-in`, labeled `continue`, as a binary/call/ternary/array-literal operand, and in an async generator — all go through `generator_runtime.rs`'s `StateTerminator::Yield { is_delegate: true, .. }` arm, which suspends via `delegated_iterator` directly (spec §14.4.14) without calling back into `eval_expr`. There's a documented `InlineYield` fallback (`generator_runtime.rs:4301-4304`) that *would* reach this PR's code for control flow the transform can't decompose, but nothing tried triggers it. Filed as jsse#625 to track whether that fallback is ever live and whether `CLAUDE.md`'s "replay-based" generator description needs updating.
- **This also means the GC-forcing `test262-extra/` regression test I'd attempted and dropped earlier (getter-based `done` check calling `$262.gc()`) was never going to discriminate** — not just because `GeneratorContext::delegated_iterator`'s tracing is a broader safety net than I'd first assumed, but because the code under test isn't in the execution path for that repro at all. Consistent with dropping it rather than shipping a non-discriminating test.
- Given the above, the value of this PR is: (a) the `with_gc_root_scope` migration is still a correct, tested simplification of whatever *does* execute this loop, if anything ever does, and (b) the ADR now documents the seam decision accurately for the next person who touches this file, including the reachability caveat. If jsse#625 concludes the legacy `self.generator_context`/`exec_statements` yield* path is fully dead, this branch (and its sibling plain-`yield` code) becomes a deletion candidate rather than a migration target — noted there, not resolved here.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release` — 670 + 6 passing, 0 failed
- [x] `./scripts/lint.sh` — rustfmt, clippy (default + perf-counters), all clean
- [x] `uv run python scripts/run-test262.py test262/test/language/expressions/yield/ test262/test/language/statements/generators/ test262/test/language/expressions/async-generator/ test262/test/language/statements/async-generator/ -j 32` — 2,435/2,435, 0 regressions
- [x] `uv run python scripts/run-test262.py -j 32` (full suite) — 99,907/99,907 (100%), 0 regressions
- [x] `uv run python scripts/run-test262.py test262-extra/ -j 32` — 316/316
- [x] `uv run python scripts/run-custom-tests.py` — 11/11
