### PR TITLE
refactor(typedarray): one receiver guard for %TypedArray% getters + validators

### DIFF
--- a/.architecture/backlog.md
+++ b/.architecture/backlog.md
@@ -7,7 +7,8 @@ Never delete rows; they are the memory that stops re-surfacing the same work.
 
 ## typedarray-getter-receiver-guard
 
-- **Status**: proposed
+- **Status**: in-flight
+- **PR**: #626
 - **Score**: 22/25 (leverage 4, locality 4, blast radius 1, heat 5)
 - **Files**: ~1 estimated — `src/interpreter/builtins/typedarray.rs`
 - **Modules**: `src/interpreter/builtins/typedarray.rs`

--- a/.architecture/backlog.md
+++ b/.architecture/backlog.md
@@ -5,6 +5,16 @@ Persistent candidate memory for the `pm-deepen` architecture routine. Statuses:
 `dropped` (hard filter — reversible), `rejected` (human declined / recurring bail — human-only reopen).
 Never delete rows; they are the memory that stops re-surfacing the same work.
 
+## typedarray-getter-receiver-guard
+
+- **Status**: proposed
+- **Score**: 22/25 (leverage 4, locality 4, blast radius 1, heat 5)
+- **Files**: ~1 estimated — `src/interpreter/builtins/typedarray.rs`
+- **Modules**: `src/interpreter/builtins/typedarray.rs`
+- **Summary**: The 4 `%TypedArray%.prototype` getters (`byteOffset` :1313, `byteLength` :1328, `length` :1343, `buffer` :1359) each re-open-code the `as_object_id→get_object[_cell]→borrow→typed_array_info→(detach/OOB branch)→else create_type_error("not a TypedArray")` receiver dance, because `validate_typed_array` (:5655) hides exactly this but only under a **throw-on-detached** policy — the getters need **return-0-on-detached** (spec TypedArrayLength→0), so they reach past the seam. Alongside sits a 3-member validator sibling family (`validate_typed_array` :5655, `validate_uint8array` :5673, `validate_uint8array_no_detach_check` :5700) differing only in brand string + detach policy. Add one `require_typed_array_receiver(this, brand, detach_policy) -> Result<TypedArrayInfo, Completion>` guard (policy = Throw / NoCheck / ReturnZero) the 4 getters and 3 validators all route through. **Genuine deepening**, not straggler-adoption: the ReturnZero policy *extends what the seam hides* (the distinction that keeps `dataview-receiver-guard` proposed while `define-method-adoption` was dropped). Direct follow-up to landed `validate-typed-array` (#543); same family relation `arraybuffer-receiver-guard` (#570) bears to it. **Correction**: an earlier scan over-counted "~10 getters" — only 4 are genuine TypedArray-prototype getters; the rest were ArrayBuffer/SAB getters (#570) and DataView getters (`dataview-receiver-guard`).
+- **First seen**: 2026-09-11
+- **Picked**: 2026-09-11 firing. Top two tied at 22/25 with `gc-root-scope-guard-eval` (blast 3); won on the lower-blast-radius tie-break. Branch adopted (`sym/jsse/routine/refactor-audit/01M26RZFXE`), not renamed.
+
 ## gc-root-scope-guard
 
 - **Status**: landed
@@ -67,8 +77,8 @@ Never delete rows; they are the memory that stops re-surfacing the same work.
 
 ## completion-unwrap-macro
 
-- **Status**: in-flight
-- **PR**: #623
+- **Status**: landed
+- **PR**: #623 (merged 2026-09-10T19:59Z; reconciled in-flight→landed by the 2026-09-11 firing). Delivered as the `propagate!` macro + `IntoAbrupt` trait in `src/interpreter/types.rs`, adopted in `string.rs` and `temporal/duration.rs`; CONTEXT.md gained the "Completion Propagation" term.
 - **Score**: 23/25 (leverage 5, locality 3, blast radius 1, heat 5)
 - **Files (this firing's scope)**: ~3 estimated — hoist macros out of `src/interpreter/builtins/temporal/duration.rs:9-25` into a crate-visible home in `src/interpreter/types.rs`, re-point `duration.rs`, adopt one representative file (`array.rs`/`string.rs`/`typedarray.rs` — chosen at step 5 from the shape-3 concentrations).
 - **Modules**: `src/interpreter/types.rs`, `src/interpreter/builtins/temporal/duration.rs`
@@ -145,7 +155,7 @@ Never delete rows; they are the memory that stops re-surfacing the same work.
 - **Score**: 18/25 (leverage 3, locality 4, blast radius 1, heat 3)
 - **Files**: ~5 estimated — `src/interpreter/builtins/number.rs`, `bigint.rs`, `string.rs` (+ helper home)
 - **Modules**: `src/interpreter/builtins/number.rs`
-- **Summary**: Five near-identical private helpers implement "return primitive X, else unwrap a wrapper object whose `class_name == "X"` reading `primitive_value`, else None/throw": `this_number_value` (`number.rs:397`), `this_boolean_value` (`:667`), `this_symbol_value` (`:258`), `this_bigint_value` (`bigint.rs:40`), `this_string_value` (`string.rs:6`), differing only by the class-name literal and the primitive extractor. A generic `this_primitive_value(this, class_name)` (or small trait) collapses the five parallel brand-and-unwrap bodies. Wrapper-object analogue of `object-this-coercion` (ToObject), so net-new. First seen 2026-09-04.
+- **Summary**: Five near-identical private helpers implement "return primitive X, else unwrap a wrapper object whose `class_name == "X"` reading `primitive_value`, else None/throw": `this_number_value` (`number.rs:397`), `this_boolean_value` (`:667`), `this_symbol_value` (`:258`), `this_bigint_value` (`bigint.rs:40`), `this_string_value` (`string.rs:6`), differing only by the class-name literal and the primitive extractor. A generic `this_primitive_value(this, class_name)` (or small trait) collapses the parallel brand-and-unwrap bodies. Wrapper-object analogue of `object-this-coercion` (ToObject), so net-new. First seen 2026-09-04. (2026-09-11 re-check: the parallel family is **4, not 5** — `this_string_value` (`string.rs:6`) is *not* a sibling: it returns `Result<String, Completion>`, takes `&mut`, and does RequireObjectCoercible + ToString fallback rather than the Option-returning brand-unwrap the other four share. Re-scored leverage 3, total 18/25.)
 
 ## regexp-last-index-accessor
 

--- a/.architecture/reviews/2026-09-11-typedarray-getter-receiver-guard.md
+++ b/.architecture/reviews/2026-09-11-typedarray-getter-receiver-guard.md
@@ -207,4 +207,82 @@ relation that `arraybuffer-receiver-guard` (#570) bears to it.
 
 ## Design
 
-_Written in step 4 (design-it-twice + adjudication); this section is amended and re-committed then._
+Three interfaces were produced in parallel by sub-agents (design-it-twice), each briefed to a different
+optimization target, then adjudicated against — in priority order — **depth, locality, seam placement,
+test surface, blast radius**. All three stay blast radius 1 (file-private in `typedarray.rs`, no exported
+interface touched) and behaviour-preserving (exact error strings, the detached-only vs detached-or-OOB
+distinction, the getters' return-0 semantics).
+
+Note the winning mechanism differs from the *pick card*'s sketch of a single
+`require_typed_array_receiver(this, brand, detach_policy)` guard: the adjudicator preferred a **combinator**
+over a policy-parameterized guard. The *hiding* is the same or greater — the drift-prone rule is baked in,
+not passed as an argument — so the card and the design agree on what is deepened, only not on the shape.
+
+### Design A — minimal surface (`require_typed_array` / `require_uint8_array`)
+
+- **Interface**: two same-shaped private fns `fn require_typed_array(interp, this) -> Result<TypedArrayInfo,
+  Completion>` and `fn require_uint8_array(...)`, the brand error string baked into each function *name*
+  (no brand parameter, **zero new types**). Mirrors the in-file #570 precedent `require_array_buffer` /
+  `require_shared_array_buffer`.
+- **Usage**: getters call the guard, then keep `if ta.is_detached.get() || is_typed_array_out_of_bounds(&ta)
+  { return 0 }` inline; validators compose the existing `check_detached*` on top; `validate_uint8array_no_
+  detach_check` becomes a pure alias and is deleted.
+- **Hides**: the `as_object_id → get_object → borrow → typed_array_info → clone → brand-throw` dance.
+- **Trade-offs**: does **not** hide the `detached||oob ⇒ 0` rule — it stays copied across the 3 numeric
+  getters; two near-duplicate bodies.
+
+### Design B — maximum flexibility (`guard_ta_receiver` + policy enums) — runner-up design
+
+- **Interface**: one `fn guard_ta_receiver(interp, this, brand: Brand, detach: DetachPolicy) -> Guard`, with
+  **four new types**: `Brand{AnyTypedArray, Exactly(TypedArrayKind)}`, `DetachPolicy{Ignore, Throw(Scope),
+  Signal(Scope)}`, `Scope{Detached, DetachedOrOob}`, `Guard{Live(TypedArrayInfo), Dead, Reject(Completion)}`
+  + `Guard::into_result()`. All five current patterns map onto one call; illegal states (e.g. a scope on a
+  no-check policy) are unrepresentable because `Scope` nests inside the checking policies.
+- **Usage**: numeric getters do a 3-arm `match guard(..Signal(DetachedOrOob)) { Live(ta)=>payload, Dead=>0,
+  Reject(c)=>c }`; validators are one-line presets, so the 19 `validate_typed_array` callers stay untouched.
+- **Hides**: the resolve+brand+liveness prologue *and* the policy vocabulary.
+- **Trade-offs**: four types to learn dilutes behaviour-per-unit-of-interface; the `Dead→0` mapping is still
+  per-getter; the enum matrix seams policy combinations with **zero or one** user (`Signal(Detached)`,
+  `Exactly(non-Uint8)`) — hypothetical seams by the "two adapters = real" test; one `unreachable!` in
+  `into_result`; largest diff.
+
+### Design C — getter-optimised combinator (`with_typed_array_ref` + `ta_number_getter`) — winner
+
+- **Interface**: two layered private fns, **zero new named types**:
+  - kernel `fn with_typed_array_ref<R>(interp, this, brand_msg: &str, f: impl FnOnce(&TypedArrayInfo) -> R)
+    -> Result<R, Completion>` — resolves the receiver, runs the *pure* `f` while the object borrow is held,
+    throws `brand_msg` on a non-TA receiver (after the borrow drops);
+  - hot-path `fn ta_number_getter(interp, this, payload: impl FnOnce(&TypedArrayInfo) -> f64) -> Completion`
+    — bakes in the brand-throw `"not a TypedArray"`, the `detached||oob ⇒ 0` collapse, and the
+    `Completion::Normal(JsValue::number(_))` wrapping.
+- **Usage**: each numeric getter collapses to `ta_number_getter(interp, this, |ta| ta.byte_offset as f64)`
+  (and `typed_array_byte_length(ta)` / `typed_array_length(ta)`) — a one-line, zero-clone read through the
+  borrow. `buffer` uses the kernel directly (`|ta| ta.buffer_object_id`). The three validators layer their
+  own brand/kind + `check_detached*` refinements on the kernel, `validate_typed_array`'s signature and its
+  19 callers unchanged.
+- **Hides**: the resolve+brand+borrow-ordering prologue (kernel) *and*, for the numeric getters, the entire
+  spec `TypedArrayLength → 0`-on-detached rule (combinator). A numeric getter is *structurally incapable* of
+  the classic bugs: wrong brand string, skipped OOB half, payload-instead-of-0 on a dead view, or touching
+  `interp` out of borrow order — the payload closure is `FnOnce(&TypedArrayInfo) -> f64` and is only reached
+  on a live view.
+- **Trade-offs**: `buffer` (non-numeric, no-detach) and the two uint8 validators don't ride the numeric
+  combinator — they use the shallower kernel and keep their intrinsic refinements; the kernel carries a
+  `brand_msg: &str` that the hot numeric path never varies.
+
+### Verdict
+
+**Winner: C. Runner-up design: B.** On **depth**, C's numeric getter learns one function and a single
+`&TypedArrayInfo -> f64` closure, where B forces four types and a 3-arm match and A hides only the brand
+dance. On **locality**, the drift-prone `TypedArrayLength → 0` rule lives *once* in `ta_number_getter`
+(a fifth numeric getter cannot omit it), versus concentrated-but-still-per-getter in B and copied 3× in A.
+On **seam placement**, the ReturnZero rule has three real adapters (the three numeric getters, byte-identical
+predicate) and C seams exactly that, while B additionally seams single-/zero-user policy combinations
+(hypothetical seams) and A under-seams by leaving the rule out entirely. **Test surface** slightly favours
+B (every combo directly exercisable) but C pins the actual rule directly — assert 0 on a detached view and
+that the payload closure is never invoked — so it is not decisive. **Blast radius** (A < C < B) is a
+tie-break among equals and is not reached, since C already leads on the higher criteria. A loses despite
+matching the #570 `require_array_buffer` idiom because idiom-consistency is not a criterion, and A delivers
+*less than the candidate was scored on*: the pick is a deepening precisely because the ReturnZero policy
+"extends what the seam hides" — A does not hide it, C does.
+
+Adjudicated with the advisor (transcript). Designs produced by parallel sub-agents.

--- a/.architecture/reviews/2026-09-11-typedarray-getter-receiver-guard.md
+++ b/.architecture/reviews/2026-09-11-typedarray-getter-receiver-guard.md
@@ -1,0 +1,210 @@
+# Architecture review — jsse — 2026-09-11
+
+**Scope**: `src/interpreter/` and `src/interpreter/builtins/` — the tree-walking interpreter and its
+native builtins, which dominate the recent hot spots (`git log -60`: `typedarray.rs`, `iterators.rs`,
+`string.rs`, `eval.rs`, `generator_runtime.rs`). Two PRs merged since the last firing reshaped the
+Completion landscape — #622 (`with_array_elements/_mut`) and #623 (`propagate!` + `IntoAbrupt`) — so
+their candidates were re-verified against current code, not the backlog's stale counts.
+
+**Picked**: `typedarray-getter-receiver-guard` — see PR (below) and `.architecture/backlog.md`.
+
+**Degradations**: none. `gh` authenticated; `codebase-design` vocabulary applied; sub-agent scan ran.
+
+**Diagram convention**: in every Before/After pair, solid edges are the module's public interface;
+dashed edges are calls that happen *inside* the implementation, hidden from callers.
+
+## Candidates
+
+### typedarray-getter-receiver-guard — one seam for TypedArray receiver-brand + detach policy · Strong · score 22/25
+
+- **Files**: `src/interpreter/builtins/typedarray.rs` — the 4 `%TypedArray%.prototype` getters
+  (`byteOffset` :1313, `byteLength` :1328, `length` :1343, `buffer` :1359) and the 3-member validator
+  sibling family (`validate_typed_array` :5655, `validate_uint8array` :5673,
+  `validate_uint8array_no_detach_check` :5700). File-count estimate: **~1**.
+- **Score**: **22/25**
+  - **Leverage 4** — 7 sites collapse (4 getters + 3 validators) and a whole class of receiver-validation
+    test setup disappears; consistent with the landed `arraybuffer-receiver-guard` (8 getters → leverage 5)
+    and `validate-typed-array` (leverage 5), one notch lower for the smaller site count.
+  - **Locality 4** — a change to TypedArray receiver semantics (resizable-buffer OOB, a new detach rule,
+    the brand error wording) today forces parallel edits in up to 7 places; afterwards it is one seam edit.
+  - **Blast radius 1** — contained to `typedarray.rs`, no published interface touched, ~1 file.
+  - **Heat 5** — `typedarray.rs` is among the hottest builtins (recent #543 `validate-typed-array`,
+    #570 `arraybuffer-receiver-guard`, and present in the last-60-commit window).
+- **Problem** — the module is **shallow at the receiver-validation seam**: a caller (getter) that wants a
+  validated TypedArray must itself spell out `as_object_id → get_object[_cell] → borrow →
+  typed_array_info → (detach/OOB branch) → else create_type_error("not a TypedArray")`. The seam
+  `validate_typed_array` exists and hides exactly this — but only under a **throw-on-detached** policy, so
+  the getters, which must **return 0** on a detached/out-of-bounds receiver (per spec `TypedArrayLength`
+  returning 0), reach *past* it and re-open-code the whole dance. The result is three parallel validators
+  that differ only in brand string and detach policy, plus four getters that duplicate the validator body
+  a fourth way. The interface (`this_val`) is trivial; the implementation (brand + borrow + policy branch +
+  two spellings of the throw) is repeated verbatim — the definition of a shallow module.
+- **Deletion test** — delete the getters' inline prologues and the two Uint8 validators: the brand-check
+  and policy logic **concentrates** in the one `require_typed_array_receiver` seam. It does not move to
+  callers — callers shrink to a payload expression over a returned snapshot. Concentrates → a real
+  deepening.
+- **Solution** — add one receiver guard, `require_typed_array_receiver(this, brand, detach_policy) ->
+  Result<TypedArrayInfo, Completion>`, returning an owned `TypedArrayInfo` snapshot (as
+  `validate_typed_array` already does, so no borrow is held across the payload computation). `brand`
+  selects any-TypedArray vs a specific `TypedArrayKind` (with the matching error string); `detach_policy`
+  selects Throw / NoCheck / **ReturnZero**. Re-express the 4 getters as `match guard(..ReturnZero/NoCheck..)
+  { Ok(ta) => payload, Err(_) => 0-or-throw }`, and redefine the 3 validators as thin one-line calls into
+  the guard. Extends the existing seam by one policy dimension rather than adding a new parallel one.
+- **Benefits** — **leverage**: the "what counts as a valid TypedArray receiver, and what happens when it is
+  detached" decision lives once. **locality**: the next resizable-ArrayBuffer OOB fix, or a corrected brand
+  message, is a one-line change behind the seam instead of a 7-site sweep that drift has already started on
+  (the getters say `"not a TypedArray"`, the Uint8 validators say `"not a Uint8Array"` / `"typed array is
+  detached"` — the guard makes the divergence a parameter, not an accident). **test surface**: the guard is
+  directly unit-testable for each (brand × policy) combination through one interface, where today each
+  policy is only reachable through a specific getter's observable output.
+
+```mermaid
+graph LR
+  G1[byteOffset getter] -.-> P[brand-check + borrow + detach/OOB branch + throw-tail]
+  G2[byteLength getter] -.-> P
+  G3[length getter] -.-> P
+  G4[buffer getter] -.-> P
+  V1[validate_typed_array] -.-> P
+  V2[validate_uint8array] -.-> P
+  V3[validate_uint8array_no_detach_check] -.-> P
+```
+
+```mermaid
+graph LR
+  G1[byteOffset getter] --> R[require_typed_array_receiver brand,policy]
+  G2[byteLength getter] --> R
+  G3[length getter] --> R
+  G4[buffer getter] --> R
+  V1[validate_typed_array] --> R
+  V2[validate_uint8array] --> R
+  V3[validate_uint8array_no_detach_check] --> R
+  R -.-> P[brand-check + snapshot + policy branch]
+```
+
+### gc-root-scope-guard-eval — extend with_gc_root_scope into eval.rs · Strong · score 22/25 (tied runner-up candidate)
+
+- **Files**: `src/interpreter/eval.rs` (primary; 23 `gc_root_frame` setups / 51 `gc_unroot_frame`
+  teardowns = ~28 redundant per-early-return copies across ~14 fns, 10 IIFE-workaround sites e.g. :4071,
+  2 `gc_temp_roots.push` bypasses :1066/:4327, 1 manual `remove` :4589), plus the remaining ~9 files
+  (`iterators.rs`, `promise.rs`, `exec.rs`, `atomics.rs`, `typedarray.rs`, `property.rs`, `eval/literals.rs`,
+  `mod.rs`, `bytecode/vm.rs`). File-count estimate: **~10** (full candidate). A first firing would scope to
+  `eval.rs` only, mirroring how #595 scoped to `array.rs`.
+- **Score**: **22/25** (leverage 5, locality 4, blast radius 3, heat 5) — unchanged from the backlog, held at
+  the full-candidate blast radius per the ranking rule that a one-file firing scopes the *implementation*,
+  not the *score*.
+- **Problem** — the `with_gc_root_scope` combinator already exists (`mod.rs:1358`, landed #595) and hides
+  the Temp-Root Frame teardown, but `eval.rs` — the hottest file — still hand-pairs `gc_root_frame` /
+  `gc_unroot_frame` with a teardown copy on *every* early-return branch, exactly the forgettable-epilogue
+  bug class the seam was built to remove (#595 found 3 latent over-rooting exits doing this in `array.rs`).
+- **Deletion test** — concentrates: the teardown-on-every-branch obligation collapses onto the combinator.
+- **Solution** — adopt `with_gc_root_scope` for the whole-body single-frame functions and the 10 IIFE sites;
+  leave the 2 direct `gc_temp_roots.push` bypasses and the manual `remove` as documented exceptions (as #595
+  kept `Array.from`'s nested frames raw).
+- **Benefits** — leverage across ~14 functions on the hottest path; locality of the whole GC-root-teardown
+  contract; test surface unchanged (behaviour-preserving) but the bug class is structurally excluded.
+- **Newly more implementable**: the documented blocker — `eval_expr` being `#[inline(always)]` — is **gone**
+  (no `#[inline(always)]` remains in `eval.rs`). This lowers *risk*, not the score.
+
+```mermaid
+graph LR
+  F1[eval fn A] -.-> S1[gc_root_frame]
+  F1 -.-> S2[unroot on branch 1]
+  F1 -.-> S3[unroot on branch 2]
+  F1 -.-> S4[unroot on tail]
+  F2[eval fn B] -.-> S1
+```
+
+```mermaid
+graph LR
+  F1[eval fn A] --> W[with_gc_root_scope]
+  F2[eval fn B] --> W
+  W -.-> S1[gc_root_frame]
+  W -.-> S4[truncate on every exit]
+```
+
+### completion-into-result — Completion::into_result for Result-returning iterator helpers · Worth exploring · score 21/25
+
+- **Files**: `src/interpreter/builtins/iterators.rs` (25 open-coded `match Completion { Normal(v)=>v,
+  Throw(e)=>return Err(e), _=>… }` heads with 26 fabricated `_ => UNDEFINED` arms), `types.rs`. Estimate ~2.
+- **Score**: **21/25** (leverage 4, locality 3, blast radius 1, heat 5). Verified present and **unresolved**
+  by #622/#623: `propagate!` early-returns a `Completion` and fits `eval.rs`'s `-> Completion` heads, but
+  these 25 heads live in `-> Result<_, JsValue>` helpers with `_ => continue`-style arms, so they need a
+  *Result-flavoured* sibling (`Completion::into_result(self) -> Result<JsValue, JsValue>`), not the existing
+  macro. Distinct from #623.
+- **Problem / deletion test / solution** — as recorded in the backlog; the fabricated `_ =>` arms become
+  removable dead code once the adapter head is a single `.into_result()?`.
+
+### this-primitive-value — collapse 4 brand-and-unwrap wrapper helpers · Worth exploring · score 18/25
+
+- **Files**: `number.rs` (`this_number_value` :397, `this_boolean_value` :667, `this_symbol_value` :258),
+  `bigint.rs` (`this_bigint_value` :40). Estimate ~5. **Correction from the backlog**: `this_string_value`
+  (`string.rs:6`) is **not** a parallel sibling — it returns `Result<String, Completion>`, takes `&mut`, and
+  does RequireObjectCoercible + ToString fallback. So the parallel family is **4, not 5**.
+- **Score**: **18/25** (leverage 3, locality 4, blast radius 1, heat 3).
+
+### iterator-close-return-dance — one IteratorClose core, four (now five) adapters · Worth exploring · score 20/25
+
+- **Files**: `src/interpreter/builtins/iterators.rs`. A **5th** parallel reimplementation surfaced
+  (`iterator_close_all` :637) beyond the four recorded. Drift confirmed live: `iterator_close_getter` :319
+  and `iterator_close_with_completion` :587 lack both the `is_callable` pre-check and `Completion::Exit`
+  handling that `iterator_close` :4999 and `iterator_close_result` :5030 perform.
+- **Score**: **20/25** (leverage 3, locality 4, blast radius 1, heat 5).
+
+### settle-and-return-tail — one async-generator exit tail · Worth exploring · score 20/25
+
+- **Files**: `src/interpreter/eval/generator_runtime.rs` — 47 open-coded "call settle fn + `drain_microtasks()`
+  + return `Normal(promise)`" tails; a partial seam `reject_with_type_error` (:2503) already exists for the
+  TypeError variant (15 uses). Estimate ~1.
+- **Score**: **20/25** (leverage 4, locality 4, blast radius 1, heat 3).
+
+### Other verified-present proposed candidates (unchanged, see backlog)
+
+`object-this-coercion` 20/25 (10 `to_object(this` sites, `builtins/mod.rs`), `this-weak-map-set` 20/25
+(6 WeakMap + 3 WeakSet dances, `collections.rs`), `generator-entry-guard` 19/25 (11 pairs,
+`generator_runtime.rs`), `regexp-last-index-accessor` 18/25 (read side has no seam; set side 13 uses of
+`set_last_index_strict` with ~7 bypasses), `throw-error-completion` 18/25, `pattern-bound-names-walker`
+19/25, `dataview-receiver-guard` 18/25, `array-typedarray-immutable-methods` 17/25.
+
+## Dropped
+
+Carried forward from the backlog; hard filters re-checked this run and still apply.
+
+| Candidate | Dropped because |
+|---|---|
+| `object-id-of` | Leverage 2 — `/simplify`-class round-trip cleanup, complexity renamed not concentrated |
+| `proxy-blind-callable-check` | Behaviour change (latent bug), not a behaviour-preserving deepening — file as a bug |
+| `define-accessor-adoption` | Leverage 2 — deep `define_getter` seam already exists; migrating 42 raw getters is finishing work |
+| `typedarray-shared-equality` | Leverage 2 — missed-reuse dedup, not a new seam |
+| `arg-or-undefined` | Leverage 2 — DRY helper whose interface equals its implementation (shallow by definition) |
+| `define-method-adoption` | Leverage 2 — `define_method` seam already exists; straggler adoption is `/simplify`-class |
+| `proxy-trap-skeleton` | Leverage 2 — deep `invoke_proxy_trap` already factored; only a thin skeleton would collapse |
+
+## Too large to automate
+
+| Candidate | Filter | Note |
+|---|---|---|
+| `unify-generator-async-drivers` | Blast radius 5 | ~1580/~3050-line parallel state machines; land the ctor/settle-tail candidates first |
+| `ordinary-create-from-constructor` | Blast radius 4 | 15–20 files across builtin families; best in human-scheduled waves |
+
+## Pick
+
+**`typedarray-getter-receiver-guard`** (22/25), scoped to `typedarray.rs`.
+
+The top two are **tied at 22/25**, so the deterministic tie-break — **lower blast radius** — decides it:
+`typedarray-getter-receiver-guard` is blast radius **1** (one file), the runner-up candidate
+`gc-root-scope-guard-eval` is blast radius **3** (full ~10-file candidate). Per the ranking rule, the
+runner-up's score is *not* re-lowered by scoping its first firing to `eval.rs`; the full-candidate blast
+radius is what ranks it, and at equal totals the tighter-scoped candidate wins. `gc-root-scope-guard-eval`
+is therefore the natural next firing.
+
+Why the pick is a genuine deepening and not straggler-adoption of the existing `validate_typed_array` seam
+(the test that dropped `define-method-adoption`): the getters do not merely fail to *use* the seam — they
+*cannot*, because they need a **return-0-on-detached** policy the seam does not offer. Adding a detach-policy
+parameter **extends what the seam hides**, exactly the distinction that keeps `dataview-receiver-guard`
+proposed. It is the direct follow-up to the landed `validate-typed-array` (#543) — whose summary explicitly
+left the `validate_uint8array` sibling and the throw-on-detached getters out of scope — in the same family
+relation that `arraybuffer-receiver-guard` (#570) bears to it.
+
+## Design
+
+_Written in step 4 (design-it-twice + adjudication); this section is amended and re-committed then._

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,3 +67,18 @@ _Avoid_: permanent root, closure root.
 **Rooted Slot**:
 A GC-traced container an anchor pins once and the owner then mutates in place, for a capture whose value is *replaced* over the anchor's lifetime. A native closure's own `Rc<RefCell<…>>` state is invisible to the tracer, and re-pinning each replacement would retain every superseded value, so the slot — not the value — is what gets pinned. `RootedPair` in `builtins/iterators.rs` is the two-slot case: the iterator an iterator helper is currently drawing from, plus that iterator's `next` method.
 _Avoid_: root cell, traced box, rooted buffer.
+
+## Builtins
+
+**Receiver Guard**:
+The single prologue a native method routes its `this` through to brand-check the
+receiver and hand back an owned snapshot of its kind-specific info — or throw the
+brand `TypeError` — so callers never re-spell the `as_object_id → get_object →
+borrow → <kind>_info` dance. The family: `validate_typed_array` /
+`with_typed_array_ref` (any TypedArray), `require_array_buffer` /
+`require_shared_array_buffer` (`builtins/typedarray.rs`). A guard may be
+parameterized by a detach policy: `ta_number_getter` layers the numeric getters'
+spec `TypedArrayLength → 0`-on-detached-or-out-of-bounds rule on top of the guard,
+where `validate_typed_array` instead throws. The snapshot is owned so the object
+borrow drops before any `create_type_error` (which mutates the object arena).
+_Avoid_: receiver check, brand check (for the whole prologue), this-unwrap.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,13 +72,17 @@ _Avoid_: root cell, traced box, rooted buffer.
 
 **Receiver Guard**:
 The single prologue a native method routes its `this` through to brand-check the
-receiver and hand back an owned snapshot of its kind-specific info — or throw the
-brand `TypeError` — so callers never re-spell the `as_object_id → get_object →
-borrow → <kind>_info` dance. The family: `validate_typed_array` /
-`with_typed_array_ref` (any TypedArray), `require_array_buffer` /
-`require_shared_array_buffer` (`builtins/typedarray.rs`). A guard may be
-parameterized by a detach policy: `ta_number_getter` layers the numeric getters'
-spec `TypedArrayLength → 0`-on-detached-or-out-of-bounds rule on top of the guard,
-where `validate_typed_array` instead throws. The snapshot is owned so the object
-borrow drops before any `create_type_error` (which mutates the object arena).
+receiver — or throw the brand `TypeError` — so callers never re-spell the
+`as_object_id → get_object → borrow → <kind>_info` dance. The family:
+`require_array_buffer` / `require_shared_array_buffer` (`builtins/typedarray.rs`)
+hand back an owned snapshot of the buffer's kind-specific info; `with_typed_array_ref`
+is the leaner kernel form — it runs a caller-supplied closure against the borrowed
+`TypedArrayInfo` and returns whatever the closure returns (a scalar, an owned
+snapshot via `TypedArrayInfo::clone`, or anything else), so ownership is the
+caller's choice, not the guard's. `validate_typed_array` layers a snapshot +
+detached/OOB throw on top of the kernel. A guard may be parameterized by a
+detach policy: `ta_number_getter` layers the numeric getters' spec
+`TypedArrayLength → 0`-on-detached-or-out-of-bounds rule on top of the kernel,
+where `validate_typed_array` instead throws. Either way, any borrow the guard
+holds drops before `create_type_error` runs (it mutates the object arena).
 _Avoid_: receiver check, brand check (for the whole prologue), this-unwrap.

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -5645,8 +5645,7 @@ fn ta_buffer_getter(interp: &mut Interpreter, this_val: &JsValue) -> Completion 
         ta.buffer_object_id
     }) {
         Ok(Some(buf_id)) => Completion::Normal(JsValue::object(buf_id)),
-        Ok(None) => Completion::Throw(interp.create_type_error("not a TypedArray")),
-        Err(throw) => throw,
+        Ok(None) | Err(_) => Completion::Throw(interp.create_type_error("not a TypedArray")),
     }
 }
 
@@ -5662,7 +5661,7 @@ fn ta_number_getter(
     payload: impl FnOnce(&TypedArrayInfo) -> f64,
 ) -> Completion {
     match with_typed_array_ref(interp, this_val, "not a TypedArray", |ta| {
-        if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
+        if is_ta_detached_or_oob(ta) {
             0.0
         } else {
             payload(ta)
@@ -5695,13 +5694,10 @@ fn validate_uint8array_no_detach_check(
     interp: &mut Interpreter,
     this_val: &JsValue,
 ) -> Result<TypedArrayInfo, Completion> {
-    let ta = with_typed_array_ref(interp, this_val, "not a Uint8Array", TypedArrayInfo::clone)?;
-    if !matches!(ta.kind, TypedArrayKind::Uint8) {
-        return Err(Completion::Throw(
-            interp.create_type_error("not a Uint8Array"),
-        ));
-    }
-    Ok(ta)
+    let ta = with_typed_array_ref(interp, this_val, "not a Uint8Array", |ta| {
+        matches!(ta.kind, TypedArrayKind::Uint8).then(|| ta.clone())
+    })?;
+    ta.ok_or_else(|| Completion::Throw(interp.create_type_error("not a Uint8Array")))
 }
 
 fn check_detached(interp: &mut Interpreter, ta: &TypedArrayInfo) -> Result<(), Completion> {
@@ -5714,13 +5710,19 @@ fn check_detached(interp: &mut Interpreter, ta: &TypedArrayInfo) -> Result<(), C
     }
 }
 
+/// True iff the TypedArray is detached, or tracks a resizable ArrayBuffer that
+/// has since shrunk out from under its bounds.
+fn is_ta_detached_or_oob(ta: &TypedArrayInfo) -> bool {
+    ta.is_detached.get() || is_typed_array_out_of_bounds(ta)
+}
+
 /// Combines the detached check with the out-of-bounds check that applies to
 /// typed arrays tracking a resizable ArrayBuffer that has since shrunk.
 fn check_detached_or_out_of_bounds(
     interp: &mut Interpreter,
     ta: &TypedArrayInfo,
 ) -> Result<(), Completion> {
-    if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
+    if is_ta_detached_or_oob(ta) {
         Err(Completion::Throw(
             interp.create_type_error("typed array is detached"),
         ))
@@ -6351,7 +6353,7 @@ mod validate_typed_array_tests {
     use crate::parser::Parser;
     use crate::types::JsValue;
 
-    fn interp_with(source: &str) -> Interpreter {
+    pub(super) fn interp_with(source: &str) -> Interpreter {
         let mut parser = Parser::new(source).expect("parser init");
         let program = parser.parse_program().expect("parse program");
         let mut interp = Interpreter::new();
@@ -6363,7 +6365,7 @@ mod validate_typed_array_tests {
         interp
     }
 
-    fn global(interp: &Interpreter, name: &str) -> JsValue {
+    pub(super) fn global(interp: &Interpreter, name: &str) -> JsValue {
         interp
             .get_global_var_ref(name)
             .unwrap_or_else(|| panic!("expected global {name}"))
@@ -6430,29 +6432,11 @@ mod ta_number_getter_tests {
     //! on-detached-or-out-of-bounds rule). A live receiver is mapped through the
     //! payload; a detached one yields 0 *without ever invoking the payload*; a
     //! non-TypedArray receiver throws "not a TypedArray".
+    use super::validate_typed_array_tests::{global, interp_with};
     use super::{ta_number_getter, with_typed_array_ref};
-    use crate::interpreter::{Completion, Interpreter};
-    use crate::parser::Parser;
+    use crate::interpreter::Completion;
     use crate::types::JsValue;
     use std::cell::Cell;
-
-    fn interp_with(source: &str) -> Interpreter {
-        let mut parser = Parser::new(source).expect("parser init");
-        let program = parser.parse_program().expect("parse program");
-        let mut interp = Interpreter::new();
-        let result = interp.run(&program);
-        assert!(
-            matches!(result, Completion::Normal(_) | Completion::Empty),
-            "unexpected completion: {result:?}"
-        );
-        interp
-    }
-
-    fn global(interp: &Interpreter, name: &str) -> JsValue {
-        interp
-            .get_global_var_ref(name)
-            .unwrap_or_else(|| panic!("expected global {name}"))
-    }
 
     #[test]
     fn number_getter_maps_a_live_receiver_through_the_payload() {

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1311,64 +1311,34 @@ impl Interpreter {
 
         // byteOffset getter
         self.define_getter(proto_id, "byteOffset", |interp, this_val, _args| {
-            if let Some(o) = this_val.as_object_id()
-                && let Some(obj) = interp.get_object_cell(o)
-            {
-                let obj_ref = obj.borrow();
-                if let Some(ta) = obj_ref.typed_array_info() {
-                    if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                        return Completion::Normal(JsValue::number(0.0));
-                    }
-                    return Completion::Normal(JsValue::number(ta.byte_offset as f64));
-                }
-            }
-            Completion::Throw(interp.create_type_error("not a TypedArray"))
+            ta_number_getter(interp, this_val, |ta| ta.byte_offset as f64)
         });
         // byteLength getter
         self.define_getter(proto_id, "byteLength", |interp, this_val, _args| {
-            if let Some(o) = this_val.as_object_id()
-                && let Some(obj) = interp.get_object_cell(o)
-            {
-                let obj_ref = obj.borrow();
-                if let Some(ta) = obj_ref.typed_array_info() {
-                    if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                        return Completion::Normal(JsValue::number(0.0));
-                    }
-                    return Completion::Normal(JsValue::number(typed_array_byte_length(ta) as f64));
-                }
-            }
-            Completion::Throw(interp.create_type_error("not a TypedArray"))
+            ta_number_getter(interp, this_val, |ta| typed_array_byte_length(ta) as f64)
         });
         // length getter
         self.define_getter(proto_id, "length", |interp, this_val, _args| {
-            if let Some(o) = this_val.as_object_id()
-                && let Some(obj) = interp.get_object_cell(o)
-            {
-                let obj_ref = obj.borrow();
-                if let Some(ta) = obj_ref.typed_array_info() {
-                    if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
-                        return Completion::Normal(JsValue::number(0.0));
-                    }
-                    return Completion::Normal(JsValue::number(typed_array_length(ta) as f64));
-                }
-            }
-            Completion::Throw(interp.create_type_error("not a TypedArray"))
+            ta_number_getter(interp, this_val, |ta| typed_array_length(ta) as f64)
         });
 
-        // buffer getter (returns the ArrayBuffer object - we need to find it)
-        self.define_getter(proto_id, "buffer", |interp, this_val, _args| {
-            if let Some(o) = this_val.as_object_id()
-                && let Some(obj) = interp.get_object(o)
-            {
-                let obj_ref = obj.borrow();
-                if obj_ref.typed_array_info().is_some()
-                    && let Some(buf_id) = obj_ref.view_buffer_object_id()
-                {
-                    return Completion::Normal(JsValue::object(buf_id));
-                }
-            }
-            Completion::Throw(interp.create_type_error("not a TypedArray"))
-        });
+        // buffer getter (returns the ArrayBuffer object; no detached/OOB check —
+        // the buffer survives detachment. `buffer_object_id: None` on the rare
+        // wrapperless construction path preserves the "not a TypedArray" throw.)
+        self.define_getter(
+            proto_id,
+            "buffer",
+            |interp, this_val, _args| match with_typed_array_ref(
+                interp,
+                this_val,
+                "not a TypedArray",
+                |ta| ta.buffer_object_id,
+            ) {
+                Ok(Some(buf_id)) => Completion::Normal(JsValue::object(buf_id)),
+                Ok(None) => Completion::Throw(interp.create_type_error("not a TypedArray")),
+                Err(throw) => throw,
+            },
+        );
 
         // [Symbol.iterator] = values
         let proto_id_for_iter = proto_id;
@@ -5652,71 +5622,88 @@ fn require_shared_array_buffer(
     ))
 }
 
+/// The shared `%TypedArray%.prototype` receiver-guard prologue: resolve
+/// `this_val` to its `TypedArrayInfo` and run the pure `f` against the borrowed
+/// info. A receiver that is not a TypedArray throws `TypeError(brand_msg)` — the
+/// object borrow is dropped before the error is built, because
+/// `create_type_error` mutates the object arena. `f` must not need
+/// `&mut Interpreter`; every `TypedArrayInfo` field read and the `typed_array_*`
+/// / `is_typed_array_out_of_bounds` helpers already qualify. This is the one
+/// door the prototype getters and the `validate_*` helpers route `this` through.
+fn with_typed_array_ref<R>(
+    interp: &mut Interpreter,
+    this_val: &JsValue,
+    brand_msg: &str,
+    f: impl FnOnce(&TypedArrayInfo) -> R,
+) -> Result<R, Completion> {
+    if let Some(o) = this_val.as_object_id()
+        && let Some(obj) = interp.get_object(o)
+    {
+        let obj_ref = obj.borrow();
+        if let Some(ta) = obj_ref.typed_array_info() {
+            return Ok(f(ta));
+        }
+    }
+    Err(Completion::Throw(interp.create_type_error(brand_msg)))
+}
+
+/// Express a numeric `%TypedArray%.prototype` getter as a pure
+/// `TypedArrayInfo -> f64` payload. Owns the whole getter prologue: the
+/// brand-throw `"not a TypedArray"`, the spec `TypedArrayLength`-style
+/// "detached-or-out-of-bounds ⇒ 0" collapse (so `payload` is reached only on a
+/// live view), and the `Completion::Normal(number)` wrapping. Shared by the
+/// `byteOffset` / `byteLength` / `length` getters.
+fn ta_number_getter(
+    interp: &mut Interpreter,
+    this_val: &JsValue,
+    payload: impl FnOnce(&TypedArrayInfo) -> f64,
+) -> Completion {
+    match with_typed_array_ref(interp, this_val, "not a TypedArray", |ta| {
+        if ta.is_detached.get() || is_typed_array_out_of_bounds(ta) {
+            0.0
+        } else {
+            payload(ta)
+        }
+    }) {
+        Ok(n) => Completion::Normal(JsValue::number(n)),
+        Err(throw) => throw,
+    }
+}
+
 fn validate_typed_array(
     interp: &mut Interpreter,
     this_val: &JsValue,
 ) -> Result<TypedArrayInfo, Completion> {
-    if let Some(o) = this_val.as_object_id()
-        && let Some(obj) = interp.get_object(o)
-    {
-        let ta = obj.borrow().typed_array_info().cloned();
-        if let Some(ta) = ta {
-            check_detached_or_out_of_bounds(interp, &ta)?;
-            return Ok(ta);
-        }
-    }
-    Err(Completion::Throw(
-        interp.create_type_error("not a TypedArray"),
-    ))
+    let ta = with_typed_array_ref(interp, this_val, "not a TypedArray", TypedArrayInfo::clone)?;
+    check_detached_or_out_of_bounds(interp, &ta)?;
+    Ok(ta)
 }
 
 fn validate_uint8array(
     interp: &mut Interpreter,
     this_val: &JsValue,
 ) -> Result<TypedArrayInfo, Completion> {
-    if let Some(o) = this_val.as_object_id()
-        && let Some(obj) = interp.get_object(o)
-    {
-        let obj_ref = obj.borrow();
-        if let Some(ta) = obj_ref.typed_array_info() {
-            if !matches!(ta.kind, TypedArrayKind::Uint8) {
-                return Err(Completion::Throw(
-                    interp.create_type_error("not a Uint8Array"),
-                ));
-            }
-            if ta.is_detached.get() {
-                return Err(Completion::Throw(
-                    interp.create_type_error("typed array is detached"),
-                ));
-            }
-            return Ok(ta.clone());
-        }
+    let ta = with_typed_array_ref(interp, this_val, "not a Uint8Array", TypedArrayInfo::clone)?;
+    if !matches!(ta.kind, TypedArrayKind::Uint8) {
+        return Err(Completion::Throw(
+            interp.create_type_error("not a Uint8Array"),
+        ));
     }
-    Err(Completion::Throw(
-        interp.create_type_error("not a Uint8Array"),
-    ))
+    check_detached(interp, &ta)?;
+    Ok(ta)
 }
 
 fn validate_uint8array_no_detach_check(
     interp: &mut Interpreter,
     this_val: &JsValue,
 ) -> Result<TypedArrayInfo, Completion> {
-    if let Some(o) = this_val.as_object_id()
-        && let Some(obj) = interp.get_object(o)
-    {
-        let obj_ref = obj.borrow();
-        if let Some(ta) = obj_ref.typed_array_info() {
-            if !matches!(ta.kind, TypedArrayKind::Uint8) {
-                return Err(Completion::Throw(
-                    interp.create_type_error("not a Uint8Array"),
-                ));
-            }
-            return Ok(ta.clone());
-        }
+    let ta = with_typed_array_ref(interp, this_val, "not a Uint8Array", TypedArrayInfo::clone)?;
+    if !matches!(ta.kind, TypedArrayKind::Uint8) {
+        return Err(Completion::Throw(
+            interp.create_type_error("not a Uint8Array"),
+        ));
     }
-    Err(Completion::Throw(
-        interp.create_type_error("not a Uint8Array"),
-    ))
+    Ok(ta)
 }
 
 fn check_detached(interp: &mut Interpreter, ta: &TypedArrayInfo) -> Result<(), Completion> {
@@ -6433,6 +6420,115 @@ mod validate_typed_array_tests {
             err.contains("typed array is detached"),
             "unexpected error: {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod ta_number_getter_tests {
+    //! Pins the getter-first receiver-guard seam: `with_typed_array_ref` (the
+    //! shared brand-check prologue that resolves `this` to its `TypedArrayInfo`
+    //! or throws a caller-chosen brand message) and `ta_number_getter` (the
+    //! numeric-getter combinator that bakes in the spec `TypedArrayLength -> 0`
+    //! on-detached-or-out-of-bounds rule). A live receiver is mapped through the
+    //! payload; a detached one yields 0 *without ever invoking the payload*; a
+    //! non-TypedArray receiver throws "not a TypedArray".
+    use super::{ta_number_getter, with_typed_array_ref};
+    use crate::interpreter::{Completion, Interpreter};
+    use crate::parser::Parser;
+    use crate::types::JsValue;
+    use std::cell::Cell;
+
+    fn interp_with(source: &str) -> Interpreter {
+        let mut parser = Parser::new(source).expect("parser init");
+        let program = parser.parse_program().expect("parse program");
+        let mut interp = Interpreter::new();
+        let result = interp.run(&program);
+        assert!(
+            matches!(result, Completion::Normal(_) | Completion::Empty),
+            "unexpected completion: {result:?}"
+        );
+        interp
+    }
+
+    fn global(interp: &Interpreter, name: &str) -> JsValue {
+        interp
+            .get_global_var_ref(name)
+            .unwrap_or_else(|| panic!("expected global {name}"))
+    }
+
+    #[test]
+    fn number_getter_maps_a_live_receiver_through_the_payload() {
+        let mut interp = interp_with("var ta = new Uint32Array(new ArrayBuffer(16), 8);");
+        let ta = global(&interp, "ta");
+        let comp = ta_number_getter(&mut interp, &ta, |ta| ta.byte_offset as f64);
+        match comp {
+            Completion::Normal(v) => assert_eq!(v.as_number(), Some(8.0)),
+            other => panic!("expected Normal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn number_getter_returns_zero_on_detached_without_invoking_payload() {
+        let mut interp =
+            interp_with("var buf = new ArrayBuffer(8); var dta = new Uint8Array(buf);");
+        let buf = global(&interp, "buf");
+        let dta = global(&interp, "dta");
+        interp.detach_arraybuffer(&buf);
+        let called = Cell::new(false);
+        let comp = ta_number_getter(&mut interp, &dta, |ta| {
+            called.set(true);
+            ta.byte_offset as f64
+        });
+        match comp {
+            Completion::Normal(v) => assert_eq!(v.as_number(), Some(0.0)),
+            other => panic!("expected Normal(0), got {other:?}"),
+        }
+        assert!(!called.get(), "payload must not run on a detached receiver");
+    }
+
+    #[test]
+    fn number_getter_throws_on_a_non_object_receiver() {
+        let mut interp = interp_with("");
+        let comp = ta_number_getter(&mut interp, &JsValue::UNDEFINED, |ta| ta.byte_offset as f64);
+        match comp {
+            Completion::Throw(e) => {
+                let msg = interp.format_value(&e);
+                assert!(msg.contains("not a TypedArray"), "unexpected error: {msg}");
+            }
+            other => panic!("expected Throw, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn number_getter_throws_on_a_plain_object_receiver() {
+        let mut interp = interp_with("var o = {};");
+        let o = global(&interp, "o");
+        let comp = ta_number_getter(&mut interp, &o, |ta| ta.byte_offset as f64);
+        match comp {
+            Completion::Throw(e) => {
+                let msg = interp.format_value(&e);
+                assert!(msg.contains("not a TypedArray"), "unexpected error: {msg}");
+            }
+            other => panic!("expected Throw, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kernel_honours_the_brand_message_and_runs_f_on_a_live_receiver() {
+        let mut interp = interp_with("var ta = new Uint8Array([1, 2, 3]);");
+        let ta = global(&interp, "ta");
+        let len = with_typed_array_ref(&mut interp, &ta, "not a Uint8Array", |ta| ta.array_length)
+            .expect("live TypedArray");
+        assert_eq!(len, 3);
+
+        let err =
+            match with_typed_array_ref(&mut interp, &JsValue::UNDEFINED, "not a Uint8Array", |_| 0)
+            {
+                Ok(_) => panic!("expected non-TA to be rejected"),
+                Err(Completion::Throw(e)) => interp.format_value(&e),
+                Err(other) => panic!("expected Throw, got {other:?}"),
+            };
+        assert!(err.contains("not a Uint8Array"), "unexpected error: {err}");
     }
 }
 

--- a/src/interpreter/builtins/typedarray.rs
+++ b/src/interpreter/builtins/typedarray.rs
@@ -1325,20 +1325,9 @@ impl Interpreter {
         // buffer getter (returns the ArrayBuffer object; no detached/OOB check —
         // the buffer survives detachment. `buffer_object_id: None` on the rare
         // wrapperless construction path preserves the "not a TypedArray" throw.)
-        self.define_getter(
-            proto_id,
-            "buffer",
-            |interp, this_val, _args| match with_typed_array_ref(
-                interp,
-                this_val,
-                "not a TypedArray",
-                |ta| ta.buffer_object_id,
-            ) {
-                Ok(Some(buf_id)) => Completion::Normal(JsValue::object(buf_id)),
-                Ok(None) => Completion::Throw(interp.create_type_error("not a TypedArray")),
-                Err(throw) => throw,
-            },
-        );
+        self.define_getter(proto_id, "buffer", |interp, this_val, _args| {
+            ta_buffer_getter(interp, this_val)
+        });
 
         // [Symbol.iterator] = values
         let proto_id_for_iter = proto_id;
@@ -5637,7 +5626,7 @@ fn with_typed_array_ref<R>(
     f: impl FnOnce(&TypedArrayInfo) -> R,
 ) -> Result<R, Completion> {
     if let Some(o) = this_val.as_object_id()
-        && let Some(obj) = interp.get_object(o)
+        && let Some(obj) = interp.get_object_cell(o)
     {
         let obj_ref = obj.borrow();
         if let Some(ta) = obj_ref.typed_array_info() {
@@ -5645,6 +5634,20 @@ fn with_typed_array_ref<R>(
         }
     }
     Err(Completion::Throw(interp.create_type_error(brand_msg)))
+}
+
+/// Express the non-numeric `buffer` getter the same way `ta_number_getter`
+/// expresses the numeric ones. No detach/OOB collapse — the buffer survives
+/// detachment; `Ok(None)` preserves the pre-existing `buffer_object_id: None`
+/// fall-through to the same `"not a TypedArray"` throw.
+fn ta_buffer_getter(interp: &mut Interpreter, this_val: &JsValue) -> Completion {
+    match with_typed_array_ref(interp, this_val, "not a TypedArray", |ta| {
+        ta.buffer_object_id
+    }) {
+        Ok(Some(buf_id)) => Completion::Normal(JsValue::object(buf_id)),
+        Ok(None) => Completion::Throw(interp.create_type_error("not a TypedArray")),
+        Err(throw) => throw,
+    }
 }
 
 /// Express a numeric `%TypedArray%.prototype` getter as a pure
@@ -5683,12 +5686,7 @@ fn validate_uint8array(
     interp: &mut Interpreter,
     this_val: &JsValue,
 ) -> Result<TypedArrayInfo, Completion> {
-    let ta = with_typed_array_ref(interp, this_val, "not a Uint8Array", TypedArrayInfo::clone)?;
-    if !matches!(ta.kind, TypedArrayKind::Uint8) {
-        return Err(Completion::Throw(
-            interp.create_type_error("not a Uint8Array"),
-        ));
-    }
+    let ta = validate_uint8array_no_detach_check(interp, this_val)?;
     check_detached(interp, &ta)?;
     Ok(ta)
 }


### PR DESCRIPTION
## Problem

The `%TypedArray%.prototype` module was **shallow at its receiver-validation seam**. The four
prototype getters — `byteOffset`, `byteLength`, `length`, `buffer` — each hand-spelled the same
receiver dance: `as_object_id → get_object → borrow → typed_array_info → (detach/OOB branch) → else
throw "not a TypedArray"`. The `validate_typed_array` seam already hides exactly that prologue, but
only under a **throw-on-detached** policy, so the getters (which must **return 0** on a detached or
out-of-bounds receiver, per spec `TypedArrayLength`) could not use it and re-opened the whole dance a
fourth way. Beside them sat a three-member validator sibling family
(`validate_typed_array` / `validate_uint8array` / `validate_uint8array_no_detach_check`) differing
only in brand string and detach policy. The interface (`this`) was trivial; the implementation
(brand + borrow + policy branch + two spellings of the throw) was repeated verbatim — the definition
of a shallow module, and drift had already started (`"not a TypedArray"` vs `"not a Uint8Array"` vs
`"typed array is detached"`).

## What changed (in `codebase-design` terms)

Two file-private **seams** in `typedarray.rs`, **extending what the existing receiver guard hides**
rather than adding a fourth parallel copy — the distinction that makes this a **deepening**, not
straggler-adoption of `validate_typed_array`:

- `with_typed_array_ref<R>(this, brand_msg, f)` — the shared brand-check prologue: resolve the
  receiver, run a **pure** `f` against the borrowed `TypedArrayInfo`, else throw a caller-chosen brand
  message (the object borrow drops before the error is built).
- `ta_number_getter(this, payload)` — the numeric-getter combinator that bakes in the brand-throw, the
  spec `TypedArrayLength → 0`-on-detached-or-OOB collapse (so `payload` is reached **only** on a live
  view), and the `Normal(number)` wrapping.

**Leverage**: the "what is a valid TypedArray receiver, and what happens when it is detached" decision
now lives once. **Locality**: a future resizable-buffer OOB fix or brand-message correction is a
one-line change behind the seam, not a 7-site sweep. **Test surface**: the drift-prone rule is now
directly unit-testable — assert `0` on a detached view *and that the payload is never invoked*.

**Before** (solid = interface, dashed = inside the implementation):

```mermaid
graph LR
  G1[byteOffset] -.-> P[brand-check + borrow + detach/OOB branch + throw-tail]
  G2[byteLength] -.-> P
  G3[length] -.-> P
  G4[buffer] -.-> P
  V1[validate_typed_array] -.-> P
  V2[validate_uint8array] -.-> P
  V3[validate_uint8array_no_detach_check] -.-> P
```

**After**:

```mermaid
graph LR
  G1[byteOffset] --> N[ta_number_getter]
  G2[byteLength] --> N
  G3[length] --> N
  N --> R[with_typed_array_ref]
  G4[buffer] --> R
  V1[validate_typed_array] --> R
  V2[validate_uint8array] --> R
  V3[validate_uint8array_no_detach_check] --> R
  R -.-> P[resolve + brand-throw + snapshot]
```

The 3 numeric getters collapse to one-line payload closures (zero-clone, read through the borrow);
`buffer` uses the kernel directly; the 3 validators layer their brand/kind + `check_detached*`
refinements on the kernel. `validate_typed_array`'s signature and its 19 callers are untouched.

## Behaviour-preserving

Test-first (a red test module pinning the interface before it existed). Exact error strings, the
detached-only vs detached-or-OOB distinction per site, the getters' return-0 semantics, and `buffer`'s
`buffer_object_id: None → "not a TypedArray"` fall-through are all preserved.

> **Follow-up (not fixed here):** `buffer` throwing `"not a TypedArray"` when a genuine TypedArray has
> an unmaterialised buffer-object wrapper (`buffer_object_id: None`) is a pre-existing spec oddity, kept
> as-is to stay behaviour-preserving. Worth a separate issue.

## Quality gate

- `cargo test --lib`: 675 passing + **5 new** (`ta_number_getter_tests`); 0 failures.
- `./scripts/lint.sh`: rustfmt + clippy (`-D warnings`, incl. perf-counters) clean.
- test262 `built-ins/TypedArray` + `built-ins/Uint8Array`: **3016/3016**; the 4 getters `built-ins/TypedArray/prototype/{byteOffset,byteLength,length,buffer}`: **128/128**. **0 regressions.**

Diff: **1 file** (`typedarray.rs`) + a `CONTEXT.md` term — matches the blast-radius-1 score.

## Selection (auditable)

Full review: [`.architecture/reviews/2026-09-11-typedarray-getter-receiver-guard.md`](.architecture/reviews/2026-09-11-typedarray-getter-receiver-guard.md).

- **Pick**: `typedarray-getter-receiver-guard` — **22/25** (leverage 4, locality 4, blast radius 1, heat 5).
- **Runner-up candidate**: `gc-root-scope-guard-eval` — also **22/25** (blast radius 3). The top two
  **tied**; the deterministic lower-blast-radius tie-break decided it. `gc-root-scope-guard-eval` is the
  natural next firing.
- **Winning design**: getter-first combinator (`with_typed_array_ref` + `ta_number_getter`), zero new
  named types.
- **Runner-up design**: a fully policy-parameterized `guard_ta_receiver` with four enums
  (`Brand`/`DetachPolicy`/`Scope`/`Guard`). It **lost** on depth (four types to learn dilutes
  behaviour-per-unit-of-interface) and seam placement (its enum matrix seams policy combinations with
  zero or one user — hypothetical seams by the "two adapters = real seam" test), despite a marginally
  richer test surface.

## CONTEXT.md

Adds the **Receiver Guard** term — the receiver-validation prologue family that `validate_typed_array`,
`require_array_buffer` (#570), and now `with_typed_array_ref` all instance.

## Proposed ADR

> **ADR: Receiver guards are combinators, not policy-parameterized functions, when a policy varies by
> caller group.** When a receiver-validation seam must serve caller groups with genuinely different
> post-validation policies (e.g. TypedArray getters return 0 on a detached view where prototype methods
> throw), prefer a small combinator that bakes the shared group's rule in
> (`ta_number_getter`) layered over a policy-free kernel (`with_typed_array_ref`), over one function
> parameterized by a policy enum. Rationale: the combinator keeps the hot caller's interface to one
> function and one closure, seams only rules that have two or more real adapters, and makes the
> group's rule structurally unforgettable — where an enum surfaces every policy combination, including
> single-user ones, at every call site. Supersedes nothing; complements the existing receiver-guard
> family (#543, #570).

---
🤖 Generated with Claude Code
